### PR TITLE
ci: make rust-toolchain.toml the single source of toolchain truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install
 
       - name: Check Rust formatting
         run: cargo fmt --check
@@ -84,10 +84,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install
 
       # Engine-only build for library embedders (e.g. AAP): no daemon / sidecar /
       # protocol-server / CLI surface. Makes "an embedder can build symforge" a
@@ -108,11 +108,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
-          targets: x86_64-unknown-linux-musl
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively. A hardcoded `toolchain:` input
+      # here silently loses when rust-toolchain.toml is bumped: cargo follows
+      # the toml and auto-installs that toolchain WITHOUT the musl target,
+      # which broke this job with E0463 "can't find crate for core" after the
+      # 1.95.0 -> 1.96.0 bump.
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install && rustup target add x86_64-unknown-linux-musl
 
       # Cross-compile the engine-only embed build to musl. AAP compiles the
       # SymForge engine inside musl guest-agent VMs, so a musl regression must
@@ -149,10 +152,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install
 
       - name: Run ignored 1000-file load performance smoke
         run: cargo test --release --test live_index_integration test_load_perf_1000_files -- --ignored --test-threads=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Run version sync tests
         run: python -m unittest discover -s execution -p 'test_*.py'
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install
 
       - name: Run cargo check
         run: cargo check
@@ -224,11 +224,11 @@ jobs:
       - name: Verify release versions
         run: python execution/version_sync.py check --tag "${{ needs.prepare-release.outputs.tag_name }}"
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
-          targets: ${{ matrix.target }}
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        shell: bash
+        run: rustup toolchain install && rustup target add ${{ matrix.target }}
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -387,10 +387,10 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.95.0"
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; rustup resolves it natively (channel + components).
+      - name: Install Rust toolchain (rust-toolchain.toml)
+        run: rustup toolchain install
 
       - name: Publish to crates.io
         run: >


### PR DESCRIPTION
## Why

The 1.96.0 toolchain bump (#284) updated `rust-toolchain.toml` but left **seven** hardcoded `toolchain: "1.95.0"` pins across `ci.yml` (4) and `release.yml` (3). The pins lose silently: cargo follows `rust-toolchain.toml` and rustup auto-installs that toolchain, so native jobs kept working by accident — while `embed-musl` broke with `E0463: can't find crate for core` (musl std installed for 1.95.0, build running on 1.96.0). This is what failed CI on #290.

## Fix

Delete the duplication instead of synchronizing it: every pinned `dtolnay/rust-toolchain` step becomes `rustup toolchain install`, which natively resolves `rust-toolchain.toml` (channel + components). Cross-target jobs add their target with `rustup target add` against the same resolved toolchain. Future toolchain bumps are a one-file change that cannot drift.

## Verification

- YAML parses clean (both workflows)
- This PR's own CI run exercises all four ci.yml jobs including `embed-musl` — the previously failing gate is the validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to how Rust is installed; no application or release logic changes, but release cross-builds depend on the new install + target-add sequence.
> 
> **Overview**
> **CI and release workflows no longer pin Rust `1.95.0` via `dtolnay/rust-toolchain`.** Every Rust install step now runs `rustup toolchain install`, so the channel and components come from `rust-toolchain.toml` only.
> 
> Cross-target jobs (`embed-musl`, release matrix builds) still add their targets explicitly with `rustup target add` after install, so musl and platform stdlibs stay aligned with the same resolved toolchain—avoiding the silent mismatch that broke `embed-musl` when the toml moved to 1.96.0 while workflow pins stayed on 1.95.0.
> 
> Comments in the YAML document that `rust-toolchain.toml` is the single source of truth and why hardcoded pins drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2b910073833f712d2c50c23372c2ba68f6129b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->