### PR TITLE
docs(audit): add SymForge MCP bug-report verdicts and bugfix campaign…

### DIFF
--- a/docs/SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md
+++ b/docs/SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,591 @@
+# SymForge MCP Bug-Fix Implementation Plan
+
+Date: 2026-06-03
+Source audit: `docs/SYMFORGE_MCP_BUG_REPORT_2026-06-03.md` (Codex cross-repo audit, SF-001..SF-011)
+Verification: 11 root-cause investigators + 11 adversarial verifiers + 7 live reproduction agents
+(against the real `Agent_Army_Professionals`, `testpilot`, and `symforge` repos on disk).
+
+This plan is the actionable hand-off for the coding agent. Every claim below was either
+reproduced against the real repos, proved against the live source, or both. Where the original
+report was WRONG, this plan says so and gives the corrected work. Read this, not the raw report,
+when implementing.
+
+---
+
+## TL;DR — what actually has to be built
+
+| ID | Original sev | VERIFIED verdict | Build? | One-line action |
+|---|---|---|---|---|
+| SF-001 | Critical | **ALREADY FIXED** (not reproducible >=7.10.0) | Tests + ops guard only | Add real-parser regression test; daemon binary-staleness warning. Do NOT touch the matching algorithm. |
+| SF-002 | High | **CONFIRMED defect** | YES | Kill self-caller/callee via existing `enclosing_symbol_index`; surface `unresolved_same_name_member_call`. |
+| SF-003 | High | **CONFIRMED defect** | YES | Classify import-type+`[]` parse error as parser limitation (Status: ok), not repo syntax error. Sound detector required. |
+| SF-004 | Medium | **CONFIRMED limitation** | YES | Add `expected_framework_partial` bucket for Angular `@if/@for` in `.html`. |
+| SF-005 | Medium | **CONFIRMED defect** | YES | `ask` "where is X defined and ..." must extract leading symbol token, not pass whole sentence. |
+| SF-006 | Medium | **CONFIRMED defect** | YES | Stem-equals-basename co-change gate fix + precise fallback reason (incl. chore-anchor). |
+| SF-007 | Medium | **CONFIRMED defect** | YES | Forward `checkpoint_now` to the daemon; add daemon dispatch arm. |
+| SF-008 | Medium | **CONFIRMED defect** | YES | Windows-native remediation in `format_shadow_warning` ForeignPrefix arm. |
+| SF-009 | Medium | **MECHANISM REFUTED** | Surfacing only | Scratch dotfiles already filtered; `.txt` adds 0 symbols. Add "indexed untracked files: N"; do NOT change admission. |
+| SF-010 | Low | **PARTIAL** (lazy-exposure = harness) | YES (half) | `ask` ToolHelp intent + `symforge://tools/catalog`. Document lazy-exposure as harness behavior. |
+| SF-011 | Low | **CONFIRMED defect** | YES | Language-aware `detect_conventions` (TS/NestJS/Angular branch). |
+
+Net: **8 real code fixes (SF-002..SF-008, SF-010, SF-011), 1 already-fixed (SF-001: tests+ops), 1 refuted-mechanism (SF-009: surfacing only).**
+
+---
+
+## Corrections to the original report (read before trusting it)
+
+These are the places the Codex report is factually wrong or misleading. The coding agent MUST
+follow the corrected version or it will write the wrong fix / a vacuous test.
+
+1. **SF-001 is not a live defect.** The collision filter that rejects the exact `new`/`get`/`state`
+   bare-name collision shipped in commit `251d7f0` ("tighten Pass 2 collision filter for H.4"),
+   which is an ancestor of the `v7.18.0` tag (VERIFIED: `git merge-base --is-ancestor 251d7f0 v7.18.0`
+   returns true). Current source structurally cannot emit a dependent edge for a file with ZERO
+   textual reference to the target (it requires either a `::`-boundary qualified-name suffix match
+   OR a same-name import). The audit observation is a **stale daemon binary** artifact: it ran in
+   `daemon_reused_session` mode with a PATH-shadowing `C:\Program Files\nodejs\symforge` of
+   "version unknown" (the same shadow SF-008 flags). Do NOT change the matching algorithm — doing so
+   would regress legitimate cross-module dependents pinned by `real_qualified_call_dependent_still_reported`.
+
+2. **SF-002 has a cleaner fix than the report implies.** The index already stores
+   `enclosing_symbol_index` on every reference (VERIFIED present in `domain/index.rs`, `store.rs`,
+   `context_bundle.rs`, + 13 more files). The self-caller symptom is killable by checking
+   `reference.enclosing_symbol_index != Some(target_index)` for same-file refs — precise, language-agnostic,
+   and it does NOT suppress legitimate intra-class `this.foo()` callers. The report's implied
+   byte-before-`.` heuristic is strictly more invasive (it would turn a false-positive into a
+   false-negative for the canonical NestJS delegation pattern). Use `enclosing_symbol_index`.
+
+3. **SF-003 trigger is narrower than reported, and the obvious detector is unsound.** Only the `[]`
+   array suffix on an import-type breaks (`import('rxjs').Subscription` scalar parses CLEAN; only
+   `import('rxjs').Subscription[]` errors). A grammar bump is NOT available — `tree-sitter-typescript 0.23.2`
+   is the latest published crate. CRITICAL: a detector that gates on "error-node text starts with `import(`
+   and next char is `[`" is UNSOUND — a genuinely broken file `import('rxjs').Subscription[] = [ ; foo bar`
+   produces the same error-node prefix and would be wrongly marked OK. The detector must validate the
+   WHOLE construct (no trailing ERROR/MISSING after the array suffix), e.g. re-parse the isolated type
+   annotation in a synthetic well-formed wrapper, or confirm no further error node follows.
+
+4. **SF-006 is NOT a path-normalization bug** (the reproduction's leading hypothesis was wrong; the
+   investigation proved the map lookup succeeds). The real cause: the anchor-confidence gate. Query
+   `work_item` (stem, no extension) scores only PREFIX tier (50.0) against `work_item.rs` (basename
+   incl. extension), below the `CO_CHANGE_ANCHOR_CONFIDENCE_FLOOR = 100.0`, so fusion never applies.
+   Fusion DOES work for the with-extension shape today (`query="work_item.rs"`). Also: there are
+   **four** distinct fallback reasons to disambiguate (anchor-confidence, below-shared-commit-floor,
+   no-neighbor-in-candidate-set, AND chore-anchor) — the report/investigation listed three.
+
+5. **SF-009's stated mechanism is FALSE.** The named scratch files are all dotfiles; the `ignore`
+   crate's default `hidden:true` filters them before admission ever runs. Even a non-dotfile `.txt`
+   maps to `LanguageId::None` -> Tier-2 metadata-only -> **0 symbols, 0 Tier-1 count**. The reported
+   +1450 symbols cannot come from text scratch files (arithmetically impossible); it was the
+   concurrent agent's real source edits. The report's own proposed regression test (assert
+   `.probe.txt` not indexed) would **pass today with zero code change** — a vacuous test. Only fix:
+   surface "indexed untracked files: N"; do NOT change admission defaults (breaks non-git/tempdir workflows).
+
+6. **SF-010's "lazy exposure" is harness behavior, not a SymForge defect.** SymForge eagerly returns
+   all 32 tools in one `tools/list` (rmcp `#[tool_handler]` macro). The two-pass discovery is the
+   client ToolSearch/deferred-loading layer. SymForge can only fix the `ask()` tool-meta-question half
+   and add a tool catalog. Document the other half as out of scope.
+
+---
+
+## Verification environment (ground truth)
+
+- `tree-sitter-typescript = 0.23.2` (LATEST published; no bump remedy) — `Cargo.toml:72`, `Cargo.lock` checksum `6c5f76ed...`
+- `tree-sitter-html = 0.23.2` (vanilla upstream, zero Angular rules) — `Cargo.toml:85`
+- `tree-sitter = 0.26.8` core
+- `.ts`/`.tsx` both -> `LanguageId::TypeScript` -> `LANGUAGE_TYPESCRIPT` (no separate TSX grammar; `.tsx` is covered by the same fix)
+- Real repos on disk: `C:\AI_STUFF\PROGRAMMING\Agent_Army_Professionals`, `...\testpilot` (the audit originals)
+- SF-001 fix commit `251d7f0` confirmed ancestor of `v7.18.0`.
+
+---
+
+## Repair order (gated phases, <=5 files/phase per CLAUDE.md)
+
+Ship in this order. Each issue is independently landable; group by risk and file overlap.
+Two issues touch `smart_query.rs` (SF-005, SF-010) — serialize them. Three touch the
+parse-classification path (SF-003, SF-004) and `health_view.rs`/`format.rs` — serialize them.
+
+**Phase A — High value, low risk, isolated:**
+- SF-007 (`checkpoint_now` forwarding) — `tools.rs` + `daemon.rs`, fully isolated.
+- SF-008 (Windows PATH remediation) — `path_shadow.rs` only.
+
+**Phase B — Correctness defects in resolution/ranking:**
+- SF-002 (TS same-name method) — `disambiguation.rs`, `context_bundle.rs`, `format.rs` (+ new output section).
+- SF-006 (co-change gate + reasons) — `rank_signals.rs`, `tools.rs`, calibration tests.
+
+**Phase C — Parse classification (serialize C1 then C2; shared files):**
+- SF-003 (import-type+array) — `parsing/mod.rs`, `domain/index.rs` or `store.rs`, `format.rs`, `tools.rs`, `health_view.rs`.
+- SF-004 (Angular template) — `health_view.rs`, `store.rs`, `format.rs` (+ `sidecar/handlers.rs` for get_file_context scope).
+
+**Phase D — Routing / UX (serialize D1 then D2; both touch smart_query.rs):**
+- SF-005 (`ask` compound query) — `smart_query.rs`.
+- SF-010 (`ask` ToolHelp + catalog) — `smart_query.rs`, `tools.rs`, `resources.rs`.
+
+**Phase E — Advisory quality + ops/tests:**
+- SF-011 (language-aware conventions) — `conventions.rs`.
+- SF-001 (real-parser regression test + daemon staleness guard) — `tests/find_dependents_pass2.rs`, `daemon.rs`/health.
+- SF-009 (untracked-file surfacing) — `health_view.rs`, `format.rs`, `store.rs`, `discovery/mod.rs`.
+
+Per-issue gates (every issue): `cargo fmt --check` -> `cargo check` ->
+`cargo clippy --all-targets -- -D warnings` -> `cargo test --all-targets -- --test-threads=1`
+-> for the live-verifiable ones, re-run the MCP tool against the real repo and confirm the
+corrected output. NO push/merge without human approval (commit to a review branch and stop).
+
+---
+
+## Per-issue implementation specs
+
+### SF-002 — TypeScript same-name method conflation (HIGH, CONFIRMED)
+
+**Symptom:** `get_symbol_context` lists `TestingController.startExploration` as its own caller AND
+callee because the body calls `this.testingService.startExploration(...)`. Ground truth verified:
+3 distinct `startExploration` defs in testpilot (controller:44, service:415, frontend ApiService:378).
+
+**Root cause:** `matches_exact_symbol_reference` (`src/live_index/disambiguation.rs:51-95`) accepts a
+ref as a caller when `reference.name == target_name` (81-83). The only receiver guard
+(`is_rust_receiver_method_call`, :89-92 -> :97-113) is gated `if target_kind == SymbolKind::Function
+&& *target_language == LanguageId::Rust`. TS methods are `SymbolKind::Method`/`LanguageId::TypeScript`,
+so the guard is skipped; the bare-name member call matches. The TS xref query (`xref.rs:110`) captures
+only the property name, discarding the receiver, so qualified_name is None. Callee half: `callees_for_symbol`
+(`context_bundle.rs:295-329`) has no name-vs-self check.
+
+**Fix (use the verifier's correction — `enclosing_symbol_index`, NOT byte heuristic):**
+1. Caller side: in the same-file caller branch of `collect_exact_symbol_references`
+   (`query.rs:1558-1573`), reject a Call ref whose `enclosing_symbol_index == Some(target_symbol_index)`
+   — that is the symbol calling a same-named member from inside its own body. This kills the
+   self-caller precisely, language-agnostically, without suppressing legitimate intra-class
+   `this.foo()` callers from OTHER methods.
+2. For cross-object same-name calls where the receiver type is unresolved, surface them as a new
+   `unresolved_same_name_member_call` section on `ContextBundleFoundView` rather than as exact callers
+   (per the report's acceptance criterion). Render under a clearly-labeled line in the
+   `get_symbol_context` formatter (`src/protocol/format.rs`).
+3. Callee side: in `callees_for_symbol`/`capture_callee_section`, when a callee's bare name equals the
+   target's own name AND it is a receiver method call, label it unresolved rather than rendering the
+   method as calling itself.
+
+**DO NOT:** broaden the byte-before-`.` guard globally — the verifier proved it reclassifies the
+canonical legitimate `this.target()` sibling/recursion caller (receiver IS resolvable there) into a
+false-negative. Also note: `find_references` and `edit_plan` are PUBLIC tools consuming this path; any
+change to caller counts is a user-visible contract change across TS/JS/Python/C#/Go — gate the new
+output-section change deliberately and update golden/snapshot tests.
+
+**Regression test:** `src/live_index/query.rs` tests, modeled on
+`test_capture_context_bundle_view_uses_symbol_line_and_exact_callers` (query.rs:3551). TS fixture:
+`class TestingService { startExploration() {} } class TestingController { startExploration() { return this.testingService.startExploration(); } }`.
+Assert (1) controller method `callers.total_count == 0`; (2) controller method is not its own callee
+(appears in the new unresolved section). Add a C#/Java parallel and a guard test that a true bare
+top-level `foo()` (no preceding `.`) IS still counted as a caller.
+**Verifier caveat on the test:** the `make_ref` helper (`query.rs:2593-2607`) hardcodes
+`line_range = (byte_start/100, byte_start/100)`; the naive `content.find("startExploration();")` offset
+yields line 0, which won't land inside the controller method's `line_range` (so `callees_for_symbol`'s
+line-containment filter won't fire). Use a ref builder that decouples byte_range from line_range, or
+position content so `byte_start/100` maps to the controller method's line. The report's recipe is broken as written.
+
+**Open decisions:** output shape (new field vs sibling Vec on `ContextBundleFoundView`); whether to
+also guard Rust `SymbolKind::Method` (`self.foo()`); whether `edit_plan` subtracts unresolved hits or
+reports them separately. Ship the surgical guard+labeling; DEFER the `xref` receiver-capture
+(qualified_name) enhancement (index-format/blast risk).
+
+---
+
+### SF-003 — TS import-type `[]` reported as syntax error (HIGH, CONFIRMED)
+
+**Symptom:** `private subs: import('rxjs').Subscription[] = [];` (valid TS, testpilot
+workflow-builder.component.ts:462) -> `Status: partial` in `validate_file_syntax`/`get_file_context`/`health`.
+
+**Root cause (two parts):**
+- Grammar: `tree-sitter-typescript 0.23.2` mis-parses an import-type immediately followed by `[]`.
+  Empirically isolated (dogfooded against the real pinned grammar): scalar `import('rxjs').Subscription`
+  parses CLEAN in every position; only the `[]`/tuple suffix breaks (`type T = import('x').y[]`,
+  class field, fn return, multi-dim `[][]`, generic arg all error). 0.23.2 is the latest crate -> no bump.
+- Classification: `parsing/mod.rs:273` `let has_error = root.has_error();` -> `mod.rs:95-102` binary
+  `if has_error { PartialParse } else { Processed }`. No "known grammar limitation" concept. Flows to
+  `ParseStatus::PartialParse` -> `format.rs:2127` "Status: partial", `tools.rs:746-752` parse_state
+  "partial", `health_view.rs:174-182` counted as UNEXPECTED partial. The only existing
+  expected-vs-unexpected discriminator (`is_expected_vendor_partial_parse_noise`, `health_view.rs:55-71`)
+  is path-based vendor-only.
+
+**Fix — diagnostic-content-based known-limitation classifier (grammar bump impossible). Recommended shape (B):**
+1. In `parse_source` (after `collect_deepest_error_node`), add a SOUND TypeScript-gated detector for
+   the import-type+array pattern. **Must validate the whole construct** (per verifier): confirm the
+   error region is exactly an `import(...).Member` followed by `[]`/tuple AND there is no further
+   ERROR/MISSING node after the array suffix (e.g. re-parse the isolated annotation in a synthetic
+   well-formed wrapper and confirm clean). Do NOT gate merely on "error-node text starts with `import(`
+   + next char `[`" — that false-classifies genuinely broken files.
+2. Add `FileOutcome::ExpectedGrammarLimitation { note }` (`domain/index.rs`) -> `ParseStatus::ParsedWithGrammarLimitation { note }` (`store.rs`).
+3. Render: `validate_file_syntax_result` (`format.rs:2117-2153`) -> `Status: ok` (optionally
+   `+ note: parser limitation`); `parse_state_for_file` (`tools.rs:746-752`) -> "parsed";
+   `health_view.rs` counts under expected, never unexpected.
+
+**CRITICAL serialization hazard (verifier):** `ParseStatus` derives `Serialize/Deserialize` and is
+persisted in the checkpoint snapshot (`persist.rs:54`, 14 occurrences). A new variant changes the
+on-disk format -> needs `#[serde(default)]`/untagged strategy or a snapshot written by a new binary
+fails to load on an older one. Confirm checkpoint back-compat before shipping shape (B). Shape (A)
+(extend the expected-partial predicate + thread `IndexedFile` into the two renderers —
+`validate_file_syntax_result` 2 call sites tools.rs:5800/5842, `parse_state_for_file` 1 caller
+tools.rs:3369) avoids the persisted-format hazard at the cost of renderer signature churn.
+
+**Note:** `.tsx` is already covered (same grammar) — no separate TSX handling needed (verifier corrected
+the investigation's open question; there is no `LANGUAGE_TSX` in this codebase).
+
+**Regression test:** `src/parsing/mod.rs` tests. Pin the user-visible outcome, not grammar internals:
+- Positive: class-field `import('rxjs').Subscription[] = []` -> outcome is `Processed | ExpectedGrammarLimitation`; symbols still extracted (`C` present).
+- Positive: type-alias `type S = import('rxjs').Subscription[];` (the error-node-starts-with-`[` variant the naive detector misses).
+- **Negative control (REQUIRED):** genuinely broken `import('rxjs').Subscription[] = [ ; foo bar baz` MUST stay partial/failed — proves the detector didn't over-broaden and mask real errors.
+- Negative control: `class C { private x: = ; }` stays partial.
+- Format layer: `validate_file_syntax_result` for the valid fixture contains "Status: ok" not "Status: partial".
+- Health: the file does not appear in `unexpected_partial_parse_files`.
+
+---
+
+### SF-004 — Angular template control-flow reported as partial HTML parse (MEDIUM, CONFIRMED limitation)
+
+**Symptom:** `@if (items.length > 0) {` / `@for (...)` in `.html` (testpilot app.html) -> `Parse status: partial`,
+`syntax error near '0) {' (line 14, col 38)`. Byte-exact reproduced against the real grammar.
+
+**Root cause:** `tree-sitter-html 0.23.2` has zero Angular rules; the `>` in the Angular expression is
+lexed as a tag close, leaving `0) {` unparseable -> ERROR node. `@if (cond) {` (no `>`) parses clean;
+the `>` relational operator is the trigger. SymForge's own source already comments it text-scans Angular
+(`html.rs:50-54`, `:148-151`). Same classification gap as SF-003: only the vendor-SCSS expected bucket exists.
+
+**Fix — add a third partial bucket `expected_framework_partial`:**
+1. `health_view.rs`: add `is_expected_framework_partial_parse(path, file)` parallel to the vendor one
+   (:55-71). Signal: `LanguageId::Html` + PartialParse + at least one extracted symbol named
+   `@if/@for/@switch/@defer/@let` (these only come from `scan_angular_text`, so precise). Add a third
+   branch in `health_stats` (:171-189) and the `expected_framework_partial_*` fields on `HealthStats`.
+2. `store.rs`: add `expected_framework_partial_*` to `PublishedIndexState` (near :543) + stats->published
+   mapping (~:1161) so daemon-proxy mode carries the bucket. **Verifier-confirmed:** `PublishedIndexState`
+   derives only Clone/Debug/PartialEq/Eq — NO serde — so NO `#[serde(default)]` needed (it's an
+   in-memory cross-process capture, not a disk snapshot). The investigation's serde worry was moot.
+3. `format.rs`: add `ParseQuarantineKind::ExpectedFrameworkPartial` (label `expected_framework_partial`,
+   reason ~"expected framework: Angular template control-flow not supported by tree-sitter-html; symbols
+   extracted best-effort"); wire `from_stats`/`from_published`/`full_section`/`compact_line`.
+4. **Required scope (verifier upgraded this from optional):** `get_file_context` is the report's actual
+   repro tool but `parse_state_label` (`sidecar/handlers.rs:132-138`) hard-maps PartialParse -> "partial"
+   with no framework awareness. Surface the framework classification in the file-context envelope too,
+   or the exact line the report quotes stays unchanged.
+
+**Heuristic caveat (verifier):** a genuinely malformed `.html` that also contains a valid `@if` would be
+re-bucketed as framework-partial, masking a real defect. Don't over-promise in the reason string; ideally
+correlate the stored `parse_diagnostic` line/span (`store.rs:245`) with an Angular control-flow line.
+
+**Regression test:** (1) parser-level: `@if (items.length > 0) {...}` yields `has_error=true` AND an
+`@if` symbol is extracted (no existing test asserts has_error for the `>` case — write fresh). (2)
+classification-level in `tests/health_parse_quarantine.rs`: app.html lands under
+`[expected_framework_partial]`, registry line includes `expected_framework_partial=1`, file NOT under
+`[unexpected_partial]`. Existing `tests/health_parse_quarantine.rs` hard-codes the registry summary
+string — update those assertions in the same change.
+
+---
+
+### SF-005 — `ask` fails compound lookup queries (MEDIUM, CONFIRMED defect)
+
+**Symptom:** `ask("Where is TestingController defined and what module imports it?")` routes the WHOLE
+sentence to `search_symbols(query="TestingController defined and what module imports it?")` -> no match,
+reported as `RouteConfidence::Exact` with no suggested next step (confident false negative).
+
+**Root cause:** the "where is " FindSymbol branch (`smart_query.rs:135-167`) captures the entire remainder
+after the prefix and only strips two trailing SUFFIXES (`.trim_end_matches(" defined").trim_end_matches(" declaration")`,
+:156-158). "defined" is mid-sentence here, so nothing is stripped; the full sentence becomes the symbol name.
+
+**Fix:**
+1. **Reorder prefixes (verifier's structural correction):** check `where is file ` (FindFile, :175)
+   BEFORE bare `where is ` (FindSymbol, :138). Currently `where is file tools.rs` wrongly routes to
+   FindSymbol with name "file tools.rs"; the new first-token logic would make that strictly worse
+   ("file"). Reordering removes the special case entirely.
+2. After prefix+kind stripping, extract only the FIRST whitespace-delimited token as the symbol
+   candidate (a symbol is one token). **Drop the hardcoded stop-word list** (verifier: fragile, buys
+   nothing over first-token extraction). Run the single token through existing `clean_symbol_name`
+   casing recovery (`smart_query.rs:551-558`) so `testingcontroller` -> `TestingController`. Verify
+   `optimize_deterministic` (snake_case, one token) survives intact.
+3. When truncation happened, set the matched/confidence signal so `assess_route` returns `Inferred`
+   (not `Exact`) WITH a `suggested_next_step` naming the chained sequence
+   (`search_symbols -> find_references`), per the acceptance criterion.
+
+**DO NOT** build a full compound-query decomposition engine (gold-plating for MEDIUM). Leading-token +
+chained-hint is sufficient.
+
+**Regression test:** `smart_query.rs` tests:
+- `classify_intent("Where is TestingController defined and what module imports it?")` -> `FindSymbol { name: "TestingController", .. }` AND `classify_intent_with_match` second element is false (truncated) — assert BOTH (verifier: name-only assertion leaves the confidence-downgrade untested).
+- `classify_intent("where is optimize_deterministic defined")` still -> "optimize_deterministic".
+- Add `where is the User class defined` fixture (interior article — currently also wrong; cover it).
+- Guard: `where is file tools.rs` routes to FindFile after reorder.
+- E2E in `tools.rs` ask tests (next to `test_ask_reports_inferred_route_confidence` :19773): index `class TestingController {}`, assert output has "Chosen tool: search_symbols", invocation contains "TestingController" not "imports it", and "Suggested next step:" present. Confirm `route_invocation` (smart_query.rs:448-490) echoes the name before relying on that assertion.
+
+**Note:** the "how does X work" branch (:217-220) shares the same trailing-only-trim weakness — track as
+a separate follow-up using the same helper.
+
+---
+
+### SF-006 — Co-change ranking fallback even with partner in scope (MEDIUM, CONFIRMED defect)
+
+**Symptom:** `work_item_store.rs` is a real co-change partner (VERIFIED: 3/3 shared commits with
+`work_item.rs`) and is returned by `search_files`, yet `rank_by="path+cochange"` reports
+"co-change ranking fallback used ... none matched returned candidates or passed rank gates".
+
+**Root cause (NOT path-normalization — repro hypothesis refuted by investigation):** the map lookup
+`neighbors.get(path)` (`query.rs:677`) SUCCEEDS. The rejection is the anchor-confidence gate
+(`rank_signals.rs:203`): `if PathMatchSignal.score(anchor, ctx) < CO_CHANGE_ANCHOR_CONFIDENCE_FLOOR (=100.0) { return 0.0 }`.
+Query `work_item` (stem) vs `work_item.rs` (basename incl. ext) gives `has_basename_match = false`
+(`"work_item.rs" != "work_item"`, :159) -> prefix branch -> `PREFIX_SCORE = 50.0 < 100.0` -> gate
+returns 0.0 for every candidate -> no CoChange tier -> `applied_hits == 0` -> misleading fallback
+(`tools.rs:4598-4608`). The message is wrong twice: the partner DID match a candidate, and rejection
+was the anchor gate (anchor+query property), not "none matched".
+
+**Fix (two coordinated changes):**
+- (A) In `PathMatchSignal::score` (`rank_signals.rs:159`) add stem-equality:
+  `has_basename_match = !basename_token.is_empty() && (file_basename == basename_token || file_stem == basename_token)`.
+  This promotes a stem-only query that names the anchor to BASENAME tier (100.0), clearing the floor.
+  Genuine prefixes (`work` vs `work_item`) must STAY prefix-tier (keep failing) — the existing
+  `weak_prefix_anchor_keeps_baseline_path_order_for_path_cochange` test uses `rou` vs `routes` and must stay green.
+  **Verifier tension to RESOLVE:** the existing prefix path guards `basename_token.len() >= 3`
+  (rank_signals.rs:171, query.rs:1236); a raw `file_stem == basename_token` has no length guard, so
+  a 1-2 char stem (`a` vs `a.ts`, `io` vs `io.rs`) would jump to basename tier in DEFAULT ranking. But
+  the report's own acceptance fixture uses 1-char `a` vs `a.test.ts`. Maintainer must resolve: honor
+  the >=3 policy (and amend the report's example) OR allow short stem-equality. Surface this explicitly.
+- (B) Surface the EXACT rejection reason (the acceptance criterion). Split the catch-all fallback into
+  FOUR distinct reasons (verifier added chore-anchor): (1) anchor reached only prefix-tier
+  (`score s < floor`; suggest `query="<anchor basename>"`); (2) partners present but below shared-commit
+  floor; (3) no neighbor key in candidate set (the genuine path-mismatch case); (4) chore-anchor excluded
+  (`is_chore_anchor_path`, `rank_signals.rs:200`, fires BEFORE the confidence gate). Compute the
+  anchor-confidence reason ONCE at anchor level (not per-candidate). Thread into
+  `search_files_ranking_explanation` (`tools.rs:1313-1337`) for `debug_ranking=true`.
+
+**Regression test:** `tests/search_files_path_cochange_calibration.rs`:
+- `stem_query_anchor_applies_cochange_for_basename_tier`: files work_item.rs / tests/work_item_store.rs /
+  stores/mod.rs + ready coupling row (shared_commits >= 2). `search_files(query="work_item",
+  rank_by="path+cochange", anchor_path=".../work_item.rs", debug_ranking=true)` -> NOT "fallback used";
+  contains Applied co-change line; `work_item_store.rs` under co-change tier. **Verify the asserted
+  output strings against `format.rs` first** (verifier: the proposed "Co-changed files"/"applied evidence"
+  substrings are unverified guesses).
+- `partial_token_anchor_still_falls_back`: query `work` (true prefix) -> fallback now contains precise
+  reason ("reached only prefix-tier path confidence" + basename hint). Update the existing calibration
+  tests' asserted substring (and the chore-anchor test `hardcoded_changelog_chore_anchor...`) to the new reasons.
+
+---
+
+### SF-007 — `checkpoint_now` unavailable in daemon-proxy mode (MEDIUM, CONFIRMED defect)
+
+**Symptom:** `checkpoint_now` hard-fails with "unavailable in daemon-proxy mode" — the default runtime.
+
+**Root cause:** it's the only index-bearing tool not wired into the proxy path. (1) `tools.rs:5136-5138`
+returns the hard-coded string the instant `self.daemon_client.is_some()`, BEFORE attempting
+`proxy_tool_call` (contrast `index_folder`/`health_compact` which proxy first). (2) `daemon.rs`
+`execute_tool_call` (2293-2421) has no `"checkpoint_now"` arm -> `unknown tool`. Forwarding IS correct:
+the daemon-side server has `daemon_client: None` + real `repo_root`, so the guard passes and the real
+checkpoint runs against the daemon's authoritative live index (the proxy-side index is `LiveIndex::empty()`).
+
+**Fix (option b — forward to daemon):**
+1. `tools.rs` `checkpoint_now`: replace the early hard-fail with the proxy-first pattern:
+   `if let Some(result) = self.proxy_tool_call("checkpoint_now", &params.0).await { return result; }`
+   at the top, then the existing local logic (5139-5168) is the fallback. `CheckpointNowInput` already
+   derives `Serialize` (verifier-confirmed, tools.rs:254) — use `&params.0` directly.
+2. `daemon.rs` `execute_tool_call`: add an arm before `other =>`:
+   `"checkpoint_now" => Ok(server.checkpoint_now(Parameters(decode_params::<CheckpointNowInput>(params)?)).await),`
+   (import `CheckpointNowInput`).
+3. Drop/neutralize the now-misleading guard string for proxy mode.
+
+**Verifier notes:**
+- A second test-only dispatcher `dispatch_tool_for_tests` (`mod.rs:498-542`) has no checkpoint_now arm
+  (falls to "unknown tool"). Not a correctness blocker, but add the arm if any parity test routes through it.
+- Timeout asymmetry: first proxy attempt is 10s (`mod.rs:325`), retry 30s (:386). A very large index could
+  spuriously time out the first attempt -> reconnect -> 30s retry (still hits daemon). Consider a longer
+  checkpoint timeout. Local-fallback in proxy mode reloads the index via `ensure_local_index`
+  (`mod.rs:437-496`) before returning None, so it does NOT checkpoint an empty index in the common case.
+
+**Regression test:** daemon round-trip in `daemon.rs` test module (mirror
+`test_daemon_executes_session_scoped_tool_calls` :3537): open session, POST
+`/v1/sessions/{id}/tools/checkpoint_now` body `{"verify_after_write": true}`, assert success + body
+contains "Checkpoint complete", NOT "unavailable in daemon-proxy mode", NOT "unknown tool", and
+`<project>/.symforge/index.bin` exists (or `load_snapshot(...).is_some()`). Keep existing local-mode
+tests (tools.rs:12382, 12403).
+
+---
+
+### SF-008 — PATH shadow remediation not Windows-native (MEDIUM, CONFIRMED defect)
+
+**Symptom:** on Windows PowerShell the shadow warning emits POSIX `add to ~/.profile: export PATH="...:$PATH"`.
+VERIFIED on this box: `Get-Command symforge -All` shows `C:\Program Files\nodejs\symforge.*` shadowing the nvm install.
+
+**Root cause:** `format_shadow_warning` (`path_shadow.rs:292-347`) picks remediation purely from
+`ShadowReport.kind`, computed only from the binary's location, never the host OS. On native Windows any
+`C:\` shadow classifies as `ForeignPrefix` (`is_system_prefix` is POSIX-only :203-207; `running_under_wsl`
+is the `#[cfg(not(unix))]` `false` stub :230-232), and the ForeignPrefix arm (:337-344) emits the POSIX
+line unconditionally. (`$PATH` is also a non-existent var in PowerShell — doubly broken.)
+
+**Fix:** make ONLY the ForeignPrefix arm host-OS-aware via `cfg!(windows)` (project precedent: `daemon.rs:1625`).
+On Windows emit PowerShell-native guidance: verification `Get-Command symforge -All`; explain `{shadow_dir}`
+precedes `{our_dir}` on PATH; remediation = reorder user PATH so `{our_dir}` precedes (`[Environment]::SetEnvironmentVariable('Path', ..., 'User')` or System Properties), with a brief note that for nvm-for-windows the active node prefix bin wins. Keep POSIX text on `#[cfg(not(windows))]`. Keep output plain ASCII (existing `is_ascii()` asserts). Do NOT change `classify_shadow`/`ShadowKind`.
+
+**Verifier notes:** key off `cfg!(windows)` (build host) — accept that Git-Bash-on-Windows users get
+PowerShell wording; include a one-line cmd/POSIX-on-Windows note to soften. Lead with the simple
+always-correct statement (our_dir must precede shadow_dir; verify with `Get-Command -All`); keep
+setx/nvm as SECONDARY notes (don't over-engineer). The npm-side `launcher.js`/`resolve-binary.js`
+POSIX emitters are gated to non-Windows-native paths — out of scope for this Rust fix.
+
+**Regression test:** `#[cfg(windows)] fn format_warning_foreign_prefix_is_powershell_native_on_windows()`
+in `path_shadow.rs` tests. Build a `ForeignPrefix` `ShadowReport` with Windows paths; assert
+`!contains("~/.profile")`, `!contains("export PATH")`, `contains("Get-Command symforge -All")`, mentions
+both bin dirs, `is_ascii()`. **Verifier:** on a real Windows build `Display` renders backslashes and the
+ForeignPrefix arm does NOT normalize `\`->`/`, so assert against backslash form or normalize first. Keep
+the Unix test gated `#[cfg(not(windows))]`.
+
+---
+
+### SF-011 — `conventions` Rust-biased for TS projects (LOW, CONFIRMED defect)
+
+**Symptom:** TS/NestJS/Angular project gets "Result-based: 3 files return Result", "0% snake_case (0/1237)",
+Rust test-module counts.
+
+**Root cause:** `detect_conventions` (`conventions.rs:18-217`) runs one Rust-flavored pass, never reads
+`IndexedFile.language` (`store.rs:238`). `Result<`/`-> Result` substring match (conventions.rs:73) fires
+on any TS type named `Result`; naming is always framed `% snake_case`/`% CamelCase`; tests count only Rust
+`tests` module + `test_`-prefixed fns.
+
+**Fix:** branch on the project's dominant code language computed inside `detect_conventions`:
+1. Tally `IndexedFile.language` over code files; pick `primary_lang`. **Verifier correction:** exclude
+   by `LanguageId` (drop Json/Toml/Yaml/Markdown/Env/Html/Css/Scss) or by `!is_config`, NOT by `FileClass`
+   — `FileClassification::for_code_path` marks EVERY path `FileClass::Code` (config only via `is_config`),
+   so a `FileClass`-based filter lets `.json` fixtures win the vote. Fold JS+TS into one bucket
+   (`.js->JavaScript`, `.ts->TypeScript` would otherwise split the vote).
+2. Gate existing Rust heuristics behind `primary_lang == Rust`. **Gate the per-file SCAN by `file.language`,
+   not just the summary branch** (verifier) — else `anyhow`/`Result` counts stay polluted by non-Rust files
+   in a Rust-majority mixed repo.
+3. TS/JS branch: error handling = `try/catch`, `throw new`, NestJS `HttpException`, RxJS `catchError`
+   (NOT the word "Result" unless Rust); naming = `% camelCase fns, % PascalCase types`; tests = count
+   `*.spec.ts`/`*.test.ts` (`is_test` already covers these — `test_file_count` is ALREADY
+   language-agnostic, verifier; only inline-module/test-fn counts are Rust-only) + `describe(`/`it(`/`test(`
+   scan + framework name. Decorators/DTO/signals via content scan (`@Controller`/`@Injectable`/`@Module`/
+   `@Component`/`@IsString`/`signal(`/`inject(`) — `SymbolRecord` does NOT store decorators (`index.rs:308-318`).
+4. Add a `language` header line to `ProjectConventions`/`format_conventions`. Keep an unknown/default
+   generic branch (no Rust-specific wording).
+
+**No internal snapshot risk:** verifier confirmed zero tests grep "Result-based"/"snake_case"/`detect_conventions`,
+so rewording the Rust branch carries no internal regression risk.
+
+**Regression test:** add `#[cfg(test)] mod tests` to `conventions.rs` (none today). (a) Rust-majority
+fixture -> still "Result-based"/"% snake_case"/nonzero test modules. (b) TS-majority fixture (NestJS
+`@Controller`/`@Injectable`, DTO `@IsString`, `*.spec.ts` with `describe(`/`it(`, `throw new HttpException`,
+AND a type named `Result<T>`) -> error_handling does NOT contain "Result-based", mentions exceptions,
+naming mentions camelCase, test count nonzero, header names TypeScript. **Verifier:** wire `file.language`
+explicitly on the fixture `IndexedFile` (don't leave it defaulted) or the test passes for the wrong reason.
+
+**Open decision:** mixed Rust+TS repo (this very repo has `npm/`) — single primary_lang vs per-language
+section. Recommend single most-common + a one-line note when a second language has >25% share.
+
+---
+
+### SF-010 — Tool discoverability (LOW, PARTIAL — fix the SymForge half only)
+
+**Symptom:** important tools missed on first discovery; `ask("what tools can I use for impact analysis?")`
+returns a code search, not a tool list.
+
+**Root cause:** (1) "lazy exposure" = HARNESS (rmcp `#[tool_handler]` returns all 32 tools eagerly;
+two-pass discovery is the client ToolSearch layer) — NOT fixable server-side, DOCUMENT as out of scope.
+(2) SymForge-owned: no tool-catalog/workflow-group concept; `ask` has no meta/tool `QueryIntent`, so the
+query falls through to `Explore` -> `explore(...)` code search.
+
+**Fix (additive, server-side):**
+1. Static workflow-grouped catalog `tool_catalog_groups()` (orientation/search/symbol-context/
+   impact-analysis/dry-run-edits/project-switching/diagnostics) + a full and a topic-filtered renderer.
+2. `smart_query.rs`: add `QueryIntent::ToolHelp { topic: Option<String> }`, detect EARLY (before
+   Understand/Explore fallbacks). **Verifier corrections:** (a) do NOT add ToolHelp to the
+   Understand|Explore upgrade guard at `tools.rs:7315-7318` or a topic word matching an indexed symbol
+   could clobber it into UnderstandSymbol; (b) scope detection to `tool(s)` + a RECOMMENDATION verb
+   (which/recommend/should I use), not any interrogative, to avoid hijacking code queries in repos with
+   a `Tool` type. Add arms to `assess_route`/`route_invocation`/`route_tool_name` (exhaustive match).
+3. `tools.rs` `ask`: ToolHelp arm returns the topic-filtered catalog (full when topic None/unknown).
+4. (Recommended) `resources.rs`: `symforge://tools/catalog` resource mirroring `repo_health_resource`.
+
+**Regression test:** `smart_query.rs`: `classify_intent("what tools can I use for impact analysis?")` ->
+`ToolHelp { topic ~ "impact" }`; `which tool should I use?` -> `ToolHelp { None }`; `how does the Tool
+registry work` -> Understand/Explore (NOT ToolHelp). `tools.rs` ask E2E: output contains all of
+find_references/find_dependents/get_symbol_context/analyze_file_impact/what_changed/diff_symbols. Drift
+guard: every `tool_catalog_groups()` name exists in `SYMFORGE_TOOL_NAMES`.
+
+---
+
+### SF-001 — find_dependents false positives (CRITICAL as reported; ALREADY FIXED in source)
+
+**Verdict: not reproducible against >=7.10.0 / HEAD.** Collision filter shipped in `251d7f0`
+(ancestor of `v7.18.0`, VERIFIED). `matches_exact_symbol_qualified_name` (`disambiguation.rs:16-49`)
+requires a `::`-boundary suffix match; `can_match_type_dependents` is false for Rust (`query.rs:279`),
+so name-only Pass-2 edges need a real import. A zero-textual-reference file appearing as a dependent is
+structurally impossible. Independent re-run via `LiveIndex::load` (the real daemon pipeline) produced 0
+edges. The audit observation is a stale daemon binary (`daemon_reused_session` + PATH-shadowed
+"version unknown" binary, SF-008).
+
+**Actions (NO algorithm change — changing it would regress legit dependents):**
+1. Close SF-001 as already-fixed; note the stale-binary cause.
+2. **Ops guard** (durable fix for the symptom class, overlaps SF-008): `health`/`health_compact` +
+   daemon proxy assert the SERVED binary version matches the installed package; warn loudly when a
+   reused daemon's binary is older. (Product decision: warn vs auto-restart.)
+3. **Test hardening:** add a real-parser end-to-end case to `tests/find_dependents_pass2.rs` (parse
+   AAP-shaped `work_item.rs` + `actor.rs` via `symforge::parsing::process_file`, not hand-built
+   `ReferenceRecord`s) asserting `find_dependents_for_file(work_item.rs)` yields ZERO refs whose path
+   contains `actor.rs`. This closes the one coverage gap (all 4 existing tests hand-build refs).
+
+**If false positives STILL reproduce on a freshly-restarted >=7.18.0 daemon against a specific AAP file:**
+capture the exact offending `ReferenceRecord` (name/qualified_name/kind) via the live index and re-open —
+only a real `stores::work_item::new`-style qualified call from an unexpected place would indicate a residual gap.
+
+---
+
+### SF-009 — Untracked scratch files in index (MEDIUM as reported; MECHANISM REFUTED)
+
+**Verdict: the stated mechanism does not reproduce.** Named scratch files are dotfiles -> filtered by
+`ignore` crate default `hidden:true` before admission. Non-dotfile `.txt` -> `LanguageId::None` ->
+Tier-2 metadata-only -> 0 symbols, 0 Tier-1 count. The reported +1450 symbols cannot come from text
+files (arithmetically impossible) — it was the concurrent agent's real source edits. Empirically
+confirmed: `discover_all_files` on a tempdir with `.git/`, `src_main.rs`, `.probe.txt`, `.verify.txt`,
+`notes.txt`, `scratch_probe.json` returns `[notes.txt, scratch_probe.json, src_main.rs]` (dotfiles
+filtered; only non-dotfile recognized-ext `.json` is Tier-1). The report's own proposed regression test
+(assert `.probe.txt` not indexed) PASSES TODAY with zero code change — do NOT write it as the acceptance test.
+
+**Actions (surfacing only — do NOT change admission defaults):**
+1. Compute a git-tracked path set once per load via `git ls-files` (NOT via the `ignore` crate — it has
+   no tracked-files concept, verifier-confirmed). **Must fail-open:** no git / no index -> feature off,
+   `untracked_indexed = 0` (else every file in a non-git tempdir counts as untracked).
+2. Count Tier-1 files NOT git-tracked AND NOT gitignored; add `untracked_indexed` to `HealthStats`;
+   render "indexed untracked files: N" in the health line (`format.rs:1620`).
+3. Optional opt-in `SYMFORGE_EXCLUDE_UNTRACKED` (default off) demoting untracked recognized-ext files to Tier-2.
+
+**Two discovery paths (verifier):** `LiveIndex::load` uses `discover_all_files` (unknown-ext -> Tier-2);
+the watcher incremental path `build_reload_data` uses `discover_files` which HARD-filters on
+`from_extension` BEFORE tiering (`discovery/mod.rs:240`). They produce different Tier-2 populations — any
+surfacing fix touching both must account for the divergence.
+
+**Regression test:** tempdir with `.git`, `src/main.rs`, root `notes.txt` (unknown ext), root `.probe.txt`.
+Assert: `.probe.txt` NOT in `discover_all_files` (documents the report bug doesn't reproduce);
+`notes.txt` is Tier-2 metadata-only, 0 symbols; after the fix, a non-dotfile untracked recognized-ext
+file -> `untracked_indexed == 1` and health line contains "indexed untracked files: 1". Define behavior
+when no git index exists (feature off).
+
+---
+
+## Cross-cutting notes for the coding agent
+
+- **Verify-as-user:** for SF-002/003/004/005/006/007/008/010/011, after the fix, re-run the relevant
+  MCP tool against the REAL repo (testpilot for TS/Angular, AAP for Rust co-change/dependents) on a
+  FRESHLY restarted daemon built from the fixed source, and confirm the corrected output. Code compiling
+  and tests passing is necessary but not sufficient.
+- **Kill stale daemon first.** SF-001 is the cautionary tale: a reused/shadowed daemon serves stale
+  behavior. Before any live verification, ensure the daemon is the one built from your branch (this also
+  validates the SF-001 ops-guard work).
+- **Exhaustive-match safety:** SF-003 (new `FileOutcome`/`ParseStatus` variant) and SF-010 (new
+  `QueryIntent` variant) intentionally break every `match` at compile time — that is the safety net; fix
+  every arm. SF-003's variant additionally touches the PERSISTED checkpoint format — handle serde back-compat.
+- **Public-tool contracts:** SF-002 changes `find_references`/`edit_plan` counts; SF-006 changes
+  `search_files` ordering for stem queries. Both are user-visible — update golden/snapshot tests and
+  treat as deliberate behavior changes, not silent.
+- **Do not touch** the uncommitted `gsd-*` -> `local-agent-*` rename in the working tree (another agent's
+  WIP, unrelated to these issues).
+- Follow CLAUDE.md: structural edits via SymForge edit tools where possible; `cargo clean` only at
+  campaign end; no push/merge without human approval (commit to a review branch and STOP).
+
+## Confidence
+
+Every "CONFIRMED"/"REFUTED"/"ALREADY FIXED" verdict above is backed by BOTH an independent root-cause
+investigation AND an adversarial verifier that re-checked the cited lines, PLUS (for SF-001..SF-009) a
+live reproduction against the real repos. The two highest-impact corrections (SF-001 already-fixed,
+SF-002 enclosing_symbol_index) were additionally re-verified directly:
+`git merge-base --is-ancestor 251d7f0 v7.18.0` (true) and `enclosing_symbol_index` present across 16 files.

--- a/docs/SYMFORGE_MCP_BUG_REPORT_2026-06-03.md
+++ b/docs/SYMFORGE_MCP_BUG_REPORT_2026-06-03.md
@@ -1,0 +1,950 @@
+# SymForge MCP Bug Report - Cross-Repo Agent Audit
+
+Date: 2026-06-03
+
+Reporter: Codex audit session
+
+Scope:
+- `C:\AI_STUFF\PROGRAMMING\Agent_Army_Professionals`
+- `C:\AI_STUFF\PROGRAMMING\testpilot`
+
+Mandate: audit-only, no product source edits.
+
+SymForge runtime observed:
+- Version: `7.18.0`
+- Runtime mode: `daemon_reused_session`
+- Sidecar port: `62260`
+- AAP initial index: `1269` files, `34587` symbols
+- AAP after re-index during concurrent work: `1331` files, `36037` symbols
+- testpilot index: `252` files, `18180` symbols
+
+## Mini-spec
+
+objective:
+Create a durable bug report for SymForge MCP issues found during a read-only audit, with enough evidence and acceptance criteria for maintainers to reproduce, fix, and regression-test the defects.
+
+non_goals:
+- Do not modify SymForge source code in this task.
+- Do not modify product source code in AAP or testpilot.
+- Do not clean or revert concurrent-agent changes.
+
+allowed_files_or_area:
+- `docs/audit/SYMFORGE_MCP_BUG_REPORT_2026-06-03.md`
+
+contracts_or_interfaces:
+- SymForge MCP tools should report trustworthy source authority, parse state, completeness, and write semantics.
+- Tools that claim exact dependency/reference behavior should avoid false positives or clearly mark uncertainty.
+- Tools exposed to agents should either work in the current runtime mode or clearly report that they are not available before use.
+
+invariants:
+- Existing dirty worktree state belongs to another agent and must not be changed.
+- Findings must separate confirmed defects from limitations and enhancement requests.
+- Reproduction steps must use only read-only or dry-run operations.
+
+acceptance_criteria:
+- Report includes environment, tested tools, issue index, per-issue repro, expected behavior, actual behavior, impact, and acceptance criteria.
+- Report distinguishes critical correctness defects from usability improvements.
+- Report captures cross-check evidence from raw shell where SymForge output was suspicious.
+
+evidence_required:
+- SymForge tool outputs from the audit.
+- Shell cross-checks for suspected false positives.
+- Git status evidence for concurrent worktree state.
+
+stop_conditions:
+- If creating the report would require changing source code, stop.
+- If another agent changes this report while it is being written, stop and reconcile.
+
+verification_command:
+- `git diff --check -- docs/audit/SYMFORGE_MCP_BUG_REPORT_2026-06-03.md`
+
+## Executive summary
+
+SymForge is already valuable as a first-pass code intelligence layer. The strongest tools in this audit were:
+
+- `health` / `health_compact`
+- `index_folder`
+- `get_repo_map`
+- `search_files`
+- `search_symbols`
+- `search_text`
+- `get_file_context`
+- `get_file_content`
+- `get_symbol`
+- `inspect_match`
+- `validate_file_syntax`
+- dry-run edit tools
+- `what_changed`
+- `diff_symbols`
+
+The strongest observed use case was compressing large files into actionable outlines. In `testpilot`, `get_file_context` reduced `backend/src/modules/testing/testing.controller.ts`, a 434-line NestJS controller, into a concise outline with imports, consumers, git churn, and co-change hints.
+
+The highest-risk defects are correctness issues in dependency/reference analysis:
+
+1. `find_dependents` produced confirmed false positives in AAP.
+2. TypeScript method analysis conflated same-name methods across object boundaries.
+3. Parse status reported valid TypeScript syntax as partial.
+4. Natural-language `ask` failed a simple compound lookup that direct tools answered.
+
+The tool is usable, but agents should not treat all SymForge dependency, caller/callee, or parse-state outputs as authoritative until the issues below are fixed.
+
+## Test matrix
+
+| Area | AAP result | testpilot result | Notes |
+|---|---:|---:|---|
+| Indexing | PASS | PASS | Both repos indexed quickly; no failed files. |
+| Watcher health | PASS | PASS | Watchers active, no overflow. |
+| Symbol search | PASS | PASS | Strong for exact symbol names. |
+| Text search | PASS with caveats | PASS with caveats | Good headers for truncation and trust. |
+| File context | PASS | PASS | Best tool family in the audit. |
+| Raw content reads | PASS | PASS | Line/symbol reads worked. |
+| Syntax validation | PASS with caveats | PASS with caveats | Some valid frontend syntax reported partial. |
+| Reference lookup | PASS with caveats | PASS with caveats | Symbol references generally usable; OO same-name ambiguity observed. |
+| File dependents | FAIL in AAP | PASS in sampled testpilot case | AAP false positives confirmed by shell. |
+| Dry-run edits | PASS | PASS | No writes performed; previews were clear. |
+| Batch dry-run edits | PASS | PASS | Failed closed on bad selector, succeeded on corrected selector. |
+| Git change detection | PASS | PASS | `what_changed` matched shell status. |
+| Symbol diff | PASS | PASS | `testpilot` code-only empty result was correct because last commit was docs/config. |
+| Co-change ranking | PARTIAL | PARTIAL | Co-change data exists, but `search_files` ranking fallback looked inconsistent. |
+| Natural-language ask | PARTIAL | FAIL for compound query | Direct tools were better. |
+| Checkpoint | FAIL | FAIL | Unavailable in daemon-proxy mode. |
+| PATH diagnosis | PASS with usability caveat | PASS with usability caveat | Correctly detected shadowing but suggested a weak fix for Windows users. |
+
+## Issue index
+
+| ID | Severity | Category | Title |
+|---|---|---|---|
+| SF-001 | Critical | Correctness | `find_dependents` reports unrelated AAP files as dependents. |
+| SF-002 | High | Correctness | TypeScript caller/callee analysis conflates same-name methods across object boundaries. |
+| SF-003 | High | Parser correctness | Valid TypeScript `import("rxjs").Subscription[]` type is reported as partial syntax error. |
+| SF-004 | Medium | Parser coverage | Angular template control-flow syntax is reported as partial HTML parse. |
+| SF-005 | Medium | Agent UX | `ask` fails compound lookup queries that direct tools can answer. |
+| SF-006 | Medium | Ranking correctness | Co-change ranking falls back even when known co-change partners are in scope. |
+| SF-007 | Medium | Runtime/tool contract | `checkpoint_now` is exposed but unavailable in daemon-proxy mode. |
+| SF-008 | Medium | Install diagnostics | PATH shadow warning is correct but the remediation is not Windows-native. |
+| SF-009 | Medium | Index hygiene | Re-index during concurrent work admitted root scratch/probe files into AAP index. |
+| SF-010 | Low | Tool discoverability | Important tools are lazily exposed and easy for agents to miss. |
+| SF-011 | Low | Convention analysis | `conventions` gives shallow or misleading summaries for TypeScript projects. |
+
+## SF-001 - `find_dependents` reports unrelated AAP files as dependents
+
+Severity: Critical
+
+Status: confirmed defect
+
+Tool:
+- `find_dependents`
+- `get_symbol_context` when it embeds file-level dependency graph output
+
+Repo:
+- `C:\AI_STUFF\PROGRAMMING\Agent_Army_Professionals`
+
+Repro:
+
+```text
+mcp__symforge.find_dependents({
+  "path": "crates/aap-db/src/stores/work_item.rs",
+  "compact": true,
+  "limit": 12
+})
+```
+
+Observed actual:
+
+SymForge reported:
+
+```text
+File-level dependency graph: 488 files depend on crates/aap-db/src/stores/work_item.rs
+  crates/aap-agents/src/actor_runtime/actor.rs  (7 refs: call)
+  crates/aap-agents/src/actor_runtime/spawn.rs  (7 refs: call)
+  crates/aap-agents/src/actors/bus_actor.rs  (7 refs: call)
+  crates/aap-agents/src/actors/coder_actor.rs  (138 refs: call)
+  ...
+```
+
+Shell cross-check:
+
+```powershell
+rg -n "work_item|WorkItem|WorkState|claim_one|aap_db" `
+  crates/aap-agents/src/actor_runtime/actor.rs `
+  crates/aap-agents/src/actor_runtime/spawn.rs `
+  crates/aap-agents/src/actors/coder_actor.rs
+```
+
+Result:
+
+```text
+no matches
+```
+
+Expected:
+
+`find_dependents(path="crates/aap-db/src/stores/work_item.rs")` should list only files that import, re-export, directly reference, or otherwise depend on symbols from that file. Unrelated actor runtime files should not appear.
+
+Impact:
+
+This is the most serious finding. It can make agents overestimate blast radius, avoid safe changes, produce false architecture conclusions, or waste large amounts of review time. Because `get_symbol_context` also embeds this file dependency graph, the false positives contaminate otherwise useful edit-prep output.
+
+Likely failure mode:
+
+The dependency graph may be collapsing broad crate/module usage, shared names, or generic call references into a per-file dependency edge. The reported `call` refs against a data-store file suggest the graph is not limited to imports or resolved symbol references.
+
+Acceptance criteria:
+
+- Add a regression fixture where `a.rs` exports `WorkItemStore`, `b.rs` imports it, and `c.rs` has unrelated functions with common names. `find_dependents(a.rs)` returns `b.rs` only.
+- For AAP, `find_dependents(crates/aap-db/src/stores/work_item.rs)` must not list files that contain no direct import/reference to `work_item`, `WorkItem*`, or exported symbols from that file.
+- If the graph is intentionally approximate, output must be labeled approximate and must separate direct imports, direct symbol references, crate-level dependents, and unresolved heuristic edges.
+- `get_symbol_context` should not embed high-volume approximate file dependency output without making uncertainty explicit.
+
+## SF-002 - TypeScript caller/callee analysis conflates same-name methods across object boundaries
+
+Severity: High
+
+Status: confirmed limitation or defect
+
+Tool:
+- `get_symbol_context`
+- likely `find_references`
+- likely `edit_plan` reference counts
+
+Repo:
+- `C:\AI_STUFF\PROGRAMMING\testpilot`
+
+Target file:
+- `backend/src/modules/testing/testing.controller.ts`
+
+Repro:
+
+```text
+mcp__symforge.get_symbol_context({
+  "name": "startExploration",
+  "path": "backend/src/modules/testing/testing.controller.ts",
+  "symbol_kind": "fn",
+  "symbol_line": 44,
+  "verbosity": "signature",
+  "sections": ["dependents", "siblings", "git"]
+})
+```
+
+Observed actual:
+
+For controller method:
+
+```ts
+async startExploration(@Body() dto: StartExplorationDto) {
+  return this.testingService.startExploration(dto.applicationId, {
+    maxDepth: dto.maxDepth,
+    maxPages: dto.maxPages,
+  });
+}
+```
+
+SymForge reported:
+
+```text
+Callers (1):
+  startExploration backend/src/modules/testing/testing.controller.ts:45 in fn startExploration
+Callees:
+  startExploration backend/src/modules/testing/testing.controller.ts:45 in fn startExploration
+```
+
+Expected:
+
+`this.testingService.startExploration(...)` is a call to `TestingService.startExploration`, not a caller of `TestingController.startExploration`. The controller method should not be listed as its own caller because it invokes a same-name service method.
+
+Impact:
+
+This can produce false refactor plans and incorrect call graphs in common TypeScript/NestJS/Angular patterns where controllers delegate to services with identical method names.
+
+Acceptance criteria:
+
+- Add a TypeScript fixture with `Controller.start()` delegating to `this.service.start()`. Querying `Controller.start` must not count `this.service.start()` as a self-reference or caller.
+- If type resolution is unavailable, report these as `unresolved_same_name_member_call` rather than exact caller/callee edges.
+- `edit_plan` should not compute "References: 1 call sites" from same-symbol lexical matches unless it can resolve the receiver type.
+
+## SF-003 - Valid TypeScript dynamic import type is reported as partial syntax error
+
+Severity: High
+
+Status: confirmed parser false positive
+
+Tool:
+- `health`
+- `get_file_context`
+- `validate_file_syntax`
+
+Repo:
+- `C:\AI_STUFF\PROGRAMMING\testpilot`
+
+Target file:
+- `frontend/src/app/features/workflows/workflow-builder.component.ts`
+
+Repro:
+
+```text
+mcp__symforge.validate_file_syntax({
+  "path": "frontend/src/app/features/workflows/workflow-builder.component.ts"
+})
+```
+
+Observed actual:
+
+SymForge reported:
+
+```text
+Status: partial
+Diagnostic: tree-sitter: syntax error near `import('rxjs').Subscription` (line 462, column 17)
+```
+
+Raw source around the line:
+
+```ts
+export class WorkflowBuilderComponent implements OnInit, OnDestroy {
+  private api = inject(ApiService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private ws = inject(WebSocketService);
+  private subs: import('rxjs').Subscription[] = [];
+```
+
+Expected:
+
+`import('rxjs').Subscription[]` is valid TypeScript type syntax and should parse without marking the file partial.
+
+Impact:
+
+Agents may treat valid source as malformed, over-prioritize nonexistent syntax bugs, or distrust symbol extraction in Angular/TypeScript files. The file still produced a useful outline, but the parse-state signal is wrong.
+
+Acceptance criteria:
+
+- Add a TypeScript parser fixture containing `private subs: import("rxjs").Subscription[] = [];`.
+- `validate_file_syntax` returns `Status: ok`.
+- `health` does not include this file in unexpected partials.
+- If the configured tree-sitter grammar cannot support this syntax, classify the diagnostic as parser limitation, not repo-owned syntax error.
+
+## SF-004 - Angular template control-flow syntax is reported as partial HTML parse
+
+Severity: Medium
+
+Status: parser coverage limitation
+
+Tool:
+- `health`
+- `get_file_context`
+
+Repo:
+- `C:\AI_STUFF\PROGRAMMING\testpilot`
+
+Target file:
+- `frontend/src/app/app.html`
+
+Repro:
+
+```text
+mcp__symforge.get_file_context({
+  "path": "frontend/src/app/app.html",
+  "sections": ["outline"]
+})
+```
+
+Observed actual:
+
+SymForge reported:
+
+```text
+Parse status: partial
+Diagnostic: tree-sitter: syntax error near `0) {` (line 14, column 38)
+```
+
+The outline included Angular control-flow constructs:
+
+```text
+mod @if
+mod @for
+router-outlet
+```
+
+Expected:
+
+Angular template control-flow syntax such as `@if (...) { ... }` and `@for (...) { ... }` should either parse cleanly or be classified as an expected framework-specific partial, not an unexpected repo-owned parse problem.
+
+Impact:
+
+Frontend-heavy Angular repos will show noisy parse-health warnings even when templates are valid.
+
+Acceptance criteria:
+
+- Add an Angular template fixture using `@if` and `@for` syntax.
+- Either parse it cleanly or categorize it as `expected_framework_partial`.
+- Health output should separate "valid framework syntax unsupported by parser" from "likely malformed file."
+
+## SF-005 - `ask` fails compound lookup queries that direct tools can answer
+
+Severity: Medium
+
+Status: confirmed agent UX defect
+
+Tool:
+- `ask`
+
+Repo:
+- `C:\AI_STUFF\PROGRAMMING\testpilot`
+
+Repro:
+
+```text
+mcp__symforge.ask({
+  "query": "Where is TestingController defined and what module imports it?"
+})
+```
+
+Observed actual:
+
+SymForge routed to:
+
+```text
+search_symbols(query="TestingController defined and what module imports it?")
+```
+
+Then returned:
+
+```text
+No symbols matching 'TestingController defined and what module imports it?'.
+```
+
+Direct calls that worked:
+
+```text
+search_symbols(query="TestingController", language="TypeScript")
+find_references(name="TestingController", path="backend/src/modules/testing/testing.controller.ts", symbol_kind="class", symbol_line=36)
+```
+
+Expected:
+
+`ask` should decompose the compound query into:
+
+1. Find `TestingController`.
+2. Fetch references or dependents for that symbol/file.
+3. Return both definition and importing module.
+
+Impact:
+
+Agents often use natural-language tools when unsure which tool to call. This failure mode gives a false "not found" result for a simple valid question.
+
+Acceptance criteria:
+
+- Add a routing test for "Where is X defined and what imports it?"
+- `ask` should not pass the whole sentence as a symbol query.
+- If query decomposition is uncertain, `ask` should return a suggested direct tool sequence instead of a false negative.
+
+## SF-006 - Co-change ranking falls back even when known co-change partners are in scope
+
+Severity: Medium
+
+Status: suspected ranking defect
+
+Tools:
+- `analyze_file_impact`
+- `search_files`
+
+Repos:
+- AAP
+- testpilot
+
+AAP repro:
+
+```text
+analyze_file_impact({
+  "path": "crates/aap-db/src/stores/work_item.rs",
+  "include_co_changes": true
+})
+```
+
+Observed co-change output:
+
+```text
+crates/aap-db/tests/work_item_store.rs coupling: 0.500
+crates/aap-db/src/stores/mod.rs coupling: 0.182
+```
+
+Then:
+
+```text
+search_files({
+  "query": "work_item",
+  "rank_by": "path+cochange",
+  "anchor_path": "crates/aap-db/src/stores/work_item.rs",
+  "debug_ranking": true
+})
+```
+
+Observed actual:
+
+`crates/aap-db/tests/work_item_store.rs` appeared in the returned files, but SymForge still reported:
+
+```text
+co-change ranking fallback used - anchor_path=... loaded 20 usable coupling partner(s), but none matched returned candidates or passed rank gates
+```
+
+testpilot showed the same pattern with:
+
+```text
+backend/src/modules/testing/testing.controller.ts
+backend/src/modules/testing/services/testing.service.ts
+```
+
+Expected:
+
+If `analyze_file_impact` says a file is a co-change partner and `search_files` returns that same file, `rank_by="path+cochange"` should either apply the co-change score or explain the precise rank gate that rejected it.
+
+Impact:
+
+The tool advertises co-change ranking, but agents cannot tell whether fallback is legitimate or a bug.
+
+Acceptance criteria:
+
+- Add a fixture with known coupling `a.ts <-> a.test.ts`.
+- `search_files(query="a", rank_by="path+cochange", anchor_path="a.ts")` ranks `a.test.ts` with visible co-change contribution.
+- Debug output must name the exact rejection reason when a known partner "does not pass rank gates."
+
+## SF-007 - `checkpoint_now` is exposed but unavailable in daemon-proxy mode
+
+Severity: Medium
+
+Status: runtime/tool-contract issue
+
+Tool:
+- `checkpoint_now`
+
+Repos:
+- AAP
+- testpilot
+
+Repro:
+
+```text
+mcp__symforge.checkpoint_now({ "verify_after_write": true })
+```
+
+Observed actual:
+
+```text
+Checkpoint failed: checkpoint_now is unavailable in daemon-proxy mode; restart with SYMFORGE_NO_DAEMON=1 for local in-process checkpointing.
+```
+
+Expected:
+
+One of:
+
+- The tool should be hidden when unavailable in the current runtime mode.
+- The daemon proxy should forward checkpoint requests to the daemon.
+- `health` should prominently report `checkpoint_now=unavailable` before agents call it.
+
+Impact:
+
+Agents may believe they can persist an index checkpoint but cannot. This is especially relevant before switching projects with `index_folder`.
+
+Acceptance criteria:
+
+- `health_compact` includes checkpoint availability.
+- Tool discovery marks `checkpoint_now` unavailable in daemon-proxy mode, or the tool works by forwarding to the daemon.
+- Error message includes a Windows-native and shell-native command example for restarting in local mode.
+
+## SF-008 - PATH shadow warning is correct but remediation is not Windows-native
+
+Severity: Medium
+
+Status: confirmed usability issue
+
+Tool:
+- `health`
+- `health_compact`
+
+Environment:
+- Windows PowerShell
+
+Observed actual:
+
+SymForge warning:
+
+```text
+bare `symforge` runs C:\Program Files\nodejs\symforge (version unknown),
+not your install C:\Users\poslj\AppData\Roaming\nvm\v22.20.0\node_modules\symforge-windows-x64\bin\symforge.exe (7.18.0)
+Fix:
+  add to ~/.profile: export PATH="C:\Users\poslj\AppData\Roaming\nvm\v22.20.0\node_modules\symforge-windows-x64\bin:$PATH"
+```
+
+Shell cross-check:
+
+```powershell
+Get-Command symforge -All
+```
+
+Output:
+
+```text
+C:\Program Files\nodejs\symforge.ps1
+C:\Program Files\nodejs\symforge.cmd
+C:\Program Files\nodejs\symforge
+```
+
+Expected:
+
+The warning should tailor remediation to the active shell/OS. For PowerShell, suggest checking `$env:Path`, NVM path ordering, or using `setx PATH` with caution. For bash/WSL, suggest profile edits.
+
+Impact:
+
+The diagnosis is valuable, but the fix is easy for a Windows user or agent to misapply.
+
+Acceptance criteria:
+
+- Health detects current shell/OS and emits Windows-native remediation under PowerShell.
+- Include `Get-Command symforge -All` as the suggested verification command on Windows.
+- Keep POSIX `~/.profile` guidance only for POSIX shells.
+
+## SF-009 - Re-index during concurrent work admitted root scratch/probe files into AAP index
+
+Severity: Medium
+
+Status: confirmed hygiene issue
+
+Tool:
+- `index_folder`
+- `health_compact`
+- `what_changed`
+
+Repo:
+- AAP
+
+Context:
+
+The user intentionally made the audit harder by noting another agent was working in the project. The AAP worktree was dirty with one tracked docs file and multiple untracked root scratch/status files:
+
+```text
+.diff_flags.txt
+.diff_sprint.txt
+.dr.txt
+.grep_aapcommon.txt
+.orch_grep.txt
+.probe.txt
+.stash.txt
+.supargs.txt
+.tinfo.txt
+.unexpected_diff.txt
+.verify.txt
+.verify2.txt
+.wsl.txt
+.wslcargo.txt
+.wt2.txt
+.wtdiff.txt
+.wtstatus.txt
+```
+
+Observed actual:
+
+Initial AAP index:
+
+```text
+1269 files, 34587 symbols
+```
+
+After switching to `testpilot` and re-indexing AAP:
+
+```text
+1331 files, 36037 symbols
+```
+
+The higher file/symbol count is consistent with untracked scratch/probe files being admitted into the source index.
+
+Expected:
+
+Root-level temporary/probe/status files should either be excluded by default, admitted as metadata-only, or explicitly surfaced as noisy untracked files. At minimum, `health` should make it obvious that untracked files changed the index shape.
+
+Impact:
+
+Concurrent-agent scratch files can pollute repo maps, symbol counts, parse warnings, search results, and token-savings metrics.
+
+Acceptance criteria:
+
+- Add an admission policy test with untracked root `.probe.txt`, `.diff_flags.txt`, and `.verify.txt` files.
+- Default repo map and symbol search should not treat these as product source.
+- Health should report "indexed untracked files: N" or "noise-filtered untracked files: N."
+- Provide a setting to include/exclude untracked files deliberately.
+
+## SF-010 - Important tools are lazily exposed and easy for agents to miss
+
+Severity: Low
+
+Status: agent UX improvement
+
+Tooling surface:
+- Tool discovery
+- Deferred MCP metadata
+
+Observed actual:
+
+The first tool discovery query exposed core tools such as `health`, `search_text`, `get_file_context`, and edit tools. A second query was needed to expose important tools such as:
+
+- `find_references`
+- `find_dependents`
+- `get_symbol_context`
+- `batch_rename`
+- `batch_edit`
+- `delete_symbol`
+- `analyze_file_impact`
+- `index_folder`
+- `context_inventory`
+- `investigation_suggest`
+
+Expected:
+
+For an agent-facing code intelligence MCP, common workflows should be discoverable as groups:
+
+- orientation
+- search
+- symbol context
+- impact analysis
+- dry-run edits
+- project switching
+- diagnostics
+
+Impact:
+
+Agents may under-test or under-use SymForge because they do not know key tools exist.
+
+Acceptance criteria:
+
+- Add a `tool_catalog` or improve `health` with grouped tool recommendations.
+- `ask("what tools can I use for impact analysis?")` should return `find_references`, `find_dependents`, `get_symbol_context`, `analyze_file_impact`, `what_changed`, and `diff_symbols`.
+- Tool discovery metadata should include workflow tags.
+
+## SF-011 - `conventions` gives shallow or misleading summaries for TypeScript projects
+
+Severity: Low
+
+Status: quality improvement
+
+Tool:
+- `conventions`
+
+Repo:
+- `testpilot`
+
+Observed actual:
+
+```text
+Error handling: Result-based: 3 files return Result, 0 unwrap()s, 0 expect()s
+Naming: Functions: 0% snake_case (0/1237). Types: 100% CamelCase (290/290).
+Tests: 1 test files, 0 inline test modules, 0 test functions
+```
+
+Expected:
+
+For a TypeScript/NestJS/Angular project, conventions should summarize:
+
+- NestJS modules/controllers/services pattern
+- decorators and DTO validation style
+- Angular component/template/service pattern
+- signal usage if Angular signals are prevalent
+- test framework and test scarcity, if detected
+- error handling via Nest exceptions, thrown `Error`, HTTP exceptions, RxJS, or promise flows
+
+Impact:
+
+The current output is Rust-biased and not actionable enough for TypeScript work.
+
+Acceptance criteria:
+
+- Add language-aware convention detectors for TypeScript/NestJS/Angular.
+- Report common decorators, module layering, DTO validation, and frontend component style.
+- Avoid "Result-based" language unless the project actually uses a Rust-like `Result` abstraction.
+
+## Positive findings to preserve
+
+These behaviors worked well and should be kept while fixing the bugs:
+
+1. `health` and `health_compact` provide useful project identity, watcher state, parse issues, git temporal status, and PATH diagnostics.
+2. `get_file_context` is highly effective for large-file orientation and should remain the default first read.
+3. `search_text` headers clearly report trust, parse state, scope, and truncation.
+4. `search_files(resolve=true)` correctly refused to over-resolve ambiguous `README` in `testpilot`.
+5. Dry-run edit tools clearly reported write semantics and did not modify files.
+6. Bad edit selectors fail closed with a useful message.
+7. `what_changed` matched shell `git status` for both repos.
+8. `diff_symbols(code_only=true)` correctly returned no code changes for a docs/config-only `testpilot` HEAD commit.
+9. `context_inventory` and `investigation_suggest` are useful for context hygiene.
+
+## Suggested repair order
+
+1. Fix `find_dependents` false positives and add direct regression tests.
+2. Fix or downgrade TypeScript same-name method caller/callee edges.
+3. Fix TypeScript dynamic import type parsing or classify it as parser limitation.
+4. Add Angular template syntax classification.
+5. Improve `ask` query decomposition for common compound questions.
+6. Fix co-change ranking or expose exact rank-gate diagnostics.
+7. Hide, forward, or pre-declare `checkpoint_now` availability in daemon-proxy mode.
+8. Improve Windows PATH remediation.
+9. Add untracked/noise file admission controls.
+10. Add workflow-oriented tool discovery and language-aware conventions.
+
+## Regression test proposals
+
+### Dependency graph fixture
+
+Files:
+
+```text
+src/store/work_item.rs
+src/uses_store.rs
+src/unrelated_actor.rs
+```
+
+Expected:
+
+```text
+find_dependents(src/store/work_item.rs) == [src/uses_store.rs]
+```
+
+### TypeScript same-name method fixture
+
+Files:
+
+```ts
+class Service {
+  start() {}
+}
+
+class Controller {
+  constructor(private service: Service) {}
+  start() {
+    return this.service.start();
+  }
+}
+```
+
+Expected:
+
+Querying `Controller.start` must not report `this.service.start()` as a caller of `Controller.start`.
+
+### Dynamic import type fixture
+
+Source:
+
+```ts
+class Example {
+  private subs: import("rxjs").Subscription[] = [];
+}
+```
+
+Expected:
+
+`validate_file_syntax` returns `Status: ok`.
+
+### Angular control-flow template fixture
+
+Source:
+
+```html
+@if (items.length > 0) {
+  @for (item of items; track item.id) {
+    <div>{{ item.name }}</div>
+  }
+}
+```
+
+Expected:
+
+Either parse cleanly or classify as expected Angular template syntax limitation.
+
+### Ask decomposition fixture
+
+Query:
+
+```text
+Where is TestingController defined and what module imports it?
+```
+
+Expected:
+
+Tool route:
+
+```text
+search_symbols("TestingController") -> find_references("TestingController")
+```
+
+### Co-change ranking fixture
+
+Setup:
+
+Create git history where `src/a.ts` and `src/a.test.ts` co-change repeatedly.
+
+Expected:
+
+```text
+search_files(query="a", rank_by="path+cochange", anchor_path="src/a.ts")
+```
+
+shows `src/a.test.ts` with nonzero co-change contribution.
+
+### Daemon checkpoint fixture
+
+Modes:
+
+- daemon proxy
+- in-process
+
+Expected:
+
+- In daemon proxy mode, tool is hidden, forwarded, or health marks it unavailable.
+- In in-process mode, checkpoint writes and verifies successfully.
+
+## Tool coverage from audit
+
+Exercised at least once:
+
+- `health`
+- `health_compact`
+- `index_folder`
+- `get_repo_map`
+- `search_files`
+- `search_symbols`
+- `search_text`
+- `get_file_context`
+- `get_file_content`
+- `get_symbol`
+- `get_symbol_context`
+- `inspect_match`
+- `find_references`
+- `find_dependents`
+- `explore`
+- `ask`
+- `conventions`
+- `edit_plan`
+- `edit_within_symbol` with `dry_run=true`
+- `replace_symbol_body` with `dry_run=true`
+- `insert_symbol` with `dry_run=true`
+- `delete_symbol` with `dry_run=true`
+- `batch_insert` with `dry_run=true`
+- `batch_edit` with `dry_run=true`
+- `batch_rename` with `dry_run=true`
+- `analyze_file_impact`
+- `what_changed`
+- `diff_symbols`
+- `validate_file_syntax`
+- `context_inventory`
+- `investigation_suggest`
+- `checkpoint_now`
+
+Not exercised with live writes:
+
+- All mutation tools were dry-run only by design.
+
+## Final assessment
+
+SymForge is strong enough to be useful in daily agent work, but it needs correctness hardening before agents should treat dependency graphs, caller/callee traces, or parser diagnostics as authoritative.
+
+The recommended policy until fixes land:
+
+- Use SymForge first for orientation and narrowing.
+- Cross-check `find_dependents`, common-name TypeScript references, and parser errors before acting.
+- Prefer dry-run edit tools and verify with `git diff`, typecheck, lint, and tests.
+- Treat `ask` as a convenience hint, not a source of truth.

--- a/docs/SYMFORGE_MCP_BUG_REPORT_2026-06-03_VERDICTS.md
+++ b/docs/SYMFORGE_MCP_BUG_REPORT_2026-06-03_VERDICTS.md
@@ -1,0 +1,172 @@
+# SymForge Bug Report — Verification Verdicts
+
+Companion to `SYMFORGE_MCP_BUG_REPORT_2026-06-03.md`. Each SF issue was independently
+root-caused (rust-pro investigator), adversarially verified (code-reviewer), and — for the
+repo-specific claims — live-reproduced against the real `Agent_Army_Professionals`, `testpilot`,
+and `symforge` repos. This file records the VERIFIED verdict and every correction to the original
+report. The actionable build instructions live in `SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md`.
+
+Method per issue:
+- **Investigation**: read the live source, cite file:line, propose fix + test.
+- **Verification**: adversarial re-check of the investigation against the code.
+- **Reproduction**: shell/parser ground truth against the real repos (where externally checkable).
+
+---
+
+## Verdict summary
+
+| ID | Report severity | VERIFIED verdict | Report accuracy |
+|---|---|---|---|
+| SF-001 | Critical | **ALREADY FIXED** — not reproducible >=7.10.0 | WRONG against current source (stale-binary artifact) |
+| SF-002 | High | CONFIRMED defect | Accurate; cleaner fix exists (enclosing_symbol_index) |
+| SF-003 | High | CONFIRMED defect | Accurate; trigger narrower (only `[]` suffix) |
+| SF-004 | Medium | CONFIRMED limitation | Accurate |
+| SF-005 | Medium | CONFIRMED defect | Accurate |
+| SF-006 | Medium | CONFIRMED defect | Accurate symptom; WRONG cause (not path-normalization) |
+| SF-007 | Medium | CONFIRMED defect | Accurate |
+| SF-008 | Medium | CONFIRMED defect | Accurate |
+| SF-009 | Medium | **MECHANISM REFUTED** | WRONG cause; scratch files add 0 symbols |
+| SF-010 | Low | PARTIAL | Half is harness behavior, not SymForge |
+| SF-011 | Low | CONFIRMED defect | Accurate |
+
+Scoreboard: 7 fully accurate, 2 accurate-symptom/wrong-cause (SF-006, SF-009-partial),
+1 already-fixed (SF-001), 1 conflated-with-harness (SF-010). The audit was high quality; the
+two consequential misses (SF-001, SF-009) are both explained by the same root operational cause —
+a stale/shadowed daemon binary and a concurrent agent editing source during the audit.
+
+---
+
+## SF-001 — find_dependents false positives :: ALREADY FIXED
+
+- **Reproduction (shell, AAP):** CONFIRMED the *ground truth* the report asserts — the 4 actor files
+  have ZERO textual reference to `work_item`, and they share the generic bare name `new` (and `state`/`get`)
+  with `WorkItemStore`'s public methods; `aap-agents` has a real `aap-db` path dependency. So a name-keyed
+  graph WOULD collide. BUT the reproducer could not run `find_dependents` itself.
+- **Investigation + verification (live source):** the name-keyed collision is already GATED. Every Call
+  edge needs a `::`-boundary qualified-name suffix match (`disambiguation.rs:16-49`) or a same-name import;
+  `can_match_type_dependents` is false for Rust. A zero-reference file as a dependent is structurally
+  impossible. The fix shipped in commit `251d7f0` (ancestor of `v7.18.0`). Independent re-run via the real
+  `LiveIndex::load` pipeline produced 0 edges.
+- **DIRECTLY RE-VERIFIED:** `git merge-base --is-ancestor 251d7f0 v7.18.0` -> true.
+- **Why the audit saw it:** stale daemon binary — `daemon_reused_session` mode + the PATH-shadowed
+  `C:\Program Files\nodejs\symforge` ("version unknown", the SF-008 shadow) served pre-fix behavior.
+- **Correction to report:** the Critical correctness verdict is invalid against current source. Do NOT
+  change the matching algorithm. Residual work is operational (binary-staleness guard) + a real-parser
+  regression test (existing 4 tests hand-build refs).
+
+## SF-002 — TS same-name method conflation :: CONFIRMED
+
+- **Reproduction (testpilot):** CONFIRMED — 3 distinct `startExploration` defs (controller:44,
+  service:415, frontend ApiService:378); controller body delegates to `this.testingService.startExploration()`.
+  Same-name cross-object ambiguity is real. (Bonus: the surface is WIDER than the report — the frontend
+  ApiService method is a 3rd collider.)
+- **Root cause:** the receiver guard in `matches_exact_symbol_reference` is gated Rust+Function-only;
+  TS methods bypass it and match on bare name. Callee half has no name-vs-self check.
+- **Correction to report:** the report implies a receiver/byte heuristic; the index already has
+  `enclosing_symbol_index` (DIRECTLY RE-VERIFIED present across 16 files) — keying on it is precise and
+  does NOT suppress legitimate intra-class `this.foo()` callers, which the byte heuristic WOULD.
+  Verifier also found the report's regression-test recipe broken (the `make_ref` helper couples
+  line_range to byte_start/100, so the ref won't land in the method's line range).
+
+## SF-003 — TS import-type `[]` parse error :: CONFIRMED
+
+- **Reproduction (dogfooded the real pinned grammar):** CONFIRMED, with a NARROWER trigger than reported.
+  Scalar `import('rxjs').Subscription` parses CLEAN everywhere; only the `[]`/tuple suffix breaks. The
+  reported diagnostic (line/col) reproduced byte-exact. `tree-sitter-typescript 0.23.2` is the LATEST
+  crate — no grammar-bump remedy.
+- **Root cause:** binary `has_error -> PartialParse` classification with no "grammar limitation" concept;
+  the only expected-partial bucket is vendor-SCSS path-based.
+- **Correction to report:** the report's implied "valid syntax mis-flagged" is right, but the obvious
+  detector is UNSOUND — verifier proved a genuinely broken `import('rxjs').Subscription[] = [ ; foo bar`
+  yields the same error-node prefix and would be wrongly marked OK. The fix MUST validate the whole
+  construct. Also: `.tsx` is already covered by the same grammar (no separate handling). And the new
+  `ParseStatus` variant touches the PERSISTED checkpoint format — serde back-compat required.
+
+## SF-004 — Angular template control-flow :: CONFIRMED limitation
+
+- **Reproduction (dogfooded tree-sitter-html 0.23.2):** CONFIRMED byte-exact (`0) {` at line 14, col 38).
+  The `>` relational operator is the trigger (`@if (cond) {` without `>` parses clean). The grammar has
+  zero Angular rules; SymForge's own source already comments it text-scans Angular.
+- **Root cause:** same classification gap as SF-003 — only the vendor-SCSS expected-partial bucket exists.
+- **Correction to report:** none material. Verifier confirmed `PublishedIndexState` has NO serde derive,
+  so the investigation's serde-default worry was moot. Heuristic caveat: a malformed `.html` that also
+  contains a valid `@if` would be mis-bucketed — don't over-promise. And the `get_file_context`
+  "Parse status: partial" line (the actual repro surface) must also be fixed, not just the health bucket.
+
+## SF-005 — `ask` compound query :: CONFIRMED
+
+- **Root cause:** the "where is " branch captures the whole remainder and only strips trailing suffixes,
+  so "...defined and what module imports it?" becomes the symbol name. Reported as `Exact` confidence
+  with no next-step hint (confident false negative).
+- **Correction to report:** verifier — must reorder `where is file ` before bare `where is ` (else a
+  new regression on file queries), and drop the proposed stop-word list in favor of first-token extraction.
+
+## SF-006 — Co-change ranking fallback :: CONFIRMED defect, WRONG cause in report
+
+- **Reproduction (git, AAP):** CONFIRMED the co-change partnership is REAL (work_item.rs has 3 commits,
+  ALL 3 also touched work_item_store.rs). The reproducer's leading hypothesis was path-normalization.
+- **Investigation REFUTED that:** the `neighbors.get(path)` lookup SUCCEEDS. The real cause is the
+  anchor-confidence gate: stem query `work_item` scores only PREFIX tier (50) against `work_item.rs`
+  (basename incl. extension), below the basename floor (100), so fusion never applies. Fusion DOES work
+  for the with-extension query shape today.
+- **Correction to report:** cause is the stem-vs-basename gate, NOT a path mismatch. The fallback message
+  is misleading on two counts. Four distinct fallback reasons must be disambiguated (incl. chore-anchor).
+  Verifier flagged a real tension: the report's 1-char acceptance fixture (`a` vs `a.test.ts`) conflicts
+  with SymForge's existing `len >= 3` prefix policy — a maintainer decision.
+
+## SF-007 — checkpoint_now in daemon-proxy mode :: CONFIRMED
+
+- **Root cause:** only index-bearing tool not wired into the proxy path; hard-fails before proxying and
+  has no daemon dispatch arm. Forwarding to the daemon (which owns the authoritative index) is correct
+  and feasible.
+- **Correction to report:** none. Verifier confirmed `CheckpointNowInput` already derives `Serialize`
+  (no manual JSON needed) and that the local-fallback reloads the index (does not checkpoint empty).
+
+## SF-008 — PATH remediation not Windows-native :: CONFIRMED
+
+- **Reproduction (this Windows box):** CONFIRMED — `Get-Command symforge -All` shows the shadow;
+  `format_shadow_warning` branches only on `ShadowKind`, never OS; any `C:\` shadow -> ForeignPrefix ->
+  POSIX `~/.profile`/`export PATH` string (and `$PATH` is a broken var in PowerShell).
+- **Correction to report:** none. Verifier — key off `cfg!(windows)`; the npm-side POSIX emitters are
+  gated to non-native-Windows paths (out of scope); lead with the simple PATH-order fix, not setx/nvm.
+
+## SF-009 — Untracked scratch files in index :: MECHANISM REFUTED
+
+- **Reproduction (AAP + empirical `discover_all_files`):** the scratch files exist and are not gitignored,
+  BUT they are dotfiles -> filtered by `ignore` default `hidden:true` before admission; and any `.txt`
+  maps to `LanguageId::None` -> Tier-2 metadata-only -> 0 symbols, 0 Tier-1 count. `discover_all_files`
+  on a representative tempdir returned only `[notes.txt(Tier-2), scratch_probe.json(Tier-1), src_main.rs]`.
+- **Correction to report:** the +1450 symbols CANNOT come from text scratch files (arithmetically
+  impossible) — it was the concurrent agent's real source edits. The report's own proposed regression test
+  (assert `.probe.txt` not indexed) PASSES today with zero code change (vacuous). Only real residue:
+  surface "indexed untracked files: N" for non-dotfile untracked recognized-extension files. Do NOT change
+  admission defaults.
+
+## SF-010 — Tool discoverability :: PARTIAL
+
+- **Root cause:** "lazy exposure" (two-pass discovery) is HARNESS behavior — SymForge eagerly returns all
+  32 tools via the rmcp `#[tool_handler]` macro. The SymForge-owned half: `ask` has no tool-meta intent,
+  so `ask("what tools for impact analysis?")` becomes a code search.
+- **Correction to report:** the discoverability complaint conflates harness behavior with a SymForge gap.
+  Fix the `ask` ToolHelp + tool-catalog half; document the lazy-exposure half as out of scope. Verifier:
+  keep ToolHelp out of the Understand|Explore upgrade guard, and scope detection to `tool(s)` + a
+  recommendation verb to avoid hijacking code queries.
+
+## SF-011 — conventions Rust-biased :: CONFIRMED
+
+- **Root cause:** `detect_conventions` runs one Rust-flavored pass, never reads `IndexedFile.language`.
+- **Correction to report:** verifier — the dominant-language filter must exclude config files by
+  `LanguageId`/`is_config`, NOT by `FileClass` (every path is `FileClass::Code`); gate the per-file SCAN by
+  language (not just the summary branch); `test_file_count` is already language-agnostic (only inline-module
+  counts are Rust-only); fold JS+TS into one language bucket.
+
+---
+
+## Operational meta-finding
+
+Two of the report's misses (SF-001 already-fixed, SF-009 wrong-cause) trace to the SAME operational
+conditions the audit itself documented: it ran against a PATH-shadowed daemon of "version unknown"
+(`daemon_reused_session`) while a concurrent agent edited source. This argues strongly for the SF-001
+ops-guard work (assert served-binary freshness in `health`) as the highest-leverage durable fix — it
+would have surfaced both the stale-binary cause of SF-001 and the real source-of-truth of the SF-009
+count delta. Prioritize it even though SF-001's algorithm needs no change.

--- a/docs/goals/symforge-bugfix-campaign.goal.md
+++ b/docs/goals/symforge-bugfix-campaign.goal.md
@@ -1,0 +1,296 @@
+/goal Resolve all 11 SF issues from the 2026-06-03 SymForge MCP audit per the
+verified implementation plan — fix the 8 real code defects (SF-002..SF-008, SF-010,
+SF-011), add tests + ops guard for the already-fixed SF-001, and add untracked-file
+surfacing for the refuted-mechanism SF-009 — until every per-issue acceptance
+criterion + regression test is met, the full verification suite is green, each
+live-verifiable fix is proven against the REAL repos on a freshly-restarted daemon,
+and the work is integrated to a review branch — without changing the find_dependents
+matching algorithm (SF-001), without changing index admission defaults (SF-009),
+without touching the working-tree gsd-* -> local-agent-* rename, and without any
+push/merge to main (commit to a review branch and STOP for human review).
+
+Context:
+  - Repo: C:\AI_STUFF\PROGRAMMING\symforge  (Rust MCP server — symbol-aware code
+    navigation/editing tools). Branch: main. Cargo version 7.18.1 (HEAD is PAST the
+    v7.18.0 tag — this matters for SF-001 below). Project rules: see
+    C:\AI_STUFF\PROGRAMMING\symforge\CLAUDE.md (verification commands, CI gates,
+    Tool Consolidation Pattern, key source-file map).
+  - SOURCE OF TRUTH (read both BEFORE doing anything; do NOT re-derive the analysis):
+      * Actionable plan (repair order, per-issue fix location/approach/regression
+        test/risk, ALL verifier corrections baked in):
+        C:\AI_STUFF\PROGRAMMING\symforge\docs\SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md
+      * Per-issue verified verdicts + corrections:
+        C:\AI_STUFF\PROGRAMMING\symforge\docs\SYMFORGE_MCP_BUG_REPORT_2026-06-03_VERDICTS.md
+      * Original audit (reference only — superseded where it conflicts with the two above):
+        C:\AI_STUFF\PROGRAMMING\symforge\docs\SYMFORGE_MCP_BUG_REPORT_2026-06-03.md
+    Provenance: produced by 11 root-cause investigators + 11 adversarial verifiers
+    + 7 live-reproduction agents against the REAL Agent_Army_Professionals (AAP),
+    testpilot, and symforge repos. Treat these docs as gospel; this goal POINTS to
+    them — open the per-issue spec section before implementing each issue.
+  - Real repos on disk (confirmed present), used for live verify-as-user:
+      * C:\AI_STUFF\PROGRAMMING\Agent_Army_Professionals  (Rust — co-change, dependents)
+      * C:\AI_STUFF\PROGRAMMING\testpilot  (TypeScript / Angular — TS/HTML parsing, xref)
+  - Verified ground truth (do not re-litigate): tree-sitter-typescript = 0.23.2 and
+    tree-sitter-html = 0.23.2 are the LATEST published crates (no grammar-bump remedy);
+    .ts/.tsx share LANGUAGE_TYPESCRIPT (one fix covers both); SF-001 collision-filter
+    commit 251d7f0 is a VERIFIED ancestor of v7.18.0 (git merge-base --is-ancestor
+    returns true), so the fix is already in this HEAD.
+  - SCOPE COUNTS: 8 confirmed code fixes (SF-002, SF-003, SF-004, SF-005, SF-006,
+    SF-007, SF-008, SF-010 [half only], SF-011); SF-001 = tests + optional ops guard
+    ONLY (already fixed); SF-009 = surfacing ONLY (mechanism refuted).
+  - Runner: this is a self-orchestrating overnight-capable campaign. The runner is the
+    ORCHESTRATOR — it dispatches specialists per issue, gates each fix, integrates via
+    git-master to a review branch, then STOPS. Always use `git -C C:\AI_STUFF\PROGRAMMING\symforge`
+    (the runner may be in HOME). This goal file is throwaway: self-delete it when the
+    campaign is complete and the results doc is written.
+
+Success criteria (MEASURABLE — "done" = a concrete, checkable outcome, NOT
+  "it compiles" / "tests pass alone" / "it works"):
+  [1] All 11 SF issues are resolved exactly per their per-issue spec in
+      SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md, including the verifier corrections, and
+      each issue's named regression test(s) exist and pass. Specifically:
+        - SF-001: a REAL-PARSER end-to-end test in tests/find_dependents_pass2.rs that
+          parses AAP-shaped work_item.rs + actor.rs via symforge::parsing::process_file
+          (NOT hand-built ReferenceRecords) asserts find_dependents_for_file(work_item.rs)
+          yields ZERO refs whose path contains actor.rs. NO change to the matching algorithm.
+        - SF-002: controller method callers.total_count == 0 for the testpilot
+          same-name delegation fixture; controller is NOT its own callee (appears in a
+          new unresolved_same_name_member_call section); a true bare top-level foo() is
+          STILL counted; fix uses enclosing_symbol_index (NOT a byte heuristic).
+        - SF-003: the import-type+[] fixture classifies as ok/parsed with symbols still
+          extracted; the negative-control broken file ("import('rxjs').Subscription[] = [ ; foo bar")
+          STAYS partial/failed (detector is SOUND — validates the whole construct);
+          checkpoint serde back-compat is preserved.
+        - SF-004: an Angular @if/@for .html lands under [expected_framework_partial]
+          (not [unexpected_partial]) in health AND get_file_context no longer labels it
+          a bare "partial".
+        - SF-005: ask("Where is TestingController defined and what module imports it?")
+          classifies as FindSymbol{name:"TestingController"} with the truncation flag set
+          (confidence downgraded to Inferred + a suggested_next_step naming
+          search_symbols -> find_references); "where is file tools.rs" still routes to FindFile.
+        - SF-006: a stem query that names the anchor (query="work_item",
+          anchor=".../work_item.rs", rank_by="path+cochange") applies co-change (NOT
+          "fallback used") with the partner under the co-change tier; a true-prefix query
+          ("work") still falls back BUT with the precise reason (one of the four distinct
+          reasons incl. chore-anchor). The maintainer's >=3-char stem policy decision is
+          recorded in the results doc.
+        - SF-007: a daemon round-trip checkpoint_now succeeds (body contains "Checkpoint
+          complete", NOT "unavailable in daemon-proxy mode", NOT "unknown tool"; snapshot
+          exists), via proxy-first forwarding + a daemon dispatch arm.
+        - SF-008: on a Windows build, format_shadow_warning ForeignPrefix arm emits
+          PowerShell-native guidance (contains "Get-Command symforge -All", names both bin
+          dirs, is_ascii(); does NOT contain "~/.profile" or "export PATH"); POSIX text
+          retained for non-Windows. classify_shadow/ShadowKind unchanged.
+        - SF-009: a non-dotfile untracked recognized-ext file surfaces as
+          untracked_indexed == 1 and the health line contains "indexed untracked files: 1";
+          feature FAILS OPEN (no git / no index -> off, count 0); admission defaults UNCHANGED.
+        - SF-010: ask("what tools can I use for impact analysis?") classifies as
+          ToolHelp and returns a tool list containing find_references / find_dependents /
+          get_symbol_context / analyze_file_impact / what_changed / diff_symbols; "how does
+          the Tool registry work" still routes to Understand/Explore (NOT ToolHelp); every
+          tool_catalog_groups() name exists in SYMFORGE_TOOL_NAMES. Lazy-exposure half is
+          documented as harness behavior (out of scope).
+        - SF-011: a TS-majority fixture yields conventions whose error_handling does NOT
+          say "Result-based", mentions exceptions, naming mentions camelCase, test count is
+          nonzero, and a "language: TypeScript" header is present; a Rust-majority fixture
+          still yields "Result-based"/% snake_case. Config files excluded by LanguageId/is_config
+          (NOT FileClass); per-file scan gated by language.
+  [2] The full project verification suite is GREEN on the final review branch:
+      cargo fmt --check, cargo check, cargo clippy --all-targets -- -D warnings,
+      cargo test --all-targets -- --test-threads=1, cargo build --release. If npm/ was
+      touched: cd npm && npm test. (No npm/ change is expected for these issues.)
+  [3] LIVE verify-as-user PROOF (compiling + green tests is necessary but NOT
+      sufficient): for SF-002, SF-003, SF-004, SF-005, SF-006, SF-007, SF-008, SF-010,
+      SF-011, the relevant MCP tool was re-run against the REAL repo (testpilot for
+      TS/Angular: SF-002/003/004; AAP for Rust co-change/dependents: SF-006/SF-001
+      cross-check; symforge-self or either for routing/ops: SF-005/007/008/010/011) on a
+      daemon FRESHLY built+restarted from the fixed branch, and the corrected output was
+      observed and captured (exact tool, args, before/after snippet) in the results doc.
+  [4] All work is integrated by git-master onto ONE review branch
+      (e.g. fix/symforge-mcp-audit-2026-06-03), committed in scoped commits (per-issue or
+      per-phase, cleanup never mixed with feature/refactor). NOTHING is pushed, no PR is
+      opened, no merge to main — the campaign PAUSES at this gate for human review.
+  [5] ONE honest results doc is written (incrementally, to survive a crash) at
+      C:\AI_STUFF\PROGRAMMING\symforge\docs\SYMFORGE_BUGFIX_RESULTS_2026-06-03.md
+      recording per-issue: FIXED / VERIFIED-LIVE / TEST-ONLY / DEFERRED, the verification
+      evidence, the live-verify before/after, any open maintainer decision (SF-006 length
+      policy; SF-002 output-shape; SF-003 shape A-vs-B), and any remaining gap. Mock is
+      labeled mock, unverified is labeled unverified. No premature "all works".
+
+Constraints:
+  [SF-001-frozen]   Do NOT change the find_dependents matching algorithm
+                    (matches_exact_symbol_qualified_name / matches_exact_symbol_reference /
+                    can_match_type_dependents). Changing it regresses legit cross-module
+                    dependents pinned by real_qualified_call_dependent_still_reported.
+                    SF-001 work = real-parser regression test + (optional, high-leverage)
+                    daemon binary-staleness health guard ONLY.
+  [SF-009-frozen]   Do NOT change index admission defaults / the ignore-crate hidden
+                    filter / language tiering. SF-009 work = surface "indexed untracked
+                    files: N" ONLY, and it MUST fail open (no git index -> feature off).
+  [SF-010-scope]    Only the ask() ToolHelp intent + symforge://tools/catalog half is in
+                    scope. The "lazy exposure" two-pass discovery is HARNESS behavior —
+                    document it out of scope, do NOT attempt a server-side fix.
+  [verify-as-user]  "Verified" means a live, real-flow MCP tool call against the real repo
+                    on a freshly-restarted daemon — NEVER code-reading, NEVER "tests
+                    passed" alone. Capture exact tool+args+output.
+  [kill-stale-daemon] Before EVERY live verification: kill stray symforge daemons, rebuild
+                    from the fixed branch, confirm the SERVED binary is the new one (PID +
+                    version), bypass any reused session/cache. SF-001 is the cautionary
+                    tale — a shadowed/reused daemon serves stale behavior and produced the
+                    audit's two biggest misses.
+  [code-is-gospel]  Trust the file:line citations in the plan, but RE-READ each cited
+                    symbol/file immediately before editing (context may be stale); verify
+                    claims against the running code, treat comments/docs as stale-until-confirmed.
+  [exhaustive-match] SF-003 (new FileOutcome/ParseStatus variant) and SF-010 (new
+                    QueryIntent variant) intentionally break every match at compile time —
+                    that is the safety net; fix EVERY arm including the test-only
+                    dispatch_tool_for_tests / decode paths. SF-003 ADDITIONALLY changes the
+                    PERSISTED checkpoint format — confirm serde back-compat (a snapshot
+                    written by the new binary must still load, and vice versa) before shipping.
+  [public-contracts] SF-002 changes find_references/edit_plan caller counts (TS/JS/Py/C#/Go);
+                    SF-006 changes search_files ordering for stem queries. These are
+                    user-visible — update golden/snapshot tests and treat as DELIBERATE
+                    behavior changes, never silent. VERIFY asserted output substrings
+                    against the live format.rs before writing test assertions (the plan flags
+                    several proposed substrings as unverified guesses).
+  [tool-consolidation] When adding/removing any tool surface (SF-010 catalog/resource,
+                    SF-007 dispatch), follow the Tool Consolidation Pattern in CLAUDE.md
+                    (input struct + handler branch + daemon.rs dispatch + init.rs tool-name
+                    list + cross-ref descriptions + tests).
+  [scope-phases]    <=5 files per phase (CLAUDE.md). Serialize phases/issues that share a
+                    file: SF-005 & SF-010 both touch smart_query.rs (serialize D1->D2);
+                    SF-003 & SF-004 share format.rs/health_view.rs/store.rs (serialize
+                    C1->C2). Do NOT batch a multi-file refactor in one response.
+  [do-not-touch]    Leave the uncommitted working-tree gsd-* -> local-agent-* rename alone
+                    (another agent's WIP, unrelated). Do not stage/revert/commit it.
+  [cargo-cache]     Keep target/ WARM across the whole campaign for incremental speed. Run
+                    cargo clean ONLY at the very end (campaign boundary), never between
+                    phases/agents.
+  [resource-throttle] Max 2 truly-parallel heavy cargo/check/clippy/test agents; batch
+                    larger fan-outs. Read-only investigation can fan out wider. Serialize
+                    same-file edits.
+  [safety-gate]     NO push / NO PR / NO merge to main / NO force / NO destructive git.
+                    git-master commits to a REVIEW BRANCH and STOPS. Pause for explicit
+                    human approval before any of the above. Especially binding for an
+                    unattended run.
+
+Agent routing (dispatch the right specialist per issue; respect the 2-heavy-parallel cap):
+  - rust-pro (Matsakis) — all the Rust code fixes: SF-002, SF-003, SF-004, SF-005,
+    SF-006, SF-007, SF-008, SF-010, SF-011, plus the SF-001 test + SF-009 surfacing.
+  - code-reviewer (Linus, read-only) — pre-merge review gate on every issue, with
+    special attention to [SF-001-frozen]/[SF-009-frozen]/[public-contracts]/[exhaustive-match].
+  - test-runner (Kent Beck) — run + repair the per-issue regression tests and the full
+    suite; confirm golden/snapshot updates are deliberate.
+  - debugger (House) — if the SF-003 sound-detector or SF-007 daemon round-trip misbehaves
+    at runtime, root-cause it.
+  - tech-researcher (Sherlock) — only if an open decision needs primary-source resolution
+    (e.g. checkpoint serde back-compat strategy, SF-006 length policy) beyond what the plan states.
+  - git-master (Junio Hamano) — Phase F integration: collect all issue work onto the review
+    branch, scoped commits, resolve conflicts. HARD-GATED: commit + STOP, no push/merge.
+  - browser-tester / charlotte — NOT needed (these are MCP-tool flows, not browser UI);
+    live verify-as-user is done by invoking the MCP tools directly against a fresh daemon.
+
+Checklist: (this file is the running log — tick items as completed; serialize where flagged)
+
+PHASE 0 — BASELINE
+  [ ] git -C <repo>: confirm branch main, clean except the known docs + working-tree
+      gsd-* rename; create the review branch fix/symforge-mcp-audit-2026-06-03 from main.
+  [ ] Read SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md and VERDICTS.md fully (gospel).
+  [ ] Establish a green baseline: cargo fmt --check, cargo check, cargo clippy
+      --all-targets -- -D warnings, cargo test --all-targets -- --test-threads=1. Record
+      the baseline state. Kill stray symforge daemons; note current served binary/PID.
+  [ ] Build a release daemon from the baseline branch and confirm it serves (version + PID)
+      so the "freshly restarted daemon" procedure is established for later live verifies.
+  [ ] Create the results doc skeleton (one row per SF issue) and write to it incrementally.
+
+PHASE A — High value, isolated (SF-007, SF-008) — can run as 2 parallel rust-pro agents
+  [ ] SF-007 checkpoint_now forwarding — tools.rs (proxy-first) + daemon.rs (dispatch arm;
+      import CheckpointNowInput; add dispatch_tool_for_tests arm if a parity test routes there).
+      Gate: code -> code-reviewer -> test-runner (daemon round-trip test) -> LIVE verify
+      (fresh daemon, checkpoint_now over the proxy returns "Checkpoint complete").
+  [ ] SF-008 Windows PATH remediation — path_shadow.rs ForeignPrefix arm via cfg!(windows);
+      keep ShadowKind/classify_shadow unchanged; ASCII-only; assert backslash form on Windows.
+      Gate: code -> code-reviewer -> test-runner (#[cfg(windows)] test) -> LIVE verify
+      (trigger/inspect the shadow warning on this Windows box; confirm PowerShell-native text).
+
+PHASE B — Resolution/ranking correctness (SF-002, SF-006) — serialize if file overlap; else 2 parallel
+  [ ] SF-002 TS same-name method — use enclosing_symbol_index in the same-file caller branch
+      (query.rs), add unresolved_same_name_member_call section (context_bundle.rs +
+      ContextBundleFoundView), render it (format.rs); callee-side self-call guard. Update
+      find_references/edit_plan golden tests deliberately. Use a ref builder that decouples
+      byte_range from line_range in the regression test (the plan's make_ref recipe is broken).
+      Gate: code -> code-reviewer (public-contract focus) -> test-runner -> LIVE verify
+      (testpilot get_symbol_context on TestingController.startExploration: total_count==0, not self-callee).
+  [ ] SF-006 co-change stem gate + reasons — rank_signals.rs (stem-equality in PathMatchSignal::score;
+      resolve the >=3-char policy and RECORD the decision), tools.rs (split the catch-all fallback
+      into the FOUR distinct reasons incl. chore-anchor; compute anchor-confidence reason once),
+      calibration tests. Verify asserted format substrings against format.rs FIRST. Keep
+      weak_prefix_anchor_keeps_baseline_path_order... green.
+      Gate: code -> code-reviewer -> test-runner -> LIVE verify (AAP search_files query="work_item"
+      anchor work_item.rs rank_by=path+cochange debug_ranking=true: applies co-change, partner under tier).
+
+PHASE C — Parse classification (SERIALIZE C1 -> C2; shared format.rs/health_view.rs/store.rs)
+  [ ] C1 SF-003 import-type+[] -> grammar-limitation classification. SOUND detector (validate the
+      WHOLE construct; negative control MUST stay partial). New FileOutcome::ExpectedGrammarLimitation
+      -> ParseStatus::ParsedWithGrammarLimitation. CONFIRM checkpoint serde back-compat before
+      choosing shape B (else shape A). Fix EVERY broken match arm. Touches parsing/mod.rs,
+      domain/index.rs|store.rs, format.rs, tools.rs, health_view.rs.
+      Gate: code -> code-reviewer (exhaustive-match + serde back-compat) -> test-runner (positive +
+      type-alias positive + REQUIRED negative control) -> LIVE verify (testpilot validate_file_syntax /
+      get_file_context on workflow-builder.component.ts: Status ok/parsed, not partial; symbols present).
+  [ ] C2 SF-004 Angular @if/@for -> expected_framework_partial bucket. health_view.rs (detector +
+      third branch + HealthStats fields), store.rs (PublishedIndexState fields — NO serde, no default),
+      format.rs (ParseQuarantineKind::ExpectedFrameworkPartial + wiring), sidecar/handlers.rs
+      (get_file_context parse_state label). Update health_parse_quarantine.rs hard-coded registry strings.
+      Gate: code -> code-reviewer -> test-runner -> LIVE verify (testpilot app.html: under
+      [expected_framework_partial], get_file_context no longer bare "partial").
+
+PHASE D — Routing/UX (SERIALIZE D1 -> D2; both touch smart_query.rs)
+  [ ] D1 SF-005 ask compound query — reorder "where is file " before bare "where is "; first-token
+      extraction (drop the stop-word list); clean_symbol_name casing; downgrade to Inferred +
+      suggested_next_step on truncation. Tests assert BOTH name and the truncated flag; add
+      interior-article + FindFile-guard fixtures + tools.rs ask E2E.
+      Gate: code -> code-reviewer -> test-runner -> LIVE verify (ask the compound question on a fresh
+      daemon: Chosen tool search_symbols, invocation has "TestingController" not "imports it", Suggested next step present).
+  [ ] D2 SF-010 ask ToolHelp + catalog — add QueryIntent::ToolHelp{topic} detected EARLY (scoped to
+      tool(s) + recommendation verb; NOT in the Understand|Explore upgrade guard); tool_catalog_groups();
+      ask arm; symforge://tools/catalog resource (resources.rs); init.rs/Tool Consolidation Pattern;
+      drift guard test (every catalog name in SYMFORGE_TOOL_NAMES). Fix every QueryIntent match arm.
+      Gate: code -> code-reviewer (exhaustive-match) -> test-runner -> LIVE verify (ask "what tools for
+      impact analysis?" returns the impact tools; "how does the Tool registry work" is NOT ToolHelp).
+
+PHASE E — Advisory + ops/tests (SF-011, SF-001, SF-009) — SF-011/SF-001/SF-009 are file-disjoint enough to parallel ~2 at a time
+  [ ] SF-011 language-aware conventions — conventions.rs: dominant-lang vote excluding config by
+      LanguageId/is_config (NOT FileClass); fold JS+TS; gate per-file scan by file.language; TS/JS
+      branch (try/catch, throw new, HttpException, RxJS catchError, camelCase/PascalCase, *.spec.ts +
+      describe/it scan, decorator content-scan); language header; generic default branch. Add the
+      #[cfg(test)] mod tests (none today) — wire file.language explicitly on fixtures.
+      Gate: code -> code-reviewer -> test-runner -> LIVE verify (testpilot conventions: no "Result-based",
+      mentions exceptions, camelCase, language: TypeScript; AAP conventions still Rust-flavored).
+  [ ] SF-001 test + ops guard — tests/find_dependents_pass2.rs real-parser end-to-end test (NO algorithm
+      change); optional but HIGH-LEVERAGE daemon/health served-binary-staleness guard (overlaps SF-008;
+      product decision warn-vs-restart — record it). This guard is the durable fix for the audit's two misses.
+      Gate: code -> code-reviewer ([SF-001-frozen] check) -> test-runner -> (ops guard) LIVE verify a
+      reused/older daemon triggers the warning.
+  [ ] SF-009 untracked-file surfacing — git ls-files tracked set (NOT via ignore crate); count Tier-1
+      not-tracked & not-ignored; untracked_indexed on HealthStats; "indexed untracked files: N" in the
+      health line (format.rs); FAIL OPEN when no git index; optional SYMFORGE_EXCLUDE_UNTRACKED (default
+      off). Account for the two discovery paths (discover_all_files vs build_reload_data/discover_files).
+      Gate: code -> code-reviewer ([SF-009-frozen] check) -> test-runner -> LIVE verify (health line shows
+      the untracked count on a repo with an untracked recognized-ext file; off on a non-git tempdir).
+
+PHASE F — INTEGRATE (git-master) — HARD-GATED
+  [ ] git-master collects all issue work onto fix/symforge-mcp-audit-2026-06-03 in scoped commits
+      (per-issue/per-phase; cleanup never mixed with feature). Resolve any conflicts. Do NOT touch the
+      gsd-* working-tree rename. Re-run the FULL suite on the integrated branch (criterion [2]).
+  [ ] STOP. No push, no PR, no merge. Leave the branch for human review.
+
+PHASE G — VERIFY END-TO-END + REPORT
+  [ ] On a daemon freshly built+restarted from the integrated review branch (kill-stale-daemon first,
+      confirm version+PID), re-run the live verify-as-user matrix for SF-002/003/004/005/006/007/008/010/011
+      against the real repos and capture before/after evidence (criterion [3]).
+  [ ] Finalize the honest results doc (criterion [5]): per-issue status, evidence, live before/after,
+      open maintainer decisions, remaining gaps. Mock-as-mock, unverified-as-unverified.
+  [ ] cargo clean (campaign boundary — reclaim disk).
+  [ ] Self-delete this goal file. Report: review branch name, results-doc path, the human-review gate,
+      and any open decision the maintainer must make.


### PR DESCRIPTION
… plan

Independently verified the 11-issue Codex audit (SF-001..SF-011) against the real AAP, testpilot, and symforge repos via parallel specialist agents (root-cause + adversarial verification + live reproduction).

Adds:
- SYMFORGE_MCP_BUG_REPORT_2026-06-03.md            original Codex audit
- SYMFORGE_MCP_BUG_REPORT_2026-06-03_VERDICTS.md   per-issue verified verdicts + corrections
- SYMFORGE_BUGFIX_IMPLEMENTATION_PLAN.md           gated repair order + per-issue specs for a coding agent
- goals/symforge-bugfix-campaign.goal.md           self-orchestrating /goal campaign file

Key corrections to the original audit (baked into the plan):
- SF-001 already fixed >=7.10.0 (251d7f0); audit hit a stale/shadowed daemon
- SF-002 fix via enclosing_symbol_index, not a byte/receiver heuristic
- SF-003 needs whole-construct validation + checkpoint serde back-compat
- SF-006 cause is stem-vs-basename anchor gate, not path normalization
- SF-009 mechanism refuted (scratch dotfiles add 0 symbols)
- SF-010 lazy tool exposure is harness behavior, not a SymForge gap

Docs only. No product source changed.