### PR TITLE
feat(stel): harden Phase 2 L2 admission states (P2-S3)

### DIFF
--- a/specs/002-v8-phase2-stel-controller/tasks.md
+++ b/specs/002-v8-phase2-stel-controller/tasks.md
@@ -39,12 +39,12 @@
 
 ## P2-S3: L2 Admission Hardening (US2)
 
-- [ ] T020 [US2] Implement `cache_hit` decision path in `src/stel/controller.rs` (session target match)
-- [ ] T021 [US2] Implement `degrade` path with degrade_flags (outline_only, token caps) per stel-schema
-- [ ] T022 [US2] Implement non-P-FF `bypass` when predicted net ≤ 0 (honest StelBypassBody)
-- [ ] T023 [US2] Ensure L3 honors all four decisions in `src/stel/executor.rs`
-- [ ] T024 [P] [US2] Add L2 admission unit tests (`src/stel/controller.rs` tests or `tests/stel_l2_admission.rs`)
-- [ ] T025 [US2] Verify P-FF bypass enforcement unchanged (`tests/stel_l3_enforcement.rs`)
+- [x] T020 [US2] Implement `cache_hit` decision path in `src/stel/controller.rs` (session target match)
+- [x] T021 [US2] Implement `degrade` path with degrade_flags (outline_only, token caps) per stel-schema
+- [x] T022 [US2] Implement non-P-FF `bypass` when predicted net ≤ 0 (honest StelBypassBody)
+- [x] T023 [US2] Ensure L3 honors all four decisions in `src/stel/executor.rs`
+- [x] T024 [P] [US2] Add L2 admission unit tests (`src/stel/controller.rs` tests or `tests/stel_l2_admission.rs`)
+- [x] T025 [US2] Verify P-FF bypass enforcement unchanged (`tests/stel_l3_enforcement.rs`)
 
 **Checkpoint**: All admission states covered by tests; golden + L3 suites green.
 

--- a/src/protocol/session.rs
+++ b/src/protocol/session.rs
@@ -118,6 +118,26 @@ impl SessionContext {
         inner.fetched_files.contains_key(path)
     }
 
+    /// Prior token cost recorded for a fetched symbol, if any.
+    pub fn symbol_prior_tokens(&self, path: &str, name: &str) -> Option<u32> {
+        let inner = self.inner.lock();
+        inner
+            .fetched_symbols
+            .get(&(path.to_string(), name.to_string()))
+            .copied()
+    }
+
+    /// Prior token cost recorded for a fetched file, if any.
+    pub fn file_prior_tokens(&self, path: &str) -> Option<u32> {
+        let inner = self.inner.lock();
+        inner.fetched_files.get(path).copied()
+    }
+
+    /// Session age in seconds for cache-hit metadata.
+    pub fn session_age_secs(&self) -> u64 {
+        self.inner.lock().started_at.elapsed().as_secs()
+    }
+
     /// Take a snapshot for display.
     pub fn snapshot(&self) -> SessionSnapshot {
         let inner = self.inner.lock();

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -8011,12 +8011,13 @@ impl SymForgeServer {
         request: &crate::stel::StelRequest,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
         use crate::protocol::smart_query;
-        use crate::stel::controller::{build_estimate, evaluate_plan};
+        use crate::stel::controller::{build_estimate, evaluate_plan_with_session};
         use crate::stel::executor::{
-            ServedStepResult, chain_failure_decision, format_bypass_body,
-            format_multi_step_serve_body, format_partial_multi_step_serve_body,
-            format_single_step_serve_body, is_enforced_bypass, route_tool_label,
-            serve_chain_outcome_class, serve_step_failed, serve_step_outcome, tools_executed,
+            ServedStepResult, apply_degrade_to_plan, chain_failure_decision, format_bypass_body,
+            format_cache_hit_body, format_multi_step_serve_body,
+            format_partial_multi_step_serve_body, format_single_step_serve_body, is_degrade,
+            route_tool_label, serve_chain_outcome_class, serve_step_failed, serve_step_outcome,
+            should_skip_legacy_dispatch, tools_executed,
         };
         use crate::stel::handler::{self, metrics_for_decision};
         use crate::stel::planner::{build_plan, plan_summary_line};
@@ -8028,7 +8029,7 @@ impl SymForgeServer {
         }
 
         let plan = build_plan(request);
-        let decision = evaluate_plan(request, &plan);
+        let decision = evaluate_plan_with_session(request, &plan, Some(&self.session_context));
         let step = plan
             .steps
             .first()
@@ -8045,8 +8046,12 @@ impl SymForgeServer {
             return statused_tool_result(output, OutcomeClass::Found);
         }
 
-        if is_enforced_bypass(&decision) {
-            let body = format_bypass_body(&decision);
+        if should_skip_legacy_dispatch(&decision) {
+            let body = if decision.decision == crate::stel::AdmissionDecision::CacheHit {
+                format_cache_hit_body(&decision)
+            } else {
+                format_bypass_body(&decision)
+            };
             let output = self.finalize_symforge_with_ledger(
                 "symforge",
                 request,
@@ -8064,10 +8069,16 @@ impl SymForgeServer {
             return statused_tool_result(output, OutcomeClass::Found);
         }
 
+        let exec_plan = if is_degrade(&decision) {
+            apply_degrade_to_plan(&plan, &decision)
+        } else {
+            plan.clone()
+        };
+
         let mut step_results = Vec::new();
         let mut outcome_class = OutcomeClass::Found;
         let mut chain_failed = false;
-        for step in &plan.steps {
+        for step in &exec_plan.steps {
             let tool_body = self
                 .dispatch_tool_for_tests(&step.tool, step.args.clone())
                 .await;
@@ -8093,11 +8104,11 @@ impl SymForgeServer {
         }
 
         let chain_failure_note = chain_failed.then(|| effective_decision.decision_reason.clone());
-        let body = if plan.steps.len() == 1 {
+        let body = if exec_plan.steps.len() == 1 {
             format_single_step_serve_body(
                 &plan,
                 &effective_decision,
-                &plan.steps[0],
+                &exec_plan.steps[0],
                 &step_results[0].body,
             )
         } else if chain_failed {

--- a/src/stel/calibration.rs
+++ b/src/stel/calibration.rs
@@ -13,7 +13,9 @@ pub const TUNING_REVIEW_MIN_EVENTS: usize = 5;
 pub struct StelCalibrationSummary {
     pub total_events: usize,
     pub serve_count: usize,
+    pub degrade_count: usize,
     pub bypass_count: usize,
+    pub cache_hit_count: usize,
     pub pff_bypass_count: usize,
     pub legacy_executed_count: usize,
     pub total_schema_tokens: u64,
@@ -29,7 +31,9 @@ pub fn summarize_calibration(events: &[StelLedgerEvent]) -> StelCalibrationSumma
     let mut summary = StelCalibrationSummary {
         total_events: events.len(),
         serve_count: 0,
+        degrade_count: 0,
         bypass_count: 0,
+        cache_hit_count: 0,
         pff_bypass_count: 0,
         legacy_executed_count: 0,
         total_schema_tokens: 0,
@@ -43,13 +47,13 @@ pub fn summarize_calibration(events: &[StelLedgerEvent]) -> StelCalibrationSumma
     for event in events {
         match event.decision {
             AdmissionDecision::Serve => summary.serve_count += 1,
-            AdmissionDecision::Bypass => {
-                summary.bypass_count += 1;
-                if event.tools_called.is_empty() {
-                    summary.pff_bypass_count += 1;
-                }
-            }
+            AdmissionDecision::Degrade => summary.degrade_count += 1,
+            AdmissionDecision::CacheHit => summary.cache_hit_count += 1,
+            AdmissionDecision::Bypass => summary.bypass_count += 1,
             _ => {}
+        }
+        if event.pff_bypass == Some(true) {
+            summary.pff_bypass_count += 1;
         }
         if !event.tools_called.is_empty() {
             summary.legacy_executed_count += 1;
@@ -83,7 +87,9 @@ pub fn format_calibration_section(summary: &StelCalibrationSummary) -> String {
         "── calibration (observational) ──".to_string(),
         format!("events: {}", summary.total_events),
         format!("serve: {}", summary.serve_count),
+        format!("degrade: {}", summary.degrade_count),
         format!("bypass: {}", summary.bypass_count),
+        format!("cache_hit: {}", summary.cache_hit_count),
         format!("pff_bypass: {}", summary.pff_bypass_count),
         format!("legacy_executed: {}", summary.legacy_executed_count),
         format!("schema_tokens: {}", summary.total_schema_tokens),
@@ -172,7 +178,9 @@ mod tests {
         let summary = summarize_calibration(&[]);
         assert_eq!(summary.total_events, 0);
         assert_eq!(summary.serve_count, 0);
+        assert_eq!(summary.degrade_count, 0);
         assert_eq!(summary.bypass_count, 0);
+        assert_eq!(summary.cache_hit_count, 0);
         assert_eq!(summary.pff_bypass_count, 0);
         assert_eq!(summary.legacy_executed_count, 0);
         assert_eq!(summary.total_schema_tokens, 0);
@@ -229,6 +237,8 @@ mod tests {
         let section = format_calibration_section(&summary);
         assert!(section.contains("── calibration (observational) ──"));
         assert!(section.contains("serve: 1"));
+        assert!(section.contains("degrade: 0"));
+        assert!(section.contains("cache_hit: 0"));
         assert!(section.contains("legacy_executed: 1"));
         assert!(section.contains("tuning:"));
     }

--- a/src/stel/controller.rs
+++ b/src/stel/controller.rs
@@ -1,18 +1,24 @@
 //! STEL L2 economics controller — evaluate [`StelPlan`] → [`StelDecision`] / [`StelEstimate`].
 //!
-//! Phase 1 slice: economics scoring; P-FF bypass is enforced in [`super::executor`].
+//! Phase 2 P2-S3: normative admission states (`serve | degrade | bypass | cache_hit`).
+
+use crate::protocol::session::SessionContext;
 
 use super::types::{
-    AdmissionDecision, GoldenRouteRow, StelBypassBody, StelDecision, StelEstimate, StelPlan,
-    StelRequest,
+    AdmissionDecision, GoldenRouteRow, RouteConfidence, StelBypassBody, StelCacheBody,
+    StelDecision, StelEstimate, StelPlan, StelPlanStep, StelRequest,
 };
 
 /// Compact-3 worst-case schema tax per call (A-006 conservative path; no amortization credit).
 pub const COMPACT_SCHEMA_TOKENS: u32 = 45;
 /// Compact `symforge` invoke overhead per call (schema example + Phase 0 doctrine).
 pub const COMPACT_INVOKE_TOKENS: u32 = 80;
-/// Minimum predicted net vs manual before `serve` is recommended (schema example).
+/// Minimum predicted net vs manual before `serve` (schema `margin_high`).
 pub const SERVE_MARGIN_TOKENS: i32 = 50;
+/// Predicted net at or below this (but above zero) triggers `degrade` (`margin_low`).
+pub const DEGRADE_MARGIN_LOW_TOKENS: i32 = SERVE_MARGIN_TOKENS;
+/// Default capped response budget applied on degrade when request omits `max_tokens`.
+pub const DEGRADE_DEFAULT_MAX_TOKENS: u32 = 400;
 
 /// Token economics breakdown for one planned invocation.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -27,14 +33,36 @@ pub struct EconomicsBreakdown {
 
 /// Evaluate L2 admission for a draft plan (does not execute L3).
 pub fn evaluate_plan(request: &StelRequest, plan: &StelPlan) -> StelDecision {
+    evaluate_plan_with_session(request, plan, None)
+}
+
+/// Evaluate L2 admission with optional in-process session context for cache-hit detection.
+pub fn evaluate_plan_with_session(
+    request: &StelRequest,
+    plan: &StelPlan,
+    session: Option<&SessionContext>,
+) -> StelDecision {
     if let Some(bypass) = detect_pff_bypass(request) {
-        let economics = economics_for_bypass(&bypass);
+        return decision_from_pff_bypass(plan, request, bypass);
+    }
+
+    if let Some(session) = session
+        && let Some(cache) = detect_session_cache_hit(plan, session)
+    {
+        return decision_from_cache_hit(plan, request, cache);
+    }
+
+    let economics = estimate_economics(plan);
+    let net = economics.predicted_net_vs_manual;
+
+    if net <= 0 {
+        let bypass = economics_bypass_body(plan, &economics);
         return StelDecision {
             plan_id: plan.plan_id.clone(),
             decision: AdmissionDecision::Bypass,
             decision_reason: format!(
-                "{}; predicted_net={}",
-                bypass.reason, economics.predicted_net_vs_manual
+                "predicted_net={net} <= 0; economics bypass via host_read `{}`",
+                bypass.path
             ),
             effective_max_tokens: request.max_tokens,
             degrade_flags: vec![],
@@ -44,30 +72,60 @@ pub fn evaluate_plan(request: &StelRequest, plan: &StelPlan) -> StelDecision {
         };
     }
 
-    let economics = estimate_economics(plan);
-    let recommended = economics.predicted_net_vs_manual > SERVE_MARGIN_TOKENS;
-    let decision = if recommended {
-        AdmissionDecision::Serve
-    } else {
-        // Metadata classification only — enforcement deferred to a later slice.
-        AdmissionDecision::Bypass
-    };
-    let decision_reason = if recommended {
-        format!(
-            "predicted_net={} > margin={}",
-            economics.predicted_net_vs_manual, SERVE_MARGIN_TOKENS
-        )
-    } else {
-        format!(
-            "predicted_net={} <= margin={} (non-P-FF bypass metadata; L3 not gated)",
-            economics.predicted_net_vs_manual, SERVE_MARGIN_TOKENS
-        )
-    };
+    let mandatory_degrade =
+        plan.confidence == RouteConfidence::Fallback && net < SERVE_MARGIN_TOKENS;
+    let economics_degrade = net <= DEGRADE_MARGIN_LOW_TOKENS;
+
+    if mandatory_degrade || economics_degrade {
+        let mut degrade_flags = Vec::new();
+        if mandatory_degrade {
+            degrade_flags.push("fallback_mandatory".to_string());
+        }
+        if plan
+            .steps
+            .iter()
+            .any(|step| step.tool == "get_file_context")
+        {
+            degrade_flags.push("outline_only".to_string());
+        } else {
+            degrade_flags.push("max_tokens_cap".to_string());
+        }
+        degrade_flags.sort();
+        degrade_flags.dedup();
+
+        let effective_max_tokens = request
+            .max_tokens
+            .or(Some(DEGRADE_DEFAULT_MAX_TOKENS))
+            .map(|cap| cap.min(DEGRADE_DEFAULT_MAX_TOKENS));
+
+        let reason = if mandatory_degrade {
+            format!(
+                "predicted_net={net} < margin={}; fallback confidence requires degrade",
+                SERVE_MARGIN_TOKENS
+            )
+        } else {
+            format!(
+                "predicted_net={net} <= margin_low={}",
+                DEGRADE_MARGIN_LOW_TOKENS
+            )
+        };
+
+        return StelDecision {
+            plan_id: plan.plan_id.clone(),
+            decision: AdmissionDecision::Degrade,
+            decision_reason: reason,
+            effective_max_tokens,
+            degrade_flags,
+            steps: Some(plan.steps.clone()),
+            bypass: None,
+            cache: None,
+        };
+    }
 
     StelDecision {
         plan_id: plan.plan_id.clone(),
-        decision,
-        decision_reason,
+        decision: AdmissionDecision::Serve,
+        decision_reason: format!("predicted_net={net} > margin={}", SERVE_MARGIN_TOKENS),
         effective_max_tokens: request.max_tokens,
         degrade_flags: vec![],
         steps: Some(plan.steps.clone()),
@@ -76,30 +134,163 @@ pub fn evaluate_plan(request: &StelRequest, plan: &StelPlan) -> StelDecision {
     }
 }
 
+fn decision_from_pff_bypass(
+    plan: &StelPlan,
+    request: &StelRequest,
+    bypass: StelBypassBody,
+) -> StelDecision {
+    let economics = economics_for_bypass(&bypass);
+    StelDecision {
+        plan_id: plan.plan_id.clone(),
+        decision: AdmissionDecision::Bypass,
+        decision_reason: format!(
+            "{}; predicted_net={}",
+            bypass.reason, economics.predicted_net_vs_manual
+        ),
+        effective_max_tokens: request.max_tokens,
+        degrade_flags: vec![],
+        steps: None,
+        bypass: Some(bypass),
+        cache: None,
+    }
+}
+
+fn decision_from_cache_hit(
+    plan: &StelPlan,
+    request: &StelRequest,
+    cache: StelCacheBody,
+) -> StelDecision {
+    StelDecision {
+        plan_id: plan.plan_id.clone(),
+        decision: AdmissionDecision::CacheHit,
+        decision_reason: format!(
+            "session cache hit for {} `{}` (prior_tokens={})",
+            cache.kind, cache.path, cache.prior_tokens
+        ),
+        effective_max_tokens: request.max_tokens,
+        degrade_flags: vec![],
+        steps: None,
+        bypass: None,
+        cache: Some(cache),
+    }
+}
+
+fn detect_session_cache_hit(plan: &StelPlan, session: &SessionContext) -> Option<StelCacheBody> {
+    let step = plan.steps.first()?;
+    let age = session.session_age_secs();
+    match step.tool.as_str() {
+        "get_symbol" => {
+            let name = step.args.get("name")?.as_str()?.trim();
+            if name.is_empty() {
+                return None;
+            }
+            let path = step
+                .args
+                .get("path")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .trim();
+            if !path.is_empty() && session.has_symbol(path, name) {
+                return Some(StelCacheBody {
+                    kind: "symbol".to_string(),
+                    path: path.to_string(),
+                    name: name.to_string(),
+                    prior_tokens: session.symbol_prior_tokens(path, name).unwrap_or(0),
+                    session_age_secs: age,
+                });
+            }
+            None
+        }
+        "get_file_context" | "get_file_content" => {
+            let path = step.args.get("path")?.as_str()?.trim();
+            if path.is_empty() || !session.has_file(path) {
+                return None;
+            }
+            Some(StelCacheBody {
+                kind: "file".to_string(),
+                path: path.to_string(),
+                name: String::new(),
+                prior_tokens: session.file_prior_tokens(path).unwrap_or(0),
+                session_age_secs: age,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn economics_bypass_body(plan: &StelPlan, economics: &EconomicsBreakdown) -> StelBypassBody {
+    let path = plan_primary_path(plan).unwrap_or_else(|| "unknown".to_string());
+    StelBypassBody {
+        action: "host_read".to_string(),
+        path: path.clone(),
+        start_line: 1,
+        end_line: Some(80),
+        predicted_manual_tokens: economics.predicted_manual_tokens,
+        predicted_symforge_tokens: economics.predicted_symforge_tokens,
+        reason: format!(
+            "predicted_net={} <= 0; host_read `{path}` cheaper than serve",
+            economics.predicted_net_vs_manual
+        ),
+    }
+}
+
+fn plan_primary_path(plan: &StelPlan) -> Option<String> {
+    plan.steps.first().and_then(primary_path_from_step)
+}
+
+fn primary_path_from_step(step: &StelPlanStep) -> Option<String> {
+    step.args
+        .get("path")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            step.args
+                .get("name")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        })
+}
+
 /// Evaluate L2 admission for a structural edit plan (no NL P-FF bypass path).
 pub fn evaluate_edit_plan(plan: &StelPlan) -> StelDecision {
     let economics = estimate_economics(plan);
-    let recommended = economics.predicted_net_vs_manual > SERVE_MARGIN_TOKENS;
-    let decision = if recommended {
-        AdmissionDecision::Serve
-    } else {
-        AdmissionDecision::Bypass
-    };
-    let decision_reason = if recommended {
-        format!(
-            "predicted_net={} > margin={}",
-            economics.predicted_net_vs_manual, SERVE_MARGIN_TOKENS
-        )
-    } else {
-        format!(
-            "predicted_net={} <= margin={} (non-P-FF bypass metadata; L3 not gated)",
-            economics.predicted_net_vs_manual, SERVE_MARGIN_TOKENS
-        )
-    };
+    let net = economics.predicted_net_vs_manual;
+    if net <= 0 {
+        let bypass = economics_bypass_body(plan, &economics);
+        return StelDecision {
+            plan_id: plan.plan_id.clone(),
+            decision: AdmissionDecision::Bypass,
+            decision_reason: format!("predicted_net={net} <= 0; edit economics bypass"),
+            effective_max_tokens: None,
+            degrade_flags: vec![],
+            steps: Some(plan.steps.clone()),
+            bypass: Some(bypass),
+            cache: None,
+        };
+    }
+    if net <= DEGRADE_MARGIN_LOW_TOKENS {
+        return StelDecision {
+            plan_id: plan.plan_id.clone(),
+            decision: AdmissionDecision::Degrade,
+            decision_reason: format!(
+                "predicted_net={net} <= margin_low={}",
+                DEGRADE_MARGIN_LOW_TOKENS
+            ),
+            effective_max_tokens: Some(DEGRADE_DEFAULT_MAX_TOKENS),
+            degrade_flags: vec!["max_tokens_cap".to_string()],
+            steps: Some(plan.steps.clone()),
+            bypass: None,
+            cache: None,
+        };
+    }
     StelDecision {
         plan_id: plan.plan_id.clone(),
-        decision,
-        decision_reason,
+        decision: AdmissionDecision::Serve,
+        decision_reason: format!("predicted_net={net} > margin={}", SERVE_MARGIN_TOKENS),
         effective_max_tokens: None,
         degrade_flags: vec![],
         steps: Some(plan.steps.clone()),
@@ -253,6 +444,24 @@ mod tests {
         request
     }
 
+    fn low_net_plan() -> StelPlan {
+        StelPlan {
+            plan_id: "low-net".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_context".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 900,
+                est_manual_tokens: 100,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        }
+    }
+
     #[test]
     fn serve_rows_classify_as_serve() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(GOLDEN_ROUTES_FIXTURE);
@@ -308,6 +517,95 @@ mod tests {
             let estimate = build_estimate(&request, &plan, &decision);
             assert!(!estimate.recommended, "{id} should not recommend serve");
         }
+    }
+
+    #[test]
+    fn negative_net_non_pff_bypass_has_host_read_body() {
+        let plan = low_net_plan();
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        assert_eq!(decision.decision, AdmissionDecision::Bypass);
+        let bypass = decision.bypass.as_ref().expect("economics bypass body");
+        assert_eq!(bypass.path, "src/lib.rs");
+        assert!(decision.decision_reason.contains("predicted_net="));
+    }
+
+    #[test]
+    fn marginal_net_degrades_with_outline_only_flag() {
+        let plan = StelPlan {
+            plan_id: "degrade".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_context".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 530,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        assert_eq!(decision.decision, AdmissionDecision::Degrade);
+        assert!(decision.degrade_flags.contains(&"outline_only".to_string()));
+        assert!(decision.effective_max_tokens.is_some());
+    }
+
+    #[test]
+    fn fallback_confidence_forces_degrade_below_margin_high() {
+        let plan = StelPlan {
+            plan_id: "fallback".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Fallback,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_content".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 530,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        assert_eq!(decision.decision, AdmissionDecision::Degrade);
+        assert!(
+            decision
+                .degrade_flags
+                .contains(&"fallback_mandatory".to_string())
+        );
+    }
+
+    #[test]
+    fn session_cache_hit_for_prefetched_symbol() {
+        let session = SessionContext::new();
+        session.record_symbol("src/lib.rs", "cfg_if", 128);
+        let plan = StelPlan {
+            plan_id: "cache".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Exact,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_symbol".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs", "name": "cfg_if" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 800,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan_with_session(&request, &plan, Some(&session));
+        assert_eq!(decision.decision, AdmissionDecision::CacheHit);
+        let cache = decision.cache.as_ref().expect("cache body");
+        assert_eq!(cache.kind, "symbol");
+        assert_eq!(cache.prior_tokens, 128);
     }
 
     #[test]

--- a/src/stel/executor.rs
+++ b/src/stel/executor.rs
@@ -5,8 +5,11 @@ use serde_json;
 use crate::protocol::result_status::OutcomeClass;
 use crate::protocol::tools::{classify_compact_tool_output, compact_tool_output_is_success};
 
+use super::controller::DEGRADE_DEFAULT_MAX_TOKENS;
 use super::planner::confidence_label;
-use super::types::{AdmissionDecision, StelBypassBody, StelDecision, StelPlan, StelPlanStep};
+use super::types::{
+    AdmissionDecision, StelBypassBody, StelCacheBody, StelDecision, StelPlan, StelPlanStep,
+};
 
 /// Outcome of one in-process legacy tool dispatch during a multi-step serve chain.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -15,9 +18,30 @@ pub struct ServedStepResult {
     pub body: String,
 }
 
-/// Whether L3 should skip legacy tool dispatch (P-FF bypass only in this slice).
+/// Whether L3 should skip legacy tool dispatch (`bypass` or `cache_hit`).
+pub fn should_skip_legacy_dispatch(decision: &StelDecision) -> bool {
+    matches!(
+        decision.decision,
+        AdmissionDecision::Bypass if decision.bypass.is_some()
+    ) || matches!(
+        decision.decision,
+        AdmissionDecision::CacheHit if decision.cache.is_some()
+    )
+}
+
+/// Back-compat alias — enforced bypass/cache_hit paths must not execute legacy tools.
 pub fn is_enforced_bypass(decision: &StelDecision) -> bool {
-    decision.decision == AdmissionDecision::Bypass && decision.bypass.is_some()
+    should_skip_legacy_dispatch(decision)
+}
+
+/// Whether the bypass body is policy P-FF (whole-file host read).
+pub fn is_pff_bypass_body(bypass: &StelBypassBody) -> bool {
+    bypass.reason.contains("policy=P-FF")
+}
+
+/// Whether L2 chose a degrade admission (caps applied before L3 dispatch).
+pub fn is_degrade(decision: &StelDecision) -> bool {
+    decision.decision == AdmissionDecision::Degrade
 }
 
 /// Human-readable bypass body plus machine-readable [`StelBypassBody`] JSON.
@@ -42,6 +66,17 @@ fn format_host_read_line(bypass: &StelBypassBody) -> String {
 fn format_bypass_body_from(bypass: &StelBypassBody, decision_reason: &str) -> String {
     let json = serde_json::to_string_pretty(bypass).expect("StelBypassBody serializes");
     let host_read = format_host_read_line(bypass);
+    let guidance = if bypass.end_line.is_none() {
+        format!(
+            "Open `{path}` in your editor and review the file directly for whole-file tasks.",
+            path = bypass.path
+        )
+    } else {
+        format!(
+            "Open `{path}` in your editor and read the suggested line range directly.",
+            path = bypass.path
+        )
+    };
     format!(
         "Decision: bypass\n\
          Economics: bypass ({decision_reason})\n\
@@ -51,14 +86,91 @@ fn format_bypass_body_from(bypass: &StelBypassBody, decision_reason: &str) -> St
          Predicted SymForge tokens avoided: {}\n\
          \n\
          SymForge did not execute a legacy tool for this request.\n\
-         Open `{path}` in your editor and review the file directly for whole-file tasks.\n\
+         {guidance}\n\
          \n\
          --- bypass payload ---\n\
          {json}",
-        bypass.action,
-        bypass.predicted_manual_tokens,
-        bypass.predicted_symforge_tokens,
-        path = bypass.path,
+        bypass.action, bypass.predicted_manual_tokens, bypass.predicted_symforge_tokens,
+    )
+}
+
+/// Human-readable cache-hit body plus machine-readable [`StelCacheBody`] JSON.
+pub fn format_cache_hit_body(decision: &StelDecision) -> String {
+    let cache = decision
+        .cache
+        .as_ref()
+        .expect("cache_hit requires StelCacheBody");
+    format_cache_hit_body_from(cache, &decision.decision_reason)
+}
+
+fn format_cache_hit_body_from(cache: &StelCacheBody, decision_reason: &str) -> String {
+    let json = serde_json::to_string_pretty(cache).expect("StelCacheBody serializes");
+    let target = if cache.name.is_empty() {
+        format!("file `{}`", cache.path)
+    } else {
+        format!("symbol `{}` in `{}`", cache.name, cache.path)
+    };
+    format!(
+        "Decision: cache_hit\n\
+         Economics: cache_hit ({decision_reason})\n\
+         Session cache: {} {target} (prior_tokens={}, session_age_secs={})\n\
+         \n\
+         SymForge did not re-execute a legacy tool for this request.\n\
+         Reuse the content already loaded in this session.\n\
+         \n\
+         --- cache payload ---\n\
+         {json}",
+        cache.kind, cache.prior_tokens, cache.session_age_secs,
+    )
+}
+
+/// Apply L2 degrade caps to a plan before L3 dispatch.
+pub fn apply_degrade_to_plan(plan: &StelPlan, decision: &StelDecision) -> StelPlan {
+    let mut degraded = plan.clone();
+    let cap = decision
+        .effective_max_tokens
+        .unwrap_or(DEGRADE_DEFAULT_MAX_TOKENS);
+    let outline_only = decision
+        .degrade_flags
+        .iter()
+        .any(|flag| flag == "outline_only");
+    let max_tokens_cap = decision
+        .degrade_flags
+        .iter()
+        .any(|flag| flag == "max_tokens_cap");
+
+    for step in &mut degraded.steps {
+        let Some(args) = step.args.as_object_mut() else {
+            continue;
+        };
+        if outline_only && step.tool == "get_file_context" {
+            args.insert("sections".to_string(), serde_json::json!(["outline"]));
+        }
+        if max_tokens_cap && supports_max_tokens_cap(&step.tool) {
+            let existing = args.get("max_tokens").and_then(|value| value.as_u64());
+            let capped = existing
+                .map(|value| value.min(u64::from(cap)))
+                .unwrap_or(u64::from(cap));
+            args.insert("max_tokens".to_string(), serde_json::json!(capped));
+        }
+    }
+    degraded
+}
+
+fn supports_max_tokens_cap(tool: &str) -> bool {
+    matches!(
+        tool,
+        "get_file_context"
+            | "get_file_content"
+            | "get_symbol"
+            | "get_symbol_context"
+            | "search_symbols"
+            | "search_text"
+            | "find_references"
+            | "find_dependents"
+            | "get_repo_map"
+            | "explore"
+            | "ask"
     )
 }
 
@@ -75,15 +187,28 @@ pub fn format_serve_step_meta(
     } else {
         "multi-hop chain step"
     };
+    let economics =
+        if decision.decision == AdmissionDecision::Degrade && !decision.degrade_flags.is_empty() {
+            format!(
+                "{} ({}) flags=[{}]",
+                decision.decision.as_str(),
+                decision.decision_reason,
+                decision.degrade_flags.join(",")
+            )
+        } else {
+            format!(
+                "{} ({})",
+                decision.decision.as_str(),
+                decision.decision_reason
+            )
+        };
     format!(
-        "Step {}: Route confidence: {}\nChosen tool: {}\nInvocation: {}\nRationale: {}\nEconomics: {} ({})",
+        "Step {}: Route confidence: {}\nChosen tool: {}\nInvocation: {}\nRationale: {}\nEconomics: {economics}",
         step_index + 1,
         confidence_label(plan.confidence),
         step.tool,
         invocation,
         rationale,
-        decision.decision.as_str(),
-        decision.decision_reason,
     )
 }
 
@@ -243,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn negative_net_without_pff_body_is_not_enforced() {
+    fn negative_net_economics_bypass_skips_legacy_dispatch() {
         use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
         let plan = StelPlan {
             plan_id: "x".to_string(),
@@ -253,7 +378,7 @@ mod tests {
             steps: vec![StelPlanStep {
                 order: 1,
                 tool: "get_file_context".to_string(),
-                args: serde_json::json!({}),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
                 est_response_tokens: 900,
                 est_manual_tokens: 100,
                 index_refs: vec![],
@@ -263,7 +388,96 @@ mod tests {
         let request = StelRequest::default();
         let decision = evaluate_plan(&request, &plan);
         assert_eq!(decision.decision, AdmissionDecision::Bypass);
-        assert!(!is_enforced_bypass(&decision));
+        assert!(is_enforced_bypass(&decision));
+        let bypass = decision.bypass.as_ref().expect("economics bypass body");
+        assert!(!is_pff_bypass_body(bypass));
+        let body = format_bypass_body(&decision);
+        assert!(body.contains("lines 1-80"));
+        assert!(!body.contains("(whole file)"));
+    }
+
+    #[test]
+    fn cache_hit_skips_legacy_dispatch() {
+        use crate::protocol::session::SessionContext;
+        use crate::stel::controller::evaluate_plan_with_session;
+        use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
+
+        let session = SessionContext::new();
+        session.record_symbol("src/lib.rs", "cfg_if", 96);
+        let plan = StelPlan {
+            plan_id: "cache".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Exact,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_symbol".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs", "name": "cfg_if" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 800,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan_with_session(&request, &plan, Some(&session));
+        assert_eq!(decision.decision, AdmissionDecision::CacheHit);
+        assert!(should_skip_legacy_dispatch(&decision));
+        let body = format_cache_hit_body(&decision);
+        assert!(body.contains("Decision: cache_hit"));
+        assert!(body.contains("did not re-execute a legacy tool"));
+    }
+
+    #[test]
+    fn apply_degrade_caps_outline_only_for_file_context() {
+        use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
+        let plan = StelPlan {
+            plan_id: "degrade".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_context".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 530,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        assert_eq!(decision.decision, AdmissionDecision::Degrade);
+        let degraded = apply_degrade_to_plan(&plan, &decision);
+        let args = degraded.steps[0].args.as_object().expect("object args");
+        assert_eq!(args["sections"], serde_json::json!(["outline"]));
+    }
+
+    #[test]
+    fn apply_degrade_caps_max_tokens_for_content_reads() {
+        use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
+        let plan = StelPlan {
+            plan_id: "degrade".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Fallback,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_content".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 530,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        assert_eq!(decision.decision, AdmissionDecision::Degrade);
+        let degraded = apply_degrade_to_plan(&plan, &decision);
+        let args = degraded.steps[0].args.as_object().expect("object args");
+        assert_eq!(args["max_tokens"], serde_json::json!(400));
     }
 
     #[test]

--- a/src/stel/ledger.rs
+++ b/src/stel/ledger.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::Serialize;
 
 use super::controller::EconomicsBreakdown;
+use super::executor::is_pff_bypass_body;
 use super::handler::estimate_tokens;
 use super::types::{AdmissionDecision, StelDecision, StelLedgerEvent, StelPlan};
 
@@ -65,6 +66,10 @@ pub struct LedgerEnvelopeMeta {
     pub route_tool: String,
     pub decision: String,
     pub bypass: bool,
+    pub pff_bypass: bool,
+    pub cache_hit: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degrade_flags: Vec<String>,
     pub legacy_executed: bool,
     pub schema_tokens: u32,
     pub invoke_tokens: u32,
@@ -101,6 +106,19 @@ pub fn build_ledger_event(input: &LedgerCaptureInput<'_>) -> StelLedgerEvent {
         net_vs_manual,
         equivalence: None,
         route_confidence: input.plan.confidence,
+        pff_bypass: (input.decision.decision == AdmissionDecision::Bypass).then(|| {
+            input
+                .decision
+                .bypass
+                .as_ref()
+                .is_some_and(is_pff_bypass_body)
+        }),
+        cache_hit: (input.decision.decision == AdmissionDecision::CacheHit).then_some(true),
+        degrade_flags: if input.decision.decision == AdmissionDecision::Degrade {
+            input.decision.degrade_flags.clone()
+        } else {
+            vec![]
+        },
     }
 }
 
@@ -121,6 +139,18 @@ pub fn capture_ledger(input: &LedgerCaptureInput<'_>) -> (StelLedgerEvent, Ledge
         route_tool: input.selected_tool.to_string(),
         decision: input.decision.decision.as_str().to_string(),
         bypass: input.decision.decision == AdmissionDecision::Bypass,
+        pff_bypass: input.decision.decision == AdmissionDecision::Bypass
+            && input
+                .decision
+                .bypass
+                .as_ref()
+                .is_some_and(is_pff_bypass_body),
+        cache_hit: input.decision.decision == AdmissionDecision::CacheHit,
+        degrade_flags: if input.decision.decision == AdmissionDecision::Degrade {
+            input.decision.degrade_flags.clone()
+        } else {
+            vec![]
+        },
         legacy_executed: input.legacy_executed,
         schema_tokens: input.economics.predicted_schema_tokens,
         invoke_tokens: input.economics.predicted_invoke_tokens,
@@ -187,6 +217,9 @@ mod tests {
         assert_eq!(event.tools_called, vec!["find_references".to_string()]);
         assert!(meta.legacy_executed);
         assert!(!meta.bypass);
+        assert!(!meta.pff_bypass);
+        assert!(!meta.cache_hit);
+        assert!(meta.degrade_flags.is_empty());
         assert_eq!(meta.route_tool, "find_references");
         assert!(meta.output_bytes > 0);
     }
@@ -216,7 +249,83 @@ mod tests {
         assert_eq!(event.decision, AdmissionDecision::Bypass);
         assert!(event.tools_called.is_empty());
         assert!(meta.bypass);
+        assert!(meta.pff_bypass);
+        assert!(!meta.cache_hit);
         assert!(!meta.legacy_executed);
+    }
+
+    #[test]
+    fn economics_bypass_ledger_records_non_pff_bypass() {
+        use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
+        let plan = StelPlan {
+            plan_id: "low-net".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_context".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 900,
+                est_manual_tokens: 100,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        let economics = estimate_economics(&plan);
+        let (event, meta) = capture_ledger(&LedgerCaptureInput {
+            plan: &plan,
+            decision: &decision,
+            economics: &economics,
+            selected_tool: "get_file_context",
+            tools_called: None,
+            legacy_executed: false,
+            output_body: "Decision: bypass",
+            surface: "symforge",
+        });
+        assert_eq!(event.decision, AdmissionDecision::Bypass);
+        assert!(meta.bypass);
+        assert!(!meta.pff_bypass);
+        assert!(!meta.legacy_executed);
+    }
+
+    #[test]
+    fn degrade_ledger_records_flags_without_legacy_tools_when_skipped() {
+        use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
+        let plan = StelPlan {
+            plan_id: "degrade".to_string(),
+            intent: IntentBucket::Read,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "get_file_context".to_string(),
+                args: serde_json::json!({ "path": "src/lib.rs" }),
+                est_response_tokens: 400,
+                est_manual_tokens: 530,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let request = StelRequest::default();
+        let decision = evaluate_plan(&request, &plan);
+        let economics = estimate_economics(&plan);
+        let (event, meta) = capture_ledger(&LedgerCaptureInput {
+            plan: &plan,
+            decision: &decision,
+            economics: &economics,
+            selected_tool: "get_file_context",
+            tools_called: None,
+            legacy_executed: true,
+            output_body: "Economics: degrade",
+            surface: "symforge",
+        });
+        assert_eq!(event.decision, AdmissionDecision::Degrade);
+        assert!(!meta.bypass);
+        assert!(meta.degrade_flags.contains(&"outline_only".to_string()));
+        assert!(meta.legacy_executed);
     }
 
     #[test]

--- a/src/stel/mod.rs
+++ b/src/stel/mod.rs
@@ -8,7 +8,7 @@
 //!   [`crate::protocol::surface_probe`].
 //! - **L1:** [`planner::build_plan`] — `StelRequest` → single- or multi-step [`StelPlan`].
 //! - **L2:** [`controller::evaluate_plan`] — economics → [`StelDecision`] / [`StelEstimate`].
-//! - **L3:** [`executor::is_enforced_bypass`] — P-FF bypass skips legacy tool dispatch; multi-step in-process chain on `serve`.
+//! - **L3:** [`executor::should_skip_legacy_dispatch`] — bypass/cache_hit skip legacy dispatch; degrade caps; multi-step chain on `serve`.
 //! - **L4:** [`ledger::SessionLedger`] — in-memory [`StelLedgerEvent`] rows + envelope `ledger:` line.
 //!
 //! Deferred: calibration auto-tuning/persistence, symforge_edit apply path.
@@ -35,6 +35,7 @@ pub use calibration::{
 pub use controller::{
     COMPACT_INVOKE_TOKENS, COMPACT_SCHEMA_TOKENS, EconomicsBreakdown, SERVE_MARGIN_TOKENS,
     build_estimate, detect_pff_bypass, estimate_economics, evaluate_edit_plan, evaluate_plan,
+    evaluate_plan_with_session,
 };
 pub use edit_apply::{
     PreApplyOutcome, ResolvedEditSymbol, apply_requested, format_already_applied_body,
@@ -45,10 +46,12 @@ pub use edit_planner::{
 };
 pub use envelope::{TrustEnvelopeInput, format_trust_envelope};
 pub use executor::{
-    ServedStepResult, chain_failure_decision, extract_served_step_bodies, format_bypass_body,
-    format_multi_step_serve_body, format_partial_multi_step_serve_body, format_serve_step_meta,
-    format_single_step_serve_body, is_enforced_bypass, route_tool_label, serve_chain_outcome_class,
-    serve_step_failed, serve_step_outcome, tools_executed,
+    ServedStepResult, apply_degrade_to_plan, chain_failure_decision, extract_served_step_bodies,
+    format_bypass_body, format_cache_hit_body, format_multi_step_serve_body,
+    format_partial_multi_step_serve_body, format_serve_step_meta, format_single_step_serve_body,
+    is_degrade, is_enforced_bypass, is_pff_bypass_body, route_tool_label,
+    serve_chain_outcome_class, serve_step_failed, serve_step_outcome, should_skip_legacy_dispatch,
+    tools_executed,
 };
 pub use golden_replay::{
     DEFERRED_MULTI_HOP_ROW_IDS, GOLDEN_ROUTES_FIXTURE, GoldenCorpusClassification,

--- a/src/stel/types.rs
+++ b/src/stel/types.rs
@@ -279,6 +279,12 @@ pub struct StelLedgerEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub equivalence: Option<Value>,
     pub route_confidence: RouteConfidence,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pff_bypass: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_hit: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degrade_flags: Vec<String>,
 }
 
 /// Per `(tool, intent_bucket)` calibration feedback (L4 → L2).

--- a/tests/stel_l2_admission.rs
+++ b/tests/stel_l2_admission.rs
@@ -1,0 +1,259 @@
+//! L2 admission hardening — serve, degrade, bypass, cache_hit states.
+#![cfg(feature = "server")]
+
+#[path = "support/stel_surface_env.rs"]
+mod stel_surface_env;
+
+use std::path::PathBuf;
+
+use symforge::live_index::LiveIndex;
+use symforge::protocol::SymForgeServer;
+use symforge::protocol::session::SessionContext;
+use symforge::stel::{
+    self, AdmissionDecision, IntentBucket, RouteConfidence, StelPlan, StelPlanStep, StelRequest,
+    apply_degrade_to_plan, evaluate_plan, evaluate_plan_with_session,
+};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn corpus_path(relative: &str) -> PathBuf {
+    repo_root().join(relative)
+}
+
+fn corpus_available(relative: &str, marker: &str) -> bool {
+    corpus_path(relative).join(marker).is_file()
+}
+
+fn corpora_available() -> bool {
+    corpus_available(stel::S4_REPLAY_CORPUS, "src/lib.rs")
+}
+
+fn server_for_corpus(relative: &str, project: &str) -> SymForgeServer {
+    let root = corpus_path(relative);
+    let shared = LiveIndex::load(&root).unwrap_or_else(|error| {
+        panic!("index {}: {error}", root.display());
+    });
+    SymForgeServer::new(
+        shared,
+        project.to_string(),
+        std::sync::Arc::new(parking_lot::Mutex::new(
+            symforge::watcher::WatcherInfo::default(),
+        )),
+        Some(root),
+        None,
+    )
+}
+
+fn tool_result_text(result: &serde_json::Value) -> &str {
+    result["content"][0]["text"]
+        .as_str()
+        .expect("symforge result must contain text content")
+}
+
+async fn dispatch_symforge(server: &SymForgeServer, request: StelRequest) -> String {
+    let params = serde_json::to_value(stel::SymforgeCallInput {
+        request,
+        probe_legacy_tool: None,
+        probe_legacy_args: None,
+    })
+    .expect("symforge params serialize");
+    let result = server
+        .dispatch_tool_result_for_tests("symforge", params)
+        .await
+        .expect("symforge dispatch");
+    let serialized = serde_json::to_value(&result).expect("serialize CallToolResult");
+    tool_result_text(&serialized).to_string()
+}
+
+fn low_net_plan() -> StelPlan {
+    StelPlan {
+        plan_id: "low-net".to_string(),
+        intent: IntentBucket::Read,
+        confidence: RouteConfidence::Inferred,
+        confidence_rationale: "test".to_string(),
+        steps: vec![StelPlanStep {
+            order: 1,
+            tool: "get_file_context".to_string(),
+            args: serde_json::json!({ "path": "src/lib.rs" }),
+            est_response_tokens: 900,
+            est_manual_tokens: 100,
+            index_refs: vec![],
+        }],
+        suggested_followup: None,
+    }
+}
+
+fn marginal_degrade_plan() -> StelPlan {
+    StelPlan {
+        plan_id: "degrade".to_string(),
+        intent: IntentBucket::Read,
+        confidence: RouteConfidence::Inferred,
+        confidence_rationale: "test".to_string(),
+        steps: vec![StelPlanStep {
+            order: 1,
+            tool: "get_file_context".to_string(),
+            args: serde_json::json!({ "path": "src/lib.rs" }),
+            est_response_tokens: 400,
+            est_manual_tokens: 530,
+            index_refs: vec![],
+        }],
+        suggested_followup: None,
+    }
+}
+
+#[test]
+fn l2_controller_covers_all_four_admission_states() {
+    let serve_request = StelRequest {
+        query: "who references cfg_if".to_string(),
+        ..Default::default()
+    };
+    let serve_plan = stel::build_plan(&serve_request);
+    let serve = evaluate_plan(&serve_request, &serve_plan);
+    assert_eq!(serve.decision, AdmissionDecision::Serve);
+
+    let bypass = evaluate_plan(&StelRequest::default(), &low_net_plan());
+    assert_eq!(bypass.decision, AdmissionDecision::Bypass);
+    assert!(bypass.bypass.is_some());
+
+    let degrade = evaluate_plan(&StelRequest::default(), &marginal_degrade_plan());
+    assert_eq!(degrade.decision, AdmissionDecision::Degrade);
+    assert!(!degrade.degrade_flags.is_empty());
+
+    let session = SessionContext::new();
+    session.record_symbol("src/lib.rs", "cfg_if", 128);
+    let cache_plan = StelPlan {
+        plan_id: "cache".to_string(),
+        intent: IntentBucket::Read,
+        confidence: RouteConfidence::Exact,
+        confidence_rationale: "test".to_string(),
+        steps: vec![StelPlanStep {
+            order: 1,
+            tool: "get_symbol".to_string(),
+            args: serde_json::json!({ "path": "src/lib.rs", "name": "cfg_if" }),
+            est_response_tokens: 400,
+            est_manual_tokens: 800,
+            index_refs: vec![],
+        }],
+        suggested_followup: None,
+    };
+    let cache_hit =
+        evaluate_plan_with_session(&StelRequest::default(), &cache_plan, Some(&session));
+    assert_eq!(cache_hit.decision, AdmissionDecision::CacheHit);
+    assert!(cache_hit.cache.is_some());
+}
+
+#[test]
+fn degrade_decision_is_distinct_from_bypass_and_serve_metadata() {
+    let bypass = evaluate_plan(&StelRequest::default(), &low_net_plan());
+    let degrade = evaluate_plan(&StelRequest::default(), &marginal_degrade_plan());
+    assert_ne!(bypass.decision, degrade.decision);
+    assert!(bypass.bypass.is_some());
+    assert!(degrade.bypass.is_none());
+    assert!(!degrade.degrade_flags.is_empty());
+    assert!(degrade.steps.is_some());
+}
+
+#[test]
+fn apply_degrade_injects_outline_only_sections() {
+    let plan = marginal_degrade_plan();
+    let decision = evaluate_plan(&StelRequest::default(), &plan);
+    let degraded = apply_degrade_to_plan(&plan, &decision);
+    let args = degraded.steps[0].args.as_object().expect("object args");
+    assert_eq!(args["sections"], serde_json::json!(["outline"]));
+}
+
+#[tokio::test]
+async fn cache_hit_dispatch_skips_legacy_tools_after_session_prefetch() {
+    if !corpora_available() {
+        eprintln!("skip cache_hit_dispatch: missing corpora");
+        return;
+    }
+
+    let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
+    let _surface = stel_surface_env::set_symforge_surface("compact");
+
+    let server = server_for_corpus(stel::S4_REPLAY_CORPUS, "l2-cache-hit");
+    let request = StelRequest {
+        query: "body of cfg_if in src/lib.rs".to_string(),
+        ..Default::default()
+    };
+
+    let first = dispatch_symforge(&server, request.clone()).await;
+    assert!(
+        first.contains("decision: serve"),
+        "prefetch should serve first:\n{first}"
+    );
+    assert!(first.contains("Chosen tool: get_symbol"));
+
+    let second = dispatch_symforge(&server, request).await;
+    assert!(
+        second.contains("decision: cache_hit"),
+        "repeat should cache_hit:\n{second}"
+    );
+    assert!(second.contains("did not re-execute a legacy tool"));
+    assert!(!second.contains("Chosen tool: get_symbol"));
+
+    let event = server.stel_ledger().lock().last().expect("ledger event");
+    assert_eq!(event.decision, AdmissionDecision::CacheHit);
+    assert!(event.tools_called.is_empty());
+    assert_eq!(event.cache_hit, Some(true));
+}
+
+#[test]
+fn calibration_summary_counts_degrade_and_cache_hit() {
+    use symforge::stel::ledger::{LedgerCaptureInput, capture_ledger};
+    use symforge::stel::{estimate_economics, summarize_calibration};
+
+    let degrade_plan = marginal_degrade_plan();
+    let degrade_decision = evaluate_plan(&StelRequest::default(), &degrade_plan);
+    let degrade_economics = estimate_economics(&degrade_plan);
+    let (degrade_event, _) = capture_ledger(&LedgerCaptureInput {
+        plan: &degrade_plan,
+        decision: &degrade_decision,
+        economics: &degrade_economics,
+        selected_tool: "get_file_context",
+        tools_called: None,
+        legacy_executed: true,
+        output_body: "Economics: degrade",
+        surface: "symforge",
+    });
+
+    let session = SessionContext::new();
+    session.record_symbol("src/lib.rs", "cfg_if", 128);
+    let cache_plan = StelPlan {
+        plan_id: "cache".to_string(),
+        intent: IntentBucket::Read,
+        confidence: RouteConfidence::Exact,
+        confidence_rationale: "test".to_string(),
+        steps: vec![StelPlanStep {
+            order: 1,
+            tool: "get_symbol".to_string(),
+            args: serde_json::json!({ "path": "src/lib.rs", "name": "cfg_if" }),
+            est_response_tokens: 400,
+            est_manual_tokens: 800,
+            index_refs: vec![],
+        }],
+        suggested_followup: None,
+    };
+    let cache_decision =
+        evaluate_plan_with_session(&StelRequest::default(), &cache_plan, Some(&session));
+    let cache_economics = estimate_economics(&cache_plan);
+    let (cache_event, _) = capture_ledger(&LedgerCaptureInput {
+        plan: &cache_plan,
+        decision: &cache_decision,
+        economics: &cache_economics,
+        selected_tool: "get_symbol",
+        tools_called: None,
+        legacy_executed: false,
+        output_body: "Decision: cache_hit",
+        surface: "symforge",
+    });
+
+    let summary = summarize_calibration(&[degrade_event, cache_event]);
+    assert_eq!(summary.degrade_count, 1);
+    assert_eq!(summary.cache_hit_count, 1);
+    assert_eq!(summary.serve_count, 0);
+    assert_eq!(summary.bypass_count, 0);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **P2-S3 L2 admission hardening** (T020–T025) on top of green `main` after Phase 2 Slice 1 multi-hop closure.

L2 now emits and L3 honors all four normative admission states: `serve`, `degrade`, `bypass`, and `cache_hit`.

## State machine changes

L2 evaluation order (`evaluate_plan_with_session`):

1. **P-FF bypass** — policy whole-file queries → `bypass` with `StelBypassBody` (`end_line: None`)
2. **Session cache hit** — prefetched symbol/file target match → `cache_hit` with `StelCacheBody` (in-process session only; no persistent cache claims)
3. **Economics bypass** — predicted net ≤ 0 (non-P-FF) → `bypass` with honest `host_read` body (partial line range)
4. **Degrade** — net ≤ `margin_low` (50) or fallback confidence below `margin_high` → `degrade` with flags:
   - `outline_only` for `get_file_context` plans
   - `max_tokens_cap` for other read tools
   - `fallback_mandatory` when fallback confidence triggers degrade
5. **Serve** — net > margin → execute plan (single- or multi-hop chain preserved)

L3 dispatch (`symforge_stel_handler`):

- `bypass` / `cache_hit` → skip legacy tools; formatted bypass/cache bodies + ledger with `legacy_executed=false`
- `degrade` → `apply_degrade_to_plan` injects caps/sections, then executes legacy chain
- `serve` → unchanged multi-hop fail-fast behavior from Slice 1
- Chain failure still maps to `reject` (not a new admission state)

## Metadata / reporting

- `StelLedgerEvent` records `pff_bypass`, `cache_hit`, and `degrade_flags`
- `LedgerEnvelopeMeta` extended for calibration/status honesty
- Calibration summary adds `degrade_count` and `cache_hit_count`; P-FF bypass counted via ledger metadata (not all tool-less bypass rows)

## Scope boundaries (unchanged)

- No P2-S4 battery gates (H3/H4/H5)
- No persistence / SQLite / EMA→L2 tuning
- No new MCP tools; compact-3 surface unchanged
- Multi-hop golden replay preserved: **32 supported serve + 4 P-FF**, `deferred_multi_hop = 0`

## Tests run

- `cargo fmt --check`
- `cargo check`
- `cargo build --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test stel:: -- --test-threads=1` (71 passed)
- `cargo test --test stel_golden_replay`
- `cargo test --test stel_multi_hop_chain`
- `cargo test --test stel_l2_admission` (new)
- `cargo test --test stel_l3_enforcement`
- `cargo test --test stel_l4_ledger`
- `cargo test --test stel_status`
- `cargo test --test stel_symforge_edit`
- `cargo test --lib protocol::surface_probe`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

