### PR TITLE
fix: batch_rename catches path-qualified usages

### DIFF
--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -609,7 +609,44 @@ pub(crate) fn execute_batch_rename(
             .collect()
     };
 
-    // Phase 3: Group all rename sites by file.
+    // Phase 2b: Supplemental literal scan for path-qualified usages.
+    // The xref index tracks call targets (e.g. "new" in Widget::new()), not
+    // path prefixes. A literal whole-word scan catches Type::method() patterns,
+    // import paths, and any other usage the xref system doesn't index.
+    let literal_sites: Vec<(String, (u32, u32))> = {
+        let guard = index.read().expect("lock poisoned");
+        let name_bytes = input.name.as_bytes();
+        let name_len = name_bytes.len();
+        let mut sites = Vec::new();
+        for (file_path, file) in &guard.files {
+            let content = &file.content;
+            let mut start = 0;
+            while let Some(pos) = content[start..]
+                .windows(name_len)
+                .position(|w| w == name_bytes)
+            {
+                let abs_pos = start + pos;
+                // Whole-word check: char before must not be alphanumeric/underscore,
+                // char after must not be alphanumeric/underscore.
+                let before_ok = abs_pos == 0
+                    || !content[abs_pos - 1].is_ascii_alphanumeric()
+                        && content[abs_pos - 1] != b'_';
+                let after_pos = abs_pos + name_len;
+                let after_ok = after_pos >= content.len()
+                    || !content[after_pos].is_ascii_alphanumeric() && content[after_pos] != b'_';
+                if before_ok && after_ok {
+                    sites.push((
+                        file_path.clone(),
+                        (abs_pos as u32, (abs_pos + name_len) as u32),
+                    ));
+                }
+                start = abs_pos + 1;
+            }
+        }
+        sites
+    };
+
+    // Phase 3: Group all rename sites by file (indexed refs + literal scan).
     let mut by_file: std::collections::HashMap<String, Vec<(u32, u32)>> =
         std::collections::HashMap::new();
     by_file
@@ -617,6 +654,9 @@ pub(crate) fn execute_batch_rename(
         .or_default()
         .push(def_name_range);
     for (path, range) in &ref_sites {
+        by_file.entry(path.clone()).or_default().push(*range);
+    }
+    for (path, range) in &literal_sites {
         by_file.entry(path.clone()).or_default().push(*range);
     }
     // Sort reverse by offset, dedup.

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -6649,6 +6649,137 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_rename_catches_path_qualified_calls() {
+        // Regression: batch_rename must catch Type::new() path-qualified calls,
+        // not just simple name references. The index tracks "new" as the call
+        // target, but "Widget" as a path prefix must also be renamed.
+        use crate::protocol::edit::BatchRenameInput;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let lib_content = b"pub struct Widget { pub name: String }\nimpl Widget {\n    pub fn new(name: &str) -> Self { Widget { name: name.to_string() } }\n}\n";
+        let main_content =
+            b"use crate::Widget;\nfn make() -> Widget {\n    Widget::new(\"default\")\n}\n";
+        std::fs::write(src_dir.join("lib.rs"), lib_content).unwrap();
+        std::fs::write(src_dir.join("main.rs"), main_content).unwrap();
+
+        let mut files = vec![];
+        for (path, content) in [
+            ("src/lib.rs", lib_content as &[u8]),
+            ("src/main.rs", main_content as &[u8]),
+        ] {
+            let result = crate::parsing::process_file(path, content, LanguageId::Rust);
+            let indexed =
+                crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+            files.push((path.to_string(), indexed));
+        }
+        let index = make_live_index_ready(files);
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+
+        let input = BatchRenameInput {
+            path: "src/lib.rs".to_string(),
+            name: "Widget".to_string(),
+            kind: None,
+            symbol_line: None,
+            new_name: "Gadget".to_string(),
+            dry_run: None,
+        };
+        let result = server.batch_rename(Parameters(input)).await;
+        assert!(result.contains("Renamed"), "result: {result}");
+
+        // Verify disk: Widget::new() in main.rs must become Gadget::new()
+        let main = std::fs::read_to_string(src_dir.join("main.rs")).unwrap();
+        assert!(
+            !main.contains("Widget"),
+            "main.rs should have no 'Widget' left after rename, got: {main}"
+        );
+        assert!(
+            main.contains("Gadget::new"),
+            "main.rs should contain Gadget::new, got: {main}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_text_agrees_with_disk_after_rename() {
+        // Regression: after batch_rename, search_text must agree with on-disk
+        // content. If rename misses some sites, search_text must still find
+        // the old name (because it's still on disk), not report zero matches.
+        use crate::protocol::edit::BatchRenameInput;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let lib_content = b"pub struct Widget { pub name: String }\nimpl Widget {\n    pub fn new(name: &str) -> Self { Widget { name: name.to_string() } }\n}\n";
+        let main_content =
+            b"use crate::Widget;\nfn make() -> Widget {\n    Widget::new(\"default\")\n}\n";
+        std::fs::write(src_dir.join("lib.rs"), lib_content).unwrap();
+        std::fs::write(src_dir.join("main.rs"), main_content).unwrap();
+
+        let mut files = vec![];
+        for (path, content) in [
+            ("src/lib.rs", lib_content as &[u8]),
+            ("src/main.rs", main_content as &[u8]),
+        ] {
+            let result = crate::parsing::process_file(path, content, LanguageId::Rust);
+            let indexed =
+                crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+            files.push((path.to_string(), indexed));
+        }
+        let index = make_live_index_ready(files);
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+
+        // Do the rename
+        let input = BatchRenameInput {
+            path: "src/lib.rs".to_string(),
+            name: "Widget".to_string(),
+            kind: None,
+            symbol_line: None,
+            new_name: "Gadget".to_string(),
+            dry_run: None,
+        };
+        let _result = server.batch_rename(Parameters(input)).await;
+
+        // Now check: if "Widget" is still on disk anywhere, search_text must find it.
+        let disk_has_widget = std::fs::read_to_string(src_dir.join("main.rs"))
+            .unwrap()
+            .contains("Widget")
+            || std::fs::read_to_string(src_dir.join("lib.rs"))
+                .unwrap()
+                .contains("Widget");
+
+        if disk_has_widget {
+            // search_text should find it too — index must not lie
+            let search_input = crate::protocol::tools::SearchTextInput {
+                query: Some("Widget".to_string()),
+                terms: None,
+                path_prefix: None,
+                glob: None,
+                exclude_glob: None,
+                language: None,
+                regex: None,
+                case_sensitive: None,
+                whole_word: None,
+                group_by: None,
+                follow_refs: None,
+                follow_refs_limit: None,
+                context: None,
+                limit: None,
+                max_per_file: None,
+                include_tests: None,
+                include_generated: None,
+            };
+            let search_result = server.search_text(Parameters(search_input)).await;
+            assert!(
+                !search_result.contains("0 matches"),
+                "search_text says 0 matches but Widget is still on disk! Index/disk desync. search_result: {search_result}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_batch_insert_adds_to_multiple_files() {
         use crate::protocol::edit::{BatchInsertInput, InsertPosition, InsertTarget};
 


### PR DESCRIPTION
## Summary

- `batch_rename` was missing `Type::new()` and similar path-qualified calls because the xref index keys references by call target name (`new`), not path prefix (`Widget`)
- Added Phase 2b: supplemental whole-word literal scan across all indexed file contents to catch path-qualified usages, import paths, and any other usage the xref system doesn't index
- Deduplicates with existing indexed references via the existing sort+dedup in Phase 3

## Test plan

- [x] `test_batch_rename_catches_path_qualified_calls` — `Widget::new("default")` correctly renamed to `Gadget::new("default")`
- [x] `test_search_text_agrees_with_disk_after_rename` — verifies index/disk consistency after partial rename
- [x] All 1063 existing tests pass
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)