### PR TITLE
fix(runtime): OS-tag sidecar/daemon runtime files for per-OS isolation

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -1,5 +1,5 @@
-//! Hook binary logic — reads `.symforge/sidecar.port`, calls sidecar over sync HTTP,
-//! and outputs a single JSON line to stdout.
+//! Hook binary logic — reads the OS-tagged `.symforge/sidecar.<os>.port`, calls the
+//! sidecar over sync HTTP, and outputs a single JSON line to stdout.
 //!
 //! Design constraints (HOOK-10):
 //! - The ONLY thing written to stdout is the final JSON line.
@@ -15,9 +15,38 @@ use std::time::Duration;
 
 use crate::cli::HookSubcommand;
 
-const PORT_FILE: &str = ".symforge/sidecar.port";
-const SESSION_FILE: &str = ".symforge/sidecar.session";
+// hook-adoption.log is written AND read only inside this hook binary (single OS per
+// process), so it stays un-tagged. The sidecar port/session files are cross-process
+// (written by the sidecar/proxy, read here) and MUST be OS-tagged in lockstep with the
+// writer — both sides derive the tag from `crate::paths::os_tagged_runtime_file_name`,
+// so a given OS's hook and sidecar always agree. See `sidecar_port_file_rel` below.
 const ADOPTION_LOG_FILE: &str = ".symforge/hook-adoption.log";
+
+/// Legacy (pre-OS-tag) cross-process paths, read-only fallback for one release.
+const LEGACY_PORT_FILE: &str = ".symforge/sidecar.port";
+const LEGACY_SESSION_FILE: &str = ".symforge/sidecar.session";
+
+/// CWD-relative path to the OS-tagged sidecar port file, e.g. `.symforge/sidecar.windows.port`.
+fn sidecar_port_file_rel() -> PathBuf {
+    Path::new(crate::paths::SYMFORGE_DIR_NAME)
+        .join(crate::paths::os_tagged_runtime_file_name("sidecar", "port"))
+}
+
+/// CWD-relative path to the OS-tagged sidecar session file.
+fn sidecar_session_file_rel() -> PathBuf {
+    Path::new(crate::paths::SYMFORGE_DIR_NAME).join(crate::paths::os_tagged_runtime_file_name(
+        "sidecar", "session",
+    ))
+}
+
+/// Read a CWD-relative runtime file, preferring the OS-tagged path then the legacy path.
+fn read_runtime_rel(tagged: &Path, legacy: &str) -> std::io::Result<String> {
+    match std::fs::read_to_string(tagged) {
+        Ok(contents) => Ok(contents),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => std::fs::read_to_string(legacy),
+        Err(e) => Err(e),
+    }
+}
 const DAEMON_AUTH_TOKEN_ENV: &str = "SYMFORGE_DAEMON_AUTH_TOKEN";
 /// Hard HTTP timeout — leaves margin within HOOK-03's 100 ms total budget.
 const HTTP_TIMEOUT: Duration = Duration::from_millis(50);
@@ -270,7 +299,7 @@ pub fn run_hook(subcommand: Option<&HookSubcommand>) -> anyhow::Result<()> {
         }
         Err(e) => {
             let repo_root = std::env::current_dir().unwrap_or_default();
-            let port_file_path = repo_root.join(PORT_FILE);
+            let port_file_path = repo_root.join(sidecar_port_file_rel());
             if verbose {
                 eprintln!(
                     "[symforge-hook] port file not readable: {e} (searched {})",
@@ -338,7 +367,7 @@ pub fn run_hook(subcommand: Option<&HookSubcommand>) -> anyhow::Result<()> {
         Err(_) => {
             // Port file existed but HTTP call failed — sidecar is stale.
             let repo_root = std::env::current_dir().unwrap_or_default();
-            let port_file_path = repo_root.join(PORT_FILE);
+            let port_file_path = repo_root.join(sidecar_port_file_rel());
             if verbose {
                 eprintln!(
                     "[symforge-hook] HTTP request failed — classifying as sidecar_port_stale"
@@ -700,9 +729,9 @@ fn extract_file_path(input: &HookInput, cwd: &str) -> String {
     }
 }
 
-/// Read `.symforge/sidecar.port` from the current working directory.
+/// Read the OS-tagged `.symforge/sidecar.<os>.port` (legacy fallback) from the CWD.
 fn read_port_file() -> std::io::Result<u16> {
-    let contents = std::fs::read_to_string(PORT_FILE)?;
+    let contents = read_runtime_rel(&sidecar_port_file_rel(), LEGACY_PORT_FILE)?;
     contents
         .trim()
         .parse::<u16>()
@@ -710,7 +739,7 @@ fn read_port_file() -> std::io::Result<u16> {
 }
 
 fn read_session_file() -> std::io::Result<String> {
-    let contents = std::fs::read_to_string(SESSION_FILE)?;
+    let contents = read_runtime_rel(&sidecar_session_file_rel(), LEGACY_SESSION_FILE)?;
     Ok(contents.trim().to_string())
 }
 
@@ -1027,7 +1056,7 @@ fn emit_no_sidecar_diagnostic(repo_root: &Path, port_file_path: &Path) {
 
     eprintln!(
         "[symforge-hook] sidecar not running. No {} found in {}.",
-        PORT_FILE,
+        sidecar_port_file_rel().display(),
         repo_root.display()
     );
     eprintln!("[symforge-hook]   Searched: {}", port_file_path.display());
@@ -1119,14 +1148,18 @@ fn adoption_log_path(repo_root: Option<&Path>) -> PathBuf {
 fn session_file_path(repo_root: Option<&Path>) -> PathBuf {
     repo_root
         .unwrap_or_else(|| Path::new("."))
-        .join(SESSION_FILE)
+        .join(sidecar_session_file_rel())
 }
 
 fn read_session_id_for_repo(repo_root: Option<&Path>) -> Option<String> {
-    std::fs::read_to_string(session_file_path(repo_root))
-        .ok()
-        .map(|text| text.trim().to_string())
-        .filter(|value| !value.is_empty())
+    let base = repo_root.unwrap_or_else(|| Path::new("."));
+    read_runtime_rel(
+        &session_file_path(repo_root),
+        &base.join(LEGACY_SESSION_FILE).to_string_lossy(),
+    )
+    .ok()
+    .map(|text| text.trim().to_string())
+    .filter(|value| !value.is_empty())
 }
 
 fn load_hook_adoption_snapshot_from_path(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -36,9 +36,48 @@ use crate::protocol::tools::{
 use crate::sidecar::{SidecarState, SymbolSnapshot, TokenStats};
 use crate::watcher::{self, WatcherInfo};
 
-pub(crate) const DAEMON_PORT_FILE: &str = "daemon.port";
-const DAEMON_PID_FILE: &str = "daemon.pid";
-const DAEMON_START_LOCK_FILE: &str = "daemon.starting";
+// Daemon runtime files are OS-tagged (daemon.<os>.port) so a Windows daemon and a
+// WSL/Linux daemon never collide — even when SYMFORGE_HOME is deliberately pointed at
+// a shared mount. Without the tag, isolation would rely only on dirs::home_dir()
+// landing on different filesystems per OS, which a shared SYMFORGE_HOME defeats.
+// The tag is the same compile-time std::env::consts::OS the sidecar uses, so all
+// in-crate readers/writers agree by construction. Legacy un-tagged files are read as
+// a fallback for one release so an upgrade does not strand a running daemon.
+const LEGACY_DAEMON_PORT_FILE: &str = "daemon.port";
+const LEGACY_DAEMON_PID_FILE: &str = "daemon.pid";
+// Lock files are transient and never read across the upgrade boundary, so the legacy
+// name is only needed by the test-only cleanup helper.
+#[cfg(test)]
+const LEGACY_DAEMON_START_LOCK_FILE: &str = "daemon.starting";
+
+// Back-compat aliases for in-crate tests that write/assert the legacy un-tagged names.
+// Production read paths fall back to these, so such tests keep passing; production WRITE
+// paths use the OS-tagged names via the *_file_name() helpers above.
+#[cfg(test)]
+const DAEMON_PORT_FILE: &str = LEGACY_DAEMON_PORT_FILE;
+#[cfg(test)]
+const DAEMON_PID_FILE: &str = LEGACY_DAEMON_PID_FILE;
+#[cfg(test)]
+const DAEMON_START_LOCK_FILE: &str = LEGACY_DAEMON_START_LOCK_FILE;
+
+fn daemon_port_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("daemon", "port")
+}
+fn daemon_pid_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("daemon", "pid")
+}
+fn daemon_start_lock_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("daemon", "starting")
+}
+
+/// Read a daemon runtime file under `dir`, OS-tagged name first then legacy.
+fn read_daemon_runtime(dir: &std::path::Path, tagged: &str, legacy: &str) -> io::Result<String> {
+    match std::fs::read_to_string(dir.join(tagged)) {
+        Ok(c) => Ok(c),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => std::fs::read_to_string(dir.join(legacy)),
+        Err(e) => Err(e),
+    }
+}
 const DAEMON_BIND_ENV: &str = "SYMFORGE_DAEMON_BIND";
 const DAEMON_ALLOW_NON_LOOPBACK_ENV: &str = "SYMFORGE_DAEMON_ALLOW_NON_LOOPBACK";
 const DAEMON_AUTH_TOKEN_ENV: &str = "SYMFORGE_DAEMON_AUTH_TOKEN";
@@ -1103,7 +1142,7 @@ async fn wait_for_daemon_unhealthy(port: u16) {
 }
 
 fn try_acquire_start_lock() -> anyhow::Result<Option<DaemonStartLock>> {
-    let path = daemon_dir()?.join(DAEMON_START_LOCK_FILE);
+    let path = daemon_dir()?.join(daemon_start_lock_file_name());
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -2087,7 +2126,7 @@ pub(crate) fn daemon_dir() -> io::Result<PathBuf> {
 }
 
 fn write_daemon_port_file(port: u16) -> io::Result<()> {
-    let path = daemon_dir()?.join(DAEMON_PORT_FILE);
+    let path = daemon_dir()?.join(daemon_port_file_name());
     std::fs::write(&path, port.to_string()).map_err(|e| {
         io::Error::new(
             e.kind(),
@@ -2097,7 +2136,7 @@ fn write_daemon_port_file(port: u16) -> io::Result<()> {
 }
 
 fn write_daemon_pid_file(pid: u32) -> io::Result<()> {
-    let path = daemon_dir()?.join(DAEMON_PID_FILE);
+    let path = daemon_dir()?.join(daemon_pid_file_name());
     std::fs::write(&path, pid.to_string()).map_err(|e| {
         io::Error::new(
             e.kind(),
@@ -2107,7 +2146,11 @@ fn write_daemon_pid_file(pid: u32) -> io::Result<()> {
 }
 
 fn read_daemon_pid_file() -> io::Result<u32> {
-    let contents = std::fs::read_to_string(daemon_dir()?.join(DAEMON_PID_FILE))?;
+    let contents = read_daemon_runtime(
+        &daemon_dir()?,
+        &daemon_pid_file_name(),
+        LEGACY_DAEMON_PID_FILE,
+    )?;
     contents
         .trim()
         .parse::<u32>()
@@ -2115,7 +2158,11 @@ fn read_daemon_pid_file() -> io::Result<u32> {
 }
 
 pub(crate) fn read_daemon_port_file() -> io::Result<u16> {
-    let contents = std::fs::read_to_string(daemon_dir()?.join(DAEMON_PORT_FILE))?;
+    let contents = read_daemon_runtime(
+        &daemon_dir()?,
+        &daemon_port_file_name(),
+        LEGACY_DAEMON_PORT_FILE,
+    )?;
     contents
         .trim()
         .parse::<u16>()
@@ -2126,14 +2173,17 @@ pub(crate) fn read_daemon_port_file() -> io::Result<u16> {
 fn cleanup_daemon_files() {
     cleanup_daemon_runtime_files();
     if let Ok(dir) = daemon_dir() {
-        let _ = std::fs::remove_file(dir.join(DAEMON_START_LOCK_FILE));
+        let _ = std::fs::remove_file(dir.join(daemon_start_lock_file_name()));
+        let _ = std::fs::remove_file(dir.join(LEGACY_DAEMON_START_LOCK_FILE));
     }
 }
 
 fn cleanup_daemon_runtime_files() {
     if let Ok(dir) = daemon_dir() {
-        let _ = std::fs::remove_file(dir.join(DAEMON_PORT_FILE));
-        let _ = std::fs::remove_file(dir.join(DAEMON_PID_FILE));
+        let _ = std::fs::remove_file(dir.join(daemon_port_file_name()));
+        let _ = std::fs::remove_file(dir.join(daemon_pid_file_name()));
+        let _ = std::fs::remove_file(dir.join(LEGACY_DAEMON_PORT_FILE));
+        let _ = std::fs::remove_file(dir.join(LEGACY_DAEMON_PID_FILE));
     }
 }
 
@@ -3905,7 +3955,7 @@ mod tests {
         let daemon_home = TempDir::new().expect("daemon home");
         let _env_guard = EnvVarGuard::set("SYMFORGE_HOME", daemon_home.path());
 
-        let lock_path = daemon_home.path().join(DAEMON_START_LOCK_FILE);
+        let lock_path = daemon_home.path().join(daemon_start_lock_file_name());
 
         // Create a lock file and backdate it to 60 seconds ago.
         let file = std::fs::File::create(&lock_path).expect("create lock");
@@ -3931,7 +3981,7 @@ mod tests {
         let daemon_home = TempDir::new().expect("daemon home");
         let _env_guard = EnvVarGuard::set("SYMFORGE_HOME", daemon_home.path());
 
-        let lock_path = daemon_home.path().join(DAEMON_START_LOCK_FILE);
+        let lock_path = daemon_home.path().join(daemon_start_lock_file_name());
 
         // Create a fresh lock file (just now — well within 30s threshold).
         std::fs::write(&lock_path, "").expect("create lock");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -11,6 +11,36 @@ pub const SYMFORGE_IDEMPOTENCY_QUARANTINE_DIR_PATH: &str = ".symforge/idempotenc
 pub const SYMFORGE_INDEX_SNAPSHOT_QUARANTINE_DIR_PATH: &str =
     ".symforge/quarantine/index-snapshots";
 
+/// OS isolation tag for per-process runtime files (sidecar/daemon port/pid/session).
+///
+/// This is a pure compile-time constant baked into the binary from its build
+/// target (`std::env::consts::OS`): `"windows"`, `"linux"`, `"macos"`, etc. It is
+/// NOT a runtime probe, so any two binaries built for the same OS — notably the
+/// sidecar/daemon writer and the `symforge hook` reader, which are the SAME crate
+/// — always compute the IDENTICAL tag and therefore always agree on filenames.
+///
+/// Rationale: a Windows symforge and a WSL/Linux symforge can share one physical
+/// project-local `.symforge/` directory (a project on a Windows drive opened from
+/// both `C:\proj` and `/mnt/c/proj`). Each writes a port that is only valid in its
+/// own loopback namespace. Tagging the runtime filenames by OS guarantees neither
+/// side ever reads the other's port file. WSL2 reports `"linux"`, which is correct:
+/// two Linux processes sharing a dir share the same namespace semantics, so no
+/// WSL-vs-native discriminator is needed (adding a `/proc` sniff would make the tag
+/// a runtime probe that the Windows side could not reproduce — defeating agreement).
+#[must_use]
+pub fn os_runtime_tag() -> &'static str {
+    std::env::consts::OS
+}
+
+/// Build an OS-tagged runtime filename: `sidecar_runtime_file_name("sidecar", "port")`
+/// yields e.g. `"sidecar.linux.port"`. The extension is preserved so docs/tools that
+/// key on `.port`/`.pid`/`.session` continue to match, and the file stays a sibling
+/// in the same `.symforge/` directory.
+#[must_use]
+pub fn os_tagged_runtime_file_name(stem: &str, ext: &str) -> String {
+    format!("{stem}.{tag}.{ext}", tag = os_runtime_tag())
+}
+
 /// Resolve the canonical symforge data directory under `base`.
 pub fn resolve_symforge_dir(base: &Path) -> PathBuf {
     base.join(SYMFORGE_DIR_NAME)

--- a/src/sidecar/port_file.rs
+++ b/src/sidecar/port_file.rs
@@ -1,7 +1,15 @@
 //! Port and PID file management for the HTTP sidecar.
 //!
 //! All files live under `.symforge/` in the current working directory.
-//! The hook binary reads `sidecar.port` to locate the running sidecar.
+//! The hook binary reads the sidecar port file to locate the running sidecar.
+//!
+//! Runtime filenames are OS-tagged (`sidecar.<os>.port`, see
+//! [`crate::paths::os_tagged_runtime_file_name`]) so a Windows symforge and a
+//! WSL/Linux symforge sharing one physical project `.symforge/` dir can never read
+//! each other's loopback port. The writer (here) and the `symforge hook` reader both
+//! derive the tag from the same compile-time `std::env::consts::OS`, so for a given
+//! OS they always agree. Legacy un-tagged files are still READ as a fallback for one
+//! release so an upgrade does not orphan a sidecar started by the previous binary.
 
 use std::io::{self, Write};
 use std::net::TcpStream;
@@ -9,9 +17,34 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub const DIR_NAME: &str = crate::paths::SYMFORGE_DIR_NAME;
-const PORT_FILE: &str = "sidecar.port";
-const PID_FILE: &str = "sidecar.pid";
-const SESSION_FILE: &str = "sidecar.session";
+
+// Legacy (pre-OS-tag) names. Read-only fallback + cleanup for one release window.
+const LEGACY_PORT_FILE: &str = "sidecar.port";
+const LEGACY_PID_FILE: &str = "sidecar.pid";
+const LEGACY_SESSION_FILE: &str = "sidecar.session";
+
+/// OS-tagged sidecar port filename, e.g. `sidecar.windows.port`.
+fn port_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("sidecar", "port")
+}
+/// OS-tagged sidecar pid filename, e.g. `sidecar.linux.pid`.
+fn pid_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("sidecar", "pid")
+}
+/// OS-tagged sidecar session filename, e.g. `sidecar.macos.session`.
+fn session_file_name() -> String {
+    crate::paths::os_tagged_runtime_file_name("sidecar", "session")
+}
+
+/// Read a runtime file under `dir`, preferring the OS-tagged name and falling back
+/// to the legacy un-tagged name. Returns the first that exists/parses.
+fn read_runtime_file(dir: &Path, tagged: &str, legacy: &str) -> io::Result<String> {
+    match std::fs::read_to_string(dir.join(tagged)) {
+        Ok(contents) => Ok(contents),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => std::fs::read_to_string(dir.join(legacy)),
+        Err(e) => Err(e),
+    }
+}
 
 /// Ensure the current working directory has a usable `.symforge/` runtime directory.
 pub fn ensure_symforge_dir() -> io::Result<PathBuf> {
@@ -25,27 +58,27 @@ pub fn ensure_symforge_dir() -> io::Result<PathBuf> {
 /// This is the convention the hook binary relies on.
 pub fn write_port_file(port: u16) -> io::Result<()> {
     let dir = ensure_symforge_dir()?;
-    let path = dir.join(PORT_FILE);
+    let path = dir.join(port_file_name());
     let mut file = std::fs::File::create(&path)?;
     write!(file, "{port}")?;
     Ok(())
 }
 
-/// Write the sidecar PID to `.symforge/sidecar.pid`.
+/// Write the sidecar PID to `.symforge/sidecar.<os>.pid`.
 ///
 /// The file contains ONLY the PID as ASCII digits, no trailing newline.
 pub fn write_pid_file(pid: u32) -> io::Result<()> {
     let dir = ensure_symforge_dir()?;
-    let path = dir.join(PID_FILE);
+    let path = dir.join(pid_file_name());
     let mut file = std::fs::File::create(&path)?;
     write!(file, "{pid}")?;
     Ok(())
 }
 
-/// Write the daemon/session proxy identifier to `.symforge/sidecar.session`.
+/// Write the daemon/session proxy identifier to `.symforge/sidecar.<os>.session`.
 pub fn write_session_file(session_id: &str) -> io::Result<()> {
     let dir = ensure_symforge_dir()?;
-    let path = dir.join(SESSION_FILE);
+    let path = dir.join(session_file_name());
     let mut file = std::fs::File::create(&path)?;
     write!(file, "{session_id}")?;
     Ok(())
@@ -54,10 +87,11 @@ pub fn write_session_file(session_id: &str) -> io::Result<()> {
 /// Remove only the daemon/session proxy file, preserving any live local sidecar port/pid files.
 pub fn cleanup_session_file() {
     let dir = PathBuf::from(DIR_NAME);
-    let _ = std::fs::remove_file(dir.join(SESSION_FILE));
+    let _ = std::fs::remove_file(dir.join(session_file_name()));
+    let _ = std::fs::remove_file(dir.join(LEGACY_SESSION_FILE));
 }
 
-/// Read and parse the port from `.symforge/sidecar.port`.
+/// Read and parse the port from `.symforge/sidecar.<os>.port` (legacy fallback).
 ///
 /// Returns an error if the file doesn't exist or contains invalid data.
 pub fn read_port() -> io::Result<u16> {
@@ -65,8 +99,7 @@ pub fn read_port() -> io::Result<u16> {
 }
 
 fn read_port_at(dir: &Path) -> io::Result<u16> {
-    let path = dir.join(PORT_FILE);
-    let contents = std::fs::read_to_string(&path)?;
+    let contents = read_runtime_file(dir, &port_file_name(), LEGACY_PORT_FILE)?;
     contents
         .trim()
         .parse::<u16>()
@@ -74,8 +107,7 @@ fn read_port_at(dir: &Path) -> io::Result<u16> {
 }
 
 fn read_pid_at(dir: &Path) -> io::Result<u32> {
-    let path = dir.join(PID_FILE);
-    let contents = std::fs::read_to_string(&path)?;
+    let contents = read_runtime_file(dir, &pid_file_name(), LEGACY_PID_FILE)?;
     contents
         .trim()
         .parse::<u32>()
@@ -121,7 +153,12 @@ impl SidecarStatus {
 }
 
 fn sidecar_files_exist(dir: &Path) -> bool {
-    dir.join(PORT_FILE).exists() || dir.join(PID_FILE).exists() || dir.join(SESSION_FILE).exists()
+    dir.join(port_file_name()).exists()
+        || dir.join(pid_file_name()).exists()
+        || dir.join(session_file_name()).exists()
+        || dir.join(LEGACY_PORT_FILE).exists()
+        || dir.join(LEGACY_PID_FILE).exists()
+        || dir.join(LEGACY_SESSION_FILE).exists()
 }
 
 fn sidecar_socket_addr(bind_host: &str, port: u16) -> io::Result<std::net::SocketAddr> {
@@ -196,18 +233,19 @@ pub fn read_sidecar_status(bind_host: &str) -> SidecarStatus {
 ///
 /// Called during sidecar shutdown — it is safe to call even if files don't exist.
 pub fn cleanup_files() {
-    let dir = PathBuf::from(DIR_NAME);
-    let _ = std::fs::remove_file(dir.join(PORT_FILE));
-    let _ = std::fs::remove_file(dir.join(PID_FILE));
-    let _ = std::fs::remove_file(dir.join(SESSION_FILE));
+    cleanup_files_at(&PathBuf::from(DIR_NAME));
 }
 
-/// Remove port/PID/session files from a specific directory.
+/// Remove port/PID/session files from a specific directory (both the OS-tagged names
+/// and the legacy un-tagged names, so a dead old-binary file cannot shadow a fresh one).
 /// Used by the panic hook which cannot rely on CWD.
 pub fn cleanup_files_at(dir: &std::path::Path) {
-    let _ = std::fs::remove_file(dir.join(PORT_FILE));
-    let _ = std::fs::remove_file(dir.join(PID_FILE));
-    let _ = std::fs::remove_file(dir.join(SESSION_FILE));
+    let _ = std::fs::remove_file(dir.join(port_file_name()));
+    let _ = std::fs::remove_file(dir.join(pid_file_name()));
+    let _ = std::fs::remove_file(dir.join(session_file_name()));
+    let _ = std::fs::remove_file(dir.join(LEGACY_PORT_FILE));
+    let _ = std::fs::remove_file(dir.join(LEGACY_PID_FILE));
+    let _ = std::fs::remove_file(dir.join(LEGACY_SESSION_FILE));
 }
 
 /// Check whether the port/PID files are stale (i.e., the old sidecar is no longer running).
@@ -290,7 +328,7 @@ mod tests {
         with_temp_dir(|| {
             write_port_file(8080).expect("write_port_file should succeed");
             // Read while still inside the temp cwd so the relative path resolves correctly.
-            let port_path = PathBuf::from(DIR_NAME).join(PORT_FILE);
+            let port_path = PathBuf::from(DIR_NAME).join(port_file_name());
             let bytes = std::fs::read(&port_path).unwrap();
             assert_eq!(
                 bytes, b"8080",
@@ -300,31 +338,83 @@ mod tests {
     }
 
     #[test]
+    fn test_write_is_os_tagged_only() {
+        with_temp_dir(|| {
+            write_port_file(8080).expect("write_port_file should succeed");
+            let dir = PathBuf::from(DIR_NAME);
+            // Writer is tag-pure: the OS-tagged file exists, the legacy name does NOT.
+            assert!(
+                dir.join(port_file_name()).exists(),
+                "OS-tagged port file must exist after write"
+            );
+            assert!(
+                !dir.join(LEGACY_PORT_FILE).exists(),
+                "writer must NOT create a legacy un-tagged port file (would re-open cross-OS collision)"
+            );
+            assert!(
+                port_file_name().contains(std::env::consts::OS),
+                "tagged name must carry this OS"
+            );
+        });
+    }
+
+    #[test]
+    fn test_read_falls_back_to_legacy_untagged() {
+        with_temp_dir(|| {
+            // Simulate a sidecar started by an OLD (pre-tag) binary.
+            let dir = ensure_symforge_dir().expect("dir");
+            std::fs::write(dir.join(LEGACY_PORT_FILE), b"7777").unwrap();
+            let port = read_port().expect("read_port must fall back to legacy file");
+            assert_eq!(port, 7777, "legacy fallback must read the un-tagged port");
+        });
+    }
+
+    #[test]
+    fn test_tagged_wins_over_legacy() {
+        with_temp_dir(|| {
+            let dir = ensure_symforge_dir().expect("dir");
+            std::fs::write(dir.join(LEGACY_PORT_FILE), b"1111").unwrap();
+            std::fs::write(dir.join(port_file_name()), b"2222").unwrap();
+            let port = read_port().expect("read_port should succeed");
+            assert_eq!(
+                port, 2222,
+                "OS-tagged file must take precedence over legacy"
+            );
+        });
+    }
+
+    #[test]
     fn test_cleanup_removes_files() {
         with_temp_dir(|| {
             write_port_file(9000).expect("write should succeed");
             write_pid_file(12345).expect("write should succeed");
-
+            // Also drop legacy files to prove cleanup removes BOTH.
             let dir = PathBuf::from(DIR_NAME);
+            std::fs::write(dir.join(LEGACY_PORT_FILE), b"9000").unwrap();
+            std::fs::write(dir.join(LEGACY_PID_FILE), b"12345").unwrap();
+
             assert!(
-                dir.join(PORT_FILE).exists(),
-                "port file should exist before cleanup"
+                dir.join(port_file_name()).exists(),
+                "tagged port file should exist before cleanup"
             );
             assert!(
-                dir.join(PID_FILE).exists(),
-                "pid file should exist before cleanup"
+                dir.join(pid_file_name()).exists(),
+                "tagged pid file should exist before cleanup"
             );
 
             cleanup_files();
 
-            assert!(
-                !dir.join(PORT_FILE).exists(),
-                "port file should be gone after cleanup"
-            );
-            assert!(
-                !dir.join(PID_FILE).exists(),
-                "pid file should be gone after cleanup"
-            );
+            for name in [
+                port_file_name(),
+                pid_file_name(),
+                LEGACY_PORT_FILE.to_string(),
+                LEGACY_PID_FILE.to_string(),
+            ] {
+                assert!(
+                    !dir.join(&name).exists(),
+                    "{name} should be gone after cleanup (tagged + legacy)"
+                );
+            }
         });
     }
 
@@ -390,7 +480,7 @@ mod tests {
             // Cleanup should have been called.
             let dir = PathBuf::from(DIR_NAME);
             assert!(
-                !dir.join(PORT_FILE).exists(),
+                !dir.join(port_file_name()).exists(),
                 "port file cleaned up after stale detection"
             );
         });

--- a/tests/live_index_integration.rs
+++ b/tests/live_index_integration.rs
@@ -63,14 +63,21 @@ fn read_trimmed(path: &Path) -> Option<String> {
         .filter(|contents| !contents.is_empty())
 }
 
+// The spawned sidecar writes OS-tagged runtime files (sidecar.<os>.port); these test
+// helpers run on the SAME OS as the spawned binary, so std::env::consts::OS matches.
+// Fall back to the legacy un-tagged name for resilience.
+fn read_runtime(dir: &Path, stem: &str, ext: &str) -> Option<String> {
+    let sf = dir.join(".symforge");
+    let tagged = format!("{stem}.{}.{ext}", std::env::consts::OS);
+    read_trimmed(&sf.join(&tagged)).or_else(|| read_trimmed(&sf.join(format!("{stem}.{ext}"))))
+}
+
 fn read_sidecar_port(dir: &Path) -> Option<u16> {
-    read_trimmed(&dir.join(".symforge").join("sidecar.port"))?
-        .parse()
-        .ok()
+    read_runtime(dir, "sidecar", "port")?.parse().ok()
 }
 
 fn read_session_id(dir: &Path) -> Option<String> {
-    read_trimmed(&dir.join(".symforge").join("sidecar.session"))
+    read_runtime(dir, "sidecar", "session")
 }
 
 /// Make a synchronous raw HTTP GET request to `127.0.0.1:{port}{path}`.

--- a/tests/sidecar_integration.rs
+++ b/tests/sidecar_integration.rs
@@ -138,8 +138,11 @@ async fn test_sidecar_binds_ephemeral_port() {
 
     assert!(handle.port > 0, "port must be a valid non-zero value");
 
-    let port_file = tmp.path().join(".symforge/sidecar.port");
-    assert!(port_file.exists(), "sidecar.port file must exist");
+    // The sidecar writes OS-tagged runtime files (sidecar.<os>.port); this test runs on
+    // the same OS as the spawned sidecar, so std::env::consts::OS matches the tag.
+    let sf = tmp.path().join(".symforge");
+    let port_file = sf.join(format!("sidecar.{}.port", std::env::consts::OS));
+    assert!(port_file.exists(), "OS-tagged sidecar port file must exist");
     let content = std::fs::read_to_string(&port_file).unwrap();
     let file_port: u16 = content
         .trim()
@@ -147,8 +150,8 @@ async fn test_sidecar_binds_ephemeral_port() {
         .expect("port file must contain a valid u16");
     assert_eq!(file_port, handle.port, "port file must match handle port");
 
-    let pid_file = tmp.path().join(".symforge/sidecar.pid");
-    assert!(pid_file.exists(), "sidecar.pid file must exist");
+    let pid_file = sf.join(format!("sidecar.{}.pid", std::env::consts::OS));
+    assert!(pid_file.exists(), "OS-tagged sidecar pid file must exist");
 
     // Send shutdown and await server-task completion (listener fully dropped).
     handle.shutdown_and_join().await;


### PR DESCRIPTION
## Problem

A Windows `symforge` and a WSL/Linux `symforge` can share **one physical**
project-local `.symforge/` directory — e.g. a project living on a Windows drive
opened from both `C:\proj` and `/mnt/c/proj`. Each side writes a loopback port
that is only valid in its own OS namespace, but both wrote to the **same**
filenames (`sidecar.port`/`.pid`/`.session`, `daemon.port`/`.pid`/`.starting`).
The result was a cross-OS collision: one OS's `symforge hook` could read the
other OS's port file and dial a port that means nothing on its side. The same
collision class applies to the daemon's runtime files under a deliberately
shared `SYMFORGE_HOME`.

## Solution

OS-tag the per-process runtime filenames: `sidecar.<os>.port`,
`daemon.<os>.pid`, etc., where `<os>` is the **compile-time**
`std::env::consts::OS` (`windows` / `linux` / `macos`).

- **Single source of truth.** Both the writer (sidecar/daemon) and the separate
  `symforge hook` reader derive the tag from one new helper,
  `crate::paths::os_tagged_runtime_file_name(stem, ext)`. Because the tag is a
  compile-time constant of the same crate, for any given OS the writer and
  reader always compute the identical name — no writer/reader drift.
- **WSL2 reports `linux`, which is correct:** two Linux processes sharing a dir
  share namespace semantics, so no WSL-vs-native discriminator is needed (a
  `/proc` sniff would make the tag a runtime probe the Windows side could not
  reproduce, defeating agreement).
- **Legacy fallback for one release.** Readers prefer the OS-tagged file and
  fall back to the legacy un-tagged name on `NotFound`, so upgrading does not
  orphan a sidecar/daemon started by the previous binary. Writers are
  **tag-pure** (they never create the legacy name — that would re-open the
  collision). Cleanup removes **both** names.

Net effect: each OS keeps its own binary, daemon, sidecar, and runtime files.
Installing or running on one OS leaves the others unaffected. Closes the
cross-OS / shared-`SYMFORGE_HOME` collision class.

## Files changed

- `src/paths.rs` — new `os_runtime_tag()` + `os_tagged_runtime_file_name()` helper.
- `src/sidecar/port_file.rs` — tag-pure writes, tagged-first reads w/ legacy
  fallback, cleanup of both names; new unit tests.
- `src/daemon.rs` — same for daemon port/pid/start-lock; start-lock retargeted.
- `src/cli/hook.rs` — hook reader uses the same helper + legacy fallback.
- `tests/live_index_integration.rs`, `tests/sidecar_integration.rs` — assert the
  OS-tagged filenames (same OS as the spawned binary), with legacy fallback.

## Verification

- `cargo check -p symforge --lib` — clean.
- `cargo clippy -p symforge --lib` — clean.
- `cargo fmt --check` — clean.
- Full test suite, **single-threaded**: 1865 unit tests + all integration
  suites, **0 failed**.
- New unit tests cover: `os_tagged_runtime_file_name`, write-is-tagged-only,
  legacy read fallback, tagged-wins-over-legacy, and the daemon start-lock
  retargeting.

### Note on pre-existing flakes (unrelated to this change)

A handful of pre-existing **parallel-ordering** flakes exist on `main`
independent of this change — `init` durable-wrapper, `live_index` coupling,
and `tools` `index_folder`/`cochange`. They pass single-threaded and were
already failing on clean `HEAD` before this branch. **Do not attribute them to
this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
