### PR TITLE
chore(infra): weekly dependabot + Rust 1.96.0 toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Automated dependency freshness. Policy: never sit on old versions —
+# upgrade by default; a stale component must justify its survival.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      tree-sitter-grammars:
+        patterns:
+          - "tree-sitter*"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - "tree-sitter*"
+
+  - package-ecosystem: npm
+    directory: /npm
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Automates the dependency-freshness policy: weekly dependabot for cargo (tree-sitter grammars grouped, minor+patch grouped), npm, and github-actions. Bumps the pinned toolchain 1.95.0 -> 1.96.0 (current stable, 2026-05-25).

Verified under 1.96.0: fmt + clippy -D warnings clean; full suite 47/47 binaries, 0 failed (--test-threads=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency automation and a minor stable Rust pin with no application logic changes.
> 
> **Overview**
> Introduces **weekly Dependabot** automation aligned with an upgrade-by-default dependency policy. **Cargo** updates run at the repo root (Monday, max 10 open PRs), with **tree-sitter** crates grouped separately and other **minor/patch** updates grouped together. **npm** (`/npm`) and **GitHub Actions** also get weekly Monday scans with lower open-PR caps.
> 
> Pins the Rust toolchain from **1.95.0** to **1.96.0** in `rust-toolchain.toml` (rustfmt + clippy unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ee2c8c66c41f7bff14dece1a9d5136ecefc60d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->