### PR TITLE
fix(npm): diagnose WSL Windows-prefix trap in launcher resolve error

### DIFF
--- a/npm/lib/resolve-binary.js
+++ b/npm/lib/resolve-binary.js
@@ -116,10 +116,22 @@ function resolveBinary(opts) {
   };
 }
 
+// Detect the WSL trap: a non-Windows process executing a symforge install whose
+// own files live under a Windows drive mount (`/mnt/<letter>/...`). That means
+// the launcher came from a Windows npm prefix that bled onto the WSL PATH, so it
+// only ships the Windows platform package — `npm install -g` from here just
+// rewrites the Windows prefix again. The fix is to install into the Linux prefix.
+function isWindowsPrefixUnderUnix(platform, selfPath) {
+  if (platform === "win32") return false;
+  if (typeof selfPath !== "string") return false;
+  return /^\/mnt\/[a-z]\//i.test(selfPath);
+}
+
 function formatResolveError(result, opts) {
   const options = opts || {};
   const platform = options.platform || process.platform;
   const arch = options.arch || process.arch;
+  const selfPath = options.selfPath || __dirname;
   const targets = result.supportedTargets.map((t) => `${t.platform}-${t.arch}`).join(", ");
 
   if (result.reason === "ok") return null;
@@ -127,6 +139,21 @@ function formatResolveError(result, opts) {
     return `symforge: unsupported platform ${platform}-${arch}; supported: ${targets}`;
   }
   if (result.reason === "platform_package_missing") {
+    if (isWindowsPrefixUnderUnix(platform, selfPath)) {
+      return (
+        `symforge: platform package ${result.platformPackage} is missing because this is a Windows ` +
+        `npm install running under ${platform}.\n` +
+        `  This launcher lives at ${selfPath} — a Windows drive mount, not your ${platform} npm prefix.\n` +
+        `  Cause: a shared Windows ~/.npmrc 'prefix=' (e.g. C:\\Users\\<you>\\.npm-global) is bleeding ` +
+        `into ${platform}, so 'npm install -g' lands in the Windows prefix and only ships the Windows binary.\n` +
+        `  Give ${platform} its own npm prefix, then reinstall:\n` +
+        `    npm config set prefix "$HOME/.npm-global"\n` +
+        `    export PATH="$HOME/.npm-global/bin:$PATH"   # ahead of any /mnt/* entries; add to ~/.profile to persist\n` +
+        `    hash -r && npm install -g symforge@latest\n` +
+        `  Verify with: which symforge   # expect $HOME/.npm-global/bin/symforge, not /mnt/...\n` +
+        `  Then run: symforge init --client all`
+      );
+    }
     return (
       `symforge: platform package ${result.platformPackage} not installed or missing its binary. ` +
       "Reinstall with optional dependencies enabled: npm install -g symforge@latest"

--- a/npm/tests/launcher.test.js
+++ b/npm/tests/launcher.test.js
@@ -74,6 +74,69 @@ test("resolveBinary reports missing optional platform package", () => {
   assert.equal(result.platformPackage, "symforge-linux-x64");
 });
 
+test("formatResolveError diagnoses the WSL Windows-prefix trap for a /mnt launcher", () => {
+  const result = resolveBinary({
+    binary: "symforge",
+    platform: "linux",
+    arch: "x64",
+    requireResolve() {
+      throw new Error("not installed");
+    },
+  });
+
+  const message = formatResolveError(result, {
+    platform: "linux",
+    arch: "x64",
+    selfPath: "/mnt/c/Users/rakovnik/.npm-global/node_modules/symforge/lib",
+  });
+
+  assert.match(message, /Windows npm install running under linux/);
+  assert.match(message, /\/mnt\/c\/Users\/rakovnik/);
+  assert.match(message, /shared Windows ~\/\.npmrc 'prefix='/);
+  assert.match(message, /npm config set prefix "\$HOME\/\.npm-global"/);
+  assert.match(message, /symforge init --client all/);
+});
+
+test("formatResolveError keeps the generic missing-package message off Windows mounts", () => {
+  const result = resolveBinary({
+    binary: "symforge",
+    platform: "linux",
+    arch: "x64",
+    requireResolve() {
+      throw new Error("not installed");
+    },
+  });
+
+  const message = formatResolveError(result, {
+    platform: "linux",
+    arch: "x64",
+    selfPath: "/home/rakovnik/.npm-global/lib/node_modules/symforge/lib",
+  });
+
+  assert.match(message, /not installed or missing its binary/);
+  assert.doesNotMatch(message, /Windows drive mount/);
+});
+
+test("formatResolveError never shows the WSL hint to a real Windows host", () => {
+  const result = resolveBinary({
+    binary: "symforge",
+    platform: "win32",
+    arch: "x64",
+    requireResolve() {
+      throw new Error("not installed");
+    },
+  });
+
+  const message = formatResolveError(result, {
+    platform: "win32",
+    arch: "x64",
+    selfPath: "/mnt/c/whatever",
+  });
+
+  assert.match(message, /not installed or missing its binary/);
+  assert.doesNotMatch(message, /Windows drive mount/);
+});
+
 test("resolveBinary rejects invalid binary names", () => {
   const result = resolveBinary({ binary: "other", platform: "linux", arch: "x64" });
 


### PR DESCRIPTION
## Problem

`npm install -g symforge` is expected to just work on WSL. It fails when npm's global prefix points at a Windows path: a shared `C:\Users\<u>\.npmrc` with `prefix=C:\Users\<u>\.npm-global` bleeds into WSL, so `npm install -g` lands in the Windows prefix and only ships `symforge-windows-x64`. The Linux launcher then can't find `symforge-linux-x64` and printed a generic "optional dependencies" message — which sent users in circles re-installing into the same Windows prefix.

Verified by review: a clean Linux prefix installs `symforge-linux-x64` and works (`symforge 7.15.2`) with no extra steps. The package is fine; the failure is environment (WSL/npm prefix), not the Rust binary.

## What this does

The only fix symforge can make without violating the AV-safe packaging invariant (no `preinstall`/`install`/`postinstall`, enforced by `npm/tests/av_safe_packaging.test.js`): make the **runtime** failure self-explanatory.

`formatResolveError` (in `npm/lib/resolve-binary.js`) now detects when a non-Windows host runs a launcher installed under a Windows drive mount (`/mnt/<drive>/`) and the platform package is missing, and emits the real cause + the durable one-time repair:

```
npm config set prefix "$HOME/.npm-global"
export PATH="$HOME/.npm-global/bin:$PATH"
hash -r && npm install -g symforge@latest
symforge init --client all
```

- New `isWindowsPrefixUnderUnix(platform, selfPath)` helper.
- `formatResolveError` gains `opts.selfPath` (defaults to `__dirname`, which is under `/mnt/...` for a Windows-prefix install, so the message fires in production without wiring `selfPath` through the launcher).
- Generic message unchanged on every other path; win32 hosts never see the WSL hint.

## Scope / non-goals

- Does **not** add install hooks (AV/EDR-safe stance intact).
- Does **not** attempt system-wide `/usr/local` installs or `/etc/profile.d` edits — those were one-off workarounds, not something every user should need.
- Cannot make a Windows-prefix install *succeed* from WSL (impossible without banned hooks); it makes the failure actionable instead of misleading.

## Tests

`cd npm && npm test` -> 13/13 pass, including the 3 new cases (WSL `/mnt` trap message, normal Linux miss keeps generic message, win32 host never sees the hint) and the unchanged AV-safe packaging assertions.

## Follow-ups (non-blocking)

- Soften PATH advice to "ensure the Linux prefix is ahead of `/mnt/*` on PATH" to avoid shadowing an existing working `/usr/local/bin/symforge`.
- `.gitignore` for `npm/.symforge/` daemon scratch (separate cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)