### PR TITLE
fix: post-v7.19.0 code-review findings 1-4 (classifier memo, checkpoint receipt, anchor-only stem promotion, JS label)

### DIFF
--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -557,7 +557,11 @@ pub(crate) fn anchor_path_match_score(query: &str, anchor_path: &str) -> f32 {
         query: &normalized_query,
         tokens: &tokens,
         current_file: None,
-        target_path: None,
+        // The scored path IS the anchor: setting `target_path` to it marks
+        // this as anchor scoring, so the SF-006 stem-equals-basename promotion
+        // applies here (and in the CoChangeSignal floor check, which scores
+        // `target_path` the same way) but NOT to ordinary candidate ranking.
+        target_path: Some(anchor_path),
         co_change_count: None,
         co_change_weighted_score: None,
     };

--- a/src/live_index/rank_signals.rs
+++ b/src/live_index/rank_signals.rs
@@ -156,16 +156,24 @@ impl RankSignal for PathMatchSignal {
             .unwrap_or("")
             .to_ascii_lowercase();
 
-        // A stem-only query that names the anchor (e.g. `work_item` for
+        // A stem-only query that names the ANCHOR (e.g. `work_item` for
         // `work_item.rs`) promotes to BASENAME tier so co-change fusion clears
-        // the anchor-confidence floor. The `file_stem == basename_token` arm is
-        // gated behind the same `>= 3` length guard the prefix path uses below
-        // (query.rs:~1236) so 1-2 char stems (`a`, `io`) stay prefix-tier and do
-        // not jump to basename tier; genuine prefixes (`work` vs `work_item`)
-        // also stay prefix-tier because neither basename nor stem equals them.
+        // the anchor-confidence floor (SF-006). The promotion applies ONLY when
+        // the path being scored IS the co-change anchor (`ctx.target_path`) —
+        // the CoChangeSignal floor check and `anchor_path_match_score` both
+        // score the anchor itself — so an anchor-gate fix does not globally
+        // reshape candidate path tiers (review finding 3, post-v7.19.0).
+        // The `file_stem == basename_token` arm is gated behind the same `>= 3`
+        // length guard the prefix path uses below (query.rs:~1236) so 1-2 char
+        // stems (`a`, `io`) stay prefix-tier and do not jump to basename tier;
+        // genuine prefixes (`work` vs `work_item`) also stay prefix-tier
+        // because neither basename nor stem equals them.
+        let scoring_the_anchor = ctx.target_path.map(Path::new) == Some(path);
         let has_basename_match = !basename_token.is_empty()
             && (file_basename == basename_token
-                || (basename_token.len() >= 3 && file_stem == basename_token));
+                || (scoring_the_anchor
+                    && basename_token.len() >= 3
+                    && file_stem == basename_token));
         let has_all_components = !component_tokens.is_empty()
             && component_tokens
                 .iter()
@@ -441,6 +449,61 @@ mod tests {
             co_change_count: None,
             co_change_weighted_score: None,
         }
+    }
+
+    /// Review finding 3 (post-v7.19.0): the SF-006 stem-equals-basename
+    /// promotion is ANCHOR-ONLY. Scoring the co-change anchor itself (path ==
+    /// ctx.target_path) promotes a ≥3-char stem query to basename tier so the
+    /// anchor-confidence floor clears; scoring an ordinary CANDIDATE with the
+    /// same stem keeps the pre-SF-006 prefix tier, so the anchor-gate fix does
+    /// not globally reshape candidate path scoring.
+    #[test]
+    fn stem_promotion_applies_to_anchor_only() {
+        let tokens = vec!["work_item".to_string()];
+
+        // Anchor scoring: target_path IS the scored path -> basename tier.
+        let anchor_ctx = RankCtx {
+            target_path: Some("src/stores/work_item.rs"),
+            ..ctx_with("work_item", &tokens)
+        };
+        assert_eq!(
+            PathMatchSignal.score(Path::new("src/stores/work_item.rs"), &anchor_ctx),
+            BASENAME_SCORE,
+            "a stem query naming the anchor must promote to basename tier"
+        );
+
+        // Candidate scoring: same stem match, but the scored path is NOT the
+        // anchor -> stays prefix tier (pre-SF-006 behavior).
+        let candidate_ctx = RankCtx {
+            target_path: Some("src/stores/other_anchor.rs"),
+            ..ctx_with("work_item", &tokens)
+        };
+        assert_eq!(
+            PathMatchSignal.score(Path::new("src/stores/work_item.rs"), &candidate_ctx),
+            PREFIX_SCORE,
+            "a non-anchor candidate must not receive the stem promotion"
+        );
+
+        // No anchor at all (plain path search): also prefix tier.
+        assert_eq!(
+            PathMatchSignal.score(
+                Path::new("src/stores/work_item.rs"),
+                &ctx_with("work_item", &tokens)
+            ),
+            PREFIX_SCORE,
+            "anchorless scoring must not receive the stem promotion"
+        );
+
+        // Exact basename queries are unaffected by the gate in all roles.
+        let basename_tokens = vec!["work_item.rs".to_string()];
+        assert_eq!(
+            PathMatchSignal.score(
+                Path::new("src/stores/work_item.rs"),
+                &ctx_with("work_item.rs", &basename_tokens)
+            ),
+            BASENAME_SCORE,
+            "an exact basename match keeps basename tier without anchor status"
+        );
     }
 
     #[test]

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -292,6 +292,78 @@ pub(crate) fn parse_source(
     Ok((symbols, has_error, diagnostic, references, alias_map))
 }
 
+/// Cache-key discriminant for [`expected_partial_memo`]: which known grammar
+/// limitation a cached verdict belongs to.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+enum ExpectedPartialCheck {
+    /// SF-003: TS import-type immediately followed by `[]`.
+    TsImportTypeArray,
+    /// SF-004: Angular control-flow relational operators in `.html`.
+    AngularControlFlow,
+}
+
+/// Upper bound on memo entries; at the cap the map is cleared wholesale.
+/// Entries are a few machine words each, so the bound is generous; clearing
+/// (vs an LRU) keeps the code trivial, and a refill costs one
+/// re-classification per still-live file.
+const EXPECTED_PARTIAL_MEMO_CAP: usize = 4096;
+
+/// Process-wide memo for the SF-003/SF-004 neutralize-and-reparse verdicts,
+/// keyed by (check, content length, content hash).
+///
+/// The classifiers cost up to two FULL tree-sitter parses per call and sit on
+/// render paths invoked repeatedly with identical content: `health_stats`
+/// iterates every partial-parse file per `health` call, and the
+/// `get_file_context` / `validate_file_syntax` / sidecar envelopes re-classify
+/// per render. A file's content is immutable for a given index generation, so
+/// a (length, 64-bit content hash) key dedups those re-parses. A wrong-verdict
+/// collision requires both equal 64-bit hashes AND equal lengths on different
+/// content that is also classified differently — astronomically unlikely for
+/// the worst case of a mislabeled health bucket. Stale entries from edited
+/// files age out via the wholesale clear at [`EXPECTED_PARTIAL_MEMO_CAP`].
+static EXPECTED_PARTIAL_MEMO: std::sync::LazyLock<std::sync::Mutex<ExpectedPartialMemoMap>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(ExpectedPartialMemoMap::new()));
+
+/// Memo key: (which check, content length, 64-bit content hash).
+type ExpectedPartialMemoKey = (ExpectedPartialCheck, u64, u64);
+/// Verdict map behind [`EXPECTED_PARTIAL_MEMO`].
+type ExpectedPartialMemoMap = std::collections::HashMap<ExpectedPartialMemoKey, bool>;
+
+/// Memoize one expected-partial classification: return the cached (check,
+/// content) verdict, computing and inserting it on a miss.
+///
+/// `compute` runs WITHOUT the lock held, so two threads may race to compute
+/// the same verdict — harmless (the verdict is deterministic) and preferable
+/// to holding a global lock across a tree-sitter parse. A poisoned lock falls
+/// back to the inner map: the map holds only derived verdicts, so there is no
+/// invariant a panicking writer could have broken.
+fn expected_partial_memo(
+    check: ExpectedPartialCheck,
+    content: &[u8],
+    compute: impl FnOnce() -> bool,
+) -> bool {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    let key = (check, content.len() as u64, hasher.finish());
+    if let Some(&verdict) = EXPECTED_PARTIAL_MEMO
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&key)
+    {
+        return verdict;
+    }
+    let verdict = compute();
+    let mut memo = EXPECTED_PARTIAL_MEMO
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if memo.len() >= EXPECTED_PARTIAL_MEMO_CAP {
+        memo.clear();
+    }
+    memo.insert(key, verdict);
+    verdict
+}
+
 /// Matches a TypeScript import-type member (`import('mod').Member`) immediately
 /// followed by one or more postfix array suffixes (`[]`), allowing interior
 /// whitespace. Capture group 1 is the scalar import-type member alone; the
@@ -349,41 +421,46 @@ pub(crate) fn is_expected_typescript_import_type_array_limitation(
         return false;
     }
 
-    let source = String::from_utf8_lossy(content);
+    // Memoized: the regex pre-gate plus up to two full re-parses below run at
+    // most once per distinct content (see `expected_partial_memo`); render
+    // paths calling this repeatedly with unchanged content hit the cache.
+    expected_partial_memo(ExpectedPartialCheck::TsImportTypeArray, content, || {
+        let source = String::from_utf8_lossy(content);
 
-    // The construct must actually be present; otherwise this limitation is not
-    // what we are looking at.
-    if !IMPORT_TYPE_ARRAY_SUFFIX_RE.is_match(&source) {
-        return false;
-    }
+        // The construct must actually be present; otherwise this limitation is not
+        // what we are looking at.
+        if !IMPORT_TYPE_ARRAY_SUFFIX_RE.is_match(&source) {
+            return false;
+        }
 
-    // Defensive: only meaningful for files that genuinely failed to parse. If
-    // the original parses clean there is no limitation to excuse.
-    let original_has_error = match panic::catch_unwind(|| parse_source(&source, language)) {
-        Ok(Ok((_, has_error, _, _, _))) => has_error,
-        _ => return false,
-    };
-    if !original_has_error {
-        return false;
-    }
+        // Defensive: only meaningful for files that genuinely failed to parse. If
+        // the original parses clean there is no limitation to excuse.
+        let original_has_error = match panic::catch_unwind(|| parse_source(&source, language)) {
+            Ok(Ok((_, has_error, _, _, _))) => has_error,
+            _ => return false,
+        };
+        if !original_has_error {
+            return false;
+        }
 
-    // Neutralize ONLY the array suffix on import-type members, then re-parse the
-    // whole file. A clean re-parse proves the array suffix was the sole cause.
-    //
-    // The `[]` run is replaced with a SINGLE SPACE (not deleted) so the
-    // neutralization is token-preserving. Deleting an empty `[]` between an
-    // import-type member and a trailing identifier fragment would GLUE them into
-    // a single valid identifier (e.g. `import('x').Sub[]scription` ->
-    // `import('x').Subscription`), making a genuinely broken file re-parse clean
-    // and be falsely excused. A space keeps `Sub[]scription` as two tokens
-    // (`Sub scription`, still broken) while the legitimate `Subscription[]`
-    // becomes `Subscription ` (a scalar import-type with trailing whitespace,
-    // still clean). Multi-dim `[][]` is one match, replaced by one space.
-    let neutralized = IMPORT_TYPE_ARRAY_SUFFIX_RE.replace_all(&source, "${1} ");
-    match panic::catch_unwind(|| parse_source(&neutralized, language)) {
-        Ok(Ok((_, has_error, _, _, _))) => !has_error,
-        _ => false,
-    }
+        // Neutralize ONLY the array suffix on import-type members, then re-parse the
+        // whole file. A clean re-parse proves the array suffix was the sole cause.
+        //
+        // The `[]` run is replaced with a SINGLE SPACE (not deleted) so the
+        // neutralization is token-preserving. Deleting an empty `[]` between an
+        // import-type member and a trailing identifier fragment would GLUE them into
+        // a single valid identifier (e.g. `import('x').Sub[]scription` ->
+        // `import('x').Subscription`), making a genuinely broken file re-parse clean
+        // and be falsely excused. A space keeps `Sub[]scription` as two tokens
+        // (`Sub scription`, still broken) while the legitimate `Subscription[]`
+        // becomes `Subscription ` (a scalar import-type with trailing whitespace,
+        // still clean). Multi-dim `[][]` is one match, replaced by one space.
+        let neutralized = IMPORT_TYPE_ARRAY_SUFFIX_RE.replace_all(&source, "${1} ");
+        match panic::catch_unwind(|| parse_source(&neutralized, language)) {
+            Ok(Ok((_, has_error, _, _, _))) => !has_error,
+            _ => false,
+        }
+    })
 }
 
 /// Matches an Angular control-flow opener (`@if`/`@for`/`@switch`/`@defer`/
@@ -461,44 +538,49 @@ pub(crate) fn is_expected_angular_template_control_flow_limitation(
         return false;
     }
 
-    let source = String::from_utf8_lossy(content);
+    // Memoized: the regex pre-gate plus up to two full re-parses below run at
+    // most once per distinct content (see `expected_partial_memo`); render
+    // paths calling this repeatedly with unchanged content hit the cache.
+    expected_partial_memo(ExpectedPartialCheck::AngularControlFlow, content, || {
+        let source = String::from_utf8_lossy(content);
 
-    // The construct must actually be present; otherwise this limitation is not
-    // what we are looking at.
-    if !ANGULAR_CONTROL_FLOW_OPENER_RE.is_match(&source) {
-        return false;
-    }
+        // The construct must actually be present; otherwise this limitation is not
+        // what we are looking at.
+        if !ANGULAR_CONTROL_FLOW_OPENER_RE.is_match(&source) {
+            return false;
+        }
 
-    // Defensive: only meaningful for files that genuinely failed to parse. If the
-    // original parses clean there is no limitation to excuse.
-    let original_has_error = match panic::catch_unwind(|| parse_source(&source, language)) {
-        Ok(Ok((_, has_error, _, _, _))) => has_error,
-        _ => return false,
-    };
-    if !original_has_error {
-        return false;
-    }
+        // Defensive: only meaningful for files that genuinely failed to parse. If the
+        // original parses clean there is no limitation to excuse.
+        let original_has_error = match panic::catch_unwind(|| parse_source(&source, language)) {
+            Ok(Ok((_, has_error, _, _, _))) => has_error,
+            _ => return false,
+        };
+        if !original_has_error {
+            return false;
+        }
 
-    // Neutralize ONLY the relational operators inside each Angular control-flow
-    // opener's `(...)` expression, then re-parse the whole file. Each `<`/`>` in
-    // capture group 3 becomes a single space; the opener keyword, the parens, and
-    // every byte outside the matched openers (including ordinary HTML tag `<`/`>`)
-    // are preserved verbatim. A clean re-parse proves the relational operators were
-    // the sole cause.
-    let neutralized =
-        ANGULAR_CONTROL_FLOW_OPENER_RE.replace_all(&source, |caps: &regex::Captures| {
-            format!(
-                "{}{}{}{}",
-                &caps[1],
-                &caps[2],
-                caps[3].replace(['<', '>'], " "),
-                &caps[4],
-            )
-        });
-    match panic::catch_unwind(|| parse_source(&neutralized, language)) {
-        Ok(Ok((_, has_error, _, _, _))) => !has_error,
-        _ => false,
-    }
+        // Neutralize ONLY the relational operators inside each Angular control-flow
+        // opener's `(...)` expression, then re-parse the whole file. Each `<`/`>` in
+        // capture group 3 becomes a single space; the opener keyword, the parens, and
+        // every byte outside the matched openers (including ordinary HTML tag `<`/`>`)
+        // are preserved verbatim. A clean re-parse proves the relational operators were
+        // the sole cause.
+        let neutralized =
+            ANGULAR_CONTROL_FLOW_OPENER_RE.replace_all(&source, |caps: &regex::Captures| {
+                format!(
+                    "{}{}{}{}",
+                    &caps[1],
+                    &caps[2],
+                    caps[3].replace(['<', '>'], " "),
+                    &caps[4],
+                )
+            });
+        match panic::catch_unwind(|| parse_source(&neutralized, language)) {
+            Ok(Ok((_, has_error, _, _, _))) => !has_error,
+            _ => false,
+        }
+    })
 }
 
 /// Extract symbol name → body-hash pairs from source code using tree-sitter.
@@ -653,6 +735,42 @@ mod tests {
             is_expected_typescript_import_type_array_limitation(&LanguageId::TypeScript, source),
             "multi-dimensional import-type-array must be recognized as an expected limitation"
         );
+    }
+
+    /// Perf regression (review finding 1, post-v7.19.0): the expensive
+    /// neutralize-and-reparse classification must be computed at most once per
+    /// distinct content. The second lookup's compute closure panics, so this
+    /// fails loudly if the memo stops short-circuiting; distinct check kinds
+    /// and distinct content must not share verdicts.
+    #[test]
+    fn test_expected_partial_memo_hit_skips_recompute() {
+        // Unique content so parallel/preceding tests cannot pre-seed the key.
+        let content = b"memo-probe :: post-v7.19.0 review fix 1 :: unique";
+        assert!(expected_partial_memo(
+            ExpectedPartialCheck::TsImportTypeArray,
+            content,
+            || true
+        ));
+        // Memo hit: the closure must NOT run again for the same (check, content).
+        assert!(expected_partial_memo(
+            ExpectedPartialCheck::TsImportTypeArray,
+            content,
+            || panic!("verdict must come from the memo, not a recompute"),
+        ));
+        // The OTHER check kind on the same content is a distinct key.
+        assert!(!expected_partial_memo(
+            ExpectedPartialCheck::AngularControlFlow,
+            content,
+            || false
+        ));
+        // Different content (same length as `content`) is a distinct key.
+        let other = b"memo-probe :: post-v7.19.0 review fix 1 :: uniquf";
+        assert_eq!(content.len(), other.len());
+        assert!(!expected_partial_memo(
+            ExpectedPartialCheck::TsImportTypeArray,
+            other,
+            || false
+        ));
     }
 
     #[test]

--- a/src/protocol/conventions.rs
+++ b/src/protocol/conventions.rs
@@ -87,9 +87,20 @@ pub fn detect_conventions(index: &LiveIndex) -> ProjectConventions {
     // `.js`/`.ts` frontend does not split its own vote.
     let mut lang_votes: std::collections::HashMap<&'static str, u32> =
         std::collections::HashMap::new();
+    // Per-member counts inside the folded JS/TS bucket, used ONLY to pick the
+    // reported label (review finding 4, post-v7.19.0): the fold keeps a mixed
+    // frontend from splitting its own vote, but a pure-JavaScript project must
+    // not be LABELED "TypeScript".
+    let mut js_file_votes = 0u32;
+    let mut ts_file_votes = 0u32;
     for (_path, file) in index.all_files() {
         if let Some(bucket) = code_language_bucket(&file.language) {
             *lang_votes.entry(bucket).or_insert(0) += 1;
+        }
+        match file.language {
+            LanguageId::JavaScript => js_file_votes += 1,
+            LanguageId::TypeScript => ts_file_votes += 1,
+            _ => {}
         }
     }
     let total_code_votes: u32 = lang_votes.values().copied().sum();
@@ -97,6 +108,19 @@ pub fn detect_conventions(index: &LiveIndex) -> ProjectConventions {
     // Deterministic ordering: by count desc, then name asc for tie-breaking.
     vote_vec.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
     let primary_lang: &'static str = vote_vec.first().map(|(name, _)| *name).unwrap_or("Unknown");
+    // Review finding 4 (post-v7.19.0): the folded JS/TS bucket keeps a mixed
+    // frontend from splitting its own vote, but a pure-JavaScript project must
+    // not be reported as "TypeScript". When the folded bucket wins with a
+    // JavaScript-majority membership, relabel the primary to "JavaScript" —
+    // every language-branched summary below matches "TypeScript" | "JavaScript",
+    // so the summary framing is unchanged. Ties keep "TypeScript" (the
+    // superset syntax).
+    let primary_lang: &'static str =
+        if primary_lang == "TypeScript" && js_file_votes > ts_file_votes {
+            "JavaScript"
+        } else {
+            primary_lang
+        };
     // Open decision (recorded): a mixed repo reports a SINGLE primary language
     // plus a one-line note when a SECOND language holds a >25% share.
     let secondary_note: Option<String> = vote_vec.get(1).and_then(|(name, count)| {
@@ -800,6 +824,64 @@ mod tests {
             conv.test_patterns.contains("describe/it/test"),
             "TS test patterns should mention describe/it/test scan, got: {}",
             conv.test_patterns
+        );
+    }
+
+    /// Review finding 4 (post-v7.19.0): a pure-JavaScript project folds into
+    /// the JS/TS vote bucket (so the vote is not split) but must be REPORTED
+    /// as "JavaScript", not "TypeScript" — while keeping the TS/JS-framed
+    /// summaries (exception-based error handling, camelCase), never Rust
+    /// wording.
+    #[test]
+    fn javascript_majority_project_is_labeled_javascript() {
+        let service = make_file(
+            "src/service.js",
+            LanguageId::JavaScript,
+            "function handleRequest(req) {\n  try { run(req); } catch (err) { throw new Error('boom'); }\n}\n",
+            vec![sym("handleRequest", SymbolKind::Function)],
+            vec![],
+        );
+        let util = make_file(
+            "src/util.js",
+            LanguageId::JavaScript,
+            "function buildPayload() { return {}; }\n",
+            vec![sym("buildPayload", SymbolKind::Function)],
+            vec![],
+        );
+        // One stray .ts file: JS still holds the bucket majority (2 > 1).
+        let typed = make_file(
+            "src/types.ts",
+            LanguageId::TypeScript,
+            "export interface Payload { ok: boolean }\n",
+            vec![sym("Payload", SymbolKind::Interface)],
+            vec![],
+        );
+
+        let conv = conventions_for(vec![
+            ("src/service.js", service),
+            ("src/util.js", util),
+            ("src/types.ts", typed),
+        ]);
+
+        assert!(
+            conv.language.starts_with("JavaScript"),
+            "JS-majority project must be labeled JavaScript, got: {}",
+            conv.language
+        );
+        assert!(
+            conv.error_handling.contains("try/catch") || conv.error_handling.contains("throw new"),
+            "JS project keeps the exception-based summary framing, got: {}",
+            conv.error_handling
+        );
+        assert!(
+            !conv.error_handling.contains("unwrap"),
+            "JS project must not get Rust error-handling wording, got: {}",
+            conv.error_handling
+        );
+        assert!(
+            conv.naming.contains("camelCase"),
+            "JS naming keeps the camelCase framing, got: {}",
+            conv.naming
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -5281,6 +5281,7 @@ impl SymForgeServer {
         // is real) so the checkpoint runs against the populated index. On
         // local-fallback the proxy returns None and the in-process logic below
         // checkpoints the locally reloaded index.
+        let daemon_configured = self.daemon_client.is_some();
         if let Some(result) = self.proxy_tool_call("checkpoint_now", &params.0).await {
             return result;
         }
@@ -5305,12 +5306,29 @@ impl SymForgeServer {
         })
         .await
         {
-            Ok(Ok(report)) => format!(
-                "Checkpoint complete: wrote {} bytes for {} file(s) to {}",
-                report.bytes,
-                report.files,
-                report.path.display()
-            ),
+            Ok(Ok(report)) => {
+                let mut message = format!(
+                    "Checkpoint complete: wrote {} bytes for {} file(s) to {}",
+                    report.bytes,
+                    report.files,
+                    report.path.display()
+                );
+                // Honest receipt (review finding 2, post-v7.19.0): reaching this
+                // point with a daemon CONFIGURED means the proxy failed and we
+                // fell back to checkpointing the locally reloaded index, which
+                // may lag the daemon's authoritative live index. Say so, instead
+                // of an output indistinguishable from the daemon path — the
+                // snapshot written here can be staler than one the daemon would
+                // have written.
+                if daemon_configured {
+                    message.push_str(
+                        "\nnote: daemon unreachable; this checkpoint wrote the locally reloaded \
+                         index, which may lag the daemon's live index. Re-run checkpoint_now once \
+                         the daemon is reachable to persist its authoritative state.",
+                    );
+                }
+                message
+            }
             Ok(Err(error)) => format!("Checkpoint failed: {error}"),
             Err(join_error) => format!("Checkpoint failed: checkpoint task panicked: {join_error}"),
         }
@@ -8699,6 +8717,45 @@ mod tests {
         );
 
         let _ = handle.shutdown_tx.send(());
+    }
+
+    /// Review finding 2 (post-v7.19.0): when a daemon is CONFIGURED but
+    /// unreachable, `checkpoint_now` falls back to checkpointing the locally
+    /// reloaded index — and its receipt must say so, because the snapshot it
+    /// writes can lag the daemon's authoritative live index. A client pointed
+    /// at a dead port (with no stored project root, so `reconnect` cannot
+    /// rediscover a real daemon) forces exactly that fallback path.
+    #[tokio::test]
+    async fn test_checkpoint_now_degraded_fallback_receipt_names_local_index() {
+        let daemon_client = crate::daemon::DaemonSessionClient::new_for_test(
+            // Port 1 is never serving; connection fails fast.
+            "http://127.0.0.1:1".to_string(),
+            "project-id".to_string(),
+            "session-id".to_string(),
+            "project-name".to_string(),
+        );
+        let server = SymForgeServer::new_daemon_proxy(daemon_client);
+        let dir = tempfile::tempdir().expect("create temp repo root");
+        server.set_repo_root(Some(dir.path().to_path_buf()));
+
+        let output = server
+            .checkpoint_now(Parameters(super::CheckpointNowInput {
+                verify_after_write: Some(true),
+            }))
+            .await;
+
+        assert!(
+            output.contains("Checkpoint complete"),
+            "local fallback should still checkpoint successfully, got: {output}"
+        );
+        assert!(
+            output.contains("daemon unreachable"),
+            "degraded-fallback receipt must disclose the daemon was unreachable, got: {output}"
+        );
+        assert!(
+            output.contains("locally reloaded index"),
+            "degraded-fallback receipt must name WHAT was checkpointed, got: {output}"
+        );
     }
 
     #[tokio::test]
@@ -12611,6 +12668,12 @@ mod tests {
         assert!(
             result.contains("Checkpoint complete"),
             "checkpoint should report success: {result}"
+        );
+        // Guard (review finding 2): the degraded-fallback disclosure is ONLY
+        // for daemon-proxy fallback; a plain local checkpoint must not carry it.
+        assert!(
+            !result.contains("daemon unreachable"),
+            "local-mode checkpoint must not claim a daemon fallback: {result}"
         );
         assert!(
             temp.path().join(".symforge").join("index.bin").exists(),


### PR DESCRIPTION
Implements findings 1-4 of docs/code-review-v7.19.0-2026-06-10.md (review of the v7.19.0 release).

- perf(parsing): memoize the SF-003/SF-004 neutralize-and-reparse classifiers by (check, content length, content hash) - health_stats and the render paths stop re-parsing unchanged partial files on every call. No IndexedFile/snapshot shape change.
- fix(protocol): checkpoint_now discloses when it fell back to checkpointing the locally reloaded index because the configured daemon was unreachable (receipt was previously indistinguishable from the daemon path). Dead-port regression test + local-mode absence guard.
- fix(rank): SF-006 stem-equals-basename promotion now applies only when scoring the co-change anchor itself (path == ctx.target_path); candidate tiers return to pre-SF-006 behavior. SF-006 calibration suite stays green.
- fix(conventions): a JS-majority folded JS/TS bucket is labeled JavaScript; summary branches unchanged (they already match both names).

Each fix carries a regression test. Local gates: cargo fmt --check, clippy --all-targets -D warnings, targeted tests green; full suite run before this PR.

Note: review finding 5 (sequential worktree-routed edits clobber prior edits to the same file - HIGH) is documented in the review doc and NOT addressed here; it needs its own investigation in the worktree routing layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live search ranking and parsing classification paths used on health/render hot paths; behavior is narrowed or cached with regression tests, but mis-scoped anchor logic or memo collisions could affect search or health bucketing.
> 
> **Overview**
> Addresses four post-v7.19.0 review findings without changing index/snapshot shapes.
> 
> **Parsing:** SF-003 (TS `import('x').Type[]`) and SF-004 (Angular control-flow) “expected partial” checks are wrapped in a process-wide memo keyed by check kind, content length, and hash (cap 4096, wholesale clear). Health and render paths stop doing duplicate neutralize-and-reparse work on the same bytes.
> 
> **Ranking:** SF-006 stem-equals-basename promotion to basename tier runs only when the scored path is the co-change anchor (`ctx.target_path`); `anchor_path_match_score` now sets `target_path` to the anchor. Ordinary candidates keep prefix-tier behavior.
> 
> **Conventions:** When the folded JS/TS vote bucket wins but `.js` files outnumber `.ts`, the reported primary language is **JavaScript** instead of defaulting to TypeScript.
> 
> **Protocol:** `checkpoint_now` appends a note when a daemon was configured but the proxy failed, so success text is not mistaken for a daemon-authoritative checkpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ca20a293cb1c44ee827911188a67e3ba2d677c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->