### PR TITLE
fix: wave 3 — tree-sitter 0.26.9, watcher NoCache, Tier-2 search, coupling eviction, Angular excuser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ chrono = "0.4"
 dirs = "6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
-tree-sitter = "=0.26.8"
+tree-sitter = "=0.26.9"
 streaming-iterator = "0.1"
 tree-sitter-rust = "=0.24.2"
 tree-sitter-python = "0.25"

--- a/src/live_index/coupling/store.rs
+++ b/src/live_index/coupling/store.rs
@@ -6,11 +6,12 @@
 //! HEAD-oid tracking. Cold-build walker and symbol-identity resolution
 //! are separate steps.
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
 use super::AnchorKey;
 use super::decay_factor;
@@ -67,6 +68,19 @@ pub struct LedgerEdgeRow {
     pub shared_inc: u32,
     pub base_weight: f64,
     pub commit_ts: i64,
+}
+
+/// Counts reported by [`CouplingStore::prune_dead_paths`]. Every figure is the
+/// number of rows physically deleted from the named table.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PruneStats {
+    /// Rows removed from `coupling` (anchor or partner path no longer live).
+    pub coupling_removed: usize,
+    /// Rows removed from `coupling_commit_edges` (same liveness rule).
+    pub edges_removed: usize,
+    /// Rows removed from `coupling_active_commits` (commit left with no
+    /// surviving ledger edge after the edge prune).
+    pub commits_removed: usize,
 }
 
 #[derive(Clone)]
@@ -449,9 +463,59 @@ impl CouplingStore {
         Ok(rows.into_iter().collect())
     }
 
+    /// Evict coupling pairs and ledger edges that reference a path no longer
+    /// present in `live_paths`, then drop any active commit left with no
+    /// surviving ledger edge. Runs in one transaction; reports the deleted
+    /// row counts.
+    ///
+    /// ## Liveness rule
+    /// A pair survives only when BOTH its anchor and partner resolve to a live
+    /// path. The path is the component of the anchor key after the `prefix:`
+    /// and before the first `#` (if any), so both `file:<path>` and
+    /// `symbol:<path>#<name>#<kind>` keys are handled by the same rule — a
+    /// symbol pair dies exactly when its file dies. Relative normalized paths
+    /// never contain `:` (no Windows drive letters; the walker normalizes to
+    /// forward slashes via `AnchorKey::file`), so the first `:` is always the
+    /// prefix delimiter.
+    ///
+    /// ## Read-path honesty
+    /// The read path gates every anchor on `index.files` (`tools.rs`) and draws
+    /// candidates only from `all_files()` (`query.rs`), so a dead pair is inert
+    /// — it can never surface a phantom file or shift ranking. The caller in
+    /// the cold-build path supplies the git-tracked set (`git ls-files`
+    /// semantics), a SUPERSET of the indexed set: this is conservative
+    /// (a live-but-unindexed path is kept, never wrongly evicted) and still
+    /// evicts the dead deleted-file pairs, which are absent from both sets.
+    ///
+    /// ## Fail-open
+    /// An empty `live_paths` is treated as "liveness unknown" and is a no-op:
+    /// it must never wipe the whole store (e.g. a fresh `git init` whose index
+    /// has no tracked files yet). Callers that genuinely want an empty store
+    /// use the cold-build purge, not this method.
+    pub fn prune_dead_paths(&self, live_paths: &HashSet<String>) -> Result<PruneStats> {
+        if live_paths.is_empty() {
+            // Fail open: an unknown/empty live set must not erase the store.
+            return Ok(PruneStats::default());
+        }
+        let mut conn = self.conn.lock().expect("coupling mutex poisoned");
+        let tx = conn.transaction()?;
+        let stats = prune_dead_paths_in_tx(&tx, live_paths)?;
+        tx.commit()?;
+        Ok(stats)
+    }
+
     /// Atomic cold build: purges `coupling`, `coupling_active_commits`, and
     /// `coupling_commit_edges`, writes the supplied state, and updates meta
     /// (last_head, last_reference_ts, cold_built_at) in a single transaction.
+    ///
+    /// When `live_paths` is `Some` and non-empty, dead-path pairs are evicted
+    /// in the same transaction (right before the post-build VACUUM) via
+    /// [`prune_dead_paths_in_tx`], so the VACUUM reclaims the freed pages in one
+    /// pass. `None` (and an empty set) skips eviction — fail-open, identical to
+    /// the pre-eviction behaviour. The freshly-built rows reference only paths
+    /// the walker just saw in git history, so eviction here removes stale pairs
+    /// left over from a *previous* cold build on the same DB file (the read
+    /// path is gated on the live index regardless — see `prune_dead_paths`).
     pub fn commit_cold_build(
         &self,
         new_rows: &[CouplingRow],
@@ -459,6 +523,7 @@ impl CouplingStore {
         new_ledger: &[LedgerEdgeRow],
         new_head: Option<&str>,
         reference_ts: i64,
+        live_paths: Option<&HashSet<String>>,
     ) -> Result<()> {
         let mut conn = self.conn.lock().expect("coupling mutex poisoned");
         let tx = conn.transaction()?;
@@ -544,6 +609,25 @@ impl CouplingStore {
              ON CONFLICT(key) DO UPDATE SET value = '0'",
             params![META_DELTA_SINCE_VACUUM],
         )?;
+
+        // Evict dead-path pairs in the same transaction so the post-build
+        // VACUUM reclaims their pages in a single pass. Skipped when no live
+        // set is supplied or it is empty (fail-open).
+        if let Some(live) = live_paths
+            && !live.is_empty()
+        {
+            let pruned = prune_dead_paths_in_tx(&tx, live)?;
+            if pruned.coupling_removed > 0 || pruned.edges_removed > 0 || pruned.commits_removed > 0
+            {
+                tracing::debug!(
+                    "coupling: cold-build pruned {} pairs, {} ledger edges, {} commits",
+                    pruned.coupling_removed,
+                    pruned.edges_removed,
+                    pruned.commits_removed,
+                );
+            }
+        }
+
         tx.commit()?;
         drop(conn);
 
@@ -759,6 +843,100 @@ impl CouplingStore {
         self.maybe_vacuum_after_delta();
         Ok(())
     }
+}
+
+/// Shared dead-path eviction body. Runs inside the caller's transaction so the
+/// cold-build path can prune in the same atomic unit that writes fresh state
+/// (one transaction, one VACUUM afterward), while the public
+/// [`CouplingStore::prune_dead_paths`] wraps it in its own transaction.
+///
+/// Precondition: `live_paths` is non-empty (the empty/unknown case is a
+/// fail-open no-op handled by callers). See
+/// [`CouplingStore::prune_dead_paths`] for the liveness rule and the
+/// read-path-honesty rationale.
+fn prune_dead_paths_in_tx(tx: &Transaction, live_paths: &HashSet<String>) -> Result<PruneStats> {
+    debug_assert!(
+        !live_paths.is_empty(),
+        "prune_dead_paths_in_tx must not be called with an empty live set"
+    );
+
+    // Temp table of live paths. A temp table + JOIN sidesteps the SQL
+    // parameter / statement-length limits a giant `IN (...)` list would hit on
+    // large repos (100k+ tracked files). Created fresh and dropped each call so
+    // repeated invocations within one connection do not leak stale rows.
+    tx.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS coupling_live_paths (path TEXT PRIMARY KEY);
+         DELETE FROM coupling_live_paths;",
+    )?;
+    {
+        let mut insert =
+            tx.prepare("INSERT OR IGNORE INTO coupling_live_paths (path) VALUES (?1)")?;
+        for path in live_paths {
+            insert.execute(params![path])?;
+        }
+    }
+
+    // SQL extracting the path component of an anchor key: drop everything up to
+    // and including the first ':' (the `prefix:` delimiter), then keep
+    // everything before the first '#' (symbol keys carry `#name#kind`), else
+    // the whole remainder (file keys). `col` is a fixed column name chosen
+    // here, never user input.
+    let path_expr = |col: &str| -> String {
+        format!(
+            "CASE \
+               WHEN instr(substr({col}, instr({col}, ':') + 1), '#') > 0 \
+               THEN substr( \
+                      substr({col}, instr({col}, ':') + 1), \
+                      1, \
+                      instr(substr({col}, instr({col}, ':') + 1), '#') - 1) \
+               ELSE substr({col}, instr({col}, ':') + 1) \
+             END"
+        )
+    };
+    let dead_clause = |col: &str| -> String {
+        format!(
+            "({expr}) NOT IN (SELECT path FROM coupling_live_paths)",
+            expr = path_expr(col),
+        )
+    };
+
+    let coupling_removed = tx.execute(
+        &format!(
+            "DELETE FROM coupling WHERE {anchor} OR {partner}",
+            anchor = dead_clause("anchor_key"),
+            partner = dead_clause("partner_key"),
+        ),
+        [],
+    )?;
+
+    let edges_removed = tx.execute(
+        &format!(
+            "DELETE FROM coupling_commit_edges WHERE {anchor} OR {partner}",
+            anchor = dead_clause("anchor_key"),
+            partner = dead_clause("partner_key"),
+        ),
+        [],
+    )?;
+
+    // Drop active commits left with no surviving ledger edge. Required for
+    // delta consistency: a later delta subtracting an aged-out commit whose
+    // edges were all evicted must be a no-op, and cold-build counters must
+    // agree with the surviving ledger.
+    let commits_removed = tx.execute(
+        "DELETE FROM coupling_active_commits
+         WHERE commit_oid NOT IN (
+             SELECT DISTINCT commit_oid FROM coupling_commit_edges
+         )",
+        [],
+    )?;
+
+    tx.execute("DROP TABLE IF EXISTS coupling_live_paths", [])?;
+
+    Ok(PruneStats {
+        coupling_removed,
+        edges_removed,
+        commits_removed,
+    })
 }
 
 #[cfg(test)]
@@ -1254,6 +1432,7 @@ mod tests {
                 &[ledger("oid1", "a.rs", "b.rs", 100)],
                 Some("head1"),
                 100,
+                None,
             )
             .unwrap();
 
@@ -1271,7 +1450,7 @@ mod tests {
         let store = CouplingStore::open_in_memory().unwrap();
 
         store
-            .commit_cold_build(&[], &[], &[], Some("head0"), 100)
+            .commit_cold_build(&[], &[], &[], Some("head0"), 100, None)
             .unwrap();
         assert_eq!(store.delta_since_vacuum().unwrap(), 0);
 
@@ -1318,7 +1497,14 @@ mod tests {
             ));
         }
         store
-            .commit_cold_build(&rows, &[("oid0".to_string(), 100)], &[], Some("head0"), 100)
+            .commit_cold_build(
+                &rows,
+                &[("oid0".to_string(), 100)],
+                &[],
+                Some("head0"),
+                100,
+                None,
+            )
             .unwrap();
         assert_eq!(store.delta_since_vacuum().unwrap(), 0);
 
@@ -1376,7 +1562,7 @@ mod tests {
         set_vacuum_env("0"); // disabled
         let store = CouplingStore::open_in_memory().unwrap();
         store
-            .commit_cold_build(&[], &[], &[], Some("head0"), 100)
+            .commit_cold_build(&[], &[], &[], Some("head0"), 100, None)
             .unwrap();
 
         for i in 1..=5 {
@@ -1400,5 +1586,169 @@ mod tests {
             "interval=0 disables periodic VACUUM, so the counter is never reset"
         );
         clear_vacuum_env();
+    }
+
+    // ---------- prune_dead_paths ----------
+
+    /// Seed a store with two live-live pairs (a<->b, b<->a) and two dead pairs
+    /// referencing `dead.rs`, plus a ledger and active commits so we can assert
+    /// orphaned-commit cleanup. `oid_live` touches a/b, `oid_dead` touches only
+    /// the dead pair, so after eviction `oid_dead` must be removed.
+    fn seed_prune_fixture() -> CouplingStore {
+        let store = CouplingStore::open_in_memory().unwrap();
+        let rows = vec![
+            sample_row("a.rs", "b.rs", 2, 5.0, 200),
+            sample_row("b.rs", "a.rs", 2, 5.0, 200),
+            sample_row("a.rs", "dead.rs", 1, 3.0, 150),
+            sample_row("dead.rs", "a.rs", 1, 3.0, 150),
+        ];
+        let commits = vec![("oid_live".to_string(), 200), ("oid_dead".to_string(), 150)];
+        let ledger_rows = vec![
+            ledger("oid_live", "a.rs", "b.rs", 200),
+            ledger("oid_live", "b.rs", "a.rs", 200),
+            ledger("oid_dead", "a.rs", "dead.rs", 150),
+            ledger("oid_dead", "dead.rs", "a.rs", 150),
+        ];
+        store
+            .commit_cold_build(&rows, &commits, &ledger_rows, Some("head"), 200, None)
+            .unwrap();
+        store
+    }
+
+    fn live_set(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn prune_dead_paths_empty_live_set_is_noop() {
+        let store = seed_prune_fixture();
+        let stats = store.prune_dead_paths(&HashSet::new()).unwrap();
+        assert_eq!(stats, PruneStats::default());
+        // Nothing removed: all four pairs still present.
+        assert_eq!(store.query(&AnchorKey::file("a.rs"), 10).unwrap().len(), 2);
+        assert_eq!(store.active_commit_oids().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn prune_dead_paths_all_live_removes_nothing() {
+        let store = seed_prune_fixture();
+        let stats = store
+            .prune_dead_paths(&live_set(&["a.rs", "b.rs", "dead.rs"]))
+            .unwrap();
+        assert_eq!(stats, PruneStats::default());
+        assert_eq!(store.query(&AnchorKey::file("a.rs"), 10).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn prune_dead_paths_evicts_dead_pairs_from_both_tables() {
+        let store = seed_prune_fixture();
+        let stats = store
+            .prune_dead_paths(&live_set(&["a.rs", "b.rs"]))
+            .unwrap();
+
+        // Two coupling rows reference dead.rs (a->dead, dead->a).
+        assert_eq!(stats.coupling_removed, 2);
+        // Two ledger edges reference dead.rs.
+        assert_eq!(stats.edges_removed, 2);
+        // oid_dead loses all its edges -> orphaned -> removed.
+        assert_eq!(stats.commits_removed, 1);
+
+        // dead.rs has no surviving partners.
+        assert!(
+            store
+                .query(&AnchorKey::file("dead.rs"), 10)
+                .unwrap()
+                .is_empty()
+        );
+        // a.rs keeps only b.rs.
+        let a = store.query(&AnchorKey::file("a.rs"), 10).unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].partner.as_str(), AnchorKey::file("b.rs").as_str());
+
+        // oid_live survives (still has live edges); oid_dead is gone.
+        let active = store.active_commit_oids().unwrap();
+        assert!(active.contains_key("oid_live"));
+        assert!(!active.contains_key("oid_dead"));
+    }
+
+    #[test]
+    fn prune_dead_paths_leaves_surviving_pairs_byte_identical() {
+        // A control store that was never seeded with the dead pairs must be
+        // byte-identical (for the live pairs) to the pruned store.
+        let pruned = seed_prune_fixture();
+        pruned
+            .prune_dead_paths(&live_set(&["a.rs", "b.rs"]))
+            .unwrap();
+
+        let control = CouplingStore::open_in_memory().unwrap();
+        control
+            .commit_cold_build(
+                &[
+                    sample_row("a.rs", "b.rs", 2, 5.0, 200),
+                    sample_row("b.rs", "a.rs", 2, 5.0, 200),
+                ],
+                &[("oid_live".to_string(), 200)],
+                &[
+                    ledger("oid_live", "a.rs", "b.rs", 200),
+                    ledger("oid_live", "b.rs", "a.rs", 200),
+                ],
+                Some("head"),
+                200,
+                None,
+            )
+            .unwrap();
+
+        let p = pruned
+            .pair_row(&AnchorKey::file("a.rs"), &AnchorKey::file("b.rs"))
+            .unwrap()
+            .unwrap();
+        let c = control
+            .pair_row(&AnchorKey::file("a.rs"), &AnchorKey::file("b.rs"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.shared_commits, c.shared_commits);
+        assert_eq!(p.last_commit_ts, c.last_commit_ts);
+        assert!((p.weighted_score - c.weighted_score).abs() < 1e-12);
+    }
+
+    #[test]
+    fn prune_dead_paths_handles_symbol_keys_by_file_component() {
+        // Symbol keys (`symbol:<path>#<name>#<kind>`) die exactly when their
+        // file component is not live; live symbol pairs survive.
+        let store = CouplingStore::open_in_memory().unwrap();
+        let live_sym = CouplingRow {
+            anchor: AnchorKey::symbol("a.rs", "alpha", "fn"),
+            partner: AnchorKey::symbol("b.rs", "beta", "fn"),
+            shared_commits: 1,
+            weighted_score: 2.0,
+            last_commit_ts: 100,
+        };
+        let dead_sym = CouplingRow {
+            anchor: AnchorKey::symbol("a.rs", "alpha", "fn"),
+            partner: AnchorKey::symbol("gone.rs", "ghost", "fn"),
+            shared_commits: 1,
+            weighted_score: 2.0,
+            last_commit_ts: 100,
+        };
+        store
+            .commit_cold_build(&[live_sym, dead_sym], &[], &[], Some("head"), 100, None)
+            .unwrap();
+
+        let stats = store
+            .prune_dead_paths(&live_set(&["a.rs", "b.rs"]))
+            .unwrap();
+        assert_eq!(
+            stats.coupling_removed, 1,
+            "only the gone.rs symbol pair dies"
+        );
+
+        let survivors = store
+            .query(&AnchorKey::symbol("a.rs", "alpha", "fn"), 10)
+            .unwrap();
+        assert_eq!(survivors.len(), 1);
+        assert_eq!(
+            survivors[0].partner.as_str(),
+            AnchorKey::symbol("b.rs", "beta", "fn").as_str()
+        );
     }
 }

--- a/src/live_index/coupling/walker.rs
+++ b/src/live_index/coupling/walker.rs
@@ -83,8 +83,32 @@ pub enum DeltaOutcome {
     },
 }
 
+/// Set of currently git-tracked paths (`git ls-files` semantics), normalized
+/// to forward slashes — the liveness source fed to the cold-build dead-path
+/// eviction. This is a SUPERSET of the live INDEX file set the read path
+/// actually gates on (`index.files`), so pruning against it is conservative:
+/// a tracked-but-unindexed file is kept, never wrongly evicted, while pairs
+/// referencing files deleted from HEAD (the actual bloat) are removed.
+///
+/// The walker's entry points (`run_init`, `start_lazy_prepare`) only carry
+/// `repo_root`, not the live `SharedIndex`, so the index file set is not in
+/// scope here; `git ls-files` is the closest read-path-honest approximation
+/// reachable from this layer. Returns `None` on any failure (no repo, fresh
+/// `git init` with no index, empty tracked set), which the caller treats as
+/// fail-open: no eviction rather than a wrongly-emptied store.
+fn live_tracked_paths(repo_root: &Path) -> Option<HashSet<String>> {
+    let repo = crate::git::GitRepo::open(repo_root).ok()?;
+    let paths = repo.tracked_paths().ok()?;
+    if paths.is_empty() {
+        return None;
+    }
+    Some(paths.into_iter().collect())
+}
+
 /// Cold-build the coupling store from a bounded slice of git history.
-/// Atomic rebuild — purges existing rows and ledger, writes fresh state.
+/// Atomic rebuild — purges existing rows and ledger, writes fresh state, then
+/// evicts dead-path pairs in the same transaction before the post-build VACUUM
+/// (see [`CouplingStore::commit_cold_build`]).
 pub fn cold_build(
     store: &CouplingStore,
     repo_root: &Path,
@@ -105,6 +129,8 @@ pub fn cold_build(
         rows_written: rows.len(),
     };
 
+    let live_paths = live_tracked_paths(repo_root);
+
     store
         .commit_cold_build(
             &rows,
@@ -112,6 +138,7 @@ pub fn cold_build(
             &ledger,
             head_oid.as_deref(),
             cfg.reference_ts,
+            live_paths.as_ref(),
         )
         .context("committing cold build")?;
     Ok(stats)
@@ -601,6 +628,52 @@ mod tests {
                 &parent_refs,
             )
         }
+
+        /// Commit that removes `removals` from the git index (and worktree),
+        /// optionally also writing `add` files. Used to exercise dead-path
+        /// eviction: after this commit the removed paths are no longer tracked.
+        fn commit_removing(
+            &self,
+            add: &[(&str, &str)],
+            removals: &[&str],
+            ts: i64,
+            msg: &str,
+        ) -> git2::Oid {
+            for (rel, content) in add {
+                let full = self.tmp.path().join(rel);
+                if let Some(parent) = full.parent() {
+                    fs::create_dir_all(parent).unwrap();
+                }
+                fs::write(&full, content).unwrap();
+            }
+            let mut index = self.repo.index().unwrap();
+            for (rel, _) in add {
+                index.add_path(Path::new(rel)).unwrap();
+            }
+            for rel in removals {
+                index.remove_path(Path::new(rel)).unwrap();
+                let _ = fs::remove_file(self.tmp.path().join(rel));
+            }
+            index.write().unwrap();
+            let tree_oid = index.write_tree().unwrap();
+            let tree = self.repo.find_tree(tree_oid).unwrap();
+            let sig =
+                git2::Signature::new("Test", "t@example.com", &git2::Time::new(ts, 0)).unwrap();
+            let parent_oid = self.repo.head().ok().and_then(|h| h.target());
+            let parents: Vec<git2::Commit> = parent_oid
+                .and_then(|oid| self.repo.find_commit(oid).ok())
+                .into_iter()
+                .collect();
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+            git_test_helpers::commit_head_with_retry(
+                &self.repo,
+                &sig,
+                &sig,
+                msg,
+                &tree,
+                &parent_refs,
+            )
+        }
     }
 
     fn now_sec() -> i64 {
@@ -929,6 +1002,102 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    // ---------- dead-path eviction at cold build ----------
+
+    /// Build a coupling store via the full `cold_build` path against a repo
+    /// where one file was deleted, and assert that every pair / ledger edge /
+    /// orphaned commit referencing the deleted path is gone, while the live
+    /// pair is byte-identical to an unpruned control filtered to live pairs.
+    #[test]
+    fn cold_build_evicts_pairs_for_deleted_paths() {
+        let repo = TestRepo::init();
+        let now_ts = 2_000_000_000i64;
+        let mut cfg = test_cfg(now_ts);
+        cfg.window_days = 365_000;
+
+        // c1: a, b, dead all change together -> 3 files -> all three pairs.
+        repo.commit(
+            &[("a.rs", "1"), ("b.rs", "1"), ("dead.rs", "1")],
+            now_ts - 86400 * 10,
+            "c1",
+        );
+        // c2: a, b change again AND dead.rs is removed from the index.
+        repo.commit_removing(
+            &[("a.rs", "2"), ("b.rs", "2")],
+            &["dead.rs"],
+            now_ts - 86400,
+            "c2",
+        );
+
+        // Pruned store via the production cold_build path (reads git ls-files).
+        let pruned = CouplingStore::open_in_memory().unwrap();
+        cold_build(&pruned, &repo.path(), &cfg).unwrap();
+
+        // Unpruned control: same window inputs, committed with live_paths=None.
+        let control = CouplingStore::open_in_memory().unwrap();
+        let (entries, head_oid) = compute_window(&repo.path(), &cfg).unwrap();
+        let (rows, ledger, active) = build_cold_inputs(&entries, &cfg);
+        control
+            .commit_cold_build(
+                &rows,
+                &active,
+                &ledger,
+                head_oid.as_deref(),
+                cfg.reference_ts,
+                None,
+            )
+            .unwrap();
+
+        // dead.rs must have no surviving pairs in the pruned store.
+        assert!(
+            pruned
+                .query(&AnchorKey::file("dead.rs"), 100)
+                .unwrap()
+                .is_empty(),
+            "deleted path must have no surviving partners"
+        );
+        // ...but the control (unpruned) must still carry them.
+        assert!(
+            !control
+                .query(&AnchorKey::file("dead.rs"), 100)
+                .unwrap()
+                .is_empty(),
+            "control must retain the dead pairs (proving the prune did work)"
+        );
+
+        // a.rs must no longer list dead.rs as a partner in the pruned store.
+        let a_partners = pruned.query(&AnchorKey::file("a.rs"), 100).unwrap();
+        assert!(
+            a_partners
+                .iter()
+                .all(|r| r.partner.as_str() != AnchorKey::file("dead.rs").as_str()),
+            "a.rs must not retain dead.rs as a partner"
+        );
+
+        // The live a.rs<->b.rs pair must be byte-identical to the control's.
+        let a_to_b_pruned = pruned
+            .pair_row(&AnchorKey::file("a.rs"), &AnchorKey::file("b.rs"))
+            .unwrap()
+            .expect("live a<->b pair must survive pruning");
+        let a_to_b_control = control
+            .pair_row(&AnchorKey::file("a.rs"), &AnchorKey::file("b.rs"))
+            .unwrap()
+            .expect("control must have a<->b pair");
+        assert_eq!(a_to_b_pruned.shared_commits, a_to_b_control.shared_commits);
+        assert_eq!(a_to_b_pruned.last_commit_ts, a_to_b_control.last_commit_ts);
+        assert!(
+            (a_to_b_pruned.weighted_score - a_to_b_control.weighted_score).abs() < 1e-12,
+            "surviving live pair weighted_score must be byte-identical to control"
+        );
+
+        // Every active commit that survives must still have a ledger edge:
+        // c1 only touched a/b/dead pairs; after eviction its a<->b edge keeps
+        // it alive. (No orphan-commit assertion possible here since c1 retains
+        // a live edge; the orphan path is covered by the store-level test.)
+        let active_oids = pruned.active_commit_oids().unwrap();
+        assert!(!active_oids.is_empty());
     }
 
     // ---------- delta equivalence ----------

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -4353,6 +4353,122 @@ impl Actor for MyActor {
     }
 
     #[test]
+    fn test_health_stats_angular_nested_paren_openers_are_framework_partial() {
+        // POSITIVE control, real parser end-to-end, mirroring the real-world
+        // testpilot `app.html` shape that the OLD `[^()]*`-bodied opener regex
+        // could never neutralize: the control expressions contain NESTED parens
+        // (`applications()`), so the single relational `>` was never reached and
+        // the file wrongly landed as an unexpected partial. The balanced-paren
+        // forward scan handles these, proving the relational operators are the
+        // sole cause, so the file is bucketed as a framework partial.
+        let content = "<div>\n\
+@if (applications().length > 0) {\n\
+  <ul>\n\
+    @for (a of applications(); track a.id) {\n\
+      <li>{{ a.name }}</li>\n\
+    }\n\
+  </ul>\n\
+}\n\
+</div>";
+        let app_html = make_real_html_indexed_file("src/app/app.html", content);
+
+        // Sanity: real parser produced a partial parse that still carries the
+        // text-scanned control-flow symbols (both halves of the SF-004 root
+        // cause), otherwise the assertion below would be vacuous.
+        assert!(
+            matches!(app_html.parse_status, ParseStatus::PartialParse { .. }),
+            "real parser must report a partial parse for the nested-paren Angular template"
+        );
+        assert!(
+            app_html
+                .symbols
+                .iter()
+                .any(|s| s.name == "@if" && s.kind == SymbolKind::Module),
+            "the @if control-flow symbol must survive the partial parse"
+        );
+
+        let index = make_index(vec![("src/app/app.html", app_html)], false);
+        let stats = index.health_stats();
+
+        assert_eq!(stats.partial_parse_count, 1);
+        assert_eq!(
+            stats.expected_framework_partial_parse_count, 1,
+            "nested-paren Angular openers must be excused as a framework partial"
+        );
+        assert_eq!(stats.unexpected_partial_parse_count, 0);
+        assert_eq!(
+            stats.expected_framework_partial_parse_files,
+            vec!["src/app/app.html".to_string()]
+        );
+        assert!(stats.unexpected_partial_parse_files.is_empty());
+    }
+
+    #[test]
+    fn test_health_stats_nested_paren_opener_plus_broken_html_stays_unexpected() {
+        // NEGATIVE control, real parser end-to-end: a nested-paren `@if
+        // (applications().length > 0)` PLUS a genuine structural defect (an
+        // unclosed `<div` with attribute garbage) elsewhere. Neutralizing only the
+        // opener's relational operators leaves the broken tag, so the whole-file
+        // re-parse stays dirty and the file is NOT excused. Proves the balanced
+        // scan still validates the WHOLE file, never masking an unrelated defect.
+        let content = "<div>\n\
+@if (applications().length > 0) {\n\
+  <span></span>\n\
+}\n\
+<div class=\n\
+<section></section\n\
+</div>";
+        let broken = make_real_html_indexed_file("src/app/broken_nested.html", content);
+        assert!(
+            broken
+                .symbols
+                .iter()
+                .any(|s| s.name == "@if" && s.kind == SymbolKind::Module),
+            "the @if symbol must be present so the cheap pre-gate fires"
+        );
+        let index = make_index(vec![("src/app/broken_nested.html", broken)], false);
+        let stats = index.health_stats();
+
+        assert_eq!(
+            stats.expected_framework_partial_parse_count, 0,
+            "broken HTML alongside a nested-paren opener must NOT be excused"
+        );
+        assert_eq!(stats.unexpected_partial_parse_count, 1);
+        assert_eq!(
+            stats.unexpected_partial_parse_files,
+            vec!["src/app/broken_nested.html".to_string()]
+        );
+        assert!(stats.expected_framework_partial_parse_files.is_empty());
+    }
+
+    #[test]
+    fn test_health_stats_unterminated_opener_paren_stays_unexpected() {
+        // NEGATIVE control for the EOF-skip branch of the balanced-paren scan: an
+        // `@if (` whose control expression is never closed (the file ends before
+        // the matching `)`). An unterminated control expression is itself a
+        // genuine defect; the scan must skip that opener (neutralize nothing in
+        // it), so the re-parse stays dirty and the file is NOT excused.
+        let content = "<div>\n@if (applications().length > 0 {\n  <span></span>\n";
+        let broken = make_real_html_indexed_file("src/app/unterminated.html", content);
+        assert!(
+            broken
+                .symbols
+                .iter()
+                .any(|s| s.name == "@if" && s.kind == SymbolKind::Module),
+            "the @if symbol must be present so the cheap pre-gate fires"
+        );
+        let index = make_index(vec![("src/app/unterminated.html", broken)], false);
+        let stats = index.health_stats();
+
+        assert_eq!(
+            stats.expected_framework_partial_parse_count, 0,
+            "an unterminated `@if (` must NOT be excused"
+        );
+        assert_eq!(stats.unexpected_partial_parse_count, 1);
+        assert!(stats.expected_framework_partial_parse_files.is_empty());
+    }
+
+    #[test]
     fn test_health_stats_does_not_mark_all_vendor_partials_expected() {
         let vendor_c = make_indexed_file_with_language(
             "vendor/other-parser/src/parser.c",

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -577,6 +577,86 @@ pub(super) fn path_has_component(path: &str, component: &str) -> bool {
         .any(|part| part.eq_ignore_ascii_case(component))
 }
 
+/// Precomputed query parts shared by the non-glob `search_files` passes.
+///
+/// Built once from the normalized query so the same exact/suffix, basename,
+/// prefix, and loose predicates apply identically to Tier-1 indexed paths and
+/// Tier-2 skipped paths — no five-filter duplication across candidate sources.
+pub(super) struct SearchFilesQueryPredicate<'a> {
+    normalized_query_lower: String,
+    tokens: &'a [String],
+    basename_token: &'a str,
+    component_tokens: &'a [String],
+    has_path_context: bool,
+}
+
+impl<'a> SearchFilesQueryPredicate<'a> {
+    fn new(normalized_query: &str, tokens: &'a [String]) -> Self {
+        let basename_token = tokens.last().map(String::as_str).unwrap_or("");
+        let component_tokens = if tokens.len() > 1 {
+            &tokens[..tokens.len() - 1]
+        } else {
+            &[][..]
+        };
+        Self {
+            normalized_query_lower: normalized_query.to_ascii_lowercase(),
+            tokens,
+            basename_token,
+            component_tokens,
+            has_path_context: normalized_query.contains('/'),
+        }
+    }
+
+    /// True when `path` matches the query under ANY of the non-glob passes
+    /// (exact, suffix, basename+components, prefix, loose). The five Tier-1
+    /// passes split these into separate buckets for per-tier labeling; the
+    /// Tier-2 metadata-only pass only needs the union, since all metadata
+    /// hits collapse into the single `MetadataOnly` tier.
+    fn matches(&self, path: &str) -> bool {
+        let path_lower = path.to_ascii_lowercase();
+
+        // Exact / suffix (strong).
+        if path_lower == self.normalized_query_lower
+            || (self.has_path_context && path_lower.ends_with(&self.normalized_query_lower))
+        {
+            return true;
+        }
+
+        // Basename exact + required directory components.
+        if !self.basename_token.is_empty() {
+            let file_basename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            if file_basename.eq_ignore_ascii_case(self.basename_token)
+                && self
+                    .component_tokens
+                    .iter()
+                    .all(|component| path_has_component(path, component))
+            {
+                return true;
+            }
+        }
+
+        // Prefix on the file stem (matches the >=3-char Tier-1 prefix pass).
+        if self.basename_token.len() >= 3 {
+            let file_stem = std::path::Path::new(path)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("");
+            if file_stem
+                .to_ascii_lowercase()
+                .starts_with(&self.basename_token.to_ascii_lowercase())
+            {
+                return true;
+            }
+        }
+
+        // Loose: every token appears somewhere in the path.
+        !self.tokens.is_empty() && self.tokens.iter().all(|token| path_lower.contains(token))
+    }
+}
+
 fn shared_directory_prefix_len(path_a: &str, path_b: &str) -> usize {
     let parts_a: Vec<&str> = path_a.split('/').collect();
     let parts_b: Vec<&str> = path_b.split('/').collect();
@@ -651,6 +731,13 @@ pub enum SearchFilesResolveView {
     Resolved {
         path: String,
     },
+    /// Resolved to a Tier-2 metadata-only path (lockfile, oversized, etc.).
+    /// The path is real and addressable, but it was never parsed, so it is
+    /// surfaced with the metadata label instead of as a plain `Resolved`.
+    ResolvedMetadataOnly {
+        path: String,
+        reason: String,
+    },
     NotFound {
         hint: String,
     },
@@ -667,6 +754,21 @@ pub enum SearchFilesTier {
     StrongPath,
     Basename,
     LoosePath,
+    /// Tier-2 admission-demoted file (lockfile, oversized, denylisted, etc.).
+    /// Stored in `LiveIndex::skipped_files()` as metadata only — never parsed.
+    /// Findable by path so it is not a silent black hole, but ranked strictly
+    /// below every Tier-1 hit via the rank floor in
+    /// `capture_search_files_view_with_noise`.
+    MetadataOnly,
+}
+
+impl SearchFilesTier {
+    /// True for the Tier-2 metadata-only floor. Used as the primary sort key
+    /// so a metadata-only hit can never outrank a real (Tier-1) source file,
+    /// regardless of path-relevance score or frecency fusion.
+    pub fn is_metadata_only(self) -> bool {
+        matches!(self, SearchFilesTier::MetadataOnly)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -683,6 +785,11 @@ pub struct SearchFilesHit {
     pub path: String,
     pub coupling_score: Option<f32>,
     pub shared_commits: Option<u32>,
+    /// Short human-readable reason a Tier-2 metadata-only path was demoted
+    /// (e.g. "lockfile", "artifact", ">1MB"). `None` for every Tier-1 hit.
+    /// Carried on the hit so the formatter can render
+    /// `[metadata-only: <reason>]` without re-deriving from the index.
+    pub metadata_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -932,6 +1039,26 @@ impl LiveIndex {
         self.files.iter().map(|(path, file)| (path, file.as_ref()))
     }
 
+    /// Iterate Tier-2 metadata-only skipped paths as `(path, reason_label)`.
+    ///
+    /// Tier-3 hard-skipped files (and any future tiers) are excluded — only
+    /// metadata-only files are surfaced as findable `search_files` hits. The
+    /// reason label is the `SkipReason` display string (e.g. "lockfile",
+    /// "artifact", ">1MB") used by the formatter's `[metadata-only: …]` suffix.
+    pub fn metadata_only_skipped_paths(&self) -> impl Iterator<Item = (&str, String)> {
+        self.skipped_files().iter().filter_map(|sf| {
+            if sf.tier() == crate::domain::index::AdmissionTier::MetadataOnly {
+                let reason = sf
+                    .reason()
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "metadata only".to_string());
+                Some((sf.path.as_str(), reason))
+            } else {
+                None
+            }
+        })
+    }
+
     /// Capture a shared immutable file entry under the read lock.
     pub fn capture_shared_file(&self, relative_path: &str) -> Option<Arc<IndexedFile>> {
         self.files.get(relative_path).cloned()
@@ -1037,7 +1164,21 @@ impl LiveIndex {
             };
         }
 
+        // Tier-2 exact match: a metadata-only skipped path (lockfile, oversized,
+        // etc.) is a real, addressable path. Resolve it WITH the metadata label
+        // instead of falling through to NotFound. Matched case-insensitively on
+        // the full relative path so `resolve=true` mirrors the Tier-1 exact rule.
         let normalized_hint_lower = normalized_hint.to_ascii_lowercase();
+        if let Some((path, reason)) = self
+            .metadata_only_skipped_paths()
+            .filter(|(path, _)| path_allowed(path))
+            .find(|(path, _)| path.to_ascii_lowercase() == normalized_hint_lower)
+        {
+            return SearchFilesResolveView::ResolvedMetadataOnly {
+                path: path.to_string(),
+                reason,
+            };
+        }
         let parts: Vec<&str> = normalized_hint
             .split('/')
             .filter(|part| !part.is_empty())
@@ -1172,23 +1313,53 @@ impl LiveIndex {
                 .map(|path| path.to_string())
                 .collect();
             glob_hits.sort();
-            let total_matches = glob_hits.len();
+            let tier1_total = glob_hits.len();
+
+            // Tier-2 metadata-only paths also participate in glob matching, but
+            // are appended after every Tier-1 hit and carry the metadata label.
+            let strong_set: HashSet<&str> = glob_hits.iter().map(String::as_str).collect();
+            let mut metadata_hits: Vec<(String, String)> = self
+                .metadata_only_skipped_paths()
+                .filter(|(path, _)| path_allowed(path))
+                .filter(|(path, _)| !strong_set.contains(*path))
+                .filter(|(path, _)| matcher.is_match(path))
+                .map(|(path, reason)| (path.to_string(), reason))
+                .collect();
+            metadata_hits.sort_by(|(lp, _), (rp, _)| lp.cmp(rp));
+
+            let total_matches = tier1_total + metadata_hits.len();
             if total_matches == 0 {
                 return SearchFilesView::NotFound {
                     query: normalized_query,
                 };
             }
             let overflow_count = total_matches.saturating_sub(limit);
-            glob_hits.truncate(limit);
-            let hits: Vec<SearchFilesHit> = glob_hits
+            // Tier-1 hits fill the limit first; metadata-only hits take any
+            // remaining slots, preserving the rank-floor invariant.
+            let mut hits: Vec<SearchFilesHit> = glob_hits
                 .into_iter()
+                .take(limit)
                 .map(|path| SearchFilesHit {
                     tier: SearchFilesTier::StrongPath,
                     path,
                     coupling_score: None,
                     shared_commits: None,
+                    metadata_reason: None,
                 })
                 .collect();
+            let remaining = limit.saturating_sub(hits.len());
+            hits.extend(
+                metadata_hits
+                    .into_iter()
+                    .take(remaining)
+                    .map(|(path, reason)| SearchFilesHit {
+                        tier: SearchFilesTier::MetadataOnly,
+                        path,
+                        coupling_score: None,
+                        shared_commits: None,
+                        metadata_reason: Some(reason),
+                    }),
+            );
             return SearchFilesView::Found {
                 query: normalized_query,
                 total_matches,
@@ -1305,8 +1476,32 @@ impl LiveIndex {
             .map(|path| path.to_string())
             .collect();
 
-        let total_matches =
+        let tier1_total =
             strong_hits.len() + basename_only_hits.len() + prefix_hits.len() + loose_hits.len();
+
+        // Tier-2 metadata-only pass: run the SAME query predicates over the
+        // skipped-file paths so demoted lockfiles/oversized files are findable
+        // BY PATH instead of vanishing into a NotFound. Exclude any path already
+        // present as a Tier-1 candidate (a path can be both indexed and skipped
+        // only transiently; dedup keeps the higher tier). These hits are pinned
+        // below every Tier-1 hit by the rank floor in the sort comparator.
+        let tier1_set: HashSet<&str> = strong_hits
+            .iter()
+            .chain(basename_only_hits.iter())
+            .chain(prefix_hits.iter())
+            .chain(loose_hits.iter())
+            .map(String::as_str)
+            .collect();
+        let metadata_predicate = SearchFilesQueryPredicate::new(&normalized_query, &tokens);
+        let metadata_hits: Vec<(String, String)> = self
+            .metadata_only_skipped_paths()
+            .filter(|(path, _)| path_allowed(path))
+            .filter(|(path, _)| !tier1_set.contains(path))
+            .filter(|(path, _)| metadata_predicate.matches(path))
+            .map(|(path, reason)| (path.to_string(), reason))
+            .collect();
+
+        let total_matches = tier1_total + metadata_hits.len();
         if total_matches == 0 {
             return SearchFilesView::NotFound {
                 query: normalized_query,
@@ -1314,30 +1509,36 @@ impl LiveIndex {
         }
 
         // Collect all classified candidates into a single list, preserving
-        // their tier label for the formatter. Ordering across the list is
-        // then driven by `super::rank_signals::combine` as the primary sort key,
-        // with within-tier tiebreakers (exact/suffix, shared dir prefix,
-        // length, lex) matching the previous per-bucket behavior.
-        let mut candidates: Vec<(String, SearchFilesTier)> = Vec::with_capacity(total_matches);
+        // their tier label and (for Tier-2) the metadata reason for the
+        // formatter. Ordering across the list is driven by the sort comparator
+        // below, where the metadata-only rank floor is the PRIMARY key:
+        // a Tier-2 hit can never outrank a Tier-1 hit regardless of path score.
+        let mut candidates: Vec<(String, SearchFilesTier, Option<String>)> =
+            Vec::with_capacity(total_matches);
         candidates.extend(
             strong_hits
                 .into_iter()
-                .map(|path| (path, SearchFilesTier::StrongPath)),
+                .map(|path| (path, SearchFilesTier::StrongPath, None)),
         );
         candidates.extend(
             basename_only_hits
                 .into_iter()
-                .map(|path| (path, SearchFilesTier::Basename)),
+                .map(|path| (path, SearchFilesTier::Basename, None)),
         );
         candidates.extend(
             prefix_hits
                 .into_iter()
-                .map(|path| (path, SearchFilesTier::LoosePath)),
+                .map(|path| (path, SearchFilesTier::LoosePath, None)),
         );
         candidates.extend(
             loose_hits
                 .into_iter()
-                .map(|path| (path, SearchFilesTier::LoosePath)),
+                .map(|path| (path, SearchFilesTier::LoosePath, None)),
+        );
+        candidates.extend(
+            metadata_hits
+                .into_iter()
+                .map(|(path, reason)| (path, SearchFilesTier::MetadataOnly, Some(reason))),
         );
 
         let shared_len = |path: &str| -> usize {
@@ -1358,7 +1559,16 @@ impl LiveIndex {
                     .fold(0.0_f32, f32::max)
             })
             .unwrap_or(0.0);
-        candidates.sort_by(|(lp, _), (rp, _)| {
+        candidates.sort_by(|(lp, l_tier, _), (rp, r_tier, _)| {
+            // Rank floor: Tier-2 metadata-only paths ALWAYS sort below every
+            // Tier-1 hit, regardless of path-relevance score. `false` (Tier-1)
+            // orders before `true` (metadata-only).
+            let l_meta = l_tier.is_metadata_only();
+            let r_meta = r_tier.is_metadata_only();
+            if l_meta != r_meta {
+                return l_meta.cmp(&r_meta);
+            }
+
             let l_score = search_files_rank_score(
                 lp,
                 &normalized_query,
@@ -1394,14 +1604,20 @@ impl LiveIndex {
 
         let hits: Vec<SearchFilesHit> = candidates
             .into_iter()
-            .map(|(path, tier)| {
-                let coupling_evidence = usable_search_files_coupling_evidence(
-                    &path,
-                    &normalized_query,
-                    &tokens,
-                    current_file,
-                    coupling_context,
-                );
+            .map(|(path, tier, metadata_reason)| {
+                // Metadata-only hits never participate in co-change promotion:
+                // they are not real source and must stay on the rank floor.
+                let coupling_evidence = if tier.is_metadata_only() {
+                    None
+                } else {
+                    usable_search_files_coupling_evidence(
+                        &path,
+                        &normalized_query,
+                        &tokens,
+                        current_file,
+                        coupling_context,
+                    )
+                };
                 let coupling_score = coupling_evidence.and_then(|evidence| {
                     if max_coupling_weight > 0.0 {
                         Some((evidence.weighted_score / max_coupling_weight).clamp(0.0, 1.0))
@@ -1418,6 +1634,7 @@ impl LiveIndex {
                     path,
                     coupling_score,
                     shared_commits: coupling_evidence.map(|evidence| evidence.shared_commits),
+                    metadata_reason,
                 }
             })
             .collect();
@@ -3064,6 +3281,191 @@ mod tests {
         );
     }
 
+    fn add_metadata_only_skip(index: &mut LiveIndex, path: &str, reason: SkipReason) {
+        index.add_skipped_file(SkippedFile {
+            path: path.to_string(),
+            size: 4096,
+            extension: std::path::Path::new(path)
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(str::to_string),
+            decision: AdmissionDecision::skip(AdmissionTier::MetadataOnly, reason),
+        });
+    }
+
+    // Fix 1(a): a query matching only a Tier-2 lockfile returns it labeled
+    // metadata-only instead of NotFound.
+    #[test]
+    fn test_capture_search_files_view_surfaces_tier2_metadata_only_path() {
+        let mut index = make_index(vec![], false);
+        add_metadata_only_skip(
+            &mut index,
+            "backend/package-lock.json",
+            SkipReason::DependencyLockfile,
+        );
+
+        let view = index.capture_search_files_view("package-lock", 20, None, None);
+
+        match view {
+            SearchFilesView::Found {
+                total_matches,
+                hits,
+                ..
+            } => {
+                assert_eq!(total_matches, 1, "the Tier-2 path counts toward matches");
+                assert_eq!(hits.len(), 1);
+                assert_eq!(hits[0].tier, SearchFilesTier::MetadataOnly);
+                assert_eq!(hits[0].path, "backend/package-lock.json");
+                assert_eq!(hits[0].metadata_reason.as_deref(), Some("lockfile"));
+            }
+            other => panic!("expected Found with a metadata-only hit, got {other:?}"),
+        }
+    }
+
+    // Fix 1(b): a query matching both real source AND a Tier-2 path ranks every
+    // source hit above the Tier-2 hit (the rank floor), regardless of path score.
+    #[test]
+    fn test_capture_search_files_view_ranks_all_source_above_tier2() {
+        // The lockfile's path scores higher on the loose-token query "lock"
+        // than the source files, yet the rank floor must still pin it last.
+        let mut index = make_index(
+            vec![
+                (
+                    "src/lock_manager.rs",
+                    make_indexed_file("src/lock_manager.rs", vec![], ParseStatus::Parsed),
+                ),
+                (
+                    "src/util/locking.rs",
+                    make_indexed_file("src/util/locking.rs", vec![], ParseStatus::Parsed),
+                ),
+            ],
+            false,
+        );
+        add_metadata_only_skip(&mut index, "Cargo.lock", SkipReason::DependencyLockfile);
+
+        let view = index.capture_search_files_view("lock", 20, None, None);
+
+        match view {
+            SearchFilesView::Found {
+                total_matches,
+                hits,
+                ..
+            } => {
+                assert_eq!(total_matches, 3);
+                let metadata_pos = hits
+                    .iter()
+                    .position(|h| h.tier == SearchFilesTier::MetadataOnly)
+                    .expect("metadata-only hit present");
+                // Every hit before the metadata hit must be Tier-1 (non-metadata),
+                // and the metadata hit must be the LAST hit.
+                assert_eq!(
+                    metadata_pos,
+                    hits.len() - 1,
+                    "metadata-only hit must sort last: {hits:?}"
+                );
+                assert!(
+                    hits[..metadata_pos]
+                        .iter()
+                        .all(|h| h.tier != SearchFilesTier::MetadataOnly),
+                    "all source hits must precede the metadata hit: {hits:?}"
+                );
+                assert_eq!(hits[metadata_pos].path, "Cargo.lock");
+            }
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    // Fix 1(c): a vendored Tier-2 path stays suppressed under the default
+    // vendor filter (include_vendor=false), exactly like vendored Tier-1 paths.
+    #[test]
+    fn test_capture_search_files_view_vendor_filter_suppresses_tier2() {
+        let mut index = make_index(vec![], false);
+        add_metadata_only_skip(
+            &mut index,
+            "node_modules/leftpad/package-lock.json",
+            SkipReason::DependencyLockfile,
+        );
+
+        // Default (vendor hidden): the vendored lockfile must NOT surface.
+        let hidden =
+            index.capture_search_files_view_with_noise("package-lock", 20, None, None, false, true);
+        assert!(
+            matches!(hidden, SearchFilesView::NotFound { .. }),
+            "vendored Tier-2 path must be suppressed by default: {hidden:?}"
+        );
+
+        // include_vendor=true: now it surfaces as metadata-only.
+        let shown =
+            index.capture_search_files_view_with_noise("package-lock", 20, None, None, true, true);
+        match shown {
+            SearchFilesView::Found { hits, .. } => {
+                assert_eq!(hits.len(), 1);
+                assert_eq!(hits[0].tier, SearchFilesTier::MetadataOnly);
+                assert_eq!(hits[0].path, "node_modules/leftpad/package-lock.json");
+            }
+            other => panic!("expected Found with vendor included, got {other:?}"),
+        }
+    }
+
+    // Fix 1(d): resolve=true on an exact Tier-2 path resolves with the
+    // metadata-only label instead of returning NotFound.
+    #[test]
+    fn test_capture_search_files_resolve_view_resolves_tier2_with_label() {
+        let mut index = make_index(vec![], false);
+        add_metadata_only_skip(
+            &mut index,
+            "backend/package-lock.json",
+            SkipReason::DependencyLockfile,
+        );
+
+        let view = index.capture_search_files_resolve_view("./backend\\package-lock.json");
+
+        assert_eq!(
+            view,
+            SearchFilesResolveView::ResolvedMetadataOnly {
+                path: "backend/package-lock.json".to_string(),
+                reason: "lockfile".to_string(),
+            }
+        );
+    }
+
+    // Fix 1 (glob): a glob query also matches Tier-2 paths, appended below the
+    // Tier-1 hits and carrying the metadata label.
+    #[test]
+    fn test_capture_search_files_view_glob_includes_tier2_below_source() {
+        let mut index = make_index(
+            vec![(
+                "src/config.json",
+                make_indexed_file("src/config.json", vec![], ParseStatus::Parsed),
+            )],
+            false,
+        );
+        add_metadata_only_skip(
+            &mut index,
+            "package-lock.json",
+            SkipReason::DependencyLockfile,
+        );
+
+        let view = index.capture_search_files_view("*.json", 20, None, None);
+
+        match view {
+            SearchFilesView::Found {
+                total_matches,
+                hits,
+                ..
+            } => {
+                assert_eq!(total_matches, 2);
+                // Tier-1 source first, Tier-2 metadata last.
+                assert_eq!(hits[0].path, "src/config.json");
+                assert_eq!(hits[0].tier, SearchFilesTier::StrongPath);
+                assert_eq!(hits[1].path, "package-lock.json");
+                assert_eq!(hits[1].tier, SearchFilesTier::MetadataOnly);
+                assert_eq!(hits[1].metadata_reason.as_deref(), Some("lockfile"));
+            }
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_capture_search_files_resolve_view_returns_exact_path_match() {
         let index = make_index(
@@ -3192,12 +3594,14 @@ mod tests {
                         path: "src/protocol/tools.rs".to_string(),
                         coupling_score: None,
                         shared_commits: None,
+                        metadata_reason: None,
                     },
                     SearchFilesHit {
                         tier: SearchFilesTier::Basename,
                         path: "src/sidecar/tools.rs".to_string(),
                         coupling_score: None,
                         shared_commits: None,
+                        metadata_reason: None,
                     },
                 ],
             }
@@ -3234,12 +3638,14 @@ mod tests {
                         path: "src/live_index/query.rs".to_string(),
                         coupling_score: None,
                         shared_commits: None,
+                        metadata_reason: None,
                     },
                     SearchFilesHit {
                         tier: SearchFilesTier::LoosePath,
                         path: "src/live_index/store.rs".to_string(),
                         coupling_score: None,
                         shared_commits: None,
+                        metadata_reason: None,
                     },
                 ],
             }
@@ -3381,6 +3787,7 @@ mod tests {
                     path: "wiki/notes.md".to_string(),
                     coupling_score: Some(1.0),
                     shared_commits: Some(3),
+                    metadata_reason: None,
                 }],
             }
         );

--- a/src/live_index/search.rs
+++ b/src/live_index/search.rs
@@ -1781,6 +1781,9 @@ pub fn tier_path_match_score(tier: SearchFilesTier) -> f64 {
         SearchFilesTier::Basename => 0.6,
         SearchFilesTier::LoosePath => 0.3,
         SearchFilesTier::CoChange => 0.0,
+        // Tier-2 metadata-only paths earn no path-match credit; the hard rank
+        // floor in `reorder_hits_by_frecency_fusion` keeps them below Tier-1.
+        SearchFilesTier::MetadataOnly => 0.0,
     }
 }
 
@@ -1841,6 +1844,13 @@ pub fn reorder_hits_by_frecency_fusion(
     debug_assert_eq!(hits.len(), breakdowns.len());
     let mut indexed: Vec<(usize, SearchFilesHit)> = hits.drain(..).enumerate().collect();
     indexed.sort_by(|a, b| {
+        // Rank floor: Tier-2 metadata-only hits never outrank a Tier-1 hit, even
+        // if frecency would score them higher. `false` (Tier-1) precedes `true`.
+        let a_meta = a.1.tier.is_metadata_only();
+        let b_meta = b.1.tier.is_metadata_only();
+        if a_meta != b_meta {
+            return a_meta.cmp(&b_meta);
+        }
         let sa = breakdowns[a.0].combined;
         let sb = breakdowns[b.0].combined;
         sb.partial_cmp(&sa)
@@ -2980,6 +2990,7 @@ mod tests {
             path: path.to_string(),
             coupling_score: None,
             shared_commits: None,
+            metadata_reason: None,
         }
     }
 

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -507,28 +507,28 @@ pub(crate) fn is_expected_typescript_import_type_array_limitation(
     })
 }
 
-/// Matches an Angular control-flow opener (`@if`/`@for`/`@switch`/`@defer`/
-/// `@else if`) together with its parenthesized control expression. Capture
-/// groups:
+/// Matches the START of an Angular control-flow opener (`@if`/`@for`/`@switch`/
+/// `@defer`/`@else if`) up to and including its opening `(`. Capture groups:
 ///   1. the boundary char before `@` (start-of-line or a non-identifier char),
 ///      preserved so we never match a keyword embedded in an identifier (e.g.
 ///      `foo@if`),
-///   2. the opener keyword plus the opening `(`,
-///   3. the control expression body (no nested parens — `[^()]*` keeps the
-///      match scoped to a single, balanced opener expression),
-///   4. the closing `)`.
+///   2. the opener keyword plus the opening `(`.
 ///
-/// Only the relational operators (`<`/`>`, covering `<`, `>`, `<=`, `>=`) inside
-/// group 3 are the `tree-sitter-html 0.23.2` grammar trigger (SF-004): the `>` in
-/// `@if (a > b) {` is lexed as a tag close, producing an ERROR node. Neutralizing
-/// those operators within group 3 only — never elsewhere in the file — lets us
-/// re-parse the whole file and prove whether the operators were the SOLE cause.
+/// This regex deliberately does NOT capture the control-expression body. The
+/// body can contain nested parentheses — real Angular like
+/// `@if (applications().length > 0) {` or `@for (a of items(); track a.id) {` —
+/// which a `[^()]*` body could never span, so the old single-regex form silently
+/// failed to capture the common case. Instead the matcher locates the opener's
+/// `(` here, then scans forward in code (see
+/// [`is_expected_angular_template_control_flow_limitation`]) with a paren-depth
+/// counter to find the matching close `)`, neutralizing the relational operators
+/// (`<`/`>`, covering `<`, `>`, `<=`, `>=`) within that balanced span only —
+/// never elsewhere in the file — so a clean re-parse proves whether those
+/// operators were the SOLE cause of the error.
 static ANGULAR_CONTROL_FLOW_OPENER_RE: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| {
-        regex::Regex::new(
-            r"(?m)(^|[^A-Za-z0-9_$])(@(?:if|for|switch|defer|else\s+if)\s*\()([^()]*)(\))",
-        )
-        .expect("SF-004 Angular control-flow opener regex is a valid pattern")
+        regex::Regex::new(r"(?m)(^|[^A-Za-z0-9_$])(@(?:if|for|switch|defer|else\s+if)\s*\()")
+            .expect("SF-004 Angular control-flow opener regex is a valid pattern")
     });
 
 /// SF-004: recognize a partial parse whose ONLY cause is the known
@@ -549,11 +549,16 @@ static ANGULAR_CONTROL_FLOW_OPENER_RE: std::sync::LazyLock<regex::Regex> =
 /// fallback was even worse — it excused arbitrary broken HTML.
 ///
 /// Instead we mirror SF-003: neutralize ONLY the suspected limitation and
-/// re-parse the whole file. For every Angular control-flow opener we replace each
-/// `<`/`>` inside its `(...)` control expression with a single space (length- and
-/// token-preserving; a space cannot fuse adjacent tokens), leaving the rest of the
-/// file — including every ordinary HTML tag's `<`/`>` — byte-for-byte unchanged.
-/// We return `true` iff:
+/// re-parse the whole file. For every Angular control-flow opener we locate its
+/// `(...)` control expression by scanning forward from the opening `(` with a
+/// paren-depth counter (so nested calls like `applications().length` and
+/// multi-clause `@for` headers are handled correctly), and replace each `<`/`>`
+/// inside that balanced span with a single space (length- and token-preserving;
+/// a space cannot fuse adjacent tokens), leaving the rest of the file — including
+/// every ordinary HTML tag's `<`/`>` — byte-for-byte unchanged. An opener whose
+/// `(` is never closed before EOF (depth never returns to zero) is skipped, not
+/// neutralized: an unterminated control expression is itself a genuine defect and
+/// must keep the file dirty. We return `true` iff:
 ///   1. the language is HTML, AND
 ///   2. the original source genuinely has a parse error, AND
 ///   3. at least one Angular control-flow opener is present (the regex matched),
@@ -607,26 +612,83 @@ pub(crate) fn is_expected_angular_template_control_flow_limitation(
         }
 
         // Neutralize ONLY the relational operators inside each Angular control-flow
-        // opener's `(...)` expression, then re-parse the whole file. Each `<`/`>` in
-        // capture group 3 becomes a single space; the opener keyword, the parens, and
-        // every byte outside the matched openers (including ordinary HTML tag `<`/`>`)
-        // are preserved verbatim. A clean re-parse proves the relational operators were
-        // the sole cause.
-        let neutralized =
-            ANGULAR_CONTROL_FLOW_OPENER_RE.replace_all(&source, |caps: &regex::Captures| {
-                format!(
-                    "{}{}{}{}",
-                    &caps[1],
-                    &caps[2],
-                    caps[3].replace(['<', '>'], " "),
-                    &caps[4],
-                )
-            });
+        // opener's balanced `(...)` expression, then re-parse the whole file. The
+        // opener keyword, the parens, and every byte outside the matched openers
+        // (including ordinary HTML tag `<`/`>`) are preserved verbatim. A clean
+        // re-parse proves the relational operators were the sole cause.
+        let neutralized = neutralize_angular_control_flow_operators(&source);
         match panic::catch_unwind(|| parse_source(&neutralized, language, false)) {
             Ok(Ok((_, has_error, _, _, _))) => !has_error,
             _ => false,
         }
     })
+}
+
+/// Replace the relational operators (`<`/`>`) inside every Angular control-flow
+/// opener's balanced `(...)` control expression with spaces, byte-length
+/// preserving, and leave the rest of `source` untouched.
+///
+/// For each opener matched by [`ANGULAR_CONTROL_FLOW_OPENER_RE`] we scan forward
+/// from the opening `(` tracking paren depth and replacing `<`/`>` with spaces
+/// until the matching close `)` (depth returns to zero). An opener whose `(` is
+/// never closed before the end of input is skipped entirely — its bytes are
+/// copied verbatim — so an unterminated control expression keeps the re-parse
+/// dirty and is NOT excused. Bytes between openers are copied verbatim.
+///
+/// Soundness: the only bytes ever changed are `<`/`>` that sit at paren depth >= 1
+/// inside a recognized opener span. A `<` or `>` of an ordinary HTML tag lives at
+/// depth 0 (outside any opener's parens) and is never touched. Replacing with a
+/// single ASCII space is length-preserving, so byte offsets — and therefore every
+/// extracted symbol's span — are identical between the original and neutralized
+/// source.
+fn neutralize_angular_control_flow_operators(source: &str) -> String {
+    let original = source.as_bytes();
+    // Work on a byte buffer so we can do constant-byte overwrites without
+    // touching `unsafe`. The only mutation is ASCII `<`/`>` -> ASCII space, so the
+    // buffer stays valid UTF-8 and `String::from_utf8` below cannot fail.
+    let mut buf = original.to_vec();
+
+    for m in ANGULAR_CONTROL_FLOW_OPENER_RE.find_iter(source) {
+        // The match ends exactly at the opener's `(`; scan the expression body
+        // that follows it.
+        let open_paren = m.end();
+        debug_assert_eq!(original.get(open_paren - 1), Some(&b'('));
+
+        let mut depth: usize = 1;
+        let mut i = open_paren;
+        let mut closed = false;
+        let mut neutralized_any = false;
+        while i < original.len() {
+            match original[i] {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        closed = true;
+                        break;
+                    }
+                }
+                b'<' | b'>' => {
+                    buf[i] = b' ';
+                    neutralized_any = true;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+
+        // Unterminated opener (EOF before the close paren): this is a genuine
+        // defect, not the excusable limitation. Roll back any neutralization we
+        // performed inside this opener so the span stays byte-for-byte original
+        // and the re-parse remains dirty.
+        if !closed && neutralized_any {
+            buf[open_paren..i].copy_from_slice(&original[open_paren..i]);
+        }
+    }
+
+    // The transform only ever replaces single-byte ASCII `<`/`>` with a
+    // single-byte ASCII space, so the buffer is still valid UTF-8.
+    String::from_utf8(buf).unwrap_or_else(|_| source.to_string())
 }
 
 /// Extract symbol name → body-hash pairs from source code using tree-sitter.
@@ -714,6 +776,48 @@ mod tests {
         assert!(!result.symbols.is_empty());
         assert_eq!(result.symbols[0].name, "doStuff");
         assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn test_process_file_jsx_parses_clean_and_extracts_symbols() {
+        // Regression: `.jsx` maps to LanguageId::JavaScript (src/domain/index.rs),
+        // and tree-sitter-javascript 0.25 parses JSX natively — fragments
+        // (`<>...</>`), self-closing components (`<Row .../>`), `prop={expr}`
+        // attributes, and `.map(...)` with JSX children all parse under the plain
+        // JavaScript grammar with NO `.tsx`-style flavor switch (`.jsx` is not a
+        // TSX path). This pins that a realistic JSX component file parses cleanly
+        // (no partial diagnostic) and the component function symbol survives.
+        let source = br#"
+import { Row } from './Row';
+
+export function Table({ rows }) {
+  return (
+    <>
+      {rows.map((r) => (
+        <Row key={r.id} value={r.value} />
+      ))}
+    </>
+  );
+}
+"#;
+        let result = process_file("src/Table.jsx", source, LanguageId::JavaScript);
+        assert_eq!(
+            result.outcome,
+            FileOutcome::Processed,
+            "a `.jsx` file must parse cleanly under the JavaScript grammar; got {:?} / {:?}",
+            result.outcome,
+            result.parse_diagnostic
+        );
+        assert!(
+            result.parse_diagnostic.is_none(),
+            "clean JSX parse must not attach a diagnostic; got {:?}",
+            result.parse_diagnostic
+        );
+        assert!(
+            result.symbols.iter().any(|s| s.name == "Table"),
+            "the JSX component function `Table` must be extracted; got {:?}",
+            result.symbols
+        );
     }
 
     #[test]

--- a/src/parsing/xref.rs
+++ b/src/parsing/xref.rs
@@ -1722,6 +1722,25 @@ fn helper(n: usize) {
         );
     }
 
+    #[test]
+    fn test_jsx_import_extracted_under_plain_js_grammar() {
+        // Regression: `.jsx` resolves to LanguageId::JavaScript and is NOT a TSX
+        // path, so it runs through the plain (non-flavored) JavaScript grammar.
+        // tree-sitter-javascript 0.25 parses JSX natively — unlike `.ts`, the JSX
+        // here is NOT a partial parse — so the import reference for the component
+        // rendered in the fragment must still be captured.
+        let source = "import { Row } from './Row';\n\
+export const Table = ({ rows }) => (\n\
+  <>{rows.map((r) => <Row key={r.id} value={r.value} />)}</>\n\
+);\n";
+        let (refs, _) = parse_and_extract(source, LanguageId::JavaScript);
+        assert!(
+            refs.iter().any(|r| r.kind == ReferenceKind::Import),
+            "JSX under the plain JavaScript grammar must still capture the import; refs: {:?}",
+            refs
+        );
+    }
+
     // --- TypeScript ---
 
     #[test]

--- a/src/protocol/explore.rs
+++ b/src/protocol/explore.rs
@@ -495,11 +495,29 @@ fn stems_match(a: &str, b: &str) -> bool {
         && (sa.starts_with(sb.as_str()) || sb.starts_with(sa.as_str()))
 }
 
+/// How a query matched a concept: either an exact word-boundary hit or a looser
+/// stemmed fallback. The header-rendering logic in the explore handler treats a
+/// stem-only match more cautiously than an exact match (a single-word concept
+/// matched only by stemming should not lead the header over the query's own
+/// specific terms).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConceptMatchKind {
+    /// At least one window of query words matched the concept key verbatim
+    /// (case-insensitive).
+    Exact,
+    /// No exact match; the concept key words matched query words only after
+    /// stemming (e.g. "indexed" -> "indexing").
+    Stemmed,
+}
+
 /// Find the best matching concept for a query.
-/// Returns the matched key and the corresponding pattern, or `None` if no concept matches.
+/// Returns the matched key, the corresponding pattern, and how it matched
+/// (exact word-boundary vs stemmed fallback), or `None` if no concept matches.
 /// Uses word-boundary matching to avoid substring collisions (e.g. "clinical" should not match "cli").
 /// Falls back to stemmed matching when exact words don't match.
-pub fn match_concept(query: &str) -> Option<(&'static str, &'static ConceptPattern)> {
+pub fn match_concept(
+    query: &str,
+) -> Option<(&'static str, &'static ConceptPattern, ConceptMatchKind)> {
     let query_words: Vec<&str> = query.split_whitespace().collect();
 
     // Exact word-boundary match (original behavior).
@@ -513,7 +531,7 @@ pub fn match_concept(query: &str) -> Option<(&'static str, &'static ConceptPatte
         })
     });
     if let Some((key, pattern)) = exact {
-        return Some((*key, pattern));
+        return Some((*key, pattern, ConceptMatchKind::Exact));
     }
 
     // Stemmed fallback with bag-of-words matching: each key word must match some query
@@ -526,7 +544,7 @@ pub fn match_concept(query: &str) -> Option<(&'static str, &'static ConceptPatte
                 .iter()
                 .all(|kw| query_words.iter().any(|qw| stems_match(qw, kw)))
         })
-        .map(|(key, pattern)| (*key, pattern))
+        .map(|(key, pattern)| (*key, pattern, ConceptMatchKind::Stemmed))
 }
 
 /// Return additional search terms for a concept based on the project's detected import roots.
@@ -683,6 +701,23 @@ mod tests {
         let concept = match_concept("handle errors");
         assert!(concept.is_some());
         assert_eq!(concept.unwrap().1.label, "Error Handling");
+    }
+
+    #[test]
+    fn test_match_concept_reports_match_provenance() {
+        // Exact word-boundary hit reports ConceptMatchKind::Exact.
+        let exact = match_concept("error handling patterns").expect("exact concept must match");
+        assert_eq!(exact.0, "error handling");
+        assert_eq!(exact.2, ConceptMatchKind::Exact);
+
+        // The stem-misfire shape from the explore-header bug: "indexed" matches the
+        // single-word "indexing" concept ONLY via stemming, never verbatim. The
+        // provenance must be Stemmed so the header logic can demote it.
+        let stemmed = match_concept("admission tiering decide which files get indexed")
+            .expect("stemmed concept must match");
+        assert_eq!(stemmed.0, "indexing");
+        assert_eq!(stemmed.1.label, "Indexing");
+        assert_eq!(stemmed.2, ConceptMatchKind::Stemmed);
     }
 
     #[test]

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -2098,6 +2098,9 @@ pub fn search_files_resolve_result_view(view: &SearchFilesResolveView) -> String
     match view {
         SearchFilesResolveView::EmptyHint => "Path hint must not be empty.".to_string(),
         SearchFilesResolveView::Resolved { path } => path.clone(),
+        SearchFilesResolveView::ResolvedMetadataOnly { path, reason } => {
+            format!("{path}  [metadata-only: {reason}]")
+        }
         SearchFilesResolveView::NotFound { hint } => {
             format!(
                 "No indexed source path matched '{hint}'. \
@@ -2155,6 +2158,9 @@ pub fn search_files_result_view(view: &SearchFilesView) -> String {
                         SearchFilesTier::StrongPath => "── Strong path matches ──",
                         SearchFilesTier::Basename => "── Basename matches ──",
                         SearchFilesTier::LoosePath => "── Loose path matches ──",
+                        SearchFilesTier::MetadataOnly => {
+                            "── Metadata-only paths (Tier-2: not parsed) ──"
+                        }
                     };
                     if lines.len() > 1 {
                         lines.push(String::new());
@@ -2166,8 +2172,16 @@ pub fn search_files_result_view(view: &SearchFilesView) -> String {
                     SearchFilesTier::StrongPath => 0.80,
                     SearchFilesTier::Basename => 0.90,
                     SearchFilesTier::LoosePath => 0.40,
+                    SearchFilesTier::MetadataOnly => 0.30,
                 };
-                if let (Some(score), Some(shared)) = (hit.coupling_score, hit.shared_commits) {
+                if hit.tier == SearchFilesTier::MetadataOnly {
+                    let reason = hit.metadata_reason.as_deref().unwrap_or("metadata only");
+                    lines.push(format!(
+                        "  {}  [metadata-only: {}]  [{:.2}]",
+                        hit.path, reason, confidence
+                    ));
+                } else if let (Some(score), Some(shared)) = (hit.coupling_score, hit.shared_commits)
+                {
                     lines.push(format!(
                         "  {}  ({:.0}% coupled, {} shared commits)  [{:.2}]",
                         hit.path,

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -2071,18 +2071,21 @@ fn test_search_files_result_view_groups_ranked_paths() {
                 path: "src/protocol/tools.rs".to_string(),
                 coupling_score: None,
                 shared_commits: None,
+                metadata_reason: None,
             },
             crate::live_index::SearchFilesHit {
                 tier: SearchFilesTier::Basename,
                 path: "src/sidecar/tools.rs".to_string(),
                 coupling_score: None,
                 shared_commits: None,
+                metadata_reason: None,
             },
             crate::live_index::SearchFilesHit {
                 tier: SearchFilesTier::LoosePath,
                 path: "src/protocol/tools_helper.rs".to_string(),
                 coupling_score: None,
                 shared_commits: None,
+                metadata_reason: None,
             },
         ],
     };
@@ -2108,6 +2111,61 @@ fn test_search_files_result_view_not_found() {
     assert_eq!(
         search_files_result_view(&view),
         "No indexed source files matching 'README.md'"
+    );
+}
+
+#[test]
+fn test_search_files_result_view_renders_metadata_only_section() {
+    let view = SearchFilesView::Found {
+        query: "package-lock".to_string(),
+        total_matches: 2,
+        overflow_count: 0,
+        hits: vec![
+            crate::live_index::SearchFilesHit {
+                tier: SearchFilesTier::StrongPath,
+                path: "src/loader.rs".to_string(),
+                coupling_score: None,
+                shared_commits: None,
+                metadata_reason: None,
+            },
+            crate::live_index::SearchFilesHit {
+                tier: SearchFilesTier::MetadataOnly,
+                path: "backend/package-lock.json".to_string(),
+                coupling_score: None,
+                shared_commits: None,
+                metadata_reason: Some("lockfile".to_string()),
+            },
+        ],
+    };
+
+    let result = search_files_result_view(&view);
+
+    assert!(result.contains("── Metadata-only paths (Tier-2: not parsed) ──"));
+    assert!(
+        result.contains("  backend/package-lock.json  [metadata-only: lockfile]"),
+        "metadata-only hit must carry its reason label: {result}"
+    );
+    // The metadata section must come AFTER the strong-path section.
+    let strong_idx = result.find("── Strong path matches ──").unwrap();
+    let metadata_idx = result
+        .find("── Metadata-only paths (Tier-2: not parsed) ──")
+        .unwrap();
+    assert!(
+        strong_idx < metadata_idx,
+        "metadata-only section must render below source sections: {result}"
+    );
+}
+
+#[test]
+fn test_search_files_resolve_result_view_metadata_only() {
+    let view = SearchFilesResolveView::ResolvedMetadataOnly {
+        path: "backend/package-lock.json".to_string(),
+        reason: "lockfile".to_string(),
+    };
+
+    assert_eq!(
+        search_files_resolve_result_view(&view),
+        "backend/package-lock.json  [metadata-only: lockfile]"
     );
 }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -868,6 +868,7 @@ fn search_files_match_type_label(view: &SearchFilesView) -> &'static str {
                 "constrained (tiered path relevance)"
             }
             Some(SearchFilesTier::LoosePath) => "heuristic (loose path relevance)",
+            Some(SearchFilesTier::MetadataOnly) => "heuristic (Tier-2 metadata-only path)",
             None => "constrained",
         },
         _ => "constrained",
@@ -1295,12 +1296,14 @@ fn search_files_tier_summary(view: &SearchFilesView) -> String {
     let mut strong = 0usize;
     let mut basename = 0usize;
     let mut loose = 0usize;
+    let mut metadata = 0usize;
     for hit in hits {
         match hit.tier {
             SearchFilesTier::CoChange => cochange += 1,
             SearchFilesTier::StrongPath => strong += 1,
             SearchFilesTier::Basename => basename += 1,
             SearchFilesTier::LoosePath => loose += 1,
+            SearchFilesTier::MetadataOnly => metadata += 1,
         }
     }
     let mut parts = Vec::new();
@@ -1315,6 +1318,9 @@ fn search_files_tier_summary(view: &SearchFilesView) -> String {
     }
     if loose > 0 {
         parts.push(format!("loose path={loose}"));
+    }
+    if metadata > 0 {
+        parts.push(format!("metadata-only={metadata}"));
     }
     if parts.is_empty() {
         "no returned files".to_string()
@@ -1578,7 +1584,8 @@ fn hidden_search_symbols_noise_count(
 
 fn search_files_resolve_candidate_count(view: &SearchFilesResolveView) -> usize {
     match view {
-        SearchFilesResolveView::Resolved { .. } => 1,
+        SearchFilesResolveView::Resolved { .. }
+        | SearchFilesResolveView::ResolvedMetadataOnly { .. } => 1,
         SearchFilesResolveView::Ambiguous {
             matches,
             overflow_count,
@@ -1657,6 +1664,9 @@ fn append_search_files_filter_summary(
 fn search_files_resolve_match_type_label(view: &SearchFilesResolveView) -> &'static str {
     match view {
         SearchFilesResolveView::Resolved { .. } => "exact (resolve)",
+        SearchFilesResolveView::ResolvedMetadataOnly { .. } => {
+            "exact (resolve, Tier-2 metadata-only)"
+        }
         SearchFilesResolveView::Ambiguous { .. } => "constrained (resolve candidates)",
         _ => "constrained",
     }
@@ -4532,6 +4542,22 @@ impl SymForgeServer {
                         &search_paths_evidence(std::iter::once(path.as_str())),
                     ))
                 }
+                SearchFilesResolveView::ResolvedMetadataOnly { path, reason } => {
+                    // Tier-2 path: never parsed, so report the metadata-only
+                    // parse state honestly instead of the misleading "parsed".
+                    Some(search_format::format_search_envelope(
+                        search_files_resolve_match_type_label(&view),
+                        "current index",
+                        "metadata-only (not parsed)",
+                        &search_completeness_label(0, hidden_noise_count),
+                        &search_files_scope_summary(
+                            "resolve=true against indexed file paths",
+                            include_vendor,
+                            include_personal_tooling,
+                        ),
+                        &format!("Tier-2 metadata-only path `{path}` ({reason}); never parsed"),
+                    ))
+                }
                 SearchFilesResolveView::Ambiguous {
                     matches,
                     overflow_count,
@@ -4623,6 +4649,7 @@ impl SymForgeServer {
                         path: entry.path.clone(),
                         coupling_score: Some(entry.coupling_score),
                         shared_commits: Some(entry.shared_commits),
+                        metadata_reason: None,
                     })
                     .collect();
                 let weak_hits: Vec<SearchFilesHit> = history
@@ -4633,6 +4660,7 @@ impl SymForgeServer {
                         path: entry.path.clone(),
                         coupling_score: Some(entry.coupling_score),
                         shared_commits: Some(entry.shared_commits),
+                        metadata_reason: None,
                     })
                     .collect();
                 if hits.is_empty() {

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -6910,8 +6910,21 @@ impl SymForgeServer {
 
         let concept = super::explore::match_concept(&params.0.query);
 
+        // A single-word concept that matched ONLY via the stemmed fallback is a
+        // weak signal: the query never named the concept verbatim. When the query
+        // also carries specific terms (computed below) the header should let those
+        // terms lead and demote such a concept to a parenthetical hint, rather than
+        // collapsing the topic to a label the user did not type. Exact matches and
+        // multi-word concept keys keep leading the header.
+        let demote_stem_only_concept = matches!(
+            concept,
+            Some((key, _, super::explore::ConceptMatchKind::Stemmed))
+                if key.split_whitespace().count() == 1
+        );
+
         let mut enriched_imports: Vec<String> = Vec::new();
-        let (label, symbol_queries, text_queries, remainder_terms) = if let Some((key, c)) = concept
+        let (label, symbol_queries, text_queries, remainder_terms) = if let Some((key, c, _)) =
+            concept
         {
             let remainder = Self::compute_remainder_terms(&params.0.query, key);
             let mut sym_q: Vec<String> = c.symbol_queries.iter().map(|s| s.to_string()).collect();
@@ -7466,7 +7479,16 @@ impl SymForgeServer {
                 .filter(|t| specific_terms.contains(t.as_str()))
                 .map(|t| t.as_str())
                 .collect();
-            format!("{label} + {}", ordered.join(", "))
+            if demote_stem_only_concept {
+                // The concept matched only via a single-word stem misfire (e.g.
+                // "indexed" -> "Indexing") while the query named real terms. Lead
+                // with those specific terms and demote the concept to an honest
+                // parenthetical hint, instead of letting a label the user never
+                // typed front the header.
+                format!("{} (+ {label} signals)", ordered.join(", "))
+            } else {
+                format!("{label} + {}", ordered.join(", "))
+            }
         } else {
             label.clone()
         };
@@ -17176,11 +17198,14 @@ mod tests {
             "explore must surface AdmissionTier for an 'admission' query: {result}"
         );
 
-        // The header must not silently collapse the topic to "Indexing": the
-        // specific matching noun stays visible.
+        // The "Indexing" concept matched ONLY via a single-word stem misfire
+        // ("indexed" -> "indexing") while the query named the real noun
+        // "admission". The header must lead with that specific term and demote
+        // the stem-only concept to a parenthetical signal hint, not front a label
+        // the user never typed.
         assert!(
-            result.contains("Exploring: Indexing + admission"),
-            "header should keep the specific query noun, not collapse to the concept: {result}"
+            result.contains("Exploring: admission (+ Indexing signals)"),
+            "stem-only single-word concept must be demoted behind the specific query noun: {result}"
         );
 
         // The specific admission match must rank above the generic concept

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -96,16 +96,28 @@ pub struct HealthResponse {
 struct RenderOptions {
     include_savings_footer: bool,
     record_stats: bool,
+    /// Byte budget for the `symbol_context` references section
+    /// (`build_with_budget`). Explicit tool calls deserve a roomy default so a
+    /// symbol with a couple dozen references renders in full; the prompt-context
+    /// hook injection stays lean to avoid flooding auto-injected context.
+    symbol_context_references_budget_bytes: u64,
 }
+
+/// ~100 tokens. Kept small for auto-injected prompt context.
+const HOOK_REFERENCES_BUDGET_BYTES: u64 = 400;
+/// ~1000 tokens. Explicit `get_symbol_context` calls render references in full.
+const TOOL_REFERENCES_BUDGET_BYTES: u64 = 4000;
 
 const HOOK_RENDER_OPTIONS: RenderOptions = RenderOptions {
     include_savings_footer: true,
     record_stats: true,
+    symbol_context_references_budget_bytes: HOOK_REFERENCES_BUDGET_BYTES,
 };
 
 const TOOL_RENDER_OPTIONS: RenderOptions = RenderOptions {
     include_savings_footer: false,
     record_stats: true,
+    symbol_context_references_budget_bytes: TOOL_REFERENCES_BUDGET_BYTES,
 };
 
 fn format_prompt_context_signal(level: &str, evidence: impl Into<String>, body: String) -> String {
@@ -1373,8 +1385,10 @@ fn symbol_context_text(
         }
     }
 
-    // Apply budget (100 tokens = 400 bytes).
-    let (body_text, remaining) = build_with_budget(&body_lines, 400);
+    // Apply the references-section budget. Tool calls get ~1000 tokens
+    // (4000 bytes); the prompt-context hook stays at ~100 tokens (400 bytes).
+    let (body_text, remaining) =
+        build_with_budget(&body_lines, options.symbol_context_references_budget_bytes);
     let completeness = if total < grand_total {
         "truncated"
     } else if remaining > 0 {
@@ -5735,5 +5749,96 @@ mod tests {
         assert_eq!(snap.read_fires, 1);
         assert_eq!(snap.write_fires, 1);
         assert_eq!(snap.read_saved_tokens, 200);
+    }
+
+    // -----------------------------------------------------------------------
+    // symbol_context references-section budget (Fix 2)
+    // -----------------------------------------------------------------------
+
+    /// Build an index where `process_request` is referenced from `ref_files`
+    /// distinct files. The references resolve by name (no `path`/`file` filter),
+    /// so all of them land in the references section. `ref_files <= 9` keeps the
+    /// count under the 10-match display cap, isolating the byte budget as the
+    /// only possible source of truncation. With long file paths the rendered
+    /// body exceeds the old 400-byte (~100 token) budget but fits the new
+    /// 4000-byte (~1000 token) tool budget.
+    fn build_referenced_symbol_index(ref_files: usize) -> SidecarState {
+        let files: Vec<(String, IndexedFile)> = (0..ref_files)
+            .map(|i| {
+                let path = format!("src/handlers/request_handler_module_{i:02}.rs");
+                let file = make_indexed_file(
+                    &path,
+                    vec![],
+                    vec![make_reference(
+                        "process_request",
+                        ReferenceKind::Call,
+                        (i as u32) + 5,
+                    )],
+                    ParseStatus::Parsed,
+                );
+                (path, file)
+            })
+            .collect();
+        let file_refs: Vec<(&str, IndexedFile)> =
+            files.iter().map(|(p, f)| (p.as_str(), f.clone())).collect();
+        make_state(file_refs)
+    }
+
+    #[test]
+    fn test_symbol_context_tool_renders_references_without_default_budget_truncation() {
+        // 9 referencing files fit under the 10-match cap, so truncation here
+        // could only come from the byte budget — which the tool path must not hit.
+        let state = build_referenced_symbol_index(9);
+        let params = SymbolContextParams {
+            name: "process_request".to_string(),
+            file: None,
+            path: None,
+            symbol_kind: None,
+            symbol_line: None,
+        };
+
+        let tool = symbol_context_tool_text(&state, &params).expect("tool render");
+
+        // Sanity: the body really is larger than the old 400-byte budget, so
+        // this test would have failed before the budget was raised.
+        assert!(
+            tool.len() > 400,
+            "expected a references body larger than the old budget: {} bytes\n{tool}",
+            tool.len()
+        );
+        assert!(
+            !tool.contains("[truncated]"),
+            "tool path must render all references without budget truncation: {tool}"
+        );
+        // All 9 referencing files should appear (none dropped by the 10-match cap).
+        for i in 0..9 {
+            let path = format!("src/handlers/request_handler_module_{i:02}.rs");
+            assert!(
+                tool.contains(&path),
+                "expected reference file {path} in output: {tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_symbol_context_hook_keeps_lean_references_budget() {
+        // The same body, rendered through the prompt-context hook path, must
+        // still truncate at the lean ~100-token budget so auto-injected context
+        // stays compact. This pins the intentional hook/tool budget split.
+        let state = build_referenced_symbol_index(9);
+        let params = SymbolContextParams {
+            name: "process_request".to_string(),
+            file: None,
+            path: None,
+            symbol_kind: None,
+            symbol_line: None,
+        };
+
+        let hook = symbol_context_hook_text(&state, &params).expect("hook render");
+
+        assert!(
+            hook.contains("[truncated]"),
+            "hook path should still truncate the references section at the lean budget: {hook}"
+        );
     }
 }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use notify::{EventKind, RecommendedWatcher as NotifyRecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{
-    DebounceEventResult, DebouncedEvent, Debouncer, RecommendedCache, new_debouncer,
+    DebounceEventResult, DebouncedEvent, Debouncer, NoCache, new_debouncer_opt,
 };
 use tracing::{debug, error, trace, warn};
 
@@ -500,7 +500,16 @@ pub(crate) fn reconcile_stale_files(repo_root: &Path, shared: &SharedIndex) -> u
 /// Dropping this struct stops the OS-level file watcher.
 pub struct WatcherHandle {
     /// The debouncer owns the OS watcher thread; dropping it stops watching.
-    _debouncer: Debouncer<NotifyRecommendedWatcher, RecommendedCache>,
+    ///
+    /// `NoCache` (not the platform-default `FileIdMap` on Windows) disables the
+    /// file-ID tracking cache. `FileIdMap` exists only to stitch rename events
+    /// into paired Modify(Name) events, which `process_events` never consumes —
+    /// it treats Create==Modify as reindex and Remove as drop, so a rename that
+    /// arrives as Remove+Create behaves identically. Crucially, `FileIdMap`
+    /// would otherwise run a full `WalkDir` (one open-handle syscall per entry,
+    /// including 100k+ gitignored `target/`/`node_modules/` entries) at
+    /// `watch()`, per Create during build floods, and again on overflow rescan.
+    _debouncer: Debouncer<NotifyRecommendedWatcher, NoCache>,
     /// Receive end of the synchronous channel from the notify callback.
     pub event_rx: std::sync::mpsc::Receiver<DebounceEventResult>,
 }
@@ -522,12 +531,20 @@ pub(crate) fn start_watcher(
 ) -> Result<WatcherHandle, notify::Error> {
     let (tx, rx) = std::sync::mpsc::channel::<DebounceEventResult>();
 
-    let mut debouncer = new_debouncer(
+    // Use `NoCache` instead of the platform-default cache. On Windows the
+    // default `RecommendedCache` is `FileIdMap`, which walks the entire tree
+    // with one open-handle syscall per entry at `watch()` time (and again on
+    // every Create / overflow rescan) to maintain rename-stitching state that
+    // `process_events` never uses. On large trees with many gitignored entries
+    // (`target/`, `node_modules/`) that walk dominates watcher startup latency.
+    let mut debouncer = new_debouncer_opt::<_, NotifyRecommendedWatcher, NoCache>(
         Duration::from_millis(debounce_ms),
         None,
         move |result: DebounceEventResult| {
             let _ = tx.send(result);
         },
+        NoCache::new(),
+        notify::Config::default(),
     )?;
 
     debouncer.watch(repo_root, RecursiveMode::Recursive)?;
@@ -640,8 +657,12 @@ pub async fn run_watcher_with_stop(
     {
         // Mark Starting until the recursive filesystem watch is actually
         // registered. The transition to Active happens only when start_watcher
-        // returns Ok (below) — registering the watch is the slow step on large
-        // trees, and reporting Active before it succeeds is misleading.
+        // returns Ok (below). Historically the slow step on large trees was not
+        // the OS-level watch registration but the debouncer's `FileIdMap` cache,
+        // which walked the whole tree (one open-handle syscall per entry) at
+        // `watch()` time; `start_watcher` now uses `NoCache` to skip that walk.
+        // We still report Active only after Ok so a registration failure is not
+        // misreported as a healthy watcher.
         let mut info = watcher_info.lock();
         info.state = WatcherState::Starting;
     }


### PR DESCRIPTION
Third wave from the dogfood campaign: five investigation-verified fixes, each root-caused with file:line evidence before implementation.

## Changes
- **chore(deps)**: tree-sitter 0.26.8 -> 0.26.9 (upstream buffer over-read on 4-byte UTF-16 chars + capture-pool ID overflow — memory-safety in the parse/xref hot path). Grammar crates unchanged.
- **perf(watcher)**: swap notify-debouncer-full default `RecommendedCache` (FileIdMap) for `NoCache`. The FileIdMap ran a full recursive WalkDir + one open-handle syscall per entry at `watch()` time — including 100k+ gitignored target//node_modules entries — plus per-Create-event stats during build floods and full re-walks on overflow rescan. Linux default is already NoCache; SymForge never consumes the rename-stitching FileIdMap provides. Live-verified: watcher still picks up creates.
- **feat(search)**: search_files surfaces Tier-2 metadata-only paths as ranked hits (`[metadata-only: lockfile]`), rank-floored below all Tier-1 source in both the candidate comparator and frecency reorder; resolve=true resolves exact Tier-2 paths honestly. Plus: get_symbol_context references budget raised 400 -> 4000 bytes on the tool path (hook path stays lean).
- **perf(coupling)**: evict dead-path pairs at cold build — 83.9% of pairs referenced deleted paths; measured 45.9 MB -> 5.94 MB on the real db with 0 dead rows remaining and live-live pairs byte-identical. git-tracked liveness (conservative superset), fail-open on git errors, temp-table JOIN for large repos.
- **fix(parsing,explore)**: Angular SF-004 excuser now balances nested parens (`@if (applications().length > 0)` correctly excused; broken HTML still surfaces), `.jsx` JSX regression fixtures (parse + xref), explore header demotes stem-only single-word concept matches (`admission (+ Indexing signals)` instead of `Indexing + admission`).

## Verification
- All four source branches individually: fmt + clippy -D warnings + full suite green
- Integrated branch: `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --all-targets -- --test-threads=1` — 47/47 suites, 0 failures
- Watcher NoCache and coupling eviction verified live against real binaries/databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches search ranking, coupling persistence, and file-watcher behavior on large repos; changes are guarded by fail-open pruning and extensive tests but affect user-visible explore/search output.
> 
> **Overview**
> Wave 3 bundles dependency, performance, search, coupling, parsing, and UX fixes from dogfood investigation.
> 
> **Dependencies & watcher:** Pins **tree-sitter** to **0.26.9** (upstream safety fixes). Replaces notify debouncer **FileIdMap** with **NoCache** so startup no longer walks the full tree (including gitignored dirs) for rename stitching SymForge does not use.
> 
> **Coupling DB:** Adds **`prune_dead_paths`** (git-tracked liveness, fail-open on empty set, temp-table SQL) and runs it inside **`commit_cold_build`** via **`live_tracked_paths`** in the walker so stale pairs for deleted files are removed before post-build **VACUUM**.
> 
> **`search_files`:** Tier-2 **metadata-only** skipped paths (lockfiles, etc.) appear as labeled hits and **`resolve=true`** **`ResolvedMetadataOnly`**; a **rank floor** keeps them below all Tier-1 results in query sort and frecency reorder. **`get_symbol_context`** uses a **4000-byte** references budget on the tool path while the hook stays at **400 bytes**.
> 
> **Parsing / explore:** Angular **SF-004** excuser uses a **balanced-paren scan** for control-flow openers (nested `applications()` cases); **`.jsx`** regression tests added. Explore **`match_concept`** reports **exact vs stemmed** provenance and demotes **stem-only single-word** concepts in headers (e.g. admission leads, “Indexing” as a hint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20902108e1aaba7d5d1d90bed602afead80f0954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->