### PR TITLE
fix: dogfood open items — .symforge growth bounds, Tier-2 UX, NUL-byte honesty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2140,7 @@ dependencies = [
  "clap",
  "dirs",
  "dunce",
+ "filetime",
  "git2",
  "globset",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,8 @@ socket2 = { version = "0.6", optional = true }
 tempfile = "3"
 once_cell = "1"
 postcard = { version = "1.1", features = ["use-std"] }
+# Cross-platform mtime backdating for tee retention age-pruning tests.
+filetime = "0.2"
 
 [patch.crates-io]
 # Upstream build.rs uses `-Wno-unused-parameter` which MSVC rejects.

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -672,6 +672,82 @@ pub fn is_dependency_lockfile(path: &std::path::Path) -> bool {
         .is_some_and(|name| LOCKFILE_BASENAMES.contains(&name))
 }
 
+/// Maximum number of NUL byte offsets [`scan_nul_bytes`] enumerates explicitly.
+/// Beyond this we report only the count plus the first few offsets — the warning
+/// exists to alert, not to exhaustively map every NUL.
+pub const NUL_OFFSET_SAMPLE_LIMIT: usize = 5;
+
+/// Result of scanning a byte slice for literal NUL (`0x00`) bytes.
+///
+/// A NUL is valid UTF-8, so it survives `String::from_utf8_lossy` intact and is
+/// then rendered invisibly (most terminals show nothing or a space). Source code
+/// that smuggles a NUL into a string/template literal (legal for Node, Python,
+/// etc.) therefore reads back as text that does NOT byte-match the file — an
+/// agent copying that rendered text for an edit produces a mismatch. This scan
+/// powers an honest warning at the content-rendering boundary.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NulScan {
+    /// Total count of NUL bytes in the scanned slice.
+    pub count: usize,
+    /// Byte offsets (relative to the scanned slice) of the first
+    /// [`NUL_OFFSET_SAMPLE_LIMIT`] NUL bytes, in ascending order.
+    pub first_offsets: Vec<usize>,
+}
+
+impl NulScan {
+    /// `true` when the scanned slice contained at least one NUL byte.
+    pub fn has_nul(&self) -> bool {
+        self.count > 0
+    }
+}
+
+/// Scan `content` for literal NUL (`0x00`) bytes, returning a count and the
+/// first [`NUL_OFFSET_SAMPLE_LIMIT`] offsets. Pure; scans the WHOLE slice it is
+/// given (callers pass the exact bytes whose rendering they are warning about).
+pub fn scan_nul_bytes(content: &[u8]) -> NulScan {
+    let mut count = 0usize;
+    let mut first_offsets = Vec::new();
+    for (offset, &byte) in content.iter().enumerate() {
+        if byte == 0 {
+            count += 1;
+            if first_offsets.len() < NUL_OFFSET_SAMPLE_LIMIT {
+                first_offsets.push(offset);
+            }
+        }
+    }
+    NulScan {
+        count,
+        first_offsets,
+    }
+}
+
+/// Render a single-line warning describing NUL bytes found by [`scan_nul_bytes`],
+/// or `None` when the slice is clean. The message is deliberately blunt: copied
+/// rendered text will not byte-match the file, so edits must use byte-exact tools.
+pub fn nul_byte_warning_line(scan: &NulScan) -> Option<String> {
+    if !scan.has_nul() {
+        return None;
+    }
+    let offsets = scan
+        .first_offsets
+        .iter()
+        .map(|o| o.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let plural = if scan.count == 1 { "" } else { "s" };
+    let offset_suffix = if scan.count > scan.first_offsets.len() {
+        format!("{offsets}, ...")
+    } else {
+        offsets
+    };
+    Some(format!(
+        "WARNING: this file contains {} NUL byte{plural} (0x00) at byte offset(s) {offset_suffix}. \
+         They are rendered invisibly above; copied text will NOT byte-match the file. \
+         Edit this file with byte-exact tools, not rendered text.",
+        scan.count
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -992,5 +1068,63 @@ mod tests {
         };
         assert_eq!(sf.tier(), AdmissionTier::MetadataOnly);
         assert_eq!(sf.reason(), Some(SkipReason::DenylistedExtension));
+    }
+
+    #[test]
+    fn test_scan_nul_bytes_clean_slice_reports_none() {
+        let scan = scan_nul_bytes(b"fn main() {}\n");
+        assert!(!scan.has_nul());
+        assert_eq!(scan.count, 0);
+        assert!(scan.first_offsets.is_empty());
+        assert_eq!(nul_byte_warning_line(&scan), None);
+    }
+
+    #[test]
+    fn test_scan_nul_bytes_empty_slice_reports_none() {
+        let scan = scan_nul_bytes(b"");
+        assert!(!scan.has_nul());
+        assert_eq!(nul_byte_warning_line(&scan), None);
+    }
+
+    #[test]
+    fn test_scan_nul_bytes_single_offset_and_singular_warning() {
+        let scan = scan_nul_bytes(b"ab\0cd");
+        assert_eq!(scan.count, 1);
+        assert_eq!(scan.first_offsets, vec![2]);
+        let warning = nul_byte_warning_line(&scan).expect("NUL present");
+        assert!(warning.contains("1 NUL byte (0x00)"), "warning: {warning}");
+        assert!(
+            warning.contains("byte offset(s) 2."),
+            "single offset, no ellipsis: {warning}"
+        );
+        assert!(warning.contains("byte-exact tools"));
+    }
+
+    #[test]
+    fn test_scan_nul_bytes_plural_warning() {
+        let scan = scan_nul_bytes(b"\0a\0b");
+        assert_eq!(scan.count, 2);
+        assert_eq!(scan.first_offsets, vec![0, 2]);
+        let warning = nul_byte_warning_line(&scan).expect("NUL present");
+        assert!(warning.contains("2 NUL bytes (0x00)"), "warning: {warning}");
+        assert!(
+            warning.contains("byte offset(s) 0, 2."),
+            "warning: {warning}"
+        );
+    }
+
+    #[test]
+    fn test_scan_nul_bytes_caps_offsets_and_adds_ellipsis() {
+        // 7 NUL bytes; only the first NUL_OFFSET_SAMPLE_LIMIT (5) are enumerated.
+        let scan = scan_nul_bytes(b"\0\0\0\0\0\0\0");
+        assert_eq!(scan.count, 7);
+        assert_eq!(scan.first_offsets.len(), NUL_OFFSET_SAMPLE_LIMIT);
+        assert_eq!(scan.first_offsets, vec![0, 1, 2, 3, 4]);
+        let warning = nul_byte_warning_line(&scan).expect("NUL present");
+        assert!(warning.contains("7 NUL bytes"), "warning: {warning}");
+        assert!(
+            warning.contains("0, 1, 2, 3, 4, ..."),
+            "more NULs than sampled => ellipsis: {warning}"
+        );
     }
 }

--- a/src/edit_safety/tee.rs
+++ b/src/edit_safety/tee.rs
@@ -2,14 +2,82 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::paths;
 
-pub const TEE_MAX_FILES: usize = 20;
+/// Maximum number of edit snapshots retained in `.symforge/tee/`. Newer
+/// snapshots beyond this count are pruned at write time. Override with
+/// `SYMFORGE_TEE_MAX_COUNT`; set to `0` to disable count-based pruning.
+pub const TEE_MAX_FILES: usize = 200;
+
+/// Maximum age of a retained snapshot. Older snapshots are pruned at write
+/// time. Override with `SYMFORGE_TEE_MAX_AGE_DAYS`; set to `0` to disable
+/// age-based pruning.
+pub const TEE_MAX_AGE_DAYS: u64 = 7;
+
 pub const TEE_MAX_FILE_BYTES: usize = 1024 * 1024;
 
+/// Env override for the retained snapshot count (`0` disables count pruning).
+pub const TEE_MAX_COUNT_ENV: &str = "SYMFORGE_TEE_MAX_COUNT";
+/// Env override for the retained snapshot age in days (`0` disables age pruning).
+pub const TEE_MAX_AGE_DAYS_ENV: &str = "SYMFORGE_TEE_MAX_AGE_DAYS";
+
 static TEE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Retention limits applied to the tee directory after each snapshot write.
+/// `0` on either field disables that dimension of pruning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TeeRetention {
+    /// Keep at most this many snapshots; `0` disables count-based pruning.
+    pub max_count: usize,
+    /// Delete snapshots older than this; `None` disables age-based pruning.
+    pub max_age: Option<Duration>,
+}
+
+impl TeeRetention {
+    /// Resolve retention limits from the environment, falling back to the
+    /// compiled defaults. Mirrors the `*_from_value` / `*_from_env` pattern
+    /// used by `persist::checkpoint_interval_from_env`.
+    pub fn from_env() -> Self {
+        Self {
+            max_count: max_count_from_value(std::env::var(TEE_MAX_COUNT_ENV).ok().as_deref()),
+            max_age: max_age_from_value(std::env::var(TEE_MAX_AGE_DAYS_ENV).ok().as_deref()),
+        }
+    }
+}
+
+impl Default for TeeRetention {
+    fn default() -> Self {
+        Self {
+            max_count: TEE_MAX_FILES,
+            max_age: Some(Duration::from_secs(TEE_MAX_AGE_DAYS * 86_400)),
+        }
+    }
+}
+
+/// Parse the count override. Unparseable values fall back to the default.
+/// `0` is honored as "disable count pruning".
+fn max_count_from_value(raw: Option<&str>) -> usize {
+    match raw.map(str::trim) {
+        Some(value) if !value.is_empty() => value.parse::<usize>().unwrap_or(TEE_MAX_FILES),
+        _ => TEE_MAX_FILES,
+    }
+}
+
+/// Parse the age override (in days). Unparseable values fall back to the
+/// default. `0` disables age pruning (returns `None`).
+fn max_age_from_value(raw: Option<&str>) -> Option<Duration> {
+    let days = match raw.map(str::trim) {
+        Some(value) if !value.is_empty() => value.parse::<u64>().unwrap_or(TEE_MAX_AGE_DAYS),
+        _ => TEE_MAX_AGE_DAYS,
+    };
+    if days == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(days * 86_400))
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TeeRecord {
@@ -62,7 +130,7 @@ impl TeeSnapshot {
 #[derive(Debug, Clone)]
 pub struct Tee {
     repo_root: PathBuf,
-    max_files: usize,
+    retention: TeeRetention,
     max_file_bytes: u64,
 }
 
@@ -70,7 +138,17 @@ impl Tee {
     pub fn for_repo(repo_root: impl AsRef<Path>) -> Self {
         Self {
             repo_root: repo_root.as_ref().to_path_buf(),
-            max_files: TEE_MAX_FILES,
+            retention: TeeRetention::from_env(),
+            max_file_bytes: TEE_MAX_FILE_BYTES as u64,
+        }
+    }
+
+    /// Construct a `Tee` with explicit retention limits, bypassing env
+    /// resolution. Primarily for tests that exercise pruning behavior.
+    pub fn with_retention(repo_root: impl AsRef<Path>, retention: TeeRetention) -> Self {
+        Self {
+            repo_root: repo_root.as_ref().to_path_buf(),
+            retention,
             max_file_bytes: TEE_MAX_FILE_BYTES as u64,
         }
     }
@@ -138,7 +216,7 @@ impl Tee {
             });
         }
 
-        if let Err(err) = enforce_retention(&tee_dir, self.max_files) {
+        if let Err(err) = enforce_retention(&tee_dir, self.retention) {
             tracing::warn!(
                 "tee snapshot retention failed for {}: {err}",
                 tee_dir.display()
@@ -195,7 +273,74 @@ fn sanitize_file_name(file_name: &str) -> String {
         .collect()
 }
 
-fn enforce_retention(tee_dir: &Path, max_files: usize) -> io::Result<()> {
+/// One snapshot file considered for retention.
+struct TeeEntry {
+    modified: SystemTime,
+    name: std::ffi::OsString,
+    path: PathBuf,
+}
+
+/// Pure retention policy: given the current snapshot set and a reference
+/// `now`, decide which files to delete. Age pruning runs first (drop anything
+/// older than `max_age`), then count pruning trims the oldest survivors down
+/// to `max_count`. Both dimensions are independently disableable
+/// (`max_count == 0` / `max_age == None`).
+///
+/// Returns the paths to delete. Kept side-effect-free so it can be unit-tested
+/// with synthetic timestamps without manipulating filesystem mtimes.
+fn plan_retention(
+    mut entries: Vec<TeeEntry>,
+    retention: TeeRetention,
+    now: SystemTime,
+) -> Vec<PathBuf> {
+    // Oldest first so count pruning can take the leading prefix.
+    entries.sort_by(|a, b| {
+        a.modified
+            .cmp(&b.modified)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    let age_cutoff = retention
+        .max_age
+        .and_then(|max_age| now.checked_sub(max_age));
+
+    let mut to_delete = Vec::new();
+    let mut survivors = Vec::with_capacity(entries.len());
+
+    // Pass 1: age pruning.
+    for entry in entries {
+        if let Some(cutoff) = age_cutoff
+            && entry.modified < cutoff
+        {
+            to_delete.push(entry.path);
+        } else {
+            survivors.push(entry);
+        }
+    }
+
+    // Pass 2: count pruning over the age survivors.
+    if retention.max_count > 0 {
+        let excess = survivors.len().saturating_sub(retention.max_count);
+        for entry in survivors.into_iter().take(excess) {
+            to_delete.push(entry.path);
+        }
+    }
+
+    to_delete
+}
+
+/// Prune the tee directory to the supplied retention limits. Enforced at
+/// write time so no background job is needed. Reads the directory, then
+/// defers the keep/delete decision to the pure [`plan_retention`] so the
+/// policy is unit-testable without touching the filesystem clock.
+///
+/// Errors are surfaced to the caller, which logs and continues — pruning
+/// must never block an edit.
+fn enforce_retention(tee_dir: &Path, retention: TeeRetention) -> io::Result<()> {
+    if retention.max_count == 0 && retention.max_age.is_none() {
+        return Ok(());
+    }
+
     let mut entries = Vec::new();
     for entry in fs::read_dir(tee_dir)? {
         let entry = entry?;
@@ -204,18 +349,181 @@ fn enforce_retention(tee_dir: &Path, max_files: usize) -> io::Result<()> {
             continue;
         }
         let modified = metadata.modified().unwrap_or(UNIX_EPOCH);
-        entries.push((modified, entry.file_name(), entry.path()));
+        entries.push(TeeEntry {
+            modified,
+            name: entry.file_name(),
+            path: entry.path(),
+        });
     }
 
-    entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    let excess = entries.len().saturating_sub(max_files);
-    for (_, _, path) in entries.into_iter().take(excess) {
+    for path in plan_retention(entries, retention, SystemTime::now()) {
         fs::remove_file(path)?;
     }
+
     Ok(())
 }
 
 fn display_relative(repo_root: &Path, path: &Path) -> String {
     let display_path = path.strip_prefix(repo_root).unwrap_or(path);
     display_path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, modified: SystemTime) -> TeeEntry {
+        TeeEntry {
+            modified,
+            name: name.into(),
+            path: PathBuf::from(name),
+        }
+    }
+
+    fn ago(now: SystemTime, days: u64) -> SystemTime {
+        now.checked_sub(Duration::from_secs(days * 86_400)).unwrap()
+    }
+
+    fn deleted_names(paths: &[PathBuf]) -> Vec<String> {
+        let mut names: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    // ─── Env-value parsing ──────────────────────────────────────────────
+
+    #[test]
+    fn max_count_defaults_and_parses() {
+        assert_eq!(max_count_from_value(None), TEE_MAX_FILES);
+        assert_eq!(max_count_from_value(Some("")), TEE_MAX_FILES);
+        assert_eq!(max_count_from_value(Some("   ")), TEE_MAX_FILES);
+        assert_eq!(max_count_from_value(Some("50")), 50);
+        assert_eq!(max_count_from_value(Some(" 50 ")), 50);
+        // 0 disables count pruning (honored, not defaulted).
+        assert_eq!(max_count_from_value(Some("0")), 0);
+        // Garbage falls back to default.
+        assert_eq!(max_count_from_value(Some("nope")), TEE_MAX_FILES);
+    }
+
+    #[test]
+    fn max_age_defaults_and_parses() {
+        let default = Some(Duration::from_secs(TEE_MAX_AGE_DAYS * 86_400));
+        assert_eq!(max_age_from_value(None), default);
+        assert_eq!(max_age_from_value(Some("")), default);
+        assert_eq!(
+            max_age_from_value(Some("3")),
+            Some(Duration::from_secs(3 * 86_400))
+        );
+        // 0 disables age pruning.
+        assert_eq!(max_age_from_value(Some("0")), None);
+        // Garbage falls back to default.
+        assert_eq!(max_age_from_value(Some("nope")), default);
+    }
+
+    // ─── Pure retention policy ──────────────────────────────────────────
+
+    #[test]
+    fn plan_retention_prunes_by_age() {
+        let now = SystemTime::now();
+        let retention = TeeRetention {
+            max_count: 0, // count disabled — isolate age behavior
+            max_age: Some(Duration::from_secs(7 * 86_400)),
+        };
+        let entries = vec![
+            entry("old-10d", ago(now, 10)),
+            entry("old-8d", ago(now, 8)),
+            entry("fresh-1d", ago(now, 1)),
+            entry("fresh-now", now),
+        ];
+
+        let deleted = plan_retention(entries, retention, now);
+
+        assert_eq!(deleted_names(&deleted), vec!["old-10d", "old-8d"]);
+    }
+
+    #[test]
+    fn plan_retention_prunes_by_count() {
+        let now = SystemTime::now();
+        let retention = TeeRetention {
+            max_count: 2,
+            max_age: None, // age disabled — isolate count behavior
+        };
+        // Distinct mtimes so ordering is deterministic; all recent.
+        let entries = vec![
+            entry("a-oldest", ago(now, 4)),
+            entry("b", ago(now, 3)),
+            entry("c", ago(now, 2)),
+            entry("d-newest", ago(now, 1)),
+        ];
+
+        let deleted = plan_retention(entries, retention, now);
+
+        // Keep newest 2 (c, d); delete oldest 2 (a, b).
+        assert_eq!(deleted_names(&deleted), vec!["a-oldest", "b"]);
+    }
+
+    #[test]
+    fn plan_retention_applies_age_then_count() {
+        let now = SystemTime::now();
+        let retention = TeeRetention {
+            max_count: 1,
+            max_age: Some(Duration::from_secs(7 * 86_400)),
+        };
+        let entries = vec![
+            entry("old-9d", ago(now, 9)),    // age-pruned
+            entry("recent-3d", ago(now, 3)), // survives age, count-pruned
+            entry("recent-1d", ago(now, 1)), // survives both
+        ];
+
+        let deleted = plan_retention(entries, retention, now);
+
+        // old-9d dropped by age; of the 2 survivors keep newest 1 (recent-1d),
+        // so recent-3d is also deleted.
+        assert_eq!(deleted_names(&deleted), vec!["old-9d", "recent-3d"]);
+    }
+
+    #[test]
+    fn plan_retention_disabled_when_both_dimensions_off() {
+        let now = SystemTime::now();
+        let retention = TeeRetention {
+            max_count: 0,
+            max_age: None,
+        };
+        let entries = vec![
+            entry("ancient", ago(now, 365)),
+            entry("a", now),
+            entry("b", now),
+        ];
+
+        let deleted = plan_retention(entries, retention, now);
+
+        assert!(
+            deleted.is_empty(),
+            "no pruning when both dimensions disabled, got {deleted:?}"
+        );
+    }
+
+    #[test]
+    fn plan_retention_count_zero_keeps_all_recent() {
+        let now = SystemTime::now();
+        let retention = TeeRetention {
+            max_count: 0,
+            max_age: Some(Duration::from_secs(7 * 86_400)),
+        };
+        let entries = vec![
+            entry("a", now),
+            entry("b", ago(now, 2)),
+            entry("c", ago(now, 6)),
+        ];
+
+        let deleted = plan_retention(entries, retention, now);
+
+        assert!(
+            deleted.is_empty(),
+            "count=0 must not prune recent files, got {deleted:?}"
+        );
+    }
 }

--- a/src/live_index/coupling/schema.rs
+++ b/src/live_index/coupling/schema.rs
@@ -6,6 +6,10 @@ pub const META_SCHEMA_VERSION: &str = "schema_version";
 pub const META_LAST_HEAD: &str = "last_indexed_head_oid";
 pub const META_COLD_BUILT_AT: &str = "cold_build_completed_at";
 pub const META_LAST_REFERENCE_TS: &str = "last_reference_ts";
+/// Number of `commit_delta` applications since the last VACUUM. Persisted so
+/// the compaction cadence survives process restarts. Cold builds reset it to 0
+/// because they VACUUM unconditionally.
+pub const META_DELTA_SINCE_VACUUM: &str = "delta_since_vacuum";
 
 pub const SCHEMA_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS coupling_meta (

--- a/src/live_index/coupling/store.rs
+++ b/src/live_index/coupling/store.rs
@@ -14,7 +14,36 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use super::AnchorKey;
 use super::decay_factor;
-use super::schema::{CURRENT_SCHEMA_VERSION, META_LAST_HEAD, META_SCHEMA_VERSION, SCHEMA_V1};
+use super::schema::{
+    CURRENT_SCHEMA_VERSION, META_DELTA_SINCE_VACUUM, META_LAST_HEAD, META_SCHEMA_VERSION, SCHEMA_V1,
+};
+
+/// Run `VACUUM` after this many `commit_delta` applications to reclaim the
+/// free pages that incremental updates leave behind. Cold builds VACUUM
+/// unconditionally (they `DELETE` every row first), so this only governs the
+/// incremental path. Override with `SYMFORGE_COUPLING_VACUUM_EVERY`; `0`
+/// disables periodic delta-driven compaction entirely.
+pub const DEFAULT_DELTA_VACUUM_INTERVAL: u64 = 50;
+
+/// Env override for the delta-driven VACUUM cadence (`0` disables it).
+pub const COUPLING_VACUUM_EVERY_ENV: &str = "SYMFORGE_COUPLING_VACUUM_EVERY";
+
+/// Resolve the delta-driven VACUUM interval from the environment, falling back
+/// to [`DEFAULT_DELTA_VACUUM_INTERVAL`]. `0` disables periodic compaction.
+/// Unparseable values fall back to the default. Mirrors the testable
+/// `*_from_value` pattern used elsewhere in the codebase.
+pub fn delta_vacuum_interval_from_value(raw: Option<&str>) -> u64 {
+    match raw.map(str::trim) {
+        Some(value) if !value.is_empty() => value
+            .parse::<u64>()
+            .unwrap_or(DEFAULT_DELTA_VACUUM_INTERVAL),
+        _ => DEFAULT_DELTA_VACUUM_INTERVAL,
+    }
+}
+
+fn delta_vacuum_interval_from_env() -> u64 {
+    delta_vacuum_interval_from_value(std::env::var(COUPLING_VACUUM_EVERY_ENV).ok().as_deref())
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CouplingRow {
@@ -340,6 +369,72 @@ impl CouplingStore {
         Ok(())
     }
 
+    /// Reclaim free pages by rewriting the database file. SQLite never returns
+    /// pages freed by `DELETE` to the OS on its own (auto_vacuum is off), so
+    /// the file grows monotonically with churn until a `VACUUM` repacks it.
+    /// Must run outside any transaction.
+    pub fn vacuum(&self) -> Result<()> {
+        let conn = self.conn.lock().expect("coupling mutex poisoned");
+        conn.execute_batch("VACUUM")
+            .context("vacuuming coupling db")?;
+        Ok(())
+    }
+
+    /// Number of `commit_delta` applications recorded since the last VACUUM.
+    /// Reset to 0 by cold builds (which VACUUM unconditionally).
+    pub fn delta_since_vacuum(&self) -> Result<u64> {
+        let conn = self.conn.lock().expect("coupling mutex poisoned");
+        let s: Option<String> = conn
+            .query_row(
+                "SELECT value FROM coupling_meta WHERE key = ?1",
+                params![META_DELTA_SINCE_VACUUM],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(s.and_then(|v| v.parse().ok()).unwrap_or(0))
+    }
+
+    /// Increment the persisted delta-since-vacuum counter and, when the
+    /// configured interval is reached, VACUUM and reset the counter. The
+    /// counter is bumped inside the delta transaction (see `commit_delta`);
+    /// this method is the post-commit "maybe compact" step, so it reads the
+    /// freshly-committed counter and acts on it. A `0` interval disables
+    /// delta-driven compaction. VACUUM failures are non-fatal.
+    fn maybe_vacuum_after_delta(&self) {
+        let interval = delta_vacuum_interval_from_env();
+        if interval == 0 {
+            return;
+        }
+        let count = match self.delta_since_vacuum() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("coupling: reading delta-vacuum counter failed: {e}");
+                return;
+            }
+        };
+        if count < interval {
+            return;
+        }
+        if let Err(e) = self.vacuum() {
+            tracing::warn!("coupling: periodic delta VACUUM failed: {e}");
+            return;
+        }
+        if let Err(e) = self.reset_delta_since_vacuum() {
+            tracing::warn!("coupling: resetting delta-vacuum counter failed: {e}");
+        }
+    }
+
+    /// Reset the persisted delta-since-vacuum counter to 0.
+    fn reset_delta_since_vacuum(&self) -> Result<()> {
+        let conn = self.conn.lock().expect("coupling mutex poisoned");
+        conn.execute(
+            "INSERT INTO coupling_meta (key, value) VALUES (?1, '0')
+             ON CONFLICT(key) DO UPDATE SET value = '0'",
+            params![META_DELTA_SINCE_VACUUM],
+        )?;
+        Ok(())
+    }
+
     /// Snapshot of the commit OIDs currently inside the bounded window,
     /// keyed to their commit timestamp. Used by delta to diff against a
     /// freshly-computed window.
@@ -442,7 +537,24 @@ impl CouplingStore {
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             params![super::schema::META_COLD_BUILT_AT, reference_ts.to_string()],
         )?;
+        // A cold build always VACUUMs (below), so the delta-since-vacuum
+        // counter starts fresh from here.
+        tx.execute(
+            "INSERT INTO coupling_meta (key, value) VALUES (?1, '0')
+             ON CONFLICT(key) DO UPDATE SET value = '0'",
+            params![META_DELTA_SINCE_VACUUM],
+        )?;
         tx.commit()?;
+        drop(conn);
+
+        // Cold build `DELETE`s every row before reinserting, orphaning a large
+        // number of pages. VACUUM unconditionally to return them to the OS;
+        // cold builds are rare (first session / wipe / schema reset), so the
+        // cost is acceptable and this is the single highest-leverage bound on
+        // coupling.db growth. Non-fatal on failure.
+        if let Err(e) = self.vacuum() {
+            tracing::warn!("coupling: post-cold-build VACUUM failed: {e}");
+        }
         Ok(())
     }
 
@@ -627,7 +739,24 @@ impl CouplingStore {
             ],
         )?;
 
+        // Bump the delta-since-vacuum counter inside the same transaction so it
+        // advances exactly once per committed delta and survives restarts.
+        // Stored as TEXT to match the other meta values; COALESCE handles the
+        // first delta after a cold build / fresh store.
+        tx.execute(
+            "INSERT INTO coupling_meta (key, value) VALUES (?1, '1')
+             ON CONFLICT(key) DO UPDATE SET
+                 value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)",
+            params![META_DELTA_SINCE_VACUUM],
+        )?;
+
         tx.commit()?;
+        drop(conn);
+
+        // After committing, compact if the configured interval is reached.
+        // Deltas churn pages via the global rescale UPDATE; periodic VACUUM
+        // bounds the slow growth the incremental path leaves behind.
+        self.maybe_vacuum_after_delta();
         Ok(())
     }
 }
@@ -1047,5 +1176,229 @@ mod tests {
             row.shared_commits, 1,
             "pair_row returns row regardless of strength; floor is caller-applied"
         );
+    }
+
+    // ─── Compaction / VACUUM bounding ───────────────────────────────────
+
+    use std::sync::Mutex as StdMutex;
+
+    // Serialises COUPLING_VACUUM_EVERY_ENV mutation across tests. Project test
+    // policy already enforces --test-threads=1, but the lock makes the env
+    // contract explicit and robust to future parallelism.
+    static VACUUM_ENV_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[allow(unsafe_code)] // test-only env helper runs under VACUUM_ENV_LOCK.
+    fn set_vacuum_env(value: &str) {
+        // SAFETY: callers hold VACUUM_ENV_LOCK; tests run single-threaded.
+        unsafe { std::env::set_var(COUPLING_VACUUM_EVERY_ENV, value) };
+    }
+
+    #[allow(unsafe_code)] // test-only env helper runs under VACUUM_ENV_LOCK.
+    fn clear_vacuum_env() {
+        // SAFETY: callers hold VACUUM_ENV_LOCK; tests run single-threaded.
+        unsafe { std::env::remove_var(COUPLING_VACUUM_EVERY_ENV) };
+    }
+
+    fn ledger(oid: &str, anchor: &str, partner: &str, ts: i64) -> LedgerEdgeRow {
+        LedgerEdgeRow {
+            commit_oid: oid.to_string(),
+            anchor_key: AnchorKey::file(anchor).as_str().to_string(),
+            partner_key: AnchorKey::file(partner).as_str().to_string(),
+            shared_inc: 1,
+            base_weight: 1.0,
+            commit_ts: ts,
+        }
+    }
+
+    #[test]
+    fn delta_vacuum_interval_parses_and_defaults() {
+        assert_eq!(
+            delta_vacuum_interval_from_value(None),
+            DEFAULT_DELTA_VACUUM_INTERVAL
+        );
+        assert_eq!(
+            delta_vacuum_interval_from_value(Some("")),
+            DEFAULT_DELTA_VACUUM_INTERVAL
+        );
+        assert_eq!(delta_vacuum_interval_from_value(Some("10")), 10);
+        assert_eq!(delta_vacuum_interval_from_value(Some(" 10 ")), 10);
+        // 0 disables periodic compaction (honored, not defaulted).
+        assert_eq!(delta_vacuum_interval_from_value(Some("0")), 0);
+        // Garbage falls back to the default.
+        assert_eq!(
+            delta_vacuum_interval_from_value(Some("nope")),
+            DEFAULT_DELTA_VACUUM_INTERVAL
+        );
+    }
+
+    #[test]
+    fn cold_build_resets_delta_counter_to_zero() {
+        let store = CouplingStore::open_in_memory().unwrap();
+        // Simulate prior deltas having advanced the counter.
+        store.reset_delta_since_vacuum().unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO coupling_meta (key, value) VALUES (?1, '42')
+                 ON CONFLICT(key) DO UPDATE SET value = '42'",
+                params![META_DELTA_SINCE_VACUUM],
+            )
+            .unwrap();
+        }
+        assert_eq!(store.delta_since_vacuum().unwrap(), 42);
+
+        store
+            .commit_cold_build(
+                &[sample_row("a.rs", "b.rs", 1, 1.0, 100)],
+                &[("oid1".to_string(), 100)],
+                &[ledger("oid1", "a.rs", "b.rs", 100)],
+                Some("head1"),
+                100,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.delta_since_vacuum().unwrap(),
+            0,
+            "cold build must reset the delta-since-vacuum counter"
+        );
+    }
+
+    #[test]
+    fn commit_delta_increments_counter_without_vacuum_below_interval() {
+        let _lock = VACUUM_ENV_LOCK.lock().unwrap();
+        set_vacuum_env("100"); // high interval — no VACUUM during this test
+        let store = CouplingStore::open_in_memory().unwrap();
+
+        store
+            .commit_cold_build(&[], &[], &[], Some("head0"), 100)
+            .unwrap();
+        assert_eq!(store.delta_since_vacuum().unwrap(), 0);
+
+        for i in 1..=3 {
+            store
+                .commit_delta(
+                    &[(format!("oid{i}"), 100 + i)],
+                    &[ledger(&format!("oid{i}"), "a.rs", "b.rs", 100 + i)],
+                    &[],
+                    Some(&format!("head{i}")),
+                    Some(100),
+                    100 + i,
+                    1_000_000,
+                )
+                .unwrap();
+            assert_eq!(
+                store.delta_since_vacuum().unwrap(),
+                i as u64,
+                "counter advances once per delta"
+            );
+        }
+        clear_vacuum_env();
+    }
+
+    #[test]
+    fn periodic_vacuum_resets_counter_and_shrinks_file() {
+        let _lock = VACUUM_ENV_LOCK.lock().unwrap();
+        set_vacuum_env("2"); // VACUUM when counter reaches 2
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("coupling.db");
+        let store = CouplingStore::open(&db_path).unwrap();
+
+        // Seed a large aggregate, then churn it to create free pages so the
+        // VACUUM has something measurable to reclaim. Cold build VACUUMs, so
+        // start the counter clean afterwards.
+        let mut rows = Vec::new();
+        for i in 0..4000 {
+            rows.push(sample_row(
+                &format!("file_{i}.rs"),
+                &format!("file_{}.rs", i + 1),
+                1,
+                1.0,
+                100,
+            ));
+        }
+        store
+            .commit_cold_build(&rows, &[("oid0".to_string(), 100)], &[], Some("head0"), 100)
+            .unwrap();
+        assert_eq!(store.delta_since_vacuum().unwrap(), 0);
+
+        // First delta: counter -> 1, below interval, no VACUUM yet.
+        store
+            .commit_delta(
+                &[("oid1".to_string(), 101)],
+                &[ledger("oid1", "a.rs", "b.rs", 101)],
+                &[],
+                Some("head1"),
+                Some(100),
+                101,
+                1_000_000,
+            )
+            .unwrap();
+        assert_eq!(store.delta_since_vacuum().unwrap(), 1);
+
+        // Manually bloat the file: delete the bulk rows (frees pages) just
+        // before the delta that crosses the interval, so VACUUM reclaims them.
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute("DELETE FROM coupling", []).unwrap();
+        }
+        let size_before = std::fs::metadata(&db_path).unwrap().len();
+
+        // Second delta: counter -> 2, reaches interval, triggers VACUUM+reset.
+        store
+            .commit_delta(
+                &[("oid2".to_string(), 102)],
+                &[ledger("oid2", "a.rs", "b.rs", 102)],
+                &[],
+                Some("head2"),
+                Some(100),
+                102,
+                1_000_000,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.delta_since_vacuum().unwrap(),
+            0,
+            "reaching the interval must VACUUM and reset the counter"
+        );
+        let size_after = std::fs::metadata(&db_path).unwrap().len();
+        assert!(
+            size_after < size_before,
+            "VACUUM should shrink the file: before={size_before}, after={size_after}"
+        );
+        clear_vacuum_env();
+    }
+
+    #[test]
+    fn periodic_vacuum_disabled_when_interval_zero() {
+        let _lock = VACUUM_ENV_LOCK.lock().unwrap();
+        set_vacuum_env("0"); // disabled
+        let store = CouplingStore::open_in_memory().unwrap();
+        store
+            .commit_cold_build(&[], &[], &[], Some("head0"), 100)
+            .unwrap();
+
+        for i in 1..=5 {
+            store
+                .commit_delta(
+                    &[(format!("oid{i}"), 100 + i)],
+                    &[ledger(&format!("oid{i}"), "a.rs", "b.rs", 100 + i)],
+                    &[],
+                    Some(&format!("head{i}")),
+                    Some(100),
+                    100 + i,
+                    1_000_000,
+                )
+                .unwrap();
+        }
+        // Counter keeps climbing because compaction is disabled; it is never
+        // reset by a VACUUM.
+        assert_eq!(
+            store.delta_since_vacuum().unwrap(),
+            5,
+            "interval=0 disables periodic VACUUM, so the counter is never reset"
+        );
+        clear_vacuum_env();
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -209,6 +209,35 @@ fn collect_deepest_error_node(root: &Node, source: &str) -> Option<(String, u32,
     })
 }
 
+/// Append a NUL-byte hint to a tree-sitter diagnostic message when `source`
+/// contains literal `0x00` bytes. tree-sitter cannot parse NUL in source (the
+/// lexer treats it as input end / blank), so the deepest-error snippet looks
+/// like `syntax error near ` ` — meaningless on its own. The hint names the real
+/// cause and the offending offsets so health/quarantine output is actionable.
+fn augment_message_with_nul_hint(message: String, source: &[u8]) -> String {
+    let scan = crate::domain::index::scan_nul_bytes(source);
+    if !scan.has_nul() {
+        return message;
+    }
+    let offsets = scan
+        .first_offsets
+        .iter()
+        .map(|o| o.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let offset_suffix = if scan.count > scan.first_offsets.len() {
+        format!("{offsets}, ...")
+    } else {
+        offsets
+    };
+    let plural = if scan.count == 1 { "" } else { "s" };
+    format!(
+        "{message} (file contains {} NUL byte{plural} at offset(s) {offset_suffix}; \
+         tree-sitter cannot parse NUL in source)",
+        scan.count
+    )
+}
+
 fn error_candidate_is_better(
     candidate: Node,
     candidate_depth: usize,
@@ -286,7 +315,12 @@ pub(crate) fn parse_source(
         collect_deepest_error_node(&root, source).map(|(message, line, column, span)| {
             ParseDiagnostic {
                 parser: "tree-sitter".to_string(),
-                message,
+                // NUL bytes (0x00) are valid UTF-8 but tree-sitter cannot parse
+                // them in source — they truncate the lexer's view and render as a
+                // blank in the error snippet (`syntax error near ` `), hiding the
+                // real cause. When the source carries NUL bytes, append a hint so
+                // health/quarantine output explains the actual problem.
+                message: augment_message_with_nul_hint(message, source.as_bytes()),
                 line: Some(line),
                 column: Some(column),
                 byte_span: Some(span),
@@ -1359,6 +1393,54 @@ export function App() {
         let result = parse_source(&source, &LanguageId::Rust, false)
             .expect("parse_source must handle null-byte input without error");
         let (_symbols, _has_error, _diagnostic, _references, _aliases) = result;
+    }
+
+    #[test]
+    fn test_augment_message_with_nul_hint_appends_for_nul_source() {
+        // Pure-logic coverage: the hint is grammar-independent, so test it
+        // directly rather than depending on a specific tree-sitter error shape.
+        let augmented = augment_message_with_nul_hint(
+            "syntax error near ` `".to_string(),
+            b"const a = `x\0y`;\n",
+        );
+        assert!(
+            augmented.contains("file contains 1 NUL byte at offset(s) 12"),
+            "hint must name count and offset; got: {augmented}"
+        );
+        assert!(
+            augmented.contains("tree-sitter cannot parse NUL in source"),
+            "hint must explain the real cause; got: {augmented}"
+        );
+        // Original message is preserved.
+        assert!(augmented.starts_with("syntax error near ` `"));
+    }
+
+    #[test]
+    fn test_augment_message_with_nul_hint_noop_for_clean_source() {
+        let original = "syntax error near `oops`".to_string();
+        let augmented = augment_message_with_nul_hint(original.clone(), b"fn main() {}\n");
+        assert_eq!(augmented, original, "clean source must not gain a NUL hint");
+    }
+
+    #[test]
+    fn test_parse_source_diagnostic_carries_nul_hint_when_present() {
+        // A NUL smuggled into a JS template literal is valid for Node but makes
+        // tree-sitter-javascript produce a partial parse. When that happens the
+        // diagnostic must explain the NUL rather than the bare `near ` `` snippet.
+        // Robust against grammar behavior: if no diagnostic is produced we skip
+        // (the augment helper is covered directly above).
+        let source = "function mint() {\n  const token = `prefix\0suffix`;\n  return token;\n}\n";
+        let (_symbols, has_error, diagnostic, _refs, _aliases) =
+            parse_source(source, &LanguageId::JavaScript, false)
+                .expect("parse_source must not crash on a NUL-bearing template literal");
+        if has_error && let Some(diag) = diagnostic {
+            assert!(
+                diag.message
+                    .contains("tree-sitter cannot parse NUL in source"),
+                "diagnostic must carry the NUL hint; got: {}",
+                diag.message
+            );
+        }
     }
 
     #[test]

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -2732,6 +2732,25 @@ pub const GET_FILE_CONTENT_MAX_BYTES: usize = 60_000;
 /// Returns `output` unchanged when `output.len() <= GET_FILE_CONTENT_MAX_BYTES`.
 /// Otherwise truncates at the last `\n` boundary under the cap and appends a
 /// footer suggesting narrower read modes. Idempotent.
+/// Append an honest NUL-byte warning to already-rendered `get_file_content`
+/// output when `content` contains literal NUL (`0x00`) bytes.
+///
+/// Central rendering-boundary guard. NUL is valid UTF-8, so it passes
+/// `String::from_utf8_lossy` untouched and then renders invisibly (terminals
+/// show nothing or a space). An agent that copies the rendered text for an edit
+/// gets bytes that do NOT match the file. The warning is appended AFTER the byte
+/// cap so truncation can never drop it. `content` is the exact byte slice whose
+/// rendering `output` represents (the full file for whole-file reads), so the
+/// reported count/offsets describe what was actually scanned.
+pub fn append_nul_byte_warning(output: String, content: &[u8]) -> String {
+    let scan = crate::domain::index::scan_nul_bytes(content);
+    match crate::domain::index::nul_byte_warning_line(&scan) {
+        Some(warning) if output.is_empty() => warning,
+        Some(warning) => format!("{output}\n{warning}"),
+        None => output,
+    }
+}
+
 pub fn cap_file_content_output(output: String) -> String {
     if output.len() <= GET_FILE_CONTENT_MAX_BYTES {
         return output;

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -33,7 +33,7 @@ impl Default for OutputLimits {
     }
 }
 
-use crate::domain::index::{AdmissionTier, SkippedFile};
+use crate::domain::index::{AdmissionTier, SkipReason, SkippedFile};
 use crate::live_index::query::{
     EXPECTED_FRAMEWORK_PARTIAL_PARSE_REASON, EXPECTED_LANGUAGE_PARTIAL_PARSE_REASON,
     EXPECTED_VENDOR_PARTIAL_PARSE_REASON,
@@ -2782,6 +2782,47 @@ pub fn not_found_file_with_suggestions(path: &str, suggestions: &[String]) -> St
     } else {
         let top: Vec<&str> = suggestions.iter().take(5).map(|s| s.as_str()).collect();
         format!("File not found: {path}. Did you mean: {}?", top.join(", "))
+    }
+}
+
+/// Honest "not indexed" response for a path that EXISTS but was deliberately
+/// admitted as Tier-2 (metadata-only) or Tier-3 (hard-skipped) rather than
+/// parsed. Distinct from `not_found_file`: the file is present on disk, so a
+/// bare "File not found" is wrong and confusing. This message names the tier,
+/// the skip reason, and the size, and points the caller at the documented
+/// escape hatch (`get_file_content` reads Tier-2 files raw from disk).
+///
+/// Example (Tier 2):
+///   `Not indexed: package-lock.json is Tier 2 (metadata only) — reason:
+///    lockfile, size 406 KB. Use get_file_content for raw reads if you need
+///    the contents.`
+pub fn not_indexed_skipped_file(
+    path: &str,
+    tier: AdmissionTier,
+    reason: Option<SkipReason>,
+    size: Option<u64>,
+) -> String {
+    let reason_str = reason
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "skipped".to_string());
+    let size_str = size
+        .map(human_size)
+        .unwrap_or_else(|| "unknown".to_string());
+    match tier {
+        AdmissionTier::Normal => {
+            // Not a skip; callers should never reach here with a Normal tier,
+            // but degrade gracefully rather than assert.
+            not_found_file(path)
+        }
+        AdmissionTier::MetadataOnly => format!(
+            "Not indexed: {path} is Tier 2 (metadata only) — reason: {reason_str}, size {size_str}. \
+             Use get_file_content for raw reads if you need the contents."
+        ),
+        AdmissionTier::HardSkip => format!(
+            "Not indexed: {path} is Tier 3 (hard-skipped) — reason: {reason_str}, size {size_str}. \
+             This file is not parsed or read; get_file_content may still read it raw if it is a \
+             text file within the repository."
+        ),
     }
 }
 

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -2540,6 +2540,43 @@ fn test_not_found_file_format() {
 }
 
 #[test]
+fn test_not_indexed_skipped_file_tier2_message() {
+    let result = not_indexed_skipped_file(
+        "package-lock.json",
+        AdmissionTier::MetadataOnly,
+        Some(SkipReason::DependencyLockfile),
+        Some(406 * 1024),
+    );
+    assert_eq!(
+        result,
+        "Not indexed: package-lock.json is Tier 2 (metadata only) — reason: lockfile, size 406 KB. \
+         Use get_file_content for raw reads if you need the contents."
+    );
+}
+
+#[test]
+fn test_not_indexed_skipped_file_tier3_message() {
+    let result = not_indexed_skipped_file(
+        "big.bin",
+        AdmissionTier::HardSkip,
+        Some(SkipReason::SizeCeiling),
+        Some(200 * 1024 * 1024),
+    );
+    assert!(
+        result.starts_with("Not indexed: big.bin is Tier 3 (hard-skipped) — reason: >100MB"),
+        "Tier-3 message should name tier and reason; got: {result}"
+    );
+}
+
+#[test]
+fn test_not_indexed_skipped_file_handles_missing_metadata() {
+    // Defensive: unknown reason/size must not panic and must render placeholders.
+    let result = not_indexed_skipped_file("vendor/x.lock", AdmissionTier::MetadataOnly, None, None);
+    assert!(result.contains("reason: skipped"), "got: {result}");
+    assert!(result.contains("size unknown"), "got: {result}");
+}
+
+#[test]
 fn test_not_found_symbol_lists_available() {
     let sym = make_symbol("existing_fn", SymbolKind::Function, 0, 1, 5);
     let (key, file) = make_file("src/lib.rs", b"fn existing_fn() {}", vec![sym]);

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -5897,10 +5897,14 @@ impl SymForgeServer {
                 // collection policy is resolved inside bump_frecency. See wiki
                 // `[[SymForge Frecency-Weighted File Ranking]]` §"Bump hooks".
                 self.bump_frecency(&[PathBuf::from(&input.path)]);
-                format::enforce_token_budget(
-                    format::cap_file_content_output(format!("{}{}", mode_annotation, output)),
-                    max_tokens,
-                )
+                // NUL-byte guard: append an honest warning (after the byte cap so
+                // truncation can never drop it) when the file content contains
+                // literal 0x00 bytes that render invisibly. See
+                // `format::append_nul_byte_warning`.
+                let capped =
+                    format::cap_file_content_output(format!("{}{}", mode_annotation, output));
+                let with_warning = format::append_nul_byte_warning(capped, &file.as_ref().content);
+                format::enforce_token_budget(with_warning, max_tokens)
             }
             None => {
                 // Not in index — try raw disk read for non-source files
@@ -5930,13 +5934,15 @@ impl SymForgeServer {
                                 // fallback branch (non-indexed source files);
                                 // collection policy is resolved inside bump_frecency.
                                 self.bump_frecency(&[PathBuf::from(&input.path)]);
-                                return format::enforce_token_budget(
-                                    format::cap_file_content_output(format!(
-                                        "{}{}",
-                                        mode_annotation, body
-                                    )),
-                                    max_tokens,
-                                );
+                                // NUL-byte guard (raw-disk fallback branch):
+                                // mirror the indexed branch — warn after the cap.
+                                let capped = format::cap_file_content_output(format!(
+                                    "{}{}",
+                                    mode_annotation, body
+                                ));
+                                let with_warning =
+                                    format::append_nul_byte_warning(capped, &content);
+                                return format::enforce_token_budget(with_warning, max_tokens);
                             }
                             Err(e) => {
                                 return format!("{} [error: could not read file: {e}]", input.path);
@@ -9102,6 +9108,190 @@ mod tests {
         assert!(
             !missing.contains("outside the repository root"),
             "an in-repo missing file must not be misreported as outside-root; got: {missing}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_content_indexed_nul_byte_appends_warning() {
+        // A source file with a NUL (0x00) mid-content (mirrors the mint.js case:
+        // valid for Node, smuggled into a template literal). It passes the
+        // first-8KB binary sniff and gets indexed, so get_file_content renders it.
+        // The NUL renders invisibly; the warning must make that explicit.
+        let content = b"const a = `x\0y`;\nfn anchor() {}\n";
+        let nul_offset = content.iter().position(|&b| b == 0).unwrap();
+        let sym = SymbolRecord {
+            name: "anchor".to_string(),
+            kind: SymbolKind::Function,
+            depth: 0,
+            sort_order: 0,
+            byte_range: (16, content.len() as u32),
+            line_range: (1, 1),
+            doc_byte_range: None,
+            item_byte_range: None,
+        };
+        let (key, file) = make_file("src/mint.js", content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let out = server
+            .get_file_content(Parameters(get_file_content_input("src/mint.js")))
+            .await;
+
+        assert!(
+            out.contains("WARNING: this file contains 1 NUL byte (0x00)"),
+            "NUL warning must be present; got: {out}"
+        );
+        assert!(
+            out.contains(&format!("byte offset(s) {nul_offset}")),
+            "warning must report the NUL byte offset {nul_offset}; got: {out}"
+        );
+        assert!(
+            out.contains("byte-exact tools"),
+            "warning must steer agents to byte-exact edits; got: {out}"
+        );
+        // Symbols are still extracted best-effort: get_file_content renders fine.
+        assert!(
+            out.contains("anchor"),
+            "content must still render; got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_content_no_nul_has_no_warning() {
+        // No false positives: a clean source file must not gain a NUL warning.
+        let content = b"const a = `xy`;\nfn anchor() {}\n";
+        let sym = SymbolRecord {
+            name: "anchor".to_string(),
+            kind: SymbolKind::Function,
+            depth: 0,
+            sort_order: 0,
+            byte_range: (15, content.len() as u32),
+            line_range: (1, 1),
+            doc_byte_range: None,
+            item_byte_range: None,
+        };
+        let (key, file) = make_file("src/clean.js", content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let out = server
+            .get_file_content(Parameters(get_file_content_input("src/clean.js")))
+            .await;
+
+        assert!(
+            !out.contains("NUL byte"),
+            "clean file must not gain a NUL warning; got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_content_raw_disk_fallback_nul_warning() {
+        // Raw-disk fallback branch (file not in index): the warning must also fire
+        // there, using the bytes read from disk.
+        let repo = TempDir::new().expect("temp repo");
+        let content = b"plain text\0with a nul\n";
+        let nul_offset = content.iter().position(|&b| b == 0).unwrap();
+        fs::write(repo.path().join("notes.txt"), content).expect("write nul file");
+        let server = make_server_with_root(
+            make_live_index_ready(vec![]),
+            Some(repo.path().to_path_buf()),
+        );
+
+        let out = server
+            .get_file_content(Parameters(get_file_content_input("notes.txt")))
+            .await;
+        assert!(
+            out.contains("WARNING: this file contains 1 NUL byte (0x00)"),
+            "raw-disk fallback must also warn on NUL; got: {out}"
+        );
+        assert!(
+            out.contains(&format!("byte offset(s) {nul_offset}")),
+            "raw-disk warning must report the NUL offset {nul_offset}; got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_symbol_body_preserves_nul_after_edited_symbol() {
+        // Byte-exactness guarantee: editing a symbol that sits BEFORE a NUL byte
+        // must leave the NUL intact on disk. The splice (apply_splice) copies the
+        // SUFFIX bytes (everything after the symbol, including the NUL) verbatim —
+        // it never re-renders the untouched file region. `target` is parsed from
+        // the clean prefix; the NUL lives in a later raw-string literal.
+        let original =
+            b"fn target() {\n    let x = 1;\n}\n\nfn after() {\n    let _b = \"lead\0tail\";\n}\n";
+        assert!(original.contains(&0u8), "fixture must contain a NUL");
+        let (_dir, server, file_path) = setup_edit_test(original);
+
+        let input = crate::protocol::edit::ReplaceSymbolBodyInput {
+            path: "src/lib.rs".to_string(),
+            name: "target".to_string(),
+            kind: None,
+            symbol_line: None,
+            new_body: "fn target() {\n    let x = 42;\n}".to_string(),
+            dry_run: None,
+            idempotency_key: None,
+            working_directory: None,
+        };
+        let result = server.replace_symbol_body(Parameters(input)).await;
+        assert!(result.contains("replaced"), "result was: {result}");
+
+        // Read back RAW bytes: the NUL must still be present, embedded in the
+        // untouched suffix literal that apply_splice copied verbatim.
+        let on_disk = std::fs::read(&file_path).unwrap();
+        let on_disk_nul = on_disk
+            .iter()
+            .position(|&b| b == 0)
+            .expect("NUL byte must survive an edit to an earlier symbol");
+        assert_eq!(
+            &on_disk[on_disk_nul - 4..on_disk_nul],
+            b"lead",
+            "NUL must remain embedded in the untouched suffix literal"
+        );
+        assert!(
+            on_disk.windows(b"x = 42".len()).any(|w| w == b"x = 42"),
+            "new body must be written"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_preserves_nul_after_edited_symbol() {
+        // Same byte-exactness guarantee for edit_within_symbol.
+        let original =
+            b"fn target() {\n    let x = 1;\n}\n\nfn after() {\n    let _b = \"lead\0tail\";\n}\n";
+        let (_dir, server, file_path) = setup_edit_test(original);
+
+        let result = server
+            .edit_within_symbol(Parameters(crate::protocol::edit::EditWithinSymbolInput {
+                path: "src/lib.rs".to_string(),
+                name: "target".to_string(),
+                kind: None,
+                symbol_line: None,
+                old_text: "let x = 1;".to_string(),
+                new_text: "let x = 7;".to_string(),
+                replace_all: false,
+                dry_run: None,
+                idempotency_key: None,
+                working_directory: None,
+            }))
+            .await;
+        assert!(
+            result.contains("edited within `target`"),
+            "result was: {result}"
+        );
+
+        let on_disk = std::fs::read(&file_path).unwrap();
+        let on_disk_nul = on_disk
+            .iter()
+            .position(|&b| b == 0)
+            .expect("NUL must survive edit_within_symbol on an earlier symbol");
+        assert_eq!(
+            &on_disk[on_disk_nul - 4..on_disk_nul],
+            b"lead",
+            "NUL must remain embedded in the untouched suffix literal"
+        );
+        assert!(
+            on_disk
+                .windows(b"let x = 7;".len())
+                .any(|w| w == b"let x = 7;"),
+            "new text must be written"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2148,6 +2148,34 @@ fn admission_tier_degradation_for_path(
     }
 }
 
+/// File-level (non-symbol) variant of admission-tier degradation. Returns an
+/// honest "not indexed" message for a path that EXISTS but was admitted as
+/// Tier-2 metadata-only or Tier-3 hard-skipped, instead of a misleading
+/// "File not found". Resolution reuses the same index-lookup + disk-fallback
+/// path as `admission_tier_degradation_for_path`, so the containment guard in
+/// `admission_degradation_view_from_disk` (path must stay within the repo root)
+/// is preserved. `None` means the path is either Tier-1 (indexed) or genuinely
+/// absent — the caller should fall through to its normal not-found handling.
+fn admission_tier_file_degradation_for_path(
+    index: &LiveIndex,
+    repo_root: Option<&Path>,
+    path: &str,
+) -> Option<String> {
+    let view = index
+        .capture_admission_tier_lookup_view(path)
+        .map(admission_degradation_view_from_lookup)
+        .or_else(|| repo_root.and_then(|root| admission_degradation_view_from_disk(root, path)))?;
+    if view.tier == AdmissionTier::Normal {
+        return None;
+    }
+    Some(format::not_indexed_skipped_file(
+        &view.path,
+        view.tier,
+        view.reason,
+        view.size,
+    ))
+}
+
 fn find_references_match_type_label(input: &FindReferencesInput, mode: &str) -> &'static str {
     if mode == "implementations" {
         return "constrained (implementations mode)";
@@ -3079,6 +3107,27 @@ impl SymForgeServer {
             guard.capture_shared_file(&params.0.path)
         };
 
+        // Honest Tier-2/Tier-3 response before any miss handling: a path like
+        // package-lock.json EXISTS but is admitted metadata-only, so it has no
+        // symbols to return. Name the tier and point at get_file_content for raw
+        // reads instead of "File not found". Only runs when the file is not in
+        // the index (Tier-1 files resolve above).
+        if file.is_none() {
+            let repo_root = self.capture_repo_root();
+            let degraded = {
+                let guard = self.index.read();
+                loading_guard!(guard);
+                admission_tier_file_degradation_for_path(
+                    &guard,
+                    repo_root.as_deref(),
+                    &params.0.path,
+                )
+            };
+            if let Some(result) = degraded {
+                return result;
+            }
+        }
+
         // Estimate mode: return token cost without full content
         if params.0.estimate == Some(true) {
             if let Some(ref file) = file {
@@ -3325,6 +3374,27 @@ impl SymForgeServer {
     pub(crate) async fn get_file_context(&self, params: Parameters<GetFileContextInput>) -> String {
         if let Some(result) = self.proxy_tool_call("get_file_context", &params.0).await {
             return result;
+        }
+        // Honest Tier-2/Tier-3 response: the path may EXIST on disk but be
+        // deliberately admitted as metadata-only (e.g. package-lock.json) or
+        // hard-skipped. Return an actionable "not indexed" message pointing at
+        // get_file_content for raw reads, instead of a misleading
+        // "File not found". Resolution reuses the index lookup + repo-root-bound
+        // disk fallback shared with the symbol-level degradation path.
+        {
+            let repo_root = self.capture_repo_root();
+            let degraded = {
+                let guard = self.index.read();
+                loading_guard!(guard);
+                admission_tier_file_degradation_for_path(
+                    &guard,
+                    repo_root.as_deref(),
+                    &params.0.path,
+                )
+            };
+            if let Some(result) = degraded {
+                return result;
+            }
         }
         if params.0.estimate == Some(true) {
             let guard = self.index.read();
@@ -5848,18 +5918,41 @@ impl SymForgeServer {
         }
         // Estimate mode: return token cost without reading content
         if input.estimate == Some(true) {
-            let guard = self.index.read();
-            loading_guard!(guard);
-            if let Some(file) = guard.capture_shared_file(&input.path) {
+            let indexed = {
+                let guard = self.index.read();
+                loading_guard!(guard);
+                guard.capture_shared_file(&input.path)
+            };
+            if let Some(file) = indexed {
                 let file_tokens = file.content.len() / 4;
                 let line_count = file.content.iter().filter(|&&b| b == b'\n').count();
                 return format!(
                     "Estimate for get_file_content(path=\"{}\"):\n  ~{} tokens (~{} lines)",
                     input.path, file_tokens, line_count
                 );
-            } else {
-                return format::not_found_file(&input.path);
             }
+            // Not indexed: get_file_content still serves Tier-2 (and other
+            // non-source) files via a raw disk read, so the estimate should
+            // reflect the disk file rather than reporting "File not found".
+            // Reuse the same repo-root containment guard as the main read path.
+            if let Some(root) = self.capture_repo_root() {
+                match edit::safe_repo_path(&root, &input.path) {
+                    Ok(canon_path) if canon_path.is_file() => {
+                        if let Ok(metadata) = std::fs::metadata(&canon_path) {
+                            let file_tokens = metadata.len() as usize / 4;
+                            return format!(
+                                "Estimate for get_file_content(path=\"{}\"):\n  ~{} tokens (raw disk read; not indexed)",
+                                input.path, file_tokens
+                            );
+                        }
+                    }
+                    Err(message) if message.contains("outside the repository") => {
+                        return format::path_outside_repo(&input.path);
+                    }
+                    _ => {}
+                }
+            }
+            return format::not_found_file(&input.path);
         }
 
         let options = match file_content_options_from_input(&input) {
@@ -8196,6 +8289,39 @@ mod tests {
         index
     }
 
+    /// Build a ready index that knows `path` only as a Tier-2 metadata-only skip
+    /// record (e.g. a dependency lockfile) — the path is NOT in `files`,
+    /// mirroring the post-admission state where lockfiles are demoted instead of
+    /// parsed. One real Tier-1 source file is also seeded so the index reports
+    /// `Ready` (an index with zero Tier-1 files reports `Empty`, matching a real
+    /// repo where source coexists with the lockfile). Used to exercise the honest
+    /// "not indexed" degradation responses in
+    /// get_file_context / get_symbol / get_file_content.
+    fn make_live_index_with_tier2_skip(
+        path: &str,
+        size: u64,
+        reason: crate::domain::index::SkipReason,
+    ) -> LiveIndex {
+        use crate::domain::index::{AdmissionDecision, AdmissionTier, SkippedFile};
+        let (anchor_key, anchor_file) = make_file(
+            "src/anchor.rs",
+            b"fn anchor() {}\n",
+            vec![make_symbol("anchor", SymbolKind::Function, 0, 0)],
+        );
+        let mut index = make_live_index_ready(vec![(anchor_key, anchor_file)]);
+        let extension = std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_string);
+        index.skipped_files = vec![SkippedFile {
+            path: path.to_string(),
+            size,
+            extension,
+            decision: AdmissionDecision::skip(AdmissionTier::MetadataOnly, reason),
+        }];
+        index
+    }
+
     fn make_live_index_ready_with_coupling_store(
         files: Vec<(String, IndexedFile)>,
         store: crate::live_index::coupling::CouplingStore,
@@ -9102,6 +9228,134 @@ mod tests {
         assert!(
             !missing.contains("outside the repository root"),
             "an in-repo missing file must not be misreported as outside-root; got: {missing}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_context_tier2_lockfile_returns_metadata_only_message() {
+        // A Tier-2 metadata-only path (e.g. package-lock.json) EXISTS but is
+        // deliberately not parsed. get_file_context must say so honestly and
+        // point at get_file_content, NOT report a misleading "File not found".
+        let index = make_live_index_with_tier2_skip(
+            "package-lock.json",
+            406 * 1024,
+            crate::domain::index::SkipReason::DependencyLockfile,
+        );
+        let server = make_server(index);
+
+        let result = server
+            .get_file_context(Parameters(super::GetFileContextInput {
+                path: "package-lock.json".to_string(),
+                max_tokens: None,
+                sections: None,
+                estimate: None,
+            }))
+            .await;
+
+        assert!(
+            result.contains("Not indexed: package-lock.json is Tier 2 (metadata only)"),
+            "Tier-2 path must report metadata-only status; got: {result}"
+        );
+        assert!(
+            result.contains("reason: lockfile"),
+            "message must name the skip reason; got: {result}"
+        );
+        assert!(
+            result.contains("get_file_content"),
+            "message must point at the raw-read escape hatch; got: {result}"
+        );
+        assert!(
+            !result.starts_with("File not found"),
+            "Tier-2 path must NOT be reported as a generic miss; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_tier2_lockfile_returns_metadata_only_message() {
+        // get_symbol on a Tier-2 metadata-only path has no symbols to return;
+        // it must degrade to the honest "not indexed" message rather than a
+        // bare "File not found" (which would imply the file is absent).
+        let index = make_live_index_with_tier2_skip(
+            "package-lock.json",
+            406 * 1024,
+            crate::domain::index::SkipReason::DependencyLockfile,
+        );
+        let server = make_server(index);
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input(
+                "package-lock.json",
+                "anything",
+            )))
+            .await;
+
+        assert!(
+            result.contains("Not indexed: package-lock.json is Tier 2 (metadata only)"),
+            "Tier-2 path must report metadata-only status; got: {result}"
+        );
+        assert!(
+            !result.starts_with("File not found"),
+            "Tier-2 path must NOT be reported as a generic miss; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_content_tier2_lockfile_returns_raw_disk_content() {
+        // Chosen semantics: get_file_content is the documented escape hatch for
+        // Tier-2 files. Even though package-lock.json is metadata-only (not in
+        // the index), get_file_content must still serve its raw bytes from disk.
+        let repo = TempDir::new().expect("temp repo");
+        let lockfile_body = b"{\n  \"name\": \"demo\",\n  \"lockfileVersion\": 3\n}\n";
+        fs::write(repo.path().join("package-lock.json"), lockfile_body)
+            .expect("write lockfile to disk");
+        let index = make_live_index_with_tier2_skip(
+            "package-lock.json",
+            lockfile_body.len() as u64,
+            crate::domain::index::SkipReason::DependencyLockfile,
+        );
+        let server = make_server_with_root(index, Some(repo.path().to_path_buf()));
+
+        let result = server
+            .get_file_content(Parameters(get_file_content_input("package-lock.json")))
+            .await;
+
+        assert!(
+            result.contains("\"lockfileVersion\": 3"),
+            "get_file_content must serve Tier-2 file raw from disk; got: {result}"
+        );
+        assert!(
+            !result.starts_with("File not found"),
+            "Tier-2 escape hatch must not report a miss; got: {result}"
+        );
+        assert!(
+            !result.contains("Not indexed:"),
+            "get_file_content must read the file, not degrade to the Tier-2 notice; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_file_context_genuinely_missing_path_still_not_found() {
+        // A path that is neither indexed nor a known skip nor present on disk
+        // must still report a plain "File not found", preserving the existing
+        // close-match suggestion behavior where applicable.
+        let server = make_server(make_live_index_ready(vec![]));
+
+        let result = server
+            .get_file_context(Parameters(super::GetFileContextInput {
+                path: "totally/absent/file.rs".to_string(),
+                max_tokens: None,
+                sections: None,
+                estimate: None,
+            }))
+            .await;
+
+        assert!(
+            result.starts_with("File not found"),
+            "genuinely missing path must report a plain not-found; got: {result}"
+        );
+        assert!(
+            !result.contains("Not indexed:"),
+            "absent path must not be misreported as a Tier-2 skip; got: {result}"
         );
     }
 

--- a/tests/edit_safety_tee.rs
+++ b/tests/edit_safety_tee.rs
@@ -1,4 +1,5 @@
-use symforge::edit_safety::tee::{TEE_MAX_FILE_BYTES, TEE_MAX_FILES, Tee, TeeSnapshot};
+use std::time::Duration;
+use symforge::edit_safety::tee::{TEE_MAX_FILE_BYTES, Tee, TeeRetention, TeeSnapshot};
 
 #[test]
 fn tee_snapshot_creates_recovery_copy_under_symforge_dir() {
@@ -27,16 +28,24 @@ fn tee_snapshot_creates_recovery_copy_under_symforge_dir() {
 }
 
 #[test]
-fn tee_snapshot_retains_at_most_twenty_records() {
+fn tee_snapshot_retains_at_most_max_count_records() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::create_dir(temp.path().join(".git")).unwrap();
     let file_path = temp.path().join("src/lib.rs");
     std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
     std::fs::write(&file_path, b"pub fn original() {}\n").unwrap();
 
-    let tee = Tee::for_repo(temp.path());
+    // Small explicit cap keeps the test fast and independent of env defaults.
+    const CAP: usize = 5;
+    let tee = Tee::with_retention(
+        temp.path(),
+        TeeRetention {
+            max_count: CAP,
+            max_age: None,
+        },
+    );
     let mut created_paths = Vec::new();
-    for i in 0..=TEE_MAX_FILES {
+    for i in 0..=CAP {
         std::fs::write(&file_path, format!("pub fn version_{i}() {{}}\n")).unwrap();
         let record = match tee.snapshot(&file_path).unwrap() {
             TeeSnapshot::Created(record) => record,
@@ -47,7 +56,7 @@ fn tee_snapshot_retains_at_most_twenty_records() {
 
     let tee_dir = temp.path().join(".symforge").join("tee");
     let retained = std::fs::read_dir(&tee_dir).unwrap().count();
-    assert_eq!(retained, TEE_MAX_FILES);
+    assert_eq!(retained, CAP);
     assert!(
         !created_paths[0].exists(),
         "oldest snapshot should be evicted"
@@ -56,6 +65,90 @@ fn tee_snapshot_retains_at_most_twenty_records() {
         created_paths.last().unwrap().exists(),
         "newest snapshot should be retained"
     );
+}
+
+#[test]
+fn tee_snapshot_prunes_by_age_at_write_time() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+    let tee_dir = temp.path().join(".symforge").join("tee");
+    std::fs::create_dir_all(&tee_dir).unwrap();
+
+    // Plant a stale snapshot far in the past, with a synthetic old mtime
+    // applied via a backdated copy through SystemTime arithmetic on the file.
+    let stale = tee_dir.join("0000000000000-000000-old.rs");
+    std::fs::write(&stale, b"stale\n").unwrap();
+    set_mtime_days_ago(&stale, 30);
+
+    // A current file to snapshot. With a 7-day age cap the write should prune
+    // the 30-day-old stale snapshot but keep the fresh one.
+    let file_path = temp.path().join("src/lib.rs");
+    std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    std::fs::write(&file_path, b"pub fn fresh() {}\n").unwrap();
+
+    let tee = Tee::with_retention(
+        temp.path(),
+        TeeRetention {
+            max_count: 0, // disable count; isolate age pruning
+            max_age: Some(Duration::from_secs(7 * 86_400)),
+        },
+    );
+    let record = match tee.snapshot(&file_path).unwrap() {
+        TeeSnapshot::Created(record) => record,
+        other => panic!("expected created snapshot, got {other:?}"),
+    };
+
+    assert!(!stale.exists(), "30-day-old snapshot should be age-pruned");
+    assert!(
+        record.tee_path.exists(),
+        "fresh snapshot should be retained"
+    );
+}
+
+#[test]
+fn tee_snapshot_pruning_disabled_when_both_limits_zero() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+    let tee_dir = temp.path().join(".symforge").join("tee");
+    std::fs::create_dir_all(&tee_dir).unwrap();
+
+    // An ancient snapshot that age-pruning would normally remove.
+    let ancient = tee_dir.join("0000000000000-000000-ancient.rs");
+    std::fs::write(&ancient, b"ancient\n").unwrap();
+    set_mtime_days_ago(&ancient, 365);
+
+    let file_path = temp.path().join("src/lib.rs");
+    std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    std::fs::write(&file_path, b"pub fn fresh() {}\n").unwrap();
+
+    // Both dimensions disabled (env=0 equivalent): no pruning at all.
+    let tee = Tee::with_retention(
+        temp.path(),
+        TeeRetention {
+            max_count: 0,
+            max_age: None,
+        },
+    );
+    let record = match tee.snapshot(&file_path).unwrap() {
+        TeeSnapshot::Created(record) => record,
+        other => panic!("expected created snapshot, got {other:?}"),
+    };
+
+    assert!(
+        ancient.exists(),
+        "365-day-old snapshot must survive when pruning is disabled"
+    );
+    assert!(record.tee_path.exists(), "fresh snapshot should exist");
+}
+
+/// Backdate a file's modified time by `days` using the cross-platform
+/// `filetime` crate, so age-based pruning can be exercised deterministically.
+fn set_mtime_days_ago(path: &std::path::Path, days: u64) {
+    let target = std::time::SystemTime::now()
+        .checked_sub(Duration::from_secs(days * 86_400))
+        .unwrap();
+    filetime::set_file_mtime(path, filetime::FileTime::from_system_time(target))
+        .expect("backdate mtime");
 }
 
 #[test]


### PR DESCRIPTION
Closes the three remaining items from the dogfood audit (follow-up to #276).

## Fixes
- **fix(state)**: bound `.symforge` growth — tee snapshots now pruned at write time (7-day age cap + newest-200 count cap, `SYMFORGE_TEE_MAX_AGE_DAYS`/`SYMFORGE_TEE_MAX_COUNT`, 0=off); coupling.db gains VACUUM after cold builds + every 50 committed deltas (`SYMFORGE_COUPLING_VACUUM_EVERY`). Measured: VACUUM reclaims 29% (48.1 MB -> 34.2 MB) on a real coupling.db; remaining size is live data (43k pairs / 52k edges), no safe eviction.
- **fix(protocol)**: Tier-2 metadata-only files report honest status instead of "File not found" — `get_file_context`/`get_symbol` now say `Not indexed: <path> is Tier 2 (metadata only) — reason: lockfile, size N` and point at `get_file_content`, which keeps serving raw disk bytes (verified live via MCP driver).
- **fix(content)**: NUL bytes (0x00) in source detected and reported — `get_file_content` appends a warning with count/offsets (NUL renders invisibly; copied text will not byte-match), parse diagnostics name the NUL instead of `syntax error near ' '`, and byte-exactness of the edit splice path is locked by read-back tests (real-world case: terminal-commander `mint.js`).

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean at head
- `cargo test --all-targets -- --test-threads=1`: 2072 lib + all integration suites, 0 failed on the merged branch
- Tier-2 UX verified live against the release binary via raw MCP stdio
- coupling.db VACUUM measured on a copy of a real 48 MB db

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible MCP strings and edit-snapshot retention (old tees are deleted by design); coupling VACUUM adds occasional SQLite I/O but failures are logged and non-blocking.
> 
> **Overview**
> This PR closes dogfood audit gaps around **`.symforge` disk growth**, **honest MCP responses for skipped files**, and **NUL-byte safety** when agents read or parse source.
> 
> **State / retention:** Edit **tee** snapshots now use a **`TeeRetention`** policy (default **newest 200** + **7-day** age), applied at each write via **`plan_retention`**, with **`SYMFORGE_TEE_MAX_COUNT`** / **`SYMFORGE_TEE_MAX_AGE_DAYS`** (`0` disables a dimension). The **coupling** SQLite store **`VACUUM`s** after cold builds and periodically after committed deltas (default every **50**, **`SYMFORGE_COUPLING_VACUUM_EVERY`**), tracking **`delta_since_vacuum`** in meta so the cadence survives restarts.
> 
> **Protocol UX:** **`get_file_context`** and **`get_symbol`** return **`Not indexed: … Tier 2/3`** (reason, size, pointer to **`get_file_content`**) for on-disk paths that are metadata-only or hard-skipped, instead of **`File not found`**. **`get_file_content`** still serves Tier-2 raw bytes; estimate mode can size non-indexed files from disk.
> 
> **NUL honesty:** Shared **`scan_nul_bytes`** / warning helpers drive **`get_file_content`** footers (after the byte cap), richer tree-sitter diagnostics when source contains **`0x00`**, and tests that symbol edits preserve trailing NULs on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef462f2fab61e0691ab5b18fc1bf9576d34f124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->