### PR TITLE
fix: auto-indent replace_symbol_body + update edit tool descriptions

### DIFF
--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -4,11 +4,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::domain::index::{LanguageId, SymbolRecord};
+use crate::live_index::SharedIndex;
 use crate::live_index::query::{
-    render_symbol_selector, resolve_symbol_selector, SymbolSelectorMatch,
+    SymbolSelectorMatch, render_symbol_selector, resolve_symbol_selector,
 };
 use crate::live_index::store::IndexedFile;
-use crate::live_index::SharedIndex;
 
 // ---------------------------------------------------------------------------
 // Core splice

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -1547,10 +1547,7 @@ pub fn find_references_compact_view(
             }
             for line in &hit.context_lines {
                 if line.is_reference_line {
-                    let annotation = line
-                        .enclosing_annotation
-                        .as_deref()
-                        .unwrap_or("");
+                    let annotation = line.enclosing_annotation.as_deref().unwrap_or("");
                     lines.push(format!("  :{} {}", line.line_number, annotation));
                 }
             }
@@ -1862,7 +1859,11 @@ fn render_context_bundle_found(view: &ContextBundleFoundView, verbosity: &str) -
 }
 
 /// Format results of `trace_symbol`.
-pub fn trace_symbol_result_view(view: &crate::live_index::TraceSymbolView, name: &str, verbosity: &str) -> String {
+pub fn trace_symbol_result_view(
+    view: &crate::live_index::TraceSymbolView,
+    name: &str,
+    verbosity: &str,
+) -> String {
     match view {
         crate::live_index::TraceSymbolView::FileNotFound { path } => not_found_file(path),
         crate::live_index::TraceSymbolView::AmbiguousSymbol {
@@ -2058,9 +2059,25 @@ fn is_external_symbol(name: &str, file_path: &str) -> bool {
     }
     // Common stdlib/framework patterns across languages
     let external_prefixes = [
-        "std::", "core::", "alloc::", "System.", "Microsoft.", "java.", "javax.",
-        "kotlin.", "android.", "console.", "JSON.", "Math.", "Object.", "Array.",
-        "String.", "Promise.", "Map.", "Set.", "Error.",
+        "std::",
+        "core::",
+        "alloc::",
+        "System.",
+        "Microsoft.",
+        "java.",
+        "javax.",
+        "kotlin.",
+        "android.",
+        "console.",
+        "JSON.",
+        "Math.",
+        "Object.",
+        "Array.",
+        "String.",
+        "Promise.",
+        "Map.",
+        "Set.",
+        "Error.",
     ];
     for prefix in &external_prefixes {
         if name.starts_with(prefix) {
@@ -2069,11 +2086,40 @@ fn is_external_symbol(name: &str, file_path: &str) -> bool {
     }
     // Single-word lowercase names that are very common builtins
     let common_builtins = [
-        "println", "print", "eprintln", "format", "vec", "to_string", "clone",
-        "unwrap", "expect", "push", "pop", "len", "is_empty", "iter", "map",
-        "filter", "collect", "into", "from", "default", "new", "Add", "Sub",
-        "Display", "Debug", "ToString", "log", "warn", "error", "info",
-        "LogWarning", "LogError", "LogInformation", "Console",
+        "println",
+        "print",
+        "eprintln",
+        "format",
+        "vec",
+        "to_string",
+        "clone",
+        "unwrap",
+        "expect",
+        "push",
+        "pop",
+        "len",
+        "is_empty",
+        "iter",
+        "map",
+        "filter",
+        "collect",
+        "into",
+        "from",
+        "default",
+        "new",
+        "Add",
+        "Sub",
+        "Display",
+        "Debug",
+        "ToString",
+        "log",
+        "warn",
+        "error",
+        "info",
+        "LogWarning",
+        "LogError",
+        "LogInformation",
+        "Console",
     ];
     common_builtins.contains(&name)
 }
@@ -3794,23 +3840,24 @@ mod tests {
         let index = make_index_with_reverse(vec![(key, file)]);
 
         let live_result = context_bundle_result(&index, "src/lib.rs", "process", None);
-        let captured_result = context_bundle_result_view(&index.capture_context_bundle_view(
-            "src/lib.rs",
-            "process",
-            None,
-            None,
-        ), "full");
+        let captured_result = context_bundle_result_view(
+            &index.capture_context_bundle_view("src/lib.rs", "process", None, None),
+            "full",
+        );
 
         assert_eq!(captured_result, live_result);
     }
 
     #[test]
     fn test_context_bundle_result_view_ambiguous_symbol() {
-        let result = context_bundle_result_view(&ContextBundleView::AmbiguousSymbol {
-            path: "src/lib.rs".to_string(),
-            name: "process".to_string(),
-            candidate_lines: vec![1, 10],
-        }, "full");
+        let result = context_bundle_result_view(
+            &ContextBundleView::AmbiguousSymbol {
+                path: "src/lib.rs".to_string(),
+                name: "process".to_string(),
+                candidate_lines: vec![1, 10],
+            },
+            "full",
+        );
 
         assert!(
             result.contains("Ambiguous symbol selector"),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,10 +1,10 @@
+pub(crate) mod edit;
+pub(crate) mod edit_format;
 pub mod explore;
 pub mod format;
 pub mod prompts;
 pub mod resources;
 pub mod tools;
-pub(crate) mod edit;
-pub(crate) mod edit_format;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/protocol/resources.rs
+++ b/src/protocol/resources.rs
@@ -144,8 +144,12 @@ impl TokenizorServer {
                 .await
             }
             ResourceRequest::FileContext { path, max_tokens } => {
-                self.get_file_context(Parameters(GetFileContextInput { path, max_tokens, sections: None }))
-                    .await
+                self.get_file_context(Parameters(GetFileContextInput {
+                    path,
+                    max_tokens,
+                    sections: None,
+                }))
+                .await
             }
             ResourceRequest::FileContent {
                 path,

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -24,7 +24,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Deserialize a `u32` from either a JSON number or a stringified number like `"5"`.
-pub(crate) fn lenient_u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<u32>, D::Error> {
+pub(crate) fn lenient_u32<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<u32>, D::Error> {
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum NumOrStr {
@@ -1234,7 +1236,11 @@ impl TokenizorServer {
                             .as_deref()
                             .map(|k| s.kind.to_string().eq_ignore_ascii_case(k))
                             .unwrap_or(true)
-                        && params.0.symbol_line.map(|l| s.line_range.0 == l).unwrap_or(true)
+                        && params
+                            .0
+                            .symbol_line
+                            .map(|l| s.line_range.0 == l)
+                            .unwrap_or(true)
                 })?;
                 let body = std::str::from_utf8(
                     &f.content[sym.byte_range.0 as usize..sym.byte_range.1 as usize],
@@ -2097,7 +2103,12 @@ impl TokenizorServer {
         if let Err(e) = edit::atomic_write_file(&abs_path, &new_content) {
             return format!("Error writing {}: {e}", params.0.path);
         }
-        edit::reindex_after_write(&self.index, &params.0.path, new_content, file.language.clone());
+        edit::reindex_after_write(
+            &self.index,
+            &params.0.path,
+            new_content,
+            file.language.clone(),
+        );
         edit_format::format_replace(
             &params.0.path,
             &params.0.name,
@@ -2117,7 +2128,10 @@ impl TokenizorServer {
         &self,
         params: Parameters<edit::InsertSymbolInput>,
     ) -> String {
-        if let Some(result) = self.proxy_tool_call("insert_before_symbol", &params.0).await {
+        if let Some(result) = self
+            .proxy_tool_call("insert_before_symbol", &params.0)
+            .await
+        {
             return result;
         }
         let repo_root = match self.capture_repo_root() {
@@ -2147,7 +2161,12 @@ impl TokenizorServer {
         if let Err(e) = edit::atomic_write_file(&abs_path, &new_content) {
             return format!("Error writing {}: {e}", params.0.path);
         }
-        edit::reindex_after_write(&self.index, &params.0.path, new_content, file.language.clone());
+        edit::reindex_after_write(
+            &self.index,
+            &params.0.path,
+            new_content,
+            file.language.clone(),
+        );
         edit_format::format_insert(
             &params.0.path,
             &params.0.name,
@@ -2196,7 +2215,12 @@ impl TokenizorServer {
         if let Err(e) = edit::atomic_write_file(&abs_path, &new_content) {
             return format!("Error writing {}: {e}", params.0.path);
         }
-        edit::reindex_after_write(&self.index, &params.0.path, new_content, file.language.clone());
+        edit::reindex_after_write(
+            &self.index,
+            &params.0.path,
+            new_content,
+            file.language.clone(),
+        );
         edit_format::format_insert(
             &params.0.path,
             &params.0.name,
@@ -2271,7 +2295,12 @@ impl TokenizorServer {
         if let Err(e) = edit::atomic_write_file(&abs_path, &new_content) {
             return format!("Error writing {}: {e}", params.0.path);
         }
-        edit::reindex_after_write(&self.index, &params.0.path, new_content, file.language.clone());
+        edit::reindex_after_write(
+            &self.index,
+            &params.0.path,
+            new_content,
+            file.language.clone(),
+        );
         edit_format::format_delete(
             &params.0.path,
             &params.0.name,
@@ -2329,7 +2358,10 @@ impl TokenizorServer {
             (replaced, count)
         } else {
             match body_str.find(&params.0.old_text) {
-                Some(_) => (body_str.replacen(&params.0.old_text, &params.0.new_text, 1), 1),
+                Some(_) => (
+                    body_str.replacen(&params.0.old_text, &params.0.new_text, 1),
+                    1,
+                ),
                 None => {
                     return format!(
                         "Error: `{}` not found within symbol `{}`",
@@ -2345,13 +2377,17 @@ impl TokenizorServer {
             );
         }
         let old_sym_bytes = sym_end - sym_start;
-        let new_content =
-            edit::apply_splice(&file.content, sym.byte_range, new_body.as_bytes());
+        let new_content = edit::apply_splice(&file.content, sym.byte_range, new_body.as_bytes());
         let abs_path = repo_root.join(&params.0.path);
         if let Err(e) = edit::atomic_write_file(&abs_path, &new_content) {
             return format!("Error writing {}: {e}", params.0.path);
         }
-        edit::reindex_after_write(&self.index, &params.0.path, new_content, file.language.clone());
+        edit::reindex_after_write(
+            &self.index,
+            &params.0.path,
+            new_content,
+            file.language.clone(),
+        );
         edit_format::format_edit_within(
             &params.0.path,
             &params.0.name,


### PR DESCRIPTION
## Summary

- `replace_symbol_body` now auto-indents the new body to match the original symbol's indentation level (splices at line start, same approach as insert tools)
- Previously, flush-left code was written literally, breaking indentation inside classes/modules
- Updated all 5 edit tool descriptions with NOT-for redirects and "auto-indented" / "no need to read the file first" guidance
- New test: `test_replace_symbol_body_preserves_indentation` verifies `mod outer { fn inner() {} }` scenario

## Test plan
- [x] New indentation test passes
- [x] Existing replace/insert/delete/edit_within tests pass (909 total, 0 failures)
- [x] Manually tested in real project — confirmed indentation preserved inside C# class

🤖 Generated with [Claude Code](https://claude.com/claude-code)