### PR TITLE
test(stel): add Phase 2 compact battery gates (P2-S4)

### DIFF
--- a/docs/research/phase2-evidence-index.md
+++ b/docs/research/phase2-evidence-index.md
@@ -36,7 +36,8 @@
 
 | Slot | Path | Status |
 |------|------|--------|
-| Gate report | [`phase2-gate-report.md`](./phase2-gate-report.md) | **COMPLETE** — H3 FAIL (1 row), H4/H5 PASS |
+| Gate report (curated) | [`phase2-gate-report.md`](./phase2-gate-report.md) | **COMPLETE** — H3 FAIL (1 row), H4/H5 PASS |
+| Gate report (generated) | [`phase2-gate-report.generated.md`](./phase2-gate-report.generated.md) | **COMPLETE** — compare-results script output |
 | Candidate battery JSON | [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json) | **COMPLETE** — 36/36 rows, STEL fields |
 | Compare-results script | [`scripts/compare-results.cjs`](../../scripts/compare-results.cjs) | **COMPLETE** |
 | Compact battery script | [`scripts/phase2-compact-battery.cjs`](../../scripts/phase2-compact-battery.cjs) | **COMPLETE** |
@@ -52,9 +53,15 @@
 ```bash
 cargo build -p symforge
 node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
-node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.md
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
 cargo test --test stel_battery_gates -- --test-threads=1
 ```
+
+Curated reviewer narrative lives in [`phase2-gate-report.md`](./phase2-gate-report.md); re-running compare-results writes only [`phase2-gate-report.generated.md`](./phase2-gate-report.generated.md).
+
+## Local corpus note (golden replay)
+
+`cargo test --test stel_golden_replay` may fail corpus-gated rows when `tests/fixtures/phase0-corpus/*` is missing or differs from the pinned clone content (empty index / not-found outcomes). This reproduces at the P2-S4 parent commit (`896840f`) and is **not caused by P2-S4** (gate code + ledger metadata only). Checked-in gate fixtures (`tests/fixtures/phase2-gate/`) and compare-results math remain deterministic; multi-hop replay against checked-in `tests/fixtures/stel_multi_hop/` passes in CI.
 
 ## Deferred from Phase 2 (explicit)
 

--- a/docs/research/phase2-evidence-index.md
+++ b/docs/research/phase2-evidence-index.md
@@ -1,6 +1,6 @@
 # Phase 2 STEL evidence index
 
-**Status**: T002 GO — Phase 2 implementation authorized on `cursor/v8-phase2-stel-controller`
+**Status:** P2-S4 battery gates — H4/H5 PASS; H3 FAIL documented (2026-06-14)
 
 **Created**: 2026-06-14
 
@@ -15,12 +15,13 @@
 | Quickstart | [`specs/002-v8-phase2-stel-controller/quickstart.md`](../../specs/002-v8-phase2-stel-controller/quickstart.md) |
 | Gate evidence contract | [`specs/002-v8-phase2-stel-controller/contracts/phase2-gate-evidence-contract.md`](../../specs/002-v8-phase2-stel-controller/contracts/phase2-gate-evidence-contract.md) |
 | Requirements checklist | [`specs/002-v8-phase2-stel-controller/checklists/requirements.md`](../../specs/002-v8-phase2-stel-controller/checklists/requirements.md) |
-| Tasks (pending) | [`specs/002-v8-phase2-stel-controller/tasks.md`](../../specs/002-v8-phase2-stel-controller/tasks.md) |
+| Tasks | [`specs/002-v8-phase2-stel-controller/tasks.md`](../../specs/002-v8-phase2-stel-controller/tasks.md) |
 
 ## Baseline
 
 - Phase 1 shipped: [`phase1-stel-checkpoint.md`](../phase1-stel-checkpoint.md)
-- Main repair commits: `d4fcd0a`, `66742f1`
+- Phase 2 Slice 1 merged: `3d64b96` (multi-hop golden closure)
+- Phase 2 Slice 2 merged: PR #306 / `896840f` tip (L2 admission hardening)
 
 ## T002 spec reviewer sign-off
 
@@ -31,17 +32,33 @@
 | Baseline commit | `bc738c3` (PR #303 merge) |
 | First slice | P2-S1/P2-S2 — multi-hop golden closure (T010–T016) |
 
-## Evidence slots (to fill during Phase 2 implementation)
+## Evidence slots
 
 | Slot | Path | Status |
 |------|------|--------|
-| Gate report | `docs/research/phase2-gate-report.md` | NOT STARTED |
-| A-029 spike | `docs/research/A-029-t2-spike.md` | NOT STARTED |
-| Phase 2 checkpoint | `docs/phase2-stel-checkpoint.md` | NOT STARTED |
-| Exit record | per gate evidence contract | NOT STARTED |
+| Gate report | [`phase2-gate-report.md`](./phase2-gate-report.md) | **COMPLETE** — H3 FAIL (1 row), H4/H5 PASS |
+| Candidate battery JSON | [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json) | **COMPLETE** — 36/36 rows, STEL fields |
+| Compare-results script | [`scripts/compare-results.cjs`](../../scripts/compare-results.cjs) | **COMPLETE** |
+| Compact battery script | [`scripts/phase2-compact-battery.cjs`](../../scripts/phase2-compact-battery.cjs) | **COMPLETE** |
+| Gate computation (Rust) | [`src/stel/gates.rs`](../../src/stel/gates.rs) | **COMPLETE** |
+| Gate test fixtures | [`tests/fixtures/phase2-gate/`](../../tests/fixtures/phase2-gate/) | **COMPLETE** |
+| Gate integration tests | [`tests/stel_battery_gates.rs`](../../tests/stel_battery_gates.rs) | **COMPLETE** |
+| A-029 spike | `docs/research/A-029-t2-spike.md` | NOT STARTED (P2-S5 blocked) |
+| Phase 2 checkpoint | `docs/phase2-stel-checkpoint.md` | NOT STARTED (P2-S6) |
+| Exit record | per gate evidence contract | IN_PROGRESS |
+
+## P2-S4 gate commands (operator)
+
+```bash
+cargo build -p symforge
+node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.md
+cargo test --test stel_battery_gates -- --test-threads=1
+```
 
 ## Deferred from Phase 2 (explicit)
 
 - Calibration / ledger persistence → Phase 3
 - B-RESULTS / RESULTS.md §8.7 → post–8.0 tag (A-024)
 - H6/H7/H8 PASS → Phase 3–4
+- A-029 T2 spike → P2-S5 (blocked until P2-S4 merge)

--- a/docs/research/phase2-gate-report.generated.md
+++ b/docs/research/phase2-gate-report.generated.md
@@ -1,0 +1,44 @@
+# Phase 2 compact-surface gate report
+
+**Report ID:** phase2-gate-2026-06-14
+**Surface:** compact
+**Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45`
+**Candidate results:** `docs/research/results-v8-phase2-candidate.json`
+**Baseline results:** `(self)`
+**Compare command:** `node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json`
+**H3 policy:** [docs/research/A-012-bypass-policy.md](docs/research/A-012-bypass-policy.md)
+
+## Gate statuses
+
+| Gate | Status |
+|------|--------|
+| H1 | NOT_CLAIMED |
+| H2 | NOT_CLAIMED |
+| H3 | FAIL |
+| H4 | PASS |
+| H5 | PASS |
+| H6 | NOT_CLAIMED |
+| H7 | NOT_CLAIMED |
+| H8 | NOT_CLAIMED |
+
+## Computed metrics
+
+- `session_net_accepted`: 13543
+- `session_net_all36`: 22602
+- H3 scope rows: 24
+- H3 sGteM violations: 1
+- H5 single-chain violations: 0
+- Measured rows: 36
+- Skipped rows: 0
+
+## Diagnostics
+
+H3 violations: records/t8_explore(S=1143,M=1000)
+
+## H3 scope note (A-012)
+
+H3 evaluates **accepted serve** rows only (bypass/degrade/cache_hit excluded). When no `*_small` task ids are present, all accepted serve rows in the golden corpus are used.
+
+## H5 note
+
+Compact surface uses one external `symforge` MCP call per task. Multi-hop rows (`chain=multi`) execute legacy tools in-process but report `mcpCalls=1`.

--- a/docs/research/phase2-gate-report.md
+++ b/docs/research/phase2-gate-report.md
@@ -1,0 +1,89 @@
+# Phase 2 compact-surface gate report
+
+**Report ID:** phase2-gate-2026-06-14  
+**Surface:** `compact` (`SYMFORGE_SURFACE=compact`)  
+**Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45`  
+**Candidate results:** [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json)  
+**Baseline results:** self (first compact-surface Phase 2 battery pin)  
+**Compare command:**
+
+```bash
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.md
+```
+
+**Battery command:**
+
+```bash
+cargo build -p symforge
+node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
+```
+
+**H3 policy:** [A-012-bypass-policy.md](./A-012-bypass-policy.md) (serve-only scope; bypass rows excluded)
+
+## Gate definitions (binding gap plan §5.1)
+
+| Gate | Definition | PASS criterion |
+|------|------------|----------------|
+| **H3** | Accepted serve rows (`decision=serve` ∧ `equivalence=EQUIVALENT`); A-012 excludes bypass | Zero rows with `sGteM=true` in H3 scope |
+| **H4** | `session_net_accepted = Σ(M−S)` over accepted serve rows only (A-026) | `session_net_accepted ≥ 0` |
+| **H5** | External MCP calls per golden row | `mcpCalls ≤ 1` for all `chain=single` rows |
+
+H3 scope uses all accepted serve rows when no `*_small` task ids exist (Phase 2 golden corpus naming).
+
+## Gate statuses
+
+| Gate | Status |
+|------|--------|
+| H1 | NOT_CLAIMED |
+| H2 | NOT_CLAIMED |
+| H3 | **FAIL** |
+| H4 | **PASS** |
+| H5 | **PASS** |
+| H6 | NOT_CLAIMED |
+| H7 | NOT_CLAIMED |
+| H8 | NOT_CLAIMED |
+
+## Computed metrics
+
+| Metric | Value |
+|--------|------:|
+| `session_net_accepted` | 13543 |
+| `session_net_all36` | 22602 |
+| H3 scope rows | 24 |
+| H3 sGteM violations | 1 |
+| H5 single-chain violations | 0 |
+| Measured rows | 36 |
+| Skipped rows | 0 |
+
+## Diagnostics
+
+H3 violations: `records/t8_explore` (S=1143, M=1000)
+
+All other accepted serve rows: `sGteM=false`.
+
+## Reviewer / action notes (H3 FAIL)
+
+**Row:** `records/t8_explore` — `explore` guidance response exceeds competent-manual window (M=1000 tokens at 4000-char cap).
+
+**Observed:** Single compact `symforge` call returns 1143 response tokens including STEL envelope + explore guidance body.
+
+**Not a multi-hop or MCP-call regression:** H5 PASS; decision=`serve`; `mcpCalls=1`.
+
+**Recommended follow-up (out of P2-S4 scope):**
+
+1. Route high-token explore queries through L2 `degrade` with `max_tokens_cap`, or
+2. Tighten explore output budget on compact surface, or
+3. Revisit M baseline for guidance-class tasks in a future measurement spike (A-011).
+
+**Phase 2 minimum exit:** H3 FAIL blocks full Phase 2 exit until resolved or spec-amended. H4 + H5 PASS on this artifact.
+
+## STEL extension fields (T030)
+
+All 36 measured rows include `stel.{plan_id,decision,tools_called,predicted_tokens,actual_tokens,net_vs_manual,route_confidence}` parsed from ledger envelope metadata.
+
+## Reproducibility
+
+- Deterministic gate math: `src/stel/gates.rs` + `scripts/compare-results.cjs`
+- CI fixtures: `tests/fixtures/phase2-gate/synthetic-*.json`
+- Integration tests: `tests/stel_battery_gates.rs`
+- Full 36-row battery requires phase0 corpora clone per [`tests/fixtures/phase0-corpus/README.md`](../../tests/fixtures/phase0-corpus/README.md)

--- a/docs/research/phase2-gate-report.md
+++ b/docs/research/phase2-gate-report.md
@@ -5,11 +5,13 @@
 **Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45`  
 **Candidate results:** [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json)  
 **Baseline results:** self (first compact-surface Phase 2 battery pin)  
-**Compare command:**
+**Compare command (reproducible script output — does not overwrite this file):**
 
 ```bash
-node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.md
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
 ```
+
+**Generated report mirror:** [`phase2-gate-report.generated.md`](./phase2-gate-report.generated.md) (auto-written by compare-results; numeric results must match this curated artifact)
 
 **Battery command:**
 

--- a/docs/research/results-v8-phase2-candidate.json
+++ b/docs/research/results-v8-phase2-candidate.json
@@ -1,0 +1,952 @@
+{
+  "measuredAt": "2026-06-14T13:42:53.593Z",
+  "symforgeBin": "/workspace/target/debug/symforge",
+  "surface": "compact",
+  "method": "ceil(bytes/4); M=competent_manual_window; STEL ledger metadata",
+  "baselineCommit": "896840f984738ce0f77e9a9c1aae94011ceaee45",
+  "rows": [
+    {
+      "id": "cfg-if/multi_search_symbol",
+      "corpus": "cfg-if-rust",
+      "S": 394,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1576,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/multi_search_symbol",
+      "decision": "serve",
+      "chain": "multi",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef93b-29",
+        "decision": "serve",
+        "tools_called": [
+          "search_symbols",
+          "get_symbol"
+        ],
+        "predicted_tokens": 800,
+        "actual_tokens": 256,
+        "net_vs_manual": 675,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/pff_whole_lib",
+      "corpus": "cfg-if-rust",
+      "S": 276,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1103,
+      "acceptedServe": false,
+      "equivalence": "BYPASS",
+      "goldenId": "cfg-if/pff_whole_lib",
+      "decision": "bypass",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": false,
+      "stel": {
+        "plan_id": "plan-19ec65ef80b-33",
+        "decision": "bypass",
+        "tools_called": [
+          "explore"
+        ],
+        "predicted_tokens": 147,
+        "actual_tokens": 147,
+        "net_vs_manual": -186,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/t1_search",
+      "corpus": "cfg-if-rust",
+      "S": 373,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1491,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef800-23",
+        "decision": "serve",
+        "tools_called": [
+          "search_text"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 243,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/t2_context",
+      "corpus": "cfg-if-rust",
+      "S": 330,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1317,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t2_context",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef801-18",
+        "decision": "serve",
+        "tools_called": [
+          "get_file_context"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 198,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "cfg-if/t3_symbols",
+      "corpus": "cfg-if-rust",
+      "S": 263,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1052,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t3_symbols",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef804-20",
+        "decision": "reject",
+        "tools_called": [
+          "search_symbols"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 131,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/t4_refs",
+      "corpus": "cfg-if-rust",
+      "S": 362,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1448,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t4_refs",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef805-21",
+        "decision": "serve",
+        "tools_called": [
+          "find_references"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 231,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "cfg-if/t5_symbol",
+      "corpus": "cfg-if-rust",
+      "S": 471,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1883,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t5_symbol",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef806-24",
+        "decision": "serve",
+        "tools_called": [
+          "get_symbol"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 342,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "cfg-if/t6_map",
+      "corpus": "cfg-if-rust",
+      "S": 268,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1071,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t6_map",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef807-15",
+        "decision": "serve",
+        "tools_called": [
+          "get_repo_map"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 136,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/t7_content",
+      "corpus": "cfg-if-rust",
+      "S": 213,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 850,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t7_content",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef808-21",
+        "decision": "reject",
+        "tools_called": [
+          "get_file_content"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 80,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/t8_explore",
+      "corpus": "cfg-if-rust",
+      "S": 392,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1566,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t8_explore",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef809-20",
+        "decision": "serve",
+        "tools_called": [
+          "explore"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 262,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "compression/pff_whole_service",
+      "corpus": "rust",
+      "S": 283,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1131,
+      "acceptedServe": false,
+      "equivalence": "BYPASS",
+      "goldenId": "compression/pff_whole_service",
+      "decision": "bypass",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": false,
+      "stel": {
+        "plan_id": "plan-19ec65ef900-27",
+        "decision": "bypass",
+        "tools_called": [
+          "search_files"
+        ],
+        "predicted_tokens": 152,
+        "actual_tokens": 152,
+        "net_vs_manual": -186,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "compression/t1_search",
+      "corpus": "rust",
+      "S": 408,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1629,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "compression/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef8dd-23",
+        "decision": "serve",
+        "tools_called": [
+          "search_text"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 277,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "compression/t2_context",
+      "corpus": "rust",
+      "S": 347,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1388,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "compression/t2_context",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef8fa-18",
+        "decision": "serve",
+        "tools_called": [
+          "get_file_context"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 216,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "compression/t3_symbol",
+      "corpus": "rust",
+      "S": 198,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 790,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "compression/t3_symbol",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef8fd-21",
+        "decision": "reject",
+        "tools_called": [
+          "get_symbol"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 68,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "compression/t4_refs",
+      "corpus": "rust",
+      "S": 309,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1234,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "compression/t4_refs",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef8fe-20",
+        "decision": "reject",
+        "tools_called": [
+          "find_references"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 175,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "compression/t5_dependents",
+      "corpus": "rust",
+      "S": 223,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 891,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "compression/t5_dependents",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef8ff-24",
+        "decision": "serve",
+        "tools_called": [
+          "find_dependents"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 90,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/multi_files_content",
+      "corpus": "is-plain-obj-ts",
+      "S": 333,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1330,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/multi_files_content",
+      "decision": "serve",
+      "chain": "multi",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef992-25",
+        "decision": "serve",
+        "tools_called": [
+          "search_files",
+          "get_file_content"
+        ],
+        "predicted_tokens": 800,
+        "actual_tokens": 193,
+        "net_vs_manual": 675,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/pff_whole_index",
+      "corpus": "is-plain-obj-ts",
+      "S": 279,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1113,
+      "acceptedServe": false,
+      "equivalence": "BYPASS",
+      "goldenId": "is-plain/pff_whole_index",
+      "decision": "bypass",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": false,
+      "stel": {
+        "plan_id": "plan-19ec65ef88a-35",
+        "decision": "bypass",
+        "tools_called": [
+          "explore"
+        ],
+        "predicted_tokens": 149,
+        "actual_tokens": 149,
+        "net_vs_manual": -186,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t1_search",
+      "corpus": "is-plain-obj-ts",
+      "S": 560,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 2239,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef880-22",
+        "decision": "serve",
+        "tools_called": [
+          "search_text"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 430,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t2_context",
+      "corpus": "is-plain-obj-ts",
+      "S": 249,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 996,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t2_context",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef881-16",
+        "decision": "serve",
+        "tools_called": [
+          "get_file_context"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 118,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "is-plain/t3_content",
+      "corpus": "is-plain-obj-ts",
+      "S": 212,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 848,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t3_content",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef882-22",
+        "decision": "reject",
+        "tools_called": [
+          "get_file_content"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 79,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t4_symbols",
+      "corpus": "is-plain-obj-ts",
+      "S": 316,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1261,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t4_symbols",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef883-20",
+        "decision": "serve",
+        "tools_called": [
+          "search_symbols"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 183,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t5_symbol",
+      "corpus": "is-plain-obj-ts",
+      "S": 199,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 794,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t5_symbol",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef884-18",
+        "decision": "reject",
+        "tools_called": [
+          "get_symbol"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 69,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t6_refs",
+      "corpus": "is-plain-obj-ts",
+      "S": 306,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1223,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t6_refs",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef885-24",
+        "decision": "serve",
+        "tools_called": [
+          "find_references"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 173,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t7_files",
+      "corpus": "is-plain-obj-ts",
+      "S": 215,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 857,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t7_files",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef886-27",
+        "decision": "reject",
+        "tools_called": [
+          "search_files"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 83,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "is-plain/t8_health",
+      "corpus": "is-plain-obj-ts",
+      "S": 413,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1650,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "is-plain/t8_health",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef888-12",
+        "decision": "serve",
+        "tools_called": [
+          "health_compact"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 282,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "records/multi_context_refs",
+      "corpus": "records-python",
+      "S": 434,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1733,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/multi_context_refs",
+      "decision": "serve",
+      "chain": "multi",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef96b-33",
+        "decision": "serve",
+        "tools_called": [
+          "get_file_context",
+          "find_references"
+        ],
+        "predicted_tokens": 800,
+        "actual_tokens": 292,
+        "net_vs_manual": 675,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/pff_whole_module",
+      "corpus": "records-python",
+      "S": 281,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1123,
+      "acceptedServe": false,
+      "equivalence": "BYPASS",
+      "goldenId": "records/pff_whole_module",
+      "decision": "bypass",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": false,
+      "stel": {
+        "plan_id": "plan-19ec65ef848-34",
+        "decision": "bypass",
+        "tools_called": [
+          "explore"
+        ],
+        "predicted_tokens": 152,
+        "actual_tokens": 152,
+        "net_vs_manual": -186,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t1_search",
+      "corpus": "records-python",
+      "S": 597,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 2385,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef83c-19",
+        "decision": "serve",
+        "tools_called": [
+          "search_text"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 466,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t2_context",
+      "corpus": "records-python",
+      "S": 847,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 3388,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t2_context",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef83d-18",
+        "decision": "serve",
+        "tools_called": [
+          "get_file_context"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 715,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "records/t3_files",
+      "corpus": "records-python",
+      "S": 262,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 1047,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t3_files",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef83f-19",
+        "decision": "serve",
+        "tools_called": [
+          "search_files"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 131,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t4_refs",
+      "corpus": "records-python",
+      "S": 246,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 983,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t4_refs",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef841-24",
+        "decision": "serve",
+        "tools_called": [
+          "find_references"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 115,
+        "net_vs_manual": 275,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "records/t5_symbol",
+      "corpus": "records-python",
+      "S": 958,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 3829,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t5_symbol",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef841-29",
+        "decision": "serve",
+        "tools_called": [
+          "get_symbol"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 827,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t6_dependents",
+      "corpus": "records-python",
+      "S": 225,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 897,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t6_dependents",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef842-26",
+        "decision": "serve",
+        "tools_called": [
+          "find_dependents"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 92,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t7_content",
+      "corpus": "records-python",
+      "S": 213,
+      "M": 1000,
+      "sGteM": false,
+      "responseBytes": 850,
+      "acceptedServe": false,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t7_content",
+      "decision": "reject",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef843-22",
+        "decision": "reject",
+        "tools_called": [
+          "get_file_content"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 80,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "records/t8_explore",
+      "corpus": "records-python",
+      "S": 1143,
+      "M": 1000,
+      "sGteM": true,
+      "responseBytes": 4572,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "records/t8_explore",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-19ec65ef844-22",
+        "decision": "serve",
+        "tools_called": [
+          "explore"
+        ],
+        "predicted_tokens": 400,
+        "actual_tokens": 1013,
+        "net_vs_manual": 275,
+        "route_confidence": "inferred"
+      }
+    }
+  ],
+  "session_net_accepted": 13543,
+  "session_net_all36": 22602,
+  "rowCount": 36,
+  "skippedRows": []
+}

--- a/scripts/compare-results.cjs
+++ b/scripts/compare-results.cjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Phase 2 in-repo compare-results — computes H3/H4/H5 on battery JSON.
+ * Formulas: docs/v8-gap-closure-plan.md §5.1 + A-012 serve-only H3 scope.
+ *
+ * Usage:
+ *   node scripts/compare-results.cjs <candidate.json> [--baseline <baseline.json>] [--report <out.md>]
+ *
+ * Exit 0 when Phase 2 minimum gates (H3 + H4) PASS; H5 reported but non-blocking for exit code.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+function loadJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function isSmallFileTaskId(id) {
+  return id.includes("_small") || id.endsWith("/small");
+}
+
+function normalizeResults(raw) {
+  const rows = (raw.rows || []).map((row) => {
+    const S = row.S ?? 0;
+    const M = row.M ?? 0;
+    const decision = row.decision || "serve";
+    const equivalence = row.equivalence || "PENDING_REVIEW";
+    const acceptedServe = decision === "serve" && equivalence === "EQUIVALENT";
+    return {
+      ...row,
+      S,
+      M,
+      sGteM: S >= M,
+      acceptedServe,
+      goldenId: row.goldenId || row.id,
+      chain: row.chain || "single",
+      mcpCalls: row.mcpCalls ?? 1,
+      eligibleH6: row.eligibleH6 ?? true,
+    };
+  });
+
+  const session_net_accepted = rows
+    .filter((r) => r.acceptedServe)
+    .reduce((sum, r) => sum + (r.M - r.S), 0);
+  const session_net_all36 = rows.reduce((sum, r) => sum + (r.M - r.S), 0);
+
+  return {
+    ...raw,
+    rows,
+    session_net_accepted,
+    session_net_all36,
+    rowCount: rows.length,
+    skippedRows: raw.skippedRows || [],
+  };
+}
+
+function h3ScopeRows(rows) {
+  const serveAccepted = rows.filter((r) => r.decision === "serve" && r.acceptedServe);
+  const small = serveAccepted.filter((r) => isSmallFileTaskId(r.id));
+  return small.length > 0 ? small : serveAccepted;
+}
+
+function computeGates(results) {
+  const h3Rows = h3ScopeRows(results.rows);
+  const h3Violations = h3Rows.filter((r) => r.sGteM);
+  const h5Violations = results.rows.filter((r) => r.chain === "single" && r.mcpCalls > 1);
+
+  const gates = {
+    H1: "NOT_CLAIMED",
+    H2: "NOT_CLAIMED",
+    H3: h3Violations.length === 0 ? "PASS" : "FAIL",
+    H4: results.session_net_accepted >= 0 ? "PASS" : "FAIL",
+    H5: h5Violations.length === 0 ? "PASS" : "FAIL",
+    H6: "NOT_CLAIMED",
+    H7: "NOT_CLAIMED",
+    H8: "NOT_CLAIMED",
+  };
+
+  const diagnostics = [];
+  if (h3Violations.length) {
+    diagnostics.push(
+      `H3 violations: ${h3Violations.map((r) => `${r.id}(S=${r.S},M=${r.M})`).join(", ")}`
+    );
+  }
+  if (results.session_net_accepted < 0) {
+    diagnostics.push(`H4 session_net_accepted=${results.session_net_accepted}`);
+  }
+  if (h5Violations.length) {
+    diagnostics.push(`H5 violations: ${h5Violations.map((r) => `${r.id}:mcpCalls=${r.mcpCalls}`).join(", ")}`);
+  }
+  if (results.skippedRows.length) {
+    diagnostics.push(`Skipped rows: ${results.skippedRows.join(", ")}`);
+  }
+  if (!diagnostics.length) {
+    diagnostics.push("All computed Phase 2 gates passed on measured rows.");
+  }
+
+  return {
+    gates,
+    h3_scope_row_count: h3Rows.length,
+    h3_small_serve_s_gte_m_count: h3Violations.length,
+    h5_single_chain_violations: h5Violations.map((r) => `${r.id}: mcpCalls=${r.mcpCalls}`),
+    session_net_accepted: results.session_net_accepted,
+    session_net_all36: results.session_net_all36,
+    diagnostics: diagnostics.join(" "),
+  };
+}
+
+function formatReportMarkdown({ results, computed, candidatePath, baselinePath, command }) {
+  const g = computed.gates;
+  return `# Phase 2 compact-surface gate report
+
+**Report ID:** phase2-gate-${new Date().toISOString().slice(0, 10)}
+**Surface:** ${results.surface || "compact"}
+**Baseline commit:** \`${results.baselineCommit || "unknown"}\`
+**Candidate results:** \`${candidatePath}\`
+**Baseline results:** \`${baselinePath || "(self)"}\`
+**Compare command:** \`${command}\`
+**H3 policy:** [docs/research/A-012-bypass-policy.md](docs/research/A-012-bypass-policy.md)
+
+## Gate statuses
+
+| Gate | Status |
+|------|--------|
+| H1 | ${g.H1} |
+| H2 | ${g.H2} |
+| H3 | ${g.H3} |
+| H4 | ${g.H4} |
+| H5 | ${g.H5} |
+| H6 | ${g.H6} |
+| H7 | ${g.H7} |
+| H8 | ${g.H8} |
+
+## Computed metrics
+
+- \`session_net_accepted\`: ${computed.session_net_accepted}
+- \`session_net_all36\`: ${computed.session_net_all36}
+- H3 scope rows: ${computed.h3_scope_row_count}
+- H3 sGteM violations: ${computed.h3_small_serve_s_gte_m_count}
+- H5 single-chain violations: ${computed.h5_single_chain_violations.length}
+- Measured rows: ${results.rowCount}
+- Skipped rows: ${results.skippedRows.length}
+
+## Diagnostics
+
+${computed.diagnostics}
+
+## H3 scope note (A-012)
+
+H3 evaluates **accepted serve** rows only (bypass/degrade/cache_hit excluded). When no \`*_small\` task ids are present, all accepted serve rows in the golden corpus are used.
+
+## H5 note
+
+Compact surface uses one external \`symforge\` MCP call per task. Multi-hop rows (\`chain=multi\`) execute legacy tools in-process but report \`mcpCalls=1\`.
+`;
+}
+
+function parseArgs(argv) {
+  const args = { candidate: null, baseline: null, report: null };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--baseline" && argv[i + 1]) {
+      args.baseline = argv[++i];
+    } else if (argv[i] === "--report" && argv[i + 1]) {
+      args.report = argv[++i];
+    } else if (!args.candidate) {
+      args.candidate = argv[i];
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.candidate) {
+    console.error("Usage: node scripts/compare-results.cjs <candidate.json> [--baseline path] [--report out.md]");
+    process.exit(2);
+  }
+  const candidatePath = path.resolve(args.candidate);
+  const results = normalizeResults(loadJson(candidatePath));
+  const computed = computeGates(results);
+  const command = `node scripts/compare-results.cjs ${path.relative(REPO_ROOT, candidatePath)}${args.baseline ? ` --baseline ${args.baseline}` : ""}`;
+
+  const payload = {
+    surface: results.surface || "compact",
+    baselineCommit: results.baselineCommit,
+    candidate: path.relative(REPO_ROOT, candidatePath),
+    ...computed,
+  };
+
+  console.log(JSON.stringify(payload, null, 2));
+
+  if (args.report) {
+    const md = formatReportMarkdown({
+      results,
+      computed,
+      candidatePath: path.relative(REPO_ROOT, candidatePath),
+      baselinePath: args.baseline,
+      command,
+    });
+    fs.writeFileSync(path.resolve(args.report), md);
+    console.error(`Wrote ${args.report}`);
+  }
+
+  const phase2MinPass = computed.gates.H3 === "PASS" && computed.gates.H4 === "PASS";
+  process.exit(phase2MinPass ? 0 : 1);
+}
+
+main();

--- a/scripts/phase2-compact-battery.cjs
+++ b/scripts/phase2-compact-battery.cjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * Phase 2 compact-surface golden battery — one external symforge call per row.
+ * Populates STEL extension fields from trust-envelope ledger metadata.
+ *
+ * Usage:
+ *   cargo build -p symforge
+ *   node scripts/phase2-compact-battery.cjs [symforge-bin] [output.json]
+ *
+ * Requires cloned phase0 corpora for full 36-row coverage; skips missing corpora
+ * with entries in skippedRows (deterministic clean-checkout behavior).
+ */
+const { spawn } = require("child_process");
+const readline = require("readline");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const BIN =
+  process.argv[2] ||
+  path.join(
+    REPO_ROOT,
+    "target/debug",
+    process.platform === "win32" ? "symforge.exe" : "symforge"
+  );
+const OUT =
+  process.argv[3] || path.join(REPO_ROOT, "docs/research/results-v8-phase2-candidate.json");
+const GOLDEN = path.join(REPO_ROOT, "docs/fixtures/routes.golden.jsonl");
+
+const SMALL_FILE = 200;
+const WINDOW = 50 * 80;
+
+function tokensFromBytes(n) {
+  return Math.ceil(n / 4);
+}
+
+function competentManualChars(raw) {
+  if (raw < SMALL_FILE) return raw;
+  return Math.min(raw, WINDOW);
+}
+
+function mTokens(raw) {
+  return tokensFromBytes(competentManualChars(raw));
+}
+
+function sTokens(text) {
+  return tokensFromBytes(Buffer.byteLength(text, "utf8"));
+}
+
+function loadGoldenRows() {
+  return fs
+    .readFileSync(GOLDEN, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function baselineCommit() {
+  try {
+    return execSync("git rev-parse HEAD", { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function corpusForRow(row) {
+  if (row.id === "cfg-if/multi_search_symbol") {
+    return path.join(REPO_ROOT, "tests/fixtures/stel_multi_hop/cfg-if-rust");
+  }
+  if (row.id === "records/multi_context_refs") {
+    return path.join(REPO_ROOT, "tests/fixtures/stel_multi_hop/records-python");
+  }
+  if (row.id === "is-plain/multi_files_content") {
+    return path.join(REPO_ROOT, "tests/fixtures/stel_multi_hop/is-plain-obj-ts");
+  }
+  if (row.id.startsWith("cfg-if/")) {
+    return path.join(REPO_ROOT, "tests/fixtures/phase0-corpus/cfg-if-rust");
+  }
+  if (row.id.startsWith("records/")) {
+    return path.join(REPO_ROOT, "tests/fixtures/phase0-corpus/records-python");
+  }
+  if (row.id.startsWith("is-plain/")) {
+    return path.join(REPO_ROOT, "tests/fixtures/phase0-corpus/is-plain-obj-ts");
+  }
+  if (row.id.startsWith("compression/")) {
+    return path.join(REPO_ROOT, "tests/fixtures/compression_ratio/rust");
+  }
+  throw new Error(`no corpus mapping for ${row.id}`);
+}
+
+function markerForRow(row) {
+  if (row.id.startsWith("cfg-if/")) return "src/lib.rs";
+  if (row.id.startsWith("records/")) return "records.py";
+  if (row.id.startsWith("is-plain/")) {
+    return row.id === "is-plain/multi_files_content" ? "test.js" : "index.js";
+  }
+  if (row.id.startsWith("compression/")) return "service.rs";
+  return null;
+}
+
+function estManualCharsFromFile(corpusDir, marker) {
+  const filePath = path.join(corpusDir, marker);
+  if (!fs.existsSync(filePath)) return 4000;
+  return fs.statSync(filePath).size;
+}
+
+/** Competent-manual baseline per phase0 battery (not raw small-file bytes alone). */
+function estManualCharsForRow(row, corpusDir, marker) {
+  const fileChars = estManualCharsFromFile(corpusDir, marker);
+  let taskFloor = row.id.startsWith("records/") ? 6000 : 4000;
+  if (Array.isArray(row.must_call) && row.must_call.includes("explore")) {
+    taskFloor = Math.max(taskFloor, 8000);
+  }
+  return Math.max(fileChars, taskFloor);
+}
+
+function parseSymforgeOutput(text) {
+  const decisionLine = text.match(/^decision: (\w+)/m);
+  const predictedLine = text.match(/^predicted: (\d+)/m);
+  const ledgerLine = text.match(/^ledger: (\{.+})$/m);
+  let ledger = null;
+  if (ledgerLine) {
+    try {
+      ledger = JSON.parse(ledgerLine[1]);
+    } catch {
+      ledger = null;
+    }
+  }
+  const decision = (ledger && ledger.decision) || (decisionLine && decisionLine[1]) || "serve";
+  const chainFailed = text.includes("Multi-hop chain failed:");
+  return {
+    decision,
+    predicted: predictedLine ? Number(predictedLine[1]) : 0,
+    ledger,
+    chainFailed,
+  };
+}
+
+function equivalenceForRow(row, parsed, text) {
+  if (parsed.decision === "bypass") return "BYPASS";
+  if (parsed.decision === "cache_hit") return "EQUIVALENT";
+  if (parsed.decision === "degrade") return parsed.chainFailed ? "SYMFORGE-LESS" : "EQUIVALENT";
+  if (parsed.chainFailed) return "SYMFORGE-LESS";
+  if (row.expected_decision === "bypass") return "BYPASS";
+  if (row.expected_equiv === false) return "BYPASS";
+  if (text.includes("── stel ──") && !parsed.chainFailed) return "EQUIVALENT";
+  return "PENDING_REVIEW";
+}
+
+function stelBlockFromLedger(ledger, parsed) {
+  if (!ledger) return null;
+  const tools =
+    ledger.route_tool && ledger.route_tool.includes("+")
+      ? ledger.route_tool.split("+")
+      : ledger.route_tool
+        ? [ledger.route_tool]
+        : [];
+  return {
+    plan_id: ledger.plan_id || "",
+    decision: ledger.decision || parsed.decision,
+    tools_called: tools,
+    predicted_tokens: parsed.predicted || ledger.output_tokens || 0,
+    actual_tokens: ledger.output_tokens || 0,
+    net_vs_manual: ledger.predicted_net ?? 0,
+    route_confidence: ledger.route_confidence || "inferred",
+  };
+}
+
+async function runCorpusBatch(corpusDir, rows) {
+  const results = [];
+  let id = 1;
+  const pending = new Map();
+
+  const proc = spawn(BIN, [], {
+    cwd: corpusDir,
+    stdio: ["pipe", "pipe", "ignore"],
+    env: {
+      ...process.env,
+      RUST_LOG: "off",
+      SYMFORGE_SURFACE: "compact",
+      SYMFORGE_NO_DAEMON: "1",
+    },
+  });
+
+  readline.createInterface({ input: proc.stdout }).on("line", (line) => {
+    if (!line.trim()) return;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (msg.id != null && pending.has(msg.id)) {
+      const { resolve, reject } = pending.get(msg.id);
+      pending.delete(msg.id);
+      if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+      else resolve(msg.result);
+    }
+  });
+
+  function request(method, params) {
+    return new Promise((resolve, reject) => {
+      const myId = id++;
+      pending.set(myId, { resolve, reject });
+      proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n");
+      setTimeout(() => {
+        if (pending.has(myId)) {
+          pending.delete(myId);
+          reject(new Error(`timeout ${method}`));
+        }
+      }, 180000);
+    });
+  }
+
+  async function callTool(name, args) {
+    const result = await request("tools/call", { name, arguments: args });
+    const text = (result.content || [])
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+    return text;
+  }
+
+  await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "phase2-compact-battery", version: "1.0" },
+  });
+  proc.stdin.write(
+    JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) + "\n"
+  );
+
+  await callTool("index_folder", { path: corpusDir });
+
+  for (const row of rows) {
+    const marker = markerForRow(row);
+    const manualChars = estManualCharsForRow(row, corpusDir, marker);
+    const text = await callTool("symforge", { query: row.query });
+    const parsed = parseSymforgeOutput(text);
+    const S = sTokens(text);
+    const M = mTokens(manualChars);
+    const equivalence = equivalenceForRow(row, parsed, text);
+    const decision = parsed.decision;
+    const acceptedServe = decision === "serve" && equivalence === "EQUIVALENT";
+    results.push({
+      id: row.id,
+      corpus: path.basename(corpusDir),
+      S,
+      M,
+      sGteM: S >= M,
+      responseBytes: Buffer.byteLength(text, "utf8"),
+      acceptedServe,
+      equivalence,
+      goldenId: row.id,
+      decision,
+      chain: row.chain || "single",
+      mcpCalls: 1,
+      eligibleH6: row.eligible_h6 !== false,
+      stel: stelBlockFromLedger(parsed.ledger, parsed),
+    });
+  }
+
+  proc.kill();
+  return results;
+}
+
+(async () => {
+  const goldenRows = loadGoldenRows();
+  const skippedRows = [];
+  const byCorpus = new Map();
+
+  for (const row of goldenRows) {
+    const corpusDir = corpusForRow(row);
+    const marker = markerForRow(row);
+    if (!marker || !fs.existsSync(path.join(corpusDir, marker))) {
+      skippedRows.push(row.id);
+      continue;
+    }
+    if (!byCorpus.has(corpusDir)) byCorpus.set(corpusDir, []);
+    byCorpus.get(corpusDir).push(row);
+  }
+
+  const allRows = [];
+  for (const [corpusDir, rows] of byCorpus.entries()) {
+    console.error(`Battery corpus ${corpusDir} (${rows.length} rows)`);
+    const batchRows = await runCorpusBatch(corpusDir, rows);
+    allRows.push(...batchRows);
+  }
+
+  allRows.sort((a, b) => a.id.localeCompare(b.id));
+
+  let session_net_accepted = 0;
+  let session_net_all36 = 0;
+  for (const row of allRows) {
+    session_net_all36 += row.M - row.S;
+    if (row.acceptedServe) session_net_accepted += row.M - row.S;
+  }
+
+  const output = {
+    measuredAt: new Date().toISOString(),
+    symforgeBin: BIN,
+    surface: "compact",
+    method: "ceil(bytes/4); M=competent_manual_window; STEL ledger metadata",
+    baselineCommit: baselineCommit(),
+    rows: allRows,
+    session_net_accepted,
+    session_net_all36,
+    rowCount: allRows.length,
+    skippedRows,
+  };
+
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(output, null, 2));
+  console.error(`Wrote ${OUT} (${allRows.length} rows, skipped ${skippedRows.length})`);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/specs/002-v8-phase2-stel-controller/quickstart.md
+++ b/specs/002-v8-phase2-stel-controller/quickstart.md
@@ -68,14 +68,15 @@ Verify unit coverage for: `serve`, `degrade`, `bypass`, `cache_hit`.
 
 ## 5. Compact-surface battery (Slice P2-S4)
 
-Run sf-bench compact surface battery (exact command depends on sf-bench workspace):
+Run in-repo compact battery and compare-results (see [`docs/research/phase2-evidence-index.md`](../../docs/research/phase2-evidence-index.md)):
 
 ```bash
-# Example — adjust paths to local sf-bench checkout
-# node compare-results.js baseline.json candidate.json --surface compact
+cargo build -p symforge
+node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
 ```
 
-Record output in `docs/research/phase2-gate-report.md` per [contracts/phase2-gate-evidence-contract.md](./contracts/phase2-gate-evidence-contract.md).
+Curated reviewer report: `docs/research/phase2-gate-report.md`. Reproducible script output: `docs/research/phase2-gate-report.generated.md` per [contracts/phase2-gate-evidence-contract.md](./contracts/phase2-gate-evidence-contract.md).
 
 Required PASS for Phase 2 exit: **H3**, **H4**; **H5** strongly recommended.
 

--- a/specs/002-v8-phase2-stel-controller/tasks.md
+++ b/specs/002-v8-phase2-stel-controller/tasks.md
@@ -4,7 +4,7 @@
 
 **Prerequisites**: [plan.md](./plan.md) (required), [spec.md](./spec.md) (required), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/phase2-gate-evidence-contract.md](./contracts/phase2-gate-evidence-contract.md)
 
-**Status**: **T002 GO recorded** — milestone branch `cursor/v8-phase2-stel-controller` authorized; P2-S1/P2-S2 in progress.
+**Status**: **P2-S4 battery gates** — H4/H5 PASS; H3 FAIL documented on `cursor/v8-phase2-battery-gates`.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -52,14 +52,14 @@
 
 ## P2-S4: Battery Gates H3/H4/H5 (US3)
 
-- [ ] T030 [US3] Ensure sf-bench row writer populates STEL extension fields per contract
-- [ ] T031 [US3] Run compact-surface battery; save candidate results JSON (operator path)
-- [ ] T032 [US3] Run compare-results; write `docs/research/phase2-gate-report.md`
-- [ ] T033 [US3] Verify H3 PASS under A-012 documented scope
-- [ ] T034 [US3] Verify H4 PASS (`session_net_accepted ≥ 0`)
-- [ ] T035 [P] [US3] Verify H5 PASS for `chain=single` rows (external mcpCalls ≤ 1)
+- [x] T030 [US3] Ensure sf-bench row writer populates STEL extension fields per contract
+- [x] T031 [US3] Run compact-surface battery; save candidate results JSON (operator path)
+- [x] T032 [US3] Run compare-results; write `docs/research/phase2-gate-report.md`
+- [x] T033 [US3] Verify H3 PASS under A-012 documented scope — **FAIL** (1 row: `records/t8_explore`; see gate report)
+- [x] T034 [US3] Verify H4 PASS (`session_net_accepted ≥ 0`)
+- [x] T035 [P] [US3] Verify H5 PASS for `chain=single` rows (external mcpCalls ≤ 1)
 
-**Checkpoint**: Gate report shows H3 + H4 PASS; H5 documented.
+**Checkpoint**: Gate report shows H4/H5 PASS; H3 FAIL documented with action notes.
 
 ---
 

--- a/src/stel/gates.rs
+++ b/src/stel/gates.rs
@@ -260,7 +260,7 @@ fn chrono_date_stub() -> String {
     format!("epoch-day-{days}")
 }
 
-/// Render gate report as markdown for `docs/research/phase2-gate-report.md`.
+/// Render gate report as markdown (typically written to `phase2-gate-report.generated.md`).
 pub fn format_gate_report_markdown(report: &Phase2GateReport) -> String {
     let gates = &report.gates;
     format!(

--- a/src/stel/gates.rs
+++ b/src/stel/gates.rs
@@ -1,0 +1,462 @@
+//! Phase 2 compact-surface battery gate computation (H3/H4/H5).
+//!
+//! Formulas match [`docs/v8-gap-closure-plan.md`](../../docs/v8-gap-closure-plan.md) §5.1
+//! with A-012 serve-only H3 scope when no `*_small` rows are present.
+
+#![allow(non_snake_case)] // sf-bench / compare-results JSON field names
+
+use serde::{Deserialize, Serialize};
+
+/// STEL extension block required on each battery row (Phase 2 contract).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BatteryRowStel {
+    pub plan_id: String,
+    pub decision: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools_called: Vec<String>,
+    pub predicted_tokens: u32,
+    pub actual_tokens: u32,
+    pub net_vs_manual: i32,
+    pub route_confidence: String,
+}
+
+/// One measured compact-surface battery row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BatteryRow {
+    pub id: String,
+    #[serde(default)]
+    pub corpus: String,
+    pub S: u32,
+    pub M: u32,
+    pub sGteM: bool,
+    pub acceptedServe: bool,
+    pub equivalence: String,
+    #[serde(default)]
+    pub goldenId: String,
+    pub decision: String,
+    #[serde(default = "default_chain")]
+    pub chain: String,
+    pub mcpCalls: u32,
+    pub eligibleH6: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stel: Option<BatteryRowStel>,
+}
+
+fn default_chain() -> String {
+    "single".to_string()
+}
+
+/// sf-bench-style battery output consumed by compare-results.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BatteryResults {
+    #[serde(default)]
+    pub measuredAt: String,
+    #[serde(default)]
+    pub symforgeBin: String,
+    #[serde(default)]
+    pub surface: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    pub baselineCommit: String,
+    pub rows: Vec<BatteryRow>,
+    #[serde(default)]
+    pub session_net_accepted: i64,
+    #[serde(default)]
+    pub session_net_all36: i64,
+    #[serde(default)]
+    pub rowCount: usize,
+    #[serde(default)]
+    pub skippedRows: Vec<String>,
+}
+
+/// Per-gate PASS/FAIL/NOT_CLAIMED status.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GateStatus {
+    Pass,
+    Fail,
+    NotClaimed,
+}
+
+impl GateStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Fail => "FAIL",
+            Self::NotClaimed => "NOT_CLAIMED",
+        }
+    }
+}
+
+/// Computed H3/H4/H5 gate report for Phase 2 evidence.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Phase2GateReport {
+    pub report_id: String,
+    pub surface: String,
+    pub baseline_commit: String,
+    pub candidate_results: String,
+    pub compare_results_command: String,
+    pub session_net_accepted: i64,
+    pub session_net_all36: i64,
+    pub h3_small_serve_s_gte_m_count: usize,
+    pub h3_scope_row_count: usize,
+    pub h3_policy_ref: String,
+    pub h5_single_chain_violations: Vec<String>,
+    pub gates: Phase2GateStatuses,
+    pub diagnostics: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Phase2GateStatuses {
+    pub H1: GateStatus,
+    pub H2: GateStatus,
+    pub H3: GateStatus,
+    pub H4: GateStatus,
+    pub H5: GateStatus,
+    pub H6: GateStatus,
+    pub H7: GateStatus,
+    pub H8: GateStatus,
+}
+
+/// Whether a row id matches the sf-bench small-file task suffix.
+pub fn is_small_file_task_id(id: &str) -> bool {
+    id.contains("_small") || id.ends_with("/small")
+}
+
+/// Rows in scope for H3 under A-012 serve-only policy.
+pub fn h3_scope_rows(rows: &[BatteryRow]) -> Vec<&BatteryRow> {
+    let serve_accepted: Vec<_> = rows
+        .iter()
+        .filter(|row| row.decision == "serve" && row.acceptedServe)
+        .collect();
+    let small: Vec<_> = serve_accepted
+        .iter()
+        .copied()
+        .filter(|row| is_small_file_task_id(&row.id))
+        .collect();
+    if small.is_empty() {
+        serve_accepted
+    } else {
+        small
+    }
+}
+
+/// Recompute session nets and sGteM flags from row economics.
+pub fn normalize_battery_results(mut results: BatteryResults) -> BatteryResults {
+    for row in &mut results.rows {
+        row.sGteM = row.S >= row.M;
+        row.acceptedServe = row.decision == "serve" && row.equivalence == "EQUIVALENT";
+        if row.goldenId.is_empty() {
+            row.goldenId.clone_from(&row.id);
+        }
+    }
+    results.session_net_accepted = results
+        .rows
+        .iter()
+        .filter(|row| row.acceptedServe)
+        .map(|row| i64::from(row.M) - i64::from(row.S))
+        .sum();
+    results.session_net_all36 = results
+        .rows
+        .iter()
+        .map(|row| i64::from(row.M) - i64::from(row.S))
+        .sum();
+    results.rowCount = results.rows.len();
+    results
+}
+
+/// Compute Phase 2 gate statuses from normalized battery results.
+pub fn compute_phase2_gates(results: &BatteryResults) -> Phase2GateReport {
+    let h3_rows = h3_scope_rows(&results.rows);
+    let h3_violations: Vec<_> = h3_rows.iter().filter(|row| row.sGteM).collect();
+    let h3_status = if h3_violations.is_empty() {
+        GateStatus::Pass
+    } else {
+        GateStatus::Fail
+    };
+
+    let h4_status = if results.session_net_accepted >= 0 {
+        GateStatus::Pass
+    } else {
+        GateStatus::Fail
+    };
+
+    let h5_violations: Vec<String> = results
+        .rows
+        .iter()
+        .filter(|row| row.chain == "single" && row.mcpCalls > 1)
+        .map(|row| format!("{}: mcpCalls={}", row.id, row.mcpCalls))
+        .collect();
+    let h5_status = if h5_violations.is_empty() {
+        GateStatus::Pass
+    } else {
+        GateStatus::Fail
+    };
+
+    let mut diagnostics = String::new();
+    if !h3_violations.is_empty() {
+        diagnostics.push_str("H3 violations (accepted serve rows with sGteM): ");
+        for row in &h3_violations {
+            diagnostics.push_str(&format!("{} (S={} M={}); ", row.id, row.S, row.M));
+        }
+    }
+    if results.session_net_accepted < 0 {
+        diagnostics.push_str(&format!(
+            "H4 session_net_accepted={} < 0. ",
+            results.session_net_accepted
+        ));
+    }
+    if !h5_violations.is_empty() {
+        diagnostics.push_str(&format!("H5 violations: {}. ", h5_violations.join(", ")));
+    }
+    if !results.skippedRows.is_empty() {
+        diagnostics.push_str(&format!(
+            "Skipped {} rows (missing corpus): {}. ",
+            results.skippedRows.len(),
+            results.skippedRows.join(", ")
+        ));
+    }
+    if diagnostics.is_empty() {
+        diagnostics.push_str("All computed Phase 2 gates passed on measured rows.");
+    }
+
+    Phase2GateReport {
+        report_id: format!("phase2-gate-{}", chrono_date_stub()),
+        surface: if results.surface.is_empty() {
+            "compact".to_string()
+        } else {
+            results.surface.clone()
+        },
+        baseline_commit: results.baselineCommit.clone(),
+        candidate_results: String::new(),
+        compare_results_command: String::new(),
+        session_net_accepted: results.session_net_accepted,
+        session_net_all36: results.session_net_all36,
+        h3_small_serve_s_gte_m_count: h3_violations.len(),
+        h3_scope_row_count: h3_rows.len(),
+        h3_policy_ref: "docs/research/A-012-bypass-policy.md".to_string(),
+        h5_single_chain_violations: h5_violations,
+        gates: Phase2GateStatuses {
+            H1: GateStatus::NotClaimed,
+            H2: GateStatus::NotClaimed,
+            H3: h3_status,
+            H4: h4_status,
+            H5: h5_status,
+            H6: GateStatus::NotClaimed,
+            H7: GateStatus::NotClaimed,
+            H8: GateStatus::NotClaimed,
+        },
+        diagnostics: diagnostics.trim().to_string(),
+    }
+}
+
+fn chrono_date_stub() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let days = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() / 86_400)
+        .unwrap_or(0);
+    format!("epoch-day-{days}")
+}
+
+/// Render gate report as markdown for `docs/research/phase2-gate-report.md`.
+pub fn format_gate_report_markdown(report: &Phase2GateReport) -> String {
+    let gates = &report.gates;
+    format!(
+        "# Phase 2 compact-surface gate report\n\n\
+         **Report ID:** {report_id}  \n\
+         **Surface:** {surface}  \n\
+         **Baseline commit:** `{baseline}`  \n\
+         **Candidate results:** `{candidate}`  \n\
+         **Compare command:** `{command}`  \n\
+         **H3 policy:** [{h3_policy}]({h3_policy})\n\n\
+         ## Gate statuses\n\n\
+         | Gate | Status |\n\
+         |------|--------|\n\
+         | H1 | {h1} |\n\
+         | H2 | {h2} |\n\
+         | H3 | {h3} |\n\
+         | H4 | {h4} |\n\
+         | H5 | {h5} |\n\
+         | H6 | {h6} |\n\
+         | H7 | {h7} |\n\
+         | H8 | {h8} |\n\n\
+         ## Computed metrics\n\n\
+         - `session_net_accepted`: {accepted}\n\
+         - `session_net_all36`: {all36}\n\
+         - H3 scope rows: {h3_scope}\n\
+         - H3 sGteM violations: {h3_violations}\n\
+         - H5 single-chain violations: {h5_count}\n\n\
+         ## Diagnostics\n\n\
+         {diagnostics}\n\n\
+         ## H3 scope note (A-012)\n\n\
+         H3 evaluates **accepted serve** rows only (bypass/degrade/cache_hit excluded). \
+         When no `*_small` task ids are present, all accepted serve rows in the golden corpus \
+         are used (Phase 2 golden naming uses `tN` ids, not sf-bench `*_small` suffix).\n\n\
+         ## H5 note\n\n\
+         Compact surface uses one external `symforge` MCP call per task. Multi-hop rows \
+         (`chain=multi`) may execute multiple legacy tools in-process but must still report \
+         `mcpCalls=1`.\n",
+        report_id = report.report_id,
+        surface = report.surface,
+        baseline = report.baseline_commit,
+        candidate = report.candidate_results,
+        command = report.compare_results_command,
+        h3_policy = report.h3_policy_ref,
+        h1 = gates.H1.as_str(),
+        h2 = gates.H2.as_str(),
+        h3 = gates.H3.as_str(),
+        h4 = gates.H4.as_str(),
+        h5 = gates.H5.as_str(),
+        h6 = gates.H6.as_str(),
+        h7 = gates.H7.as_str(),
+        h8 = gates.H8.as_str(),
+        accepted = report.session_net_accepted,
+        all36 = report.session_net_all36,
+        h3_scope = report.h3_scope_row_count,
+        h3_violations = report.h3_small_serve_s_gte_m_count,
+        h5_count = report.h5_single_chain_violations.len(),
+        diagnostics = report.diagnostics,
+    )
+}
+
+/// Phase 2 minimum exit gates (H3 + H4; H5 strongly recommended).
+pub fn phase2_minimum_gates_pass(report: &Phase2GateReport) -> bool {
+    report.gates.H3 == GateStatus::Pass && report.gates.H4 == GateStatus::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_row(
+        id: &str,
+        decision: &str,
+        equiv: &str,
+        s: u32,
+        m: u32,
+        chain: &str,
+    ) -> BatteryRow {
+        BatteryRow {
+            id: id.to_string(),
+            corpus: "test".to_string(),
+            S: s,
+            M: m,
+            sGteM: s >= m,
+            acceptedServe: decision == "serve" && equiv == "EQUIVALENT",
+            equivalence: equiv.to_string(),
+            goldenId: id.to_string(),
+            decision: decision.to_string(),
+            chain: chain.to_string(),
+            mcpCalls: 1,
+            eligibleH6: true,
+            stel: None,
+        }
+    }
+
+    #[test]
+    fn h3_passes_when_no_accepted_serve_s_gte_m() {
+        let results = normalize_battery_results(BatteryResults {
+            measuredAt: String::new(),
+            symforgeBin: String::new(),
+            surface: "compact".to_string(),
+            method: String::new(),
+            baselineCommit: "abc".to_string(),
+            rows: vec![
+                sample_row(
+                    "cfg-if/t1_search",
+                    "serve",
+                    "EQUIVALENT",
+                    100,
+                    500,
+                    "single",
+                ),
+                sample_row(
+                    "cfg-if/pff_whole_lib",
+                    "bypass",
+                    "BYPASS",
+                    50,
+                    500,
+                    "single",
+                ),
+            ],
+            session_net_accepted: 0,
+            session_net_all36: 0,
+            rowCount: 0,
+            skippedRows: vec![],
+        });
+        let report = compute_phase2_gates(&results);
+        assert_eq!(report.gates.H3, GateStatus::Pass);
+        assert_eq!(report.h3_scope_row_count, 1);
+    }
+
+    #[test]
+    fn h3_fails_on_accepted_serve_s_gte_m() {
+        let results = normalize_battery_results(BatteryResults {
+            measuredAt: String::new(),
+            symforgeBin: String::new(),
+            surface: "compact".to_string(),
+            method: String::new(),
+            baselineCommit: String::new(),
+            rows: vec![sample_row(
+                "tokio/t2_small",
+                "serve",
+                "EQUIVALENT",
+                600,
+                500,
+                "single",
+            )],
+            session_net_accepted: 0,
+            session_net_all36: 0,
+            rowCount: 0,
+            skippedRows: vec![],
+        });
+        let report = compute_phase2_gates(&results);
+        assert_eq!(report.gates.H3, GateStatus::Fail);
+        assert_eq!(report.h3_small_serve_s_gte_m_count, 1);
+    }
+
+    #[test]
+    fn h4_uses_accepted_serve_net_only() {
+        let results = normalize_battery_results(BatteryResults {
+            measuredAt: String::new(),
+            symforgeBin: String::new(),
+            surface: "compact".to_string(),
+            method: String::new(),
+            baselineCommit: String::new(),
+            rows: vec![
+                sample_row("a/t1", "serve", "EQUIVALENT", 100, 500, "single"),
+                sample_row("b/pff", "bypass", "BYPASS", 900, 500, "single"),
+            ],
+            session_net_accepted: 0,
+            session_net_all36: 0,
+            rowCount: 0,
+            skippedRows: vec![],
+        });
+        assert_eq!(results.session_net_accepted, 400);
+        let report = compute_phase2_gates(&results);
+        assert_eq!(report.gates.H4, GateStatus::Pass);
+        assert!(results.session_net_all36 < results.session_net_accepted);
+    }
+
+    #[test]
+    fn h5_fails_when_single_chain_exceeds_one_mcp_call() {
+        let mut row = sample_row("x/t1", "serve", "EQUIVALENT", 10, 100, "single");
+        row.mcpCalls = 2;
+        let results = normalize_battery_results(BatteryResults {
+            measuredAt: String::new(),
+            symforgeBin: String::new(),
+            surface: "compact".to_string(),
+            method: String::new(),
+            baselineCommit: String::new(),
+            rows: vec![row],
+            session_net_accepted: 0,
+            session_net_all36: 0,
+            rowCount: 0,
+            skippedRows: vec![],
+        });
+        let report = compute_phase2_gates(&results);
+        assert_eq!(report.gates.H5, GateStatus::Fail);
+    }
+}

--- a/src/stel/ledger.rs
+++ b/src/stel/ledger.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use super::controller::EconomicsBreakdown;
 use super::executor::is_pff_bypass_body;
 use super::handler::estimate_tokens;
+use super::planner::confidence_label;
 use super::types::{AdmissionDecision, StelDecision, StelLedgerEvent, StelPlan};
 
 /// In-memory append-only ledger for one MCP server session (no persistence in this slice).
@@ -76,6 +77,7 @@ pub struct LedgerEnvelopeMeta {
     pub predicted_net: i32,
     pub output_bytes: u64,
     pub output_tokens: u32,
+    pub route_confidence: String,
 }
 
 /// Build a schema-aligned [`StelLedgerEvent`] from a completed `symforge` invocation.
@@ -157,6 +159,7 @@ pub fn capture_ledger(input: &LedgerCaptureInput<'_>) -> (StelLedgerEvent, Ledge
         predicted_net: input.economics.predicted_net_vs_manual,
         output_bytes,
         output_tokens,
+        route_confidence: confidence_label(input.plan.confidence).to_string(),
     };
     (event, meta)
 }

--- a/src/stel/mod.rs
+++ b/src/stel/mod.rs
@@ -19,6 +19,7 @@ pub mod edit_apply;
 pub mod edit_planner;
 pub mod envelope;
 pub mod executor;
+pub mod gates;
 pub mod golden_replay;
 pub mod handler;
 pub mod ledger;
@@ -52,6 +53,11 @@ pub use executor::{
     is_degrade, is_enforced_bypass, is_pff_bypass_body, route_tool_label,
     serve_chain_outcome_class, serve_step_failed, serve_step_outcome, should_skip_legacy_dispatch,
     tools_executed,
+};
+pub use gates::{
+    BatteryResults, BatteryRow, BatteryRowStel, GateStatus, Phase2GateReport, Phase2GateStatuses,
+    compute_phase2_gates, format_gate_report_markdown, h3_scope_rows, is_small_file_task_id,
+    normalize_battery_results, phase2_minimum_gates_pass,
 };
 pub use golden_replay::{
     DEFERRED_MULTI_HOP_ROW_IDS, GOLDEN_ROUTES_FIXTURE, GoldenCorpusClassification,

--- a/tests/fixtures/phase2-gate/synthetic-h3-fail.json
+++ b/tests/fixtures/phase2-gate/synthetic-h3-fail.json
@@ -1,0 +1,23 @@
+{
+  "surface": "compact",
+  "baselineCommit": "synthetic",
+  "rows": [
+    {
+      "id": "tokio/t2_small",
+      "S": 600,
+      "M": 500,
+      "sGteM": true,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "tokio/t2_small",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true
+    }
+  ],
+  "session_net_accepted": -100,
+  "session_net_all36": -100,
+  "rowCount": 1,
+  "skippedRows": []
+}

--- a/tests/fixtures/phase2-gate/synthetic-h4-fail.json
+++ b/tests/fixtures/phase2-gate/synthetic-h4-fail.json
@@ -1,0 +1,23 @@
+{
+  "surface": "compact",
+  "baselineCommit": "synthetic",
+  "rows": [
+    {
+      "id": "cfg-if/t1_search",
+      "S": 900,
+      "M": 500,
+      "sGteM": true,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true
+    }
+  ],
+  "session_net_accepted": -400,
+  "session_net_all36": -400,
+  "rowCount": 1,
+  "skippedRows": []
+}

--- a/tests/fixtures/phase2-gate/synthetic-pass.json
+++ b/tests/fixtures/phase2-gate/synthetic-pass.json
@@ -1,0 +1,82 @@
+{
+  "measuredAt": "2026-06-14T00:00:00.000Z",
+  "symforgeBin": "target/debug/symforge",
+  "surface": "compact",
+  "method": "synthetic-fixture",
+  "baselineCommit": "synthetic",
+  "rows": [
+    {
+      "id": "cfg-if/t1_search",
+      "corpus": "cfg-if-rust",
+      "S": 194,
+      "M": 1000,
+      "sGteM": false,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/t1_search",
+      "decision": "serve",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-1",
+        "decision": "serve",
+        "tools_called": ["search_text"],
+        "predicted_tokens": 400,
+        "actual_tokens": 194,
+        "net_vs_manual": 380,
+        "route_confidence": "inferred"
+      }
+    },
+    {
+      "id": "cfg-if/pff_whole_lib",
+      "corpus": "cfg-if-rust",
+      "S": 120,
+      "M": 1000,
+      "sGteM": false,
+      "acceptedServe": false,
+      "equivalence": "BYPASS",
+      "goldenId": "cfg-if/pff_whole_lib",
+      "decision": "bypass",
+      "chain": "single",
+      "mcpCalls": 1,
+      "eligibleH6": false,
+      "stel": {
+        "plan_id": "plan-pff",
+        "decision": "bypass",
+        "tools_called": [],
+        "predicted_tokens": 0,
+        "actual_tokens": 120,
+        "net_vs_manual": 200,
+        "route_confidence": "exact"
+      }
+    },
+    {
+      "id": "cfg-if/multi_search_symbol",
+      "corpus": "cfg-if-rust",
+      "S": 350,
+      "M": 1000,
+      "sGteM": false,
+      "acceptedServe": true,
+      "equivalence": "EQUIVALENT",
+      "goldenId": "cfg-if/multi_search_symbol",
+      "decision": "serve",
+      "chain": "multi",
+      "mcpCalls": 1,
+      "eligibleH6": true,
+      "stel": {
+        "plan_id": "plan-multi",
+        "decision": "serve",
+        "tools_called": ["search_symbols", "get_symbol"],
+        "predicted_tokens": 800,
+        "actual_tokens": 350,
+        "net_vs_manual": 450,
+        "route_confidence": "inferred"
+      }
+    }
+  ],
+  "session_net_accepted": 1456,
+  "session_net_all36": 2336,
+  "rowCount": 3,
+  "skippedRows": []
+}

--- a/tests/stel_battery_gates.rs
+++ b/tests/stel_battery_gates.rs
@@ -1,0 +1,120 @@
+//! Phase 2 compact-surface battery gates — deterministic H3/H4/H5 computation.
+#![cfg(feature = "server")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use symforge::stel::{
+    self, GateStatus, compute_phase2_gates, normalize_battery_results, phase2_minimum_gates_pass,
+};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    repo_root().join("tests/fixtures/phase2-gate").join(name)
+}
+
+fn load_fixture(name: &str) -> stel::BatteryResults {
+    let text = std::fs::read_to_string(fixture_path(name)).expect("fixture readable");
+    serde_json::from_str(&text).expect("fixture json")
+}
+
+#[test]
+fn synthetic_pass_fixture_computes_h3_h4_h5_pass() {
+    let results = normalize_battery_results(load_fixture("synthetic-pass.json"));
+    let report = compute_phase2_gates(&results);
+    assert_eq!(report.gates.H3, GateStatus::Pass);
+    assert_eq!(report.gates.H4, GateStatus::Pass);
+    assert_eq!(report.gates.H5, GateStatus::Pass);
+    assert!(phase2_minimum_gates_pass(&report));
+    assert_eq!(report.h3_scope_row_count, 2);
+    assert!(report.session_net_accepted > 0);
+}
+
+#[test]
+fn synthetic_h3_fail_detects_s_gte_m_on_small_serve_row() {
+    let results = normalize_battery_results(load_fixture("synthetic-h3-fail.json"));
+    let report = compute_phase2_gates(&results);
+    assert_eq!(report.gates.H3, GateStatus::Fail);
+    assert_eq!(report.h3_small_serve_s_gte_m_count, 1);
+}
+
+#[test]
+fn synthetic_h4_fail_detects_negative_session_net_accepted() {
+    let results = normalize_battery_results(load_fixture("synthetic-h4-fail.json"));
+    let report = compute_phase2_gates(&results);
+    assert_eq!(report.gates.H4, GateStatus::Fail);
+    assert!(report.session_net_accepted < 0);
+}
+
+#[test]
+fn compare_results_script_matches_rust_gate_computation() {
+    let fixture = fixture_path("synthetic-pass.json");
+    let output = Command::new("node")
+        .arg("scripts/compare-results.cjs")
+        .arg(&fixture)
+        .current_dir(repo_root())
+        .output()
+        .expect("spawn compare-results");
+    assert!(
+        output.status.success(),
+        "compare-results failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("json stdout");
+    assert_eq!(parsed["gates"]["H3"], "PASS");
+    assert_eq!(parsed["gates"]["H4"], "PASS");
+    assert_eq!(parsed["gates"]["H5"], "PASS");
+}
+
+#[test]
+fn compare_results_script_fails_on_h4_negative_net() {
+    let fixture = fixture_path("synthetic-h4-fail.json");
+    let output = Command::new("node")
+        .arg("scripts/compare-results.cjs")
+        .arg(&fixture)
+        .current_dir(repo_root())
+        .output()
+        .expect("spawn compare-results");
+    assert!(!output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("json stdout");
+    assert_eq!(parsed["gates"]["H4"], "FAIL");
+}
+
+#[test]
+fn battery_rows_require_stel_extension_fields_in_pass_fixture() {
+    let results = load_fixture("synthetic-pass.json");
+    for row in &results.rows {
+        let stel = row.stel.as_ref().expect("stel block present");
+        assert!(!stel.plan_id.is_empty());
+        assert!(!stel.decision.is_empty());
+        assert!(!stel.route_confidence.is_empty());
+    }
+}
+
+#[test]
+fn live_candidate_artifact_computes_gates_deterministically() {
+    let path = repo_root().join("docs/research/results-v8-phase2-candidate.json");
+    if !path.is_file() {
+        eprintln!("skip live_candidate_artifact: run phase2-compact-battery first");
+        return;
+    }
+    let results = normalize_battery_results(load_fixture_from_path(path));
+    assert_eq!(results.rowCount, 36);
+    let report = compute_phase2_gates(&results);
+    assert_eq!(report.gates.H4, GateStatus::Pass);
+    assert_eq!(report.gates.H5, GateStatus::Pass);
+    assert!(report.session_net_accepted >= 0);
+    for row in &results.rows {
+        assert!(row.stel.is_some(), "missing stel block on {}", row.id);
+    }
+}
+
+fn load_fixture_from_path(path: PathBuf) -> stel::BatteryResults {
+    let text = std::fs::read_to_string(path).expect("candidate readable");
+    serde_json::from_str(&text).expect("candidate json")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **P2-S4 compact-surface battery gates** (T030–T035) — evidence/gate slice only. No A-029, no persistence, no L2/planner behavior changes beyond ledger `route_confidence` metadata for battery rows.

## Gate definitions

| Gate | Computation | Result |
|------|-------------|--------|
| **H3** | Accepted serve rows (A-012 serve-only scope); zero `sGteM` | **FAIL** (1 row) |
| **H4** | `session_net_accepted = Σ(M−S)` over accepted serve rows | **PASS** (+13543) |
| **H5** | `mcpCalls ≤ 1` for `chain=single` golden rows | **PASS** |

H3 failure: `records/t8_explore` (S=1143, M=1000) — explore guidance exceeds competent-manual window. Documented with follow-up options in gate report; not masked.

## Artifacts

- [`docs/research/phase2-gate-report.md`](docs/research/phase2-gate-report.md) — curated reviewer artifact
- [`docs/research/phase2-gate-report.generated.md`](docs/research/phase2-gate-report.generated.md) — reproducible compare-results output
- [`docs/research/results-v8-phase2-candidate.json`](docs/research/results-v8-phase2-candidate.json) — 36/36 rows with STEL extension fields
- [`docs/research/phase2-evidence-index.md`](docs/research/phase2-evidence-index.md) — updated

## Commands

```bash
cargo build -p symforge
node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
cargo test --test stel_battery_gates -- --test-threads=1
```

## Implementation

- `src/stel/gates.rs` — Rust gate computation (H3/H4/H5)
- `scripts/compare-results.cjs` — in-repo compare-results for Phase 2
- `scripts/phase2-compact-battery.cjs` — compact golden battery with STEL ledger fields
- `tests/fixtures/phase2-gate/synthetic-*.json` — deterministic gate fixtures
- `tests/stel_battery_gates.rs` — gate + compare-results integration tests
- `LedgerEnvelopeMeta.route_confidence` — T030 STEL extension support

## Scope boundaries

- No P2-S5 / A-029
- No SQLite / EMA→L2 / B-RESULTS / H6–H8 claims
- Multi-hop + L2 admission behavior preserved (existing STEL suites green)

## Tests run

All required STEL suites green; `stel_battery_gates` (7 tests) added.

---

## Review reply (a47bb00)

Addressed the non-blocking report reproducibility note in a47bb00.

Follow-up commit:
- Keeps `docs/research/phase2-gate-report.md` as the curated reviewer artifact.
- Adds/uses `docs/research/phase2-gate-report.generated.md` for reproducible script output.
- Updates evidence/index command text so re-running compare-results no longer clobbers the curated report.
- Updates quickstart reproducibility command to target the generated report.
- Numeric results remain unchanged:
  - H3 FAIL: `records/t8_explore`
  - H4 PASS: `session_net_accepted = +13543`
  - H5 PASS

Also documented the local corpus-gated golden replay note: the two replay failures reproduce at the PR parent with this machine's external `phase0-corpus` contents and are not caused by P2-S4.

Verification:
- `git diff --check`
- `cargo test --test stel_battery_gates -- --test-threads=1`
- `node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md`

No runtime behavior changed; H3 remains truthfully failed and A-029 remains blocked.

**Ready for final review/merge.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

