### PR TITLE
fix(stel): remediate Phase 2 H3 explore gate

### DIFF
--- a/docs/research/phase2-evidence-index.md
+++ b/docs/research/phase2-evidence-index.md
@@ -1,6 +1,6 @@
 # Phase 2 STEL evidence index
 
-**Status:** P2-S4 battery gates — H4/H5 PASS; H3 FAIL documented (2026-06-14)
+**Status:** P2-S4 battery gates + H3 remediation — H3/H4/H5 PASS (2026-06-14)
 
 **Created**: 2026-06-14
 
@@ -21,7 +21,8 @@
 
 - Phase 1 shipped: [`phase1-stel-checkpoint.md`](../phase1-stel-checkpoint.md)
 - Phase 2 Slice 1 merged: `3d64b96` (multi-hop golden closure)
-- Phase 2 Slice 2 merged: PR #306 / `896840f` tip (L2 admission hardening)
+- Phase 2 Slice 2 merged: PR #306 / `896840f` (L2 admission hardening)
+- Phase 2 Slice 4 merged: PR #308 / `b1f6019` (battery gate evidence)
 
 ## T002 spec reviewer sign-off
 
@@ -36,7 +37,7 @@
 
 | Slot | Path | Status |
 |------|------|--------|
-| Gate report (curated) | [`phase2-gate-report.md`](./phase2-gate-report.md) | **COMPLETE** — H3 FAIL (1 row), H4/H5 PASS |
+| Gate report (curated) | [`phase2-gate-report.md`](./phase2-gate-report.md) | **COMPLETE** — H3/H4/H5 PASS |
 | Gate report (generated) | [`phase2-gate-report.generated.md`](./phase2-gate-report.generated.md) | **COMPLETE** — compare-results script output |
 | Candidate battery JSON | [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json) | **COMPLETE** — 36/36 rows, STEL fields |
 | Compare-results script | [`scripts/compare-results.cjs`](../../scripts/compare-results.cjs) | **COMPLETE** |

--- a/docs/research/phase2-gate-report.generated.md
+++ b/docs/research/phase2-gate-report.generated.md
@@ -2,7 +2,7 @@
 
 **Report ID:** phase2-gate-2026-06-14
 **Surface:** compact
-**Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45`
+**Baseline commit:** `b1f60196e763b19cdde35584bde284f625576f2a`
 **Candidate results:** `docs/research/results-v8-phase2-candidate.json`
 **Baseline results:** `(self)`
 **Compare command:** `node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json`
@@ -14,7 +14,7 @@
 |------|--------|
 | H1 | NOT_CLAIMED |
 | H2 | NOT_CLAIMED |
-| H3 | FAIL |
+| H3 | PASS |
 | H4 | PASS |
 | H5 | PASS |
 | H6 | NOT_CLAIMED |
@@ -23,17 +23,17 @@
 
 ## Computed metrics
 
-- `session_net_accepted`: 13543
-- `session_net_all36`: 22602
+- `session_net_accepted`: 13753
+- `session_net_all36`: 22812
 - H3 scope rows: 24
-- H3 sGteM violations: 1
+- H3 sGteM violations: 0
 - H5 single-chain violations: 0
 - Measured rows: 36
 - Skipped rows: 0
 
 ## Diagnostics
 
-H3 violations: records/t8_explore(S=1143,M=1000)
+All computed Phase 2 gates passed on measured rows.
 
 ## H3 scope note (A-012)
 

--- a/docs/research/phase2-gate-report.md
+++ b/docs/research/phase2-gate-report.md
@@ -2,9 +2,9 @@
 
 **Report ID:** phase2-gate-2026-06-14  
 **Surface:** `compact` (`SYMFORGE_SURFACE=compact`)  
-**Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45`  
-**Candidate results:** [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json)  
-**Baseline results:** self (first compact-surface Phase 2 battery pin)  
+**Baseline commit:** `896840f984738ce0f77e9a9c1aae94011ceaee45` (P2-S4 first pin)
+**Candidate results:** [`results-v8-phase2-candidate.json`](./results-v8-phase2-candidate.json)
+**Refreshed at:** H3 remediation merge (post-#308)
 **Compare command (reproducible script output — does not overwrite this file):**
 
 ```bash
@@ -38,7 +38,7 @@ H3 scope uses all accepted serve rows when no `*_small` task ids exist (Phase 2 
 |------|--------|
 | H1 | NOT_CLAIMED |
 | H2 | NOT_CLAIMED |
-| H3 | **FAIL** |
+| H3 | **PASS** |
 | H4 | **PASS** |
 | H5 | **PASS** |
 | H6 | NOT_CLAIMED |
@@ -49,35 +49,27 @@ H3 scope uses all accepted serve rows when no `*_small` task ids exist (Phase 2 
 
 | Metric | Value |
 |--------|------:|
-| `session_net_accepted` | 13543 |
-| `session_net_all36` | 22602 |
+| `session_net_accepted` | 13753 |
+| `session_net_all36` | 22812 |
 | H3 scope rows | 24 |
-| H3 sGteM violations | 1 |
+| H3 sGteM violations | 0 |
 | H5 single-chain violations | 0 |
 | Measured rows | 36 |
 | Skipped rows | 0 |
 
 ## Diagnostics
 
-H3 violations: `records/t8_explore` (S=1143, M=1000)
+All computed Phase 2 gates passed on measured rows.
 
-All other accepted serve rows: `sGteM=false`.
+Prior P2-S4 failure (`records/t8_explore` S=1143, M=1000) remediated by compact-serve explore `max_tokens` cap (`COMPACT_SERVE_EXPLORE_MAX_TOKENS=750` in `src/stel/executor.rs`); refreshed row S=929, M=1000.
 
-## Reviewer / action notes (H3 FAIL)
+## H3 remediation note (P2-S4.1)
 
-**Row:** `records/t8_explore` — `explore` guidance response exceeds competent-manual window (M=1000 tokens at 4000-char cap).
+**Row:** `records/t8_explore` — explore guidance on `records-python` exceeded competent-manual window before cap.
 
-**Observed:** Single compact `symforge` call returns 1143 response tokens including STEL envelope + explore guidance body.
+**Fix:** On compact `symforge` **serve**, apply `max_tokens=750` to `explore` steps (250-token reserve for STEL envelope + serve routing meta vs H3 M=1000). Decision remains `serve`; guidance is truncated with standard budget footer when needed.
 
-**Not a multi-hop or MCP-call regression:** H5 PASS; decision=`serve`; `mcpCalls=1`.
-
-**Recommended follow-up (out of P2-S4 scope):**
-
-1. Route high-token explore queries through L2 `degrade` with `max_tokens_cap`, or
-2. Tighten explore output budget on compact surface, or
-3. Revisit M baseline for guidance-class tasks in a future measurement spike (A-011).
-
-**Phase 2 minimum exit:** H3 FAIL blocks full Phase 2 exit until resolved or spec-amended. H4 + H5 PASS on this artifact.
+**Not changed:** L2 economics thresholds, A-029, persistence, H6–H8 claims, compact-3 tool names.
 
 ## STEL extension fields (T030)
 

--- a/docs/research/results-v8-phase2-candidate.json
+++ b/docs/research/results-v8-phase2-candidate.json
@@ -1,9 +1,9 @@
 {
-  "measuredAt": "2026-06-14T13:42:53.593Z",
+  "measuredAt": "2026-06-14T15:07:35.548Z",
   "symforgeBin": "/workspace/target/debug/symforge",
   "surface": "compact",
   "method": "ceil(bytes/4); M=competent_manual_window; STEL ledger metadata",
-  "baselineCommit": "896840f984738ce0f77e9a9c1aae94011ceaee45",
+  "baselineCommit": "b1f60196e763b19cdde35584bde284f625576f2a",
   "rows": [
     {
       "id": "cfg-if/multi_search_symbol",
@@ -20,7 +20,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef93b-29",
+        "plan_id": "plan-19ec6ac847e-29",
         "decision": "serve",
         "tools_called": [
           "search_symbols",
@@ -47,7 +47,7 @@
       "mcpCalls": 1,
       "eligibleH6": false,
       "stel": {
-        "plan_id": "plan-19ec65ef80b-33",
+        "plan_id": "plan-19ec6ac836f-33",
         "decision": "bypass",
         "tools_called": [
           "explore"
@@ -73,7 +73,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef800-23",
+        "plan_id": "plan-19ec6ac8363-23",
         "decision": "serve",
         "tools_called": [
           "search_text"
@@ -99,7 +99,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef801-18",
+        "plan_id": "plan-19ec6ac8364-18",
         "decision": "serve",
         "tools_called": [
           "get_file_context"
@@ -125,7 +125,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef804-20",
+        "plan_id": "plan-19ec6ac8366-20",
         "decision": "reject",
         "tools_called": [
           "search_symbols"
@@ -151,7 +151,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef805-21",
+        "plan_id": "plan-19ec6ac8368-21",
         "decision": "serve",
         "tools_called": [
           "find_references"
@@ -177,7 +177,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef806-24",
+        "plan_id": "plan-19ec6ac8369-24",
         "decision": "serve",
         "tools_called": [
           "get_symbol"
@@ -203,7 +203,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef807-15",
+        "plan_id": "plan-19ec6ac836b-15",
         "decision": "serve",
         "tools_called": [
           "get_repo_map"
@@ -229,7 +229,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef808-21",
+        "plan_id": "plan-19ec6ac836c-21",
         "decision": "reject",
         "tools_called": [
           "get_file_content"
@@ -243,10 +243,10 @@
     {
       "id": "cfg-if/t8_explore",
       "corpus": "cfg-if-rust",
-      "S": 392,
+      "S": 396,
       "M": 1000,
       "sGteM": false,
-      "responseBytes": 1566,
+      "responseBytes": 1583,
       "acceptedServe": true,
       "equivalence": "EQUIVALENT",
       "goldenId": "cfg-if/t8_explore",
@@ -255,13 +255,13 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef809-20",
+        "plan_id": "plan-19ec6ac836d-20",
         "decision": "serve",
         "tools_called": [
           "explore"
         ],
         "predicted_tokens": 400,
-        "actual_tokens": 262,
+        "actual_tokens": 267,
         "net_vs_manual": 275,
         "route_confidence": "inferred"
       }
@@ -281,7 +281,7 @@
       "mcpCalls": 1,
       "eligibleH6": false,
       "stel": {
-        "plan_id": "plan-19ec65ef900-27",
+        "plan_id": "plan-19ec6ac8438-27",
         "decision": "bypass",
         "tools_called": [
           "search_files"
@@ -307,7 +307,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef8dd-23",
+        "plan_id": "plan-19ec6ac842d-23",
         "decision": "serve",
         "tools_called": [
           "search_text"
@@ -333,7 +333,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef8fa-18",
+        "plan_id": "plan-19ec6ac842e-18",
         "decision": "serve",
         "tools_called": [
           "get_file_context"
@@ -359,7 +359,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef8fd-21",
+        "plan_id": "plan-19ec6ac8434-21",
         "decision": "reject",
         "tools_called": [
           "get_symbol"
@@ -385,7 +385,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef8fe-20",
+        "plan_id": "plan-19ec6ac8437-20",
         "decision": "reject",
         "tools_called": [
           "find_references"
@@ -411,7 +411,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef8ff-24",
+        "plan_id": "plan-19ec6ac8438-24",
         "decision": "serve",
         "tools_called": [
           "find_dependents"
@@ -437,7 +437,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef992-25",
+        "plan_id": "plan-19ec6ac84f2-25",
         "decision": "serve",
         "tools_called": [
           "search_files",
@@ -464,7 +464,7 @@
       "mcpCalls": 1,
       "eligibleH6": false,
       "stel": {
-        "plan_id": "plan-19ec65ef88a-35",
+        "plan_id": "plan-19ec6ac83e4-35",
         "decision": "bypass",
         "tools_called": [
           "explore"
@@ -490,7 +490,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef880-22",
+        "plan_id": "plan-19ec6ac83dc-22",
         "decision": "serve",
         "tools_called": [
           "search_text"
@@ -516,7 +516,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef881-16",
+        "plan_id": "plan-19ec6ac83dd-16",
         "decision": "serve",
         "tools_called": [
           "get_file_context"
@@ -542,7 +542,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef882-22",
+        "plan_id": "plan-19ec6ac83de-22",
         "decision": "reject",
         "tools_called": [
           "get_file_content"
@@ -568,7 +568,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef883-20",
+        "plan_id": "plan-19ec6ac83df-20",
         "decision": "serve",
         "tools_called": [
           "search_symbols"
@@ -594,7 +594,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef884-18",
+        "plan_id": "plan-19ec6ac83e0-18",
         "decision": "reject",
         "tools_called": [
           "get_symbol"
@@ -620,7 +620,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef885-24",
+        "plan_id": "plan-19ec6ac83e1-24",
         "decision": "serve",
         "tools_called": [
           "find_references"
@@ -646,7 +646,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef886-27",
+        "plan_id": "plan-19ec6ac83e1-27",
         "decision": "reject",
         "tools_called": [
           "search_files"
@@ -672,7 +672,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef888-12",
+        "plan_id": "plan-19ec6ac83e3-12",
         "decision": "serve",
         "tools_called": [
           "health_compact"
@@ -698,7 +698,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef96b-33",
+        "plan_id": "plan-19ec6ac84c7-33",
         "decision": "serve",
         "tools_called": [
           "get_file_context",
@@ -725,7 +725,7 @@
       "mcpCalls": 1,
       "eligibleH6": false,
       "stel": {
-        "plan_id": "plan-19ec65ef848-34",
+        "plan_id": "plan-19ec6ac83ad-34",
         "decision": "bypass",
         "tools_called": [
           "explore"
@@ -751,7 +751,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef83c-19",
+        "plan_id": "plan-19ec6ac83a1-19",
         "decision": "serve",
         "tools_called": [
           "search_text"
@@ -777,7 +777,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef83d-18",
+        "plan_id": "plan-19ec6ac83a3-18",
         "decision": "serve",
         "tools_called": [
           "get_file_context"
@@ -803,7 +803,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef83f-19",
+        "plan_id": "plan-19ec6ac83a5-19",
         "decision": "serve",
         "tools_called": [
           "search_files"
@@ -829,7 +829,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef841-24",
+        "plan_id": "plan-19ec6ac83a6-24",
         "decision": "serve",
         "tools_called": [
           "find_references"
@@ -855,7 +855,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef841-29",
+        "plan_id": "plan-19ec6ac83a6-29",
         "decision": "serve",
         "tools_called": [
           "get_symbol"
@@ -881,7 +881,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef842-26",
+        "plan_id": "plan-19ec6ac83a7-26",
         "decision": "serve",
         "tools_called": [
           "find_dependents"
@@ -907,7 +907,7 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef843-22",
+        "plan_id": "plan-19ec6ac83a8-22",
         "decision": "reject",
         "tools_called": [
           "get_file_content"
@@ -921,10 +921,10 @@
     {
       "id": "records/t8_explore",
       "corpus": "records-python",
-      "S": 1143,
+      "S": 929,
       "M": 1000,
-      "sGteM": true,
-      "responseBytes": 4572,
+      "sGteM": false,
+      "responseBytes": 3716,
       "acceptedServe": true,
       "equivalence": "EQUIVALENT",
       "goldenId": "records/t8_explore",
@@ -933,20 +933,20 @@
       "mcpCalls": 1,
       "eligibleH6": true,
       "stel": {
-        "plan_id": "plan-19ec65ef844-22",
+        "plan_id": "plan-19ec6ac83a9-22",
         "decision": "serve",
         "tools_called": [
           "explore"
         ],
         "predicted_tokens": 400,
-        "actual_tokens": 1013,
+        "actual_tokens": 800,
         "net_vs_manual": 275,
         "route_confidence": "inferred"
       }
     }
   ],
-  "session_net_accepted": 13543,
-  "session_net_all36": 22602,
+  "session_net_accepted": 13753,
+  "session_net_all36": 22812,
   "rowCount": 36,
   "skippedRows": []
 }

--- a/specs/002-v8-phase2-stel-controller/tasks.md
+++ b/specs/002-v8-phase2-stel-controller/tasks.md
@@ -4,7 +4,7 @@
 
 **Prerequisites**: [plan.md](./plan.md) (required), [spec.md](./spec.md) (required), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/phase2-gate-evidence-contract.md](./contracts/phase2-gate-evidence-contract.md)
 
-**Status**: **P2-S4 battery gates** — H4/H5 PASS; H3 FAIL documented on `cursor/v8-phase2-battery-gates`.
+**Status**: **P2-S4.1 H3 remediation** — H3/H4/H5 PASS on refreshed battery evidence.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -55,11 +55,11 @@
 - [x] T030 [US3] Ensure sf-bench row writer populates STEL extension fields per contract
 - [x] T031 [US3] Run compact-surface battery; save candidate results JSON (operator path)
 - [x] T032 [US3] Run compare-results; write `docs/research/phase2-gate-report.md`
-- [x] T033 [US3] Verify H3 PASS under A-012 documented scope — **FAIL** (1 row: `records/t8_explore`; see gate report)
+- [x] T033 [US3] Verify H3 PASS under A-012 documented scope — **PASS** (remediated `records/t8_explore`; see gate report)
 - [x] T034 [US3] Verify H4 PASS (`session_net_accepted ≥ 0`)
 - [x] T035 [P] [US3] Verify H5 PASS for `chain=single` rows (external mcpCalls ≤ 1)
 
-**Checkpoint**: Gate report shows H4/H5 PASS; H3 FAIL documented with action notes.
+**Checkpoint**: Gate report shows H3/H4/H5 PASS on refreshed candidate artifact.
 
 ---
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -8013,11 +8013,11 @@ impl SymForgeServer {
         use crate::protocol::smart_query;
         use crate::stel::controller::{build_estimate, evaluate_plan_with_session};
         use crate::stel::executor::{
-            ServedStepResult, apply_degrade_to_plan, chain_failure_decision, format_bypass_body,
-            format_cache_hit_body, format_multi_step_serve_body,
-            format_partial_multi_step_serve_body, format_single_step_serve_body, is_degrade,
-            route_tool_label, serve_chain_outcome_class, serve_step_failed, serve_step_outcome,
-            should_skip_legacy_dispatch, tools_executed,
+            ServedStepResult, apply_compact_serve_caps, apply_degrade_to_plan,
+            chain_failure_decision, format_bypass_body, format_cache_hit_body,
+            format_multi_step_serve_body, format_partial_multi_step_serve_body,
+            format_single_step_serve_body, is_degrade, route_tool_label, serve_chain_outcome_class,
+            serve_step_failed, serve_step_outcome, should_skip_legacy_dispatch, tools_executed,
         };
         use crate::stel::handler::{self, metrics_for_decision};
         use crate::stel::planner::{build_plan, plan_summary_line};
@@ -8071,6 +8071,8 @@ impl SymForgeServer {
 
         let exec_plan = if is_degrade(&decision) {
             apply_degrade_to_plan(&plan, &decision)
+        } else if decision.decision == crate::stel::AdmissionDecision::Serve {
+            apply_compact_serve_caps(&plan, &decision)
         } else {
             plan.clone()
         };

--- a/src/stel/executor.rs
+++ b/src/stel/executor.rs
@@ -6,6 +6,14 @@ use crate::protocol::result_status::OutcomeClass;
 use crate::protocol::tools::{classify_compact_tool_output, compact_tool_output_is_success};
 
 use super::controller::DEGRADE_DEFAULT_MAX_TOKENS;
+
+/// Competent-manual token budget for Phase 2 H3 explore golden rows (4000-char window).
+pub const H3_EXPLORE_MANUAL_TOKENS: u32 = 1000;
+/// Reserve STEL envelope + serve routing meta when capping explore on compact serve.
+pub const COMPACT_SERVE_EXPLORE_OVERHEAD_TOKENS: u32 = 250;
+/// Max explore tool tokens on compact `symforge` serve so full response stays within H3 window.
+pub const COMPACT_SERVE_EXPLORE_MAX_TOKENS: u32 =
+    H3_EXPLORE_MANUAL_TOKENS.saturating_sub(COMPACT_SERVE_EXPLORE_OVERHEAD_TOKENS);
 use super::planner::confidence_label;
 use super::types::{
     AdmissionDecision, StelBypassBody, StelCacheBody, StelDecision, StelPlan, StelPlanStep,
@@ -155,6 +163,30 @@ pub fn apply_degrade_to_plan(plan: &StelPlan, decision: &StelDecision) -> StelPl
         }
     }
     degraded
+}
+
+/// Apply compact-surface serve caps before L3 dispatch (H3 explore guidance budget).
+pub fn apply_compact_serve_caps(plan: &StelPlan, decision: &StelDecision) -> StelPlan {
+    if decision.decision != AdmissionDecision::Serve {
+        return plan.clone();
+    }
+    let mut capped = plan.clone();
+    for step in &mut capped.steps {
+        if step.tool != "explore" {
+            continue;
+        }
+        let Some(args) = step.args.as_object_mut() else {
+            continue;
+        };
+        let cap = u64::from(COMPACT_SERVE_EXPLORE_MAX_TOKENS);
+        let capped_val = args
+            .get("max_tokens")
+            .and_then(|value| value.as_u64())
+            .map(|value| value.min(cap))
+            .unwrap_or(cap);
+        args.insert("max_tokens".to_string(), serde_json::json!(capped_val));
+    }
+    capped
 }
 
 fn supports_max_tokens_cap(tool: &str) -> bool {
@@ -452,6 +484,44 @@ mod tests {
         let degraded = apply_degrade_to_plan(&plan, &decision);
         let args = degraded.steps[0].args.as_object().expect("object args");
         assert_eq!(args["sections"], serde_json::json!(["outline"]));
+    }
+
+    #[test]
+    fn apply_compact_serve_caps_explore_max_tokens_for_h3_window() {
+        use crate::stel::types::{
+            AdmissionDecision, IntentBucket, RouteConfidence, StelDecision, StelPlan, StelPlanStep,
+        };
+        let plan = StelPlan {
+            plan_id: "serve-explore".to_string(),
+            intent: IntentBucket::Orient,
+            confidence: RouteConfidence::Inferred,
+            confidence_rationale: "test".to_string(),
+            steps: vec![StelPlanStep {
+                order: 1,
+                tool: "explore".to_string(),
+                args: serde_json::json!({ "query": "how to use records ORM", "depth": 2 }),
+                est_response_tokens: 400,
+                est_manual_tokens: 800,
+                index_refs: vec![],
+            }],
+            suggested_followup: None,
+        };
+        let decision = StelDecision {
+            plan_id: plan.plan_id.clone(),
+            decision: AdmissionDecision::Serve,
+            decision_reason: "test".to_string(),
+            effective_max_tokens: None,
+            degrade_flags: vec![],
+            steps: Some(plan.steps.clone()),
+            bypass: None,
+            cache: None,
+        };
+        let capped = apply_compact_serve_caps(&plan, &decision);
+        let args = capped.steps[0].args.as_object().expect("object args");
+        assert_eq!(
+            args["max_tokens"],
+            serde_json::json!(COMPACT_SERVE_EXPLORE_MAX_TOKENS)
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates the sole H3 gate violation on `records/t8_explore` (S=1143 vs M=1000) from P2-S4 battery evidence (#308). No A-029, persistence, or L2 threshold changes.

## Fix

On compact `symforge` **serve**, apply `max_tokens=750` to `explore` plan steps via `apply_compact_serve_caps` (`src/stel/executor.rs`). Reserves 250 tokens for STEL envelope + serve routing meta against the H3 competent-manual window (M=1000).

Decision remains `serve`; explore guidance truncates with the standard budget footer when needed.

## Refreshed gate evidence

| Gate | Result |
|------|--------|
| **H3** | **PASS** (0 sGteM violations) |
| **H4** | **PASS** (`session_net_accepted = +13753`) |
| **H5** | **PASS** |

`records/t8_explore` after remediation: S=929, M=1000.

## Artifacts

- [`docs/research/results-v8-phase2-candidate.json`](docs/research/results-v8-phase2-candidate.json)
- [`docs/research/phase2-gate-report.md`](docs/research/phase2-gate-report.md)
- [`docs/research/phase2-gate-report.generated.md`](docs/research/phase2-gate-report.generated.md)
- [`docs/research/phase2-evidence-index.md`](docs/research/phase2-evidence-index.md)

## Commands

```bash
cargo build -p symforge
node scripts/phase2-compact-battery.cjs target/debug/symforge docs/research/results-v8-phase2-candidate.json
node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
cargo test --test stel_battery_gates -- --test-threads=1
```

## Scope boundaries

- No A-029 / P2-S5
- No SQLite / EMA→L2 / B-RESULTS / H6–H8 claims
- No new MCP tools; compact-3 names unchanged
- Golden replay 32 supported serve + 4 P-FF preserved (explore still routes on serve)

## Tests

- `stel_battery_gates` (7/7)
- New unit test: `apply_compact_serve_caps_explore_max_tokens_for_h3_window`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

