### PR TITLE
fix(hook): bounded stdin read so the hook can never hang waiting for EOF

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -68,8 +68,12 @@ const DAEMON_FALLBACK_DEADLINE: Duration = Duration::from_millis(500);
 // ---------------------------------------------------------------------------
 
 /// Deserialized representation of a Claude Code PostToolUse stdin payload.
+///
+/// The type is `pub` so integration tests can construct an empty payload via
+/// `HookInput::default()` for [`run_hook_with_input`]; the fields stay
+/// crate-private.
 #[derive(serde::Deserialize, Default)]
-pub(crate) struct HookInput {
+pub struct HookInput {
     pub(crate) tool_name: Option<String>,
     pub(crate) tool_input: Option<HookToolInput>,
     pub(crate) cwd: Option<String>,
@@ -236,11 +240,23 @@ impl HookAdoptionSnapshot {
 ///
 /// Never returns an error — failures produce the fail-open empty JSON.
 pub fn run_hook(subcommand: Option<&HookSubcommand>) -> anyhow::Result<()> {
-    let verbose = is_hook_verbose();
-
     // Always read stdin so we have context for path/query extraction.
     // For explicit subcommands the payload may be empty or absent — that's fine.
-    let input = parse_stdin_input();
+    run_hook_with_input(parse_stdin_input(), subcommand)
+}
+
+/// `run_hook` with the stdin payload supplied by the caller instead of read
+/// from the process's stdin.
+///
+/// This is the seam in-process callers (integration tests) must use: reading
+/// the real stdin from inside a test binary blocks until the harness's stdin
+/// reaches EOF, which never happens when the launching environment holds the
+/// pipe open.
+pub fn run_hook_with_input(
+    input: HookInput,
+    subcommand: Option<&HookSubcommand>,
+) -> anyhow::Result<()> {
+    let verbose = is_hook_verbose();
 
     // PreTool is a special case: no sidecar call needed, just output a
     // tool-preference suggestion based on the tool_name from stdin.
@@ -485,19 +501,42 @@ pub fn run_hook(subcommand: Option<&HookSubcommand>) -> anyhow::Result<()> {
 /// PostToolUse JSON payload.
 ///
 /// Returns `HookInput::default()` on any parse failure (fail-open).
+/// Upper bound on waiting for the hook payload on stdin.
+///
+/// Claude Code writes the payload and closes the pipe at spawn, so the read
+/// normally completes in well under a millisecond. The bound only matters when
+/// stdin is held open with no writer (e.g. the hook is invoked interactively,
+/// or from an environment that never closes the inherited pipe) — without it
+/// the read blocks forever and the hook hangs the session instead of failing
+/// open.
+const STDIN_READ_TIMEOUT_MS: u64 = 250;
+
 pub(crate) fn parse_stdin_input() -> HookInput {
-    let stdin = std::io::stdin();
-    let mut stdin_json = String::new();
-    for line in stdin.lock().lines() {
-        match line {
-            Ok(l) => {
-                stdin_json.push_str(&l);
-                stdin_json.push('\n');
+    // The blocking read happens on a helper thread so the hook can enforce a
+    // deadline. On timeout the thread is leaked — it stays parked on the stdin
+    // read — which is acceptable because the hook is a one-shot process and
+    // exits immediately after responding. In-process callers (tests) must use
+    // `run_hook_with_input` and never reach this function.
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut stdin_json = String::new();
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(l) => {
+                    stdin_json.push_str(&l);
+                    stdin_json.push('\n');
+                }
+                Err(_) => break,
             }
-            Err(_) => break,
         }
+        let _ = tx.send(stdin_json);
+    });
+    match rx.recv_timeout(Duration::from_millis(STDIN_READ_TIMEOUT_MS)) {
+        Ok(stdin_json) => serde_json::from_str(&stdin_json).unwrap_or_default(),
+        // Timeout or disconnected sender: fail open with an empty payload.
+        Err(_) => HookInput::default(),
     }
-    serde_json::from_str(&stdin_json).unwrap_or_default()
 }
 
 /// Converts an absolute path to a relative path by stripping the `cwd` prefix.

--- a/tests/hook_subprocess_integration.rs
+++ b/tests/hook_subprocess_integration.rs
@@ -282,6 +282,43 @@ fn run_hook_stale_sidecar_and_dead_daemon_degrades_to_pass_through() {
     );
 }
 
+/// Regression guard: a hook whose stdin is held open without data must exit
+/// fail-open instead of hanging.
+///
+/// `parse_stdin_input` reads stdin on a bounded helper thread and gives up
+/// after `STDIN_READ_TIMEOUT_MS`, treating the payload as empty. Before that
+/// bound existed, the read blocked until EOF — forever, when the spawning
+/// environment kept the inherited pipe open with no writer. The same unbounded
+/// read also wedged `sidecar_integration` whenever its harness was launched
+/// with an open stdin (the recurring 0-CPU test stall).
+#[test]
+fn run_hook_stdin_held_open_exits_fail_open_within_deadline() {
+    let tmp = TempDir::new().expect("tempdir creation");
+    let bin = env!("CARGO_BIN_EXE_symforge");
+    let mut child = Command::new(bin)
+        .arg("hook")
+        .current_dir(tmp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("symforge binary should spawn");
+
+    // Deliberately neither write to nor close the child's stdin: the pipe
+    // stays open with no writer for the child's whole lifetime. The 5s
+    // deadline is generous headroom over the 250ms stdin bound; the kill
+    // inside wait_with_timeout keeps a regression from leaking the child.
+    let status = wait_with_timeout(&mut child, Duration::from_secs(5))
+        .expect("wait on hook subprocess")
+        .expect("hook must exit fail-open despite stdin held open, not hang");
+    assert!(
+        status.success(),
+        "hook with held-open stdin must exit zero (fail-open): {status:?}"
+    );
+
+    drop(child.stdin.take());
+}
+
 /// Marker body returned by the mock daemon's enrichment endpoint. Distinct
 /// from any fail-open output so the test can prove enrichment was served.
 const ENRICHED_MARKER: &str = "MOCK_DAEMON_ENRICHED_OUTLINE";

--- a/tests/sidecar_integration.rs
+++ b/tests/sidecar_integration.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 use once_cell::sync::Lazy;
 use symforge::{
     cli::HookSubcommand,
-    cli::hook::{event_name_for, fail_open_json, run_hook, success_json},
+    cli::hook::{HookInput, event_name_for, fail_open_json, run_hook_with_input, success_json},
     domain::{LanguageId, ReferenceKind, ReferenceRecord, SymbolKind, SymbolRecord},
     live_index::{IndexedFile, LiveIndex, ParseStatus, SharedIndex},
     sidecar::spawn_sidecar,
@@ -362,8 +362,12 @@ async fn test_hook_binary_latency() {
     // Port file already written by spawn_sidecar.
     // SessionStart calls /repo-map — no file path env var needed.
     let start = Instant::now();
-    // run_hook writes JSON to stdout — acceptable in test context.
-    run_hook(Some(&HookSubcommand::SessionStart)).expect("run_hook must succeed");
+    // run_hook_with_input writes JSON to stdout — acceptable in test context.
+    // The input is injected (empty payload) instead of read from stdin: the
+    // test binary's stdin belongs to the harness's launcher and may never
+    // reach EOF, which would block this test forever.
+    run_hook_with_input(HookInput::default(), Some(&HookSubcommand::SessionStart))
+        .expect("run_hook_with_input must succeed");
     let elapsed = start.elapsed();
 
     assert!(


### PR DESCRIPTION
## Why

`run_hook` read stdin to EOF with no timeout. When the invoking environment holds the inherited pipe open with no writer, the read blocks **forever**. The same unbounded read wedged the `sidecar_integration` suite at 0 CPU whenever its harness was launched with an open stdin: `test_hook_binary_latency` calls `run_hook` in-process, parking the whole single-threaded suite on the harness's stdin (reproduced deterministically; 19-minute 0-CPU stalls).

## What

- `parse_stdin_input` reads on a helper thread with a 250ms `recv_timeout`; on timeout it fails open with an empty payload. Claude Code writes the payload and closes the pipe at spawn, so real invocations finish in <1ms and never see the bound.
- New seam `run_hook_with_input(input, sub)`: `run_hook` minus the stdin read. In-process callers (tests) inject the payload and never touch process stdin. `HookInput` is now `pub` (fields stay crate-private).
- `test_hook_binary_latency` uses the seam — it measures the sidecar round trip it was written to measure, independent of stdin wiring.
- New subprocess regression test: hook spawned with stdin piped but never written/closed must exit fail-open within the deadline.

## Verification

- `sidecar_integration` 27/27 in 0.78s from the exact environment that previously wedged for 19 minutes (PowerShell background task, stdin held open)
- `hook_subprocess_integration` 6/6 including the new regression test
- Full local suite: 59 binaries, 0 failures, `--test-threads=1`; fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reliability fix on the hook entry path with fail-open on timeout; normal Claude Code invocations are unchanged, with a small risk of empty context if stdin is unusually slow.
> 
> **Overview**
> **Prevents the Claude Code hook from hanging when stdin never reaches EOF** by bounding stdin reads and giving tests a way to bypass process stdin.
> 
> `parse_stdin_input` now reads on a helper thread with a **250ms** deadline; on timeout it **fail-opens** with an empty `HookInput` instead of blocking forever when the inherited pipe stays open with no writer. `run_hook` delegates to new **`run_hook_with_input`**, which accepts an injected payload; **`HookInput`** is **`pub`** so tests can use `HookInput::default()`. In-process **`sidecar_integration`** latency coverage switches to the seam so it no longer blocks on the harness stdin. A subprocess test spawns `symforge hook` with a piped stdin that is never written or closed and asserts exit within the deadline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5848933823d7c260a10e306ab11441c2ca6d3b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->