### PR TITLE
fix: gate Windows-specific path tests with #[cfg(windows)]

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -490,6 +490,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn test_relative_path_normalizes_backslashes() {
         // Simulate a Windows-style result from strip_prefix.
         // Since we're on MSYS/Windows the path may use backslashes.

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -580,6 +580,7 @@ mod tests {
     // --- Plan 02: Path normalization tests ---
 
     #[test]
+    #[cfg(windows)]
     fn test_normalize_event_path_basic() {
         // Windows-style absolute path: strip root prefix, normalize slashes
         let abs = Path::new(r"C:\repo\src\main.rs");
@@ -589,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn test_normalize_event_path_unc_prefix() {
         // Windows extended-length path with \\?\ prefix
         let abs = Path::new(r"\\?\C:\repo\src\main.rs");
@@ -598,6 +600,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn test_normalize_event_path_outside_repo() {
         // Path is completely outside the repo root — should return None
         let abs = Path::new(r"C:\other\file.rs");


### PR DESCRIPTION
Three tests that use Windows paths (C:\repo, \?\) fail on Linux CI runners. Adding #[cfg(windows)] ensures they only compile and run on Windows.