### PR TITLE
fix(edit): rebase rerouted edit bases onto the worktree target (review finding 5)

### DIFF
--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -247,6 +247,139 @@ pub(crate) fn reindex_after_write(
 }
 
 // ---------------------------------------------------------------------------
+// Rerouted edit base (review finding 5, post-v7.19.0)
+// ---------------------------------------------------------------------------
+
+/// The effective base record an edit splices into, plus whether it had to be
+/// rebased from the rerouted worktree target.
+pub(crate) struct EditBase {
+    pub file: std::sync::Arc<IndexedFile>,
+    /// `true` when the base was re-read and re-parsed from the rerouted
+    /// target because it diverged from the indexed copy. Callers use this to
+    /// label source authority honestly (`worktree target (rebased)`).
+    pub rebased: bool,
+}
+
+/// Resolve the edit BASE for a possibly rerouted edit.
+///
+/// A rerouted edit must splice into the resolved worktree TARGET's current
+/// bytes — never the index's content. The index mirrors the indexed copy,
+/// which routed writes deliberately do not touch, so using index content as
+/// the base silently discards every earlier routed edit to the same file
+/// while each call still reports success (review finding 5: sequential
+/// routed edits clobbered each other; only the last survived).
+///
+/// Behavior:
+///   - pass-through edit (`rerouted == false`): indexed record, unchanged;
+///   - rerouted, target byte-identical to the index: indexed record (exact
+///     symbol ranges preserved);
+///   - rerouted, target diverged: the target's bytes are re-read and
+///     re-parsed so symbol resolution and splicing run against worktree
+///     truth. Symbols that no longer parse in the worktree file surface as
+///     ordinary resolution errors — honest failure beats silent data loss.
+pub(crate) fn rebase_edit_base_for_reroute(
+    file: std::sync::Arc<IndexedFile>,
+    resolved: &crate::worktree::ResolvedTarget,
+) -> Result<EditBase, String> {
+    if !resolved.rerouted {
+        return Ok(EditBase {
+            file,
+            rebased: false,
+        });
+    }
+    let target_bytes = std::fs::read(&resolved.target_path).map_err(|e| {
+        format!(
+            "Error: cannot read rerouted edit target {}: {e}",
+            resolved.target_path.display()
+        )
+    })?;
+    if target_bytes == file.content {
+        return Ok(EditBase {
+            file,
+            rebased: false,
+        });
+    }
+    let result =
+        crate::parsing::process_file(&file.relative_path, &target_bytes, file.language.clone());
+    Ok(EditBase {
+        file: std::sync::Arc::new(IndexedFile::from_parse_result(result, target_bytes)),
+        rebased: true,
+    })
+}
+
+/// Line-ending-insensitive content equality: treats `\r\n` and `\n` as the
+/// same terminator. A fresh `git worktree add` checkout can materialize CRLF
+/// on Windows (core.autocrlf) while the index holds the indexed root's LF
+/// bytes — that is not a real divergence and must not trip the batch guard.
+fn line_ending_insensitive_eq(a: &[u8], b: &[u8]) -> bool {
+    let mut ai = a.iter().peekable();
+    let mut bi = b.iter().peekable();
+    loop {
+        // Skip a `\r` only when it is part of a `\r\n` pair.
+        while ai.peek() == Some(&&b'\r') {
+            let mut look = ai.clone();
+            look.next();
+            if look.peek() == Some(&&b'\n') {
+                ai.next();
+            } else {
+                break;
+            }
+        }
+        while bi.peek() == Some(&&b'\r') {
+            let mut look = bi.clone();
+            look.next();
+            if look.peek() == Some(&&b'\n') {
+                bi.next();
+            } else {
+                break;
+            }
+        }
+        match (ai.next(), bi.next()) {
+            (None, None) => return true,
+            (Some(x), Some(y)) if x == y => {}
+            _ => return false,
+        }
+    }
+}
+
+/// Fail-closed divergence guard for the BATCH executors (review finding 5).
+///
+/// The batch pipelines resolve symbol byte ranges against the index snapshot
+/// before path routing happens, so they cannot (yet) rebase onto a diverged
+/// worktree target the way the single-symbol tools do. Until that refactor
+/// lands, a rerouted batch write onto a target that differs from the indexed
+/// content would silently destroy earlier routed edits — so refuse it loudly
+/// instead. A rerouted batch onto a byte-identical target stays allowed.
+pub(crate) fn guard_batch_reroute_divergence(
+    resolved: &crate::worktree::ResolvedTarget,
+    indexed_content: &[u8],
+    relative_path: &str,
+) -> Result<(), String> {
+    if !resolved.rerouted {
+        return Ok(());
+    }
+    let target_bytes = std::fs::read(&resolved.target_path).map_err(|e| {
+        format!(
+            "Error: cannot read rerouted batch target {}: {e}",
+            resolved.target_path.display()
+        )
+    })?;
+    if target_bytes == indexed_content || line_ending_insensitive_eq(&target_bytes, indexed_content)
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "Error: rerouted batch edit refused for '{relative_path}': the worktree target {} has \
+         diverged from the indexed copy (likely an earlier routed edit). Batch tools splice \
+         index-resolved byte ranges and would overwrite those changes. Use the single-symbol \
+         edit tools (replace_symbol_body / edit_within_symbol / insert_symbol / delete_symbol) \
+         with the same working_directory — they rebase onto the worktree target — or commit the \
+         worktree changes and reindex.",
+        resolved.target_path.display()
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Symbol resolution wrapper
 // ---------------------------------------------------------------------------
 
@@ -1624,6 +1757,10 @@ pub(crate) fn execute_batch_edit(
             Ok(r) => r,
             Err(e) => return Err(format!("Path resolution error for '{path}': {e}")),
         };
+        // Review finding 5 (post-v7.19.0): fail closed instead of clobbering
+        // a diverged rerouted target — this batch's splices were resolved
+        // against the index snapshot, not the worktree file.
+        guard_batch_reroute_divergence(&resolved_target, &file.content, path)?;
         let abs_path = resolved_target.target_path.clone();
         staged.push(StagedFile {
             path: path.clone(),
@@ -2036,6 +2173,10 @@ pub(crate) fn execute_batch_rename(
             Ok(r) => r,
             Err(e) => return Err(format!("Path resolution error for '{path}': {e}")),
         };
+        // Review finding 5 (post-v7.19.0): fail closed instead of clobbering
+        // a diverged rerouted target — rename ranges were validated against
+        // the index snapshot, not the worktree file.
+        guard_batch_reroute_divergence(&resolved_target, &original, path)?;
         staged.push(StagedFile {
             path: path.clone(),
             abs_path: resolved_target.target_path.clone(),
@@ -2426,6 +2567,10 @@ pub(crate) fn execute_batch_insert(
             Ok(r) => r,
             Err(e) => return Err(format!("Target {path}: path resolution error: {e}")),
         };
+        // Review finding 5 (post-v7.19.0): fail closed instead of clobbering
+        // a diverged rerouted target — these insert anchors were resolved
+        // against the index snapshot, not the worktree file.
+        guard_batch_reroute_divergence(&resolved_target, &file.content, &path)?;
         staged.push(StagedFile {
             path: path.clone(),
             abs_path: resolved_target.target_path.clone(),

--- a/src/protocol/edit_format.rs
+++ b/src/protocol/edit_format.rs
@@ -8,6 +8,11 @@ pub(crate) enum EditSafetyMode {
 pub(crate) enum EditSourceAuthority {
     DiskRefreshed,
     CurrentIndex,
+    /// The edit base was re-read and re-parsed from the rerouted worktree
+    /// TARGET because it had diverged from the indexed copy (a prior routed
+    /// edit). Splicing into index content here would silently discard those
+    /// earlier routed edits (review finding 5, post-v7.19.0).
+    WorktreeTarget,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -34,6 +39,7 @@ fn source_authority_label(authority: EditSourceAuthority) -> &'static str {
     match authority {
         EditSourceAuthority::DiskRefreshed => "disk-refreshed",
         EditSourceAuthority::CurrentIndex => "current index",
+        EditSourceAuthority::WorktreeTarget => "worktree target (rebased)",
     }
 }
 

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -560,6 +560,20 @@ impl SymForgeServer {
                 );
             }
         };
+        // Review finding 5 (post-v7.19.0): a rerouted edit must splice into
+        // the worktree TARGET's current bytes. The index mirrors the indexed
+        // copy (routed writes never touch it), so using index content as the
+        // base would silently discard every earlier routed edit to this file.
+        let edit_base = match edit::rebase_edit_base_for_reroute(file, &resolved_target) {
+            Ok(base) => base,
+            Err(e) => return fail_and_return_mutation_replay(&idempotency, e),
+        };
+        let source_authority = if edit_base.rebased {
+            edit_format::EditSourceAuthority::WorktreeTarget
+        } else {
+            source_authority
+        };
+        let file = edit_base.file;
         if let Some(warning) = Self::check_edit_capability(
             &file.language,
             crate::parsing::config_extractors::EditCapability::StructuralEditSafe,
@@ -651,13 +665,21 @@ impl SymForgeServer {
         // Detect parent impl type for type-aware reference filtering.
         // Methods inside `impl Foo` only warn about refs in files that also mention `Foo`.
         let parent_type = edit::find_parent_impl_type(&file, &sym);
-        edit::reindex_after_write(
-            &self.index,
-            &resolved_path,
-            &params.0.path,
-            &new_content,
-            file.language.clone(),
-        );
+        // Review finding 5 (post-v7.19.0): only a pass-through write updates
+        // the index. A routed write leaves the indexed copy untouched, so
+        // replacing the index entry with worktree bytes would make the index
+        // lie about the indexed root — and the next edit's freshness check
+        // would "correct" it back from disk, erasing the routed state it was
+        // spliced from.
+        if !resolved_target.rerouted {
+            edit::reindex_after_write(
+                &self.index,
+                &resolved_path,
+                &params.0.path,
+                &new_content,
+                file.language.clone(),
+            );
+        }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
         let warnings = edit::detect_stale_references(
             &self.index,
@@ -782,6 +804,20 @@ impl SymForgeServer {
                 );
             }
         };
+        // Review finding 5 (post-v7.19.0): a rerouted edit must splice into
+        // the worktree TARGET's current bytes. The index mirrors the indexed
+        // copy (routed writes never touch it), so using index content as the
+        // base would silently discard every earlier routed edit to this file.
+        let edit_base = match edit::rebase_edit_base_for_reroute(file, &resolved_target) {
+            Ok(base) => base,
+            Err(e) => return fail_and_return_mutation_replay(&idempotency, e),
+        };
+        let source_authority = if edit_base.rebased {
+            edit_format::EditSourceAuthority::WorktreeTarget
+        } else {
+            source_authority
+        };
+        let file = edit_base.file;
         if let Some(warning) = Self::check_edit_capability(
             &file.language,
             crate::parsing::config_extractors::EditCapability::StructuralEditSafe,
@@ -834,13 +870,21 @@ impl SymForgeServer {
                 return output;
             }
         };
-        edit::reindex_after_write(
-            &self.index,
-            &resolved_path,
-            &params.0.path,
-            &new_content,
-            file.language.clone(),
-        );
+        // Review finding 5 (post-v7.19.0): only a pass-through write updates
+        // the index. A routed write leaves the indexed copy untouched, so
+        // replacing the index entry with worktree bytes would make the index
+        // lie about the indexed root — and the next edit's freshness check
+        // would "correct" it back from disk, erasing the routed state it was
+        // spliced from.
+        if !resolved_target.rerouted {
+            edit::reindex_after_write(
+                &self.index,
+                &resolved_path,
+                &params.0.path,
+                &new_content,
+                file.language.clone(),
+            );
+        }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
         let mut out = format!(
             "{}\n{}",
@@ -945,6 +989,20 @@ impl SymForgeServer {
                 );
             }
         };
+        // Review finding 5 (post-v7.19.0): a rerouted edit must splice into
+        // the worktree TARGET's current bytes. The index mirrors the indexed
+        // copy (routed writes never touch it), so using index content as the
+        // base would silently discard every earlier routed edit to this file.
+        let edit_base = match edit::rebase_edit_base_for_reroute(file, &resolved_target) {
+            Ok(base) => base,
+            Err(e) => return fail_and_return_mutation_replay(&idempotency, e),
+        };
+        let source_authority = if edit_base.rebased {
+            edit_format::EditSourceAuthority::WorktreeTarget
+        } else {
+            source_authority
+        };
+        let file = edit_base.file;
         if let Some(warning) = Self::check_edit_capability(
             &file.language,
             crate::parsing::config_extractors::EditCapability::StructuralEditSafe,
@@ -992,13 +1050,21 @@ impl SymForgeServer {
                 return output;
             }
         };
-        edit::reindex_after_write(
-            &self.index,
-            &resolved_path,
-            &params.0.path,
-            &new_content,
-            file.language.clone(),
-        );
+        // Review finding 5 (post-v7.19.0): only a pass-through write updates
+        // the index. A routed write leaves the indexed copy untouched, so
+        // replacing the index entry with worktree bytes would make the index
+        // lie about the indexed root — and the next edit's freshness check
+        // would "correct" it back from disk, erasing the routed state it was
+        // spliced from.
+        if !resolved_target.rerouted {
+            edit::reindex_after_write(
+                &self.index,
+                &resolved_path,
+                &params.0.path,
+                &new_content,
+                file.language.clone(),
+            );
+        }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
         let mut out = format!(
             "{}\n{}",
@@ -1105,6 +1171,20 @@ impl SymForgeServer {
                 );
             }
         };
+        // Review finding 5 (post-v7.19.0): a rerouted edit must splice into
+        // the worktree TARGET's current bytes. The index mirrors the indexed
+        // copy (routed writes never touch it), so using index content as the
+        // base would silently discard every earlier routed edit to this file.
+        let edit_base = match edit::rebase_edit_base_for_reroute(file, &resolved_target) {
+            Ok(base) => base,
+            Err(e) => return fail_and_return_mutation_replay(&idempotency, e),
+        };
+        let source_authority = if edit_base.rebased {
+            edit_format::EditSourceAuthority::WorktreeTarget
+        } else {
+            source_authority
+        };
+        let file = edit_base.file;
         if let Some(warning) = Self::check_edit_capability(
             &file.language,
             crate::parsing::config_extractors::EditCapability::TextEditSafe,
@@ -1267,13 +1347,21 @@ impl SymForgeServer {
                 return output;
             }
         };
-        edit::reindex_after_write(
-            &self.index,
-            &resolved_path,
-            &params.0.path,
-            &new_content,
-            file.language.clone(),
-        );
+        // Review finding 5 (post-v7.19.0): only a pass-through write updates
+        // the index. A routed write leaves the indexed copy untouched, so
+        // replacing the index entry with worktree bytes would make the index
+        // lie about the indexed root — and the next edit's freshness check
+        // would "correct" it back from disk, erasing the routed state it was
+        // spliced from.
+        if !resolved_target.rerouted {
+            edit::reindex_after_write(
+                &self.index,
+                &resolved_path,
+                &params.0.path,
+                &new_content,
+                file.language.clone(),
+            );
+        }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
         let mut out = format!(
             "{}\n{}",

--- a/tests/worktree_awareness.rs
+++ b/tests/worktree_awareness.rs
@@ -1151,3 +1151,264 @@ async fn conventions_surfaces_worktree_awareness_guidance() {
     assert_not_contains(&output, "Feature-gated on `SYMFORGE_WORKTREE_AWARE=1`");
     assert_contains(&output, "README");
 }
+
+// ─── Review finding 5 (post-v7.19.0): routed edits must compound ────────────
+//
+// Sequential routed edits to the SAME file clobbered each other: each edit
+// spliced into the index's content (mirroring the indexed copy, which routed
+// writes never touch) and overwrote the worktree target wholesale, so only
+// the LAST edit survived while every call reported success. The fix rebases
+// the edit base from the rerouted target when it has diverged, and stops
+// poisoning the index entry with worktree bytes after a routed write.
+
+/// Two sequential routed edits to the same file must BOTH persist in the
+/// worktree target. This is the exact data-loss shape observed live during
+/// the post-v7.19.0 review (only the last of N edits survived).
+#[tokio::test]
+async fn sequential_routed_edits_to_same_file_all_persist() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    // Edit 1: replace `hello`.
+    let first = call(
+        &fx.server,
+        "replace_symbol_body",
+        json!({
+            "path": "src/lib.rs",
+            "name": "hello",
+            "new_body": "fn hello() {\n    println!(\"EDIT_ONE\");\n}",
+            "working_directory": wt_arg.clone(),
+        }),
+    )
+    .await;
+    assert_contains(&first, "rerouted: true");
+
+    // Edit 2: a different symbol in the SAME file, also routed.
+    let second = call(
+        &fx.server,
+        "replace_symbol_body",
+        json!({
+            "path": "src/lib.rs",
+            "name": "world",
+            "new_body": "fn world() {\n    println!(\"EDIT_TWO\");\n}",
+            "working_directory": wt_arg,
+        }),
+    )
+    .await;
+    assert_contains(&second, "rerouted: true");
+    // The second edit's base came from the diverged worktree target, and the
+    // envelope must say so.
+    assert_contains(&second, "worktree target (rebased)");
+
+    let wt_after = fx.read_worktree("src/lib.rs");
+    assert!(
+        wt_after.contains("EDIT_ONE"),
+        "edit 1 must survive edit 2 (review finding 5 regression): {wt_after}"
+    );
+    assert!(
+        wt_after.contains("EDIT_TWO"),
+        "edit 2 must be applied: {wt_after}"
+    );
+
+    // The indexed copy stays untouched by both routed edits.
+    let indexed_after = fx.read_indexed("src/lib.rs");
+    assert!(
+        !indexed_after.contains("EDIT_ONE") && !indexed_after.contains("EDIT_TWO"),
+        "indexed copy must not receive routed writes: {indexed_after}"
+    );
+}
+
+/// Three sequential routed edits across three DIFFERENT single-symbol tools
+/// (replace, edit_within, insert) must all persist — the rebase has to work
+/// for every tool, not just `replace_symbol_body`.
+#[tokio::test]
+async fn sequential_routed_edits_across_tools_all_persist() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    let r1 = call(
+        &fx.server,
+        "replace_symbol_body",
+        json!({
+            "path": "src/lib.rs",
+            "name": "hello",
+            "new_body": "fn hello() {\n    println!(\"TOOL_ONE\");\n}",
+            "working_directory": wt_arg.clone(),
+        }),
+    )
+    .await;
+    assert_contains(&r1, "rerouted: true");
+
+    let r2 = call(
+        &fx.server,
+        "edit_within_symbol",
+        json!({
+            "path": "src/lib.rs",
+            "name": "world",
+            "old_text": "println!(\"world\");",
+            "new_text": "println!(\"TOOL_TWO\");",
+            "working_directory": wt_arg.clone(),
+        }),
+    )
+    .await;
+    assert_contains(&r2, "rerouted: true");
+    assert_contains(&r2, "worktree target (rebased)");
+
+    let r3 = call(
+        &fx.server,
+        "insert_symbol",
+        json!({
+            "path": "src/lib.rs",
+            "name": "world",
+            "position": "after",
+            "content": "fn tool_three() {}",
+            "working_directory": wt_arg,
+        }),
+    )
+    .await;
+    assert_contains(&r3, "rerouted: true");
+    assert_contains(&r3, "worktree target (rebased)");
+
+    let wt_after = fx.read_worktree("src/lib.rs");
+    for needle in ["TOOL_ONE", "TOOL_TWO", "fn tool_three()"] {
+        assert!(
+            wt_after.contains(needle),
+            "all three routed edits must persist; missing `{needle}`: {wt_after}"
+        );
+    }
+}
+
+/// A routed edit must NOT replace the index entry with worktree bytes: the
+/// index mirrors the indexed copy, which a routed write deliberately leaves
+/// untouched. (This was the second half of finding 5 — the poisoned entry was
+/// then "corrected" back from disk by the next edit's freshness check,
+/// erasing the routed state from the edit base.)
+#[tokio::test]
+async fn routed_edit_does_not_poison_index_entry() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    let result = call(
+        &fx.server,
+        "replace_symbol_body",
+        json!({
+            "path": "src/lib.rs",
+            "name": "hello",
+            "new_body": "fn hello() {\n    println!(\"WT_ONLY\");\n}",
+            "working_directory": wt_arg,
+        }),
+    )
+    .await;
+    assert_contains(&result, "rerouted: true");
+
+    // The index serves the INDEXED copy; the routed write must not leak in.
+    let index_view = call(
+        &fx.server,
+        "get_file_content",
+        json!({ "path": "src/lib.rs" }),
+    )
+    .await;
+    assert_not_contains(&index_view, "WT_ONLY");
+    assert_contains(&index_view, "println!(\"hello\");");
+}
+
+/// Batch executors splice index-resolved byte ranges, so a rerouted batch
+/// onto a DIVERGED target must fail closed with an actionable error instead
+/// of silently clobbering earlier routed edits. (Full batch rebase is a
+/// follow-up; refusing loudly is the contract until then.)
+#[tokio::test]
+async fn routed_batch_edit_fails_closed_on_diverged_target() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    // Diverge the worktree target with a routed single-symbol edit.
+    let first = call(
+        &fx.server,
+        "replace_symbol_body",
+        json!({
+            "path": "src/lib.rs",
+            "name": "hello",
+            "new_body": "fn hello() {\n    println!(\"DIVERGED\");\n}",
+            "working_directory": wt_arg.clone(),
+        }),
+    )
+    .await;
+    assert_contains(&first, "rerouted: true");
+    let wt_before = fx.read_worktree("src/lib.rs");
+
+    // A routed batch edit onto the diverged target must refuse to write.
+    let batch = call(
+        &fx.server,
+        "batch_edit",
+        json!({
+            "edits": [{
+                "path": "src/lib.rs",
+                "name": "world",
+                "operation": {
+                    "type": "edit_within",
+                    "old_text": "println!(\"world\");",
+                    "new_text": "println!(\"BATCH_CLOBBER\");"
+                }
+            }],
+            "working_directory": wt_arg,
+        }),
+    )
+    .await;
+    assert_contains(&batch, "diverged");
+    assert_contains(&batch, "single-symbol");
+
+    // Nothing was written: the earlier routed edit survives, the batch text
+    // never landed.
+    let wt_after = fx.read_worktree("src/lib.rs");
+    assert_eq!(
+        wt_before, wt_after,
+        "failed-closed batch must not modify the worktree target"
+    );
+    assert!(
+        wt_after.contains("DIVERGED") && !wt_after.contains("BATCH_CLOBBER"),
+        "earlier routed edit must survive the refused batch: {wt_after}"
+    );
+}
+
+/// A rerouted batch onto a target that is still byte-identical to the indexed
+/// copy stays allowed — the guard only fires on divergence.
+#[tokio::test]
+async fn routed_batch_edit_on_identical_target_still_allowed() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    let batch = call(
+        &fx.server,
+        "batch_edit",
+        json!({
+            "edits": [{
+                "path": "src/lib.rs",
+                "name": "hello",
+                "operation": {
+                    "type": "edit_within",
+                    "old_text": "println!(\"hello\");",
+                    "new_text": "println!(\"BATCH_FRESH\");"
+                }
+            }],
+            "working_directory": wt_arg,
+        }),
+    )
+    .await;
+    assert_not_contains(&batch, "diverged");
+
+    let wt_after = fx.read_worktree("src/lib.rs");
+    assert!(
+        wt_after.contains("BATCH_FRESH"),
+        "fresh-target routed batch must still write: {wt_after}"
+    );
+    let indexed_after = fx.read_indexed("src/lib.rs");
+    assert!(
+        !indexed_after.contains("BATCH_FRESH"),
+        "indexed copy must stay untouched: {indexed_after}"
+    );
+}


### PR DESCRIPTION
Fixes review finding 5 (docs/code-review-v7.19.0-2026-06-10.md, HIGH): sequential worktree-routed edits to the same file silently discarded all but the last edit, while each call reported success.

Root cause (two halves):
1. Routed edits spliced into the INDEX's content - which mirrors the indexed copy that routed writes never touch - then overwrote the worktree target wholesale.
2. reindex_after_write then replaced the index entry with worktree bytes, which the next edit's freshness check 'corrected' back from the indexed path, erasing the routed state from the edit base.

Fix:
- Single-symbol tools (replace_symbol_body, insert_symbol, delete_symbol, edit_within_symbol): when rerouted and the target has diverged, the edit base is re-read and re-parsed from the target bytes, so symbol resolution and splicing run against worktree truth. The envelope reports 'Source authority: worktree target (rebased)'.
- Routed writes no longer update the index entry; the index keeps telling the truth about the indexed copy (regression: routed_edit_does_not_poison_index_entry).
- Batch executors (batch_edit / batch_insert / batch_rename) fail CLOSED on a diverged rerouted target with an actionable error instead of clobbering - their splices are index-resolved byte ranges; full batch rebase is a follow-up. The comparison is line-ending-insensitive so fresh Windows worktree checkouts (CRLF vs indexed LF) stay allowed.

New AC regressions (worktree_awareness): sequential same-file routed edits persist (same tool and across replace/edit_within/insert), index entry stays unpoisoned, diverged routed batch refuses without writing, identical-target routed batch still allowed.

Gates: cargo fmt --check, clippy --all-targets -D warnings, full cargo test --all-targets -- --test-threads=1 (0 failures, clean target dir).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core edit/splice and index-update behavior for worktree-routed writes; incorrect rebasing or batch guards could still corrupt files or block legitimate batch edits.
> 
> **Overview**
> **Fixes silent data loss when multiple worktree-routed edits hit the same file** — each call succeeded but only the last change survived because splices used index content and overwrote the worktree target.
> 
> **Single-symbol edit tools** (`replace_symbol_body`, `insert_symbol`, `delete_symbol`, `edit_within_symbol`) now call `rebase_edit_base_for_reroute`: when the path is rerouted and the worktree file differs from the index, the splice base is re-read and re-parsed from the target. Responses can show **Source authority: worktree target (rebased)** via new `EditSourceAuthority::WorktreeTarget`. **Routed writes skip `reindex_after_write`** so the index still reflects the indexed copy, not worktree bytes.
> 
> **Batch paths** (`batch_edit`, batch rename, `batch_insert`) call `guard_batch_reroute_divergence` and **error** if a rerouted target diverged (index-resolved ranges cannot rebase yet). Comparison ignores CRLF vs LF for fresh Windows worktrees.
> 
> **Tests** in `worktree_awareness.rs` cover sequential routed edits, index non-poisoning, diverged-batch refusal, and identical-target batch still allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808cdbcbd78795763e362ccd910bb2fa40dd0401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->