### PR TITLE
fix: prevent analyze_file_impact from destroying index, fix close_ses…

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -255,21 +255,23 @@ impl DaemonState {
     }
 
     pub fn close_session(&self, session_id: &str) -> Option<CloseSessionResponse> {
-        let session = self
-            .sessions
-            .write()
-            .expect("lock poisoned")
-            .remove(session_id)?;
+        // Lock ordering: projects before sessions (matches open_project_session).
+        // We need the project_id from the session first, so peek with a read lock,
+        // then acquire projects.write(), then sessions.write() to remove.
+        let project_id = {
+            let sessions = self.sessions.read().expect("lock poisoned");
+            sessions.get(session_id)?.project_id.clone()
+        };
 
         let mut project_removed = false;
         let remaining_sessions = {
             let mut projects = self.projects.write().expect("lock poisoned");
-            match projects.get_mut(&session.project_id) {
+            match projects.get_mut(&project_id) {
                 Some(project) => {
                     project.session_ids.remove(session_id);
                     let remaining = project.session_ids.len();
                     if remaining == 0 {
-                        if let Some(removed) = projects.remove(&session.project_id) {
+                        if let Some(removed) = projects.remove(&project_id) {
                             let mut watcher_task = removed.watcher_task;
                             abort_watcher_task(&mut watcher_task);
                         }
@@ -280,6 +282,13 @@ impl DaemonState {
                 None => 0,
             }
         };
+
+        // Now remove the session (projects lock fully released).
+        let session = self
+            .sessions
+            .write()
+            .expect("lock poisoned")
+            .remove(session_id)?;
 
         Some(CloseSessionResponse {
             session_id: session.session_id,

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -884,11 +884,16 @@ pub fn file_content_from_indexed_file_with_context(
     context: search::ContentContext,
 ) -> String {
     if let Some(chunk_index) = context.chunk_index {
-        return render_numbered_chunk_excerpt(
-            file,
-            chunk_index,
-            context.max_lines.expect("chunked reads require max_lines"),
-        );
+        let max_lines = match context.max_lines {
+            Some(ml) => ml,
+            None => {
+                return format!(
+                    "{} [error: chunked read requires max_lines parameter]",
+                    file.relative_path
+                );
+            }
+        };
+        return render_numbered_chunk_excerpt(file, chunk_index, max_lines);
     }
 
     if let Some(around_symbol) = context.around_symbol.as_deref() {

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -507,13 +507,17 @@ async fn handle_edit_impact(
 
     // Read file from disk and re-index.
     let abs_path = resolve_repo_root(&state)?.join(path);
-    let bytes = std::fs::read(&abs_path).unwrap_or_default();
-    let file_bytes_new = bytes.len() as u64;
-    let file_bytes = if file_bytes_new > 0 {
-        file_bytes_new
-    } else {
-        file_bytes_pre
+    let bytes = match std::fs::read(&abs_path) {
+        Ok(b) => b,
+        Err(_) => {
+            // File unreadable (locked, deleted, wrong path). Return the pre-edit
+            // snapshot as "no change" instead of overwriting the index with an
+            // empty parse — that would destroy all symbols for this file.
+            let text = format!("── Impact: {} ──\nFile not readable on disk; index preserved.", path);
+            return Ok(text);
+        }
     };
+    let file_bytes = (bytes.len() as u64).max(file_bytes_pre);
 
     let result = crate::parsing::process_file(path, &bytes, language);
     let post_symbols: Vec<SymbolSnapshot> = result
@@ -1730,16 +1734,51 @@ mod tests {
         };
 
         // The handler will try to read src/db.rs from disk (cwd). Since the file
-        // doesn't exist on disk in this test, it will use empty bytes — that's OK,
-        // the important thing is it returns a string response, not an error.
+        // doesn't exist on disk in this test, the handler should return Ok with a
+        // "not readable" message and preserve the index instead of destroying it.
         let result = impact_handler(State(state), Query(params)).await;
-        // Should return Ok with some text
         assert!(
             result.is_ok(),
             "impact_handler should return Ok even if file missing from disk"
         );
         let text = result.unwrap();
-        assert!(text.contains("tokens saved"), "should have footer");
+        assert!(
+            text.contains("not readable") || text.contains("index preserved"),
+            "should indicate file was unreadable and index preserved; got: {text}"
+        );
+    }
+
+    /// Proves that analyze_file_impact preserves the index when the file
+    /// cannot be read from disk (the critical regression fix).
+    #[tokio::test]
+    async fn test_impact_handler_edit_preserves_index_when_file_unreadable() {
+        let file = make_indexed_file(
+            "src/db.rs",
+            vec![make_symbol("connect", SymbolKind::Function, 1, 10)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let state = make_state(vec![("src/db.rs", file)]);
+
+        let params = ImpactParams {
+            path: "src/db.rs".to_string(),
+            new_file: None,
+        };
+
+        // File doesn't exist on disk — impact should preserve existing index.
+        let result = impact_handler(State(state.clone()), Query(params)).await;
+        assert!(result.is_ok(), "should return Ok, got: {result:?}");
+
+        // Verify the index still has the original symbol.
+        let guard = state.index.read().unwrap();
+        let indexed = guard.get_file("src/db.rs").expect("file must still be in index");
+        assert_eq!(
+            indexed.symbols.len(),
+            1,
+            "index must retain original symbols; got {} symbols",
+            indexed.symbols.len()
+        );
+        assert_eq!(indexed.symbols[0].name, "connect");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
…sion deadlock

- handlers.rs: replace unwrap_or_default() with proper error handling in handle_edit_impact — when a file cannot be read from disk (locked, deleted, wrong path), return early with an informative message instead of parsing empty bytes and overwriting the index with 0 symbols. This was a critical regression where calling analyze_file_impact would destroy all symbols for the target file.

- daemon.rs: fix lock ordering in close_session — was acquiring sessions.write() then projects.write() (ABBA pattern vs open_project_session which uses projects→sessions). Now peeks project_id via sessions.read(), then acquires projects.write(), then sessions.write(), matching the lock order used everywhere else.

- format.rs: replace .expect() panic in chunked file reads with a graceful error message when max_lines is missing.