### PR TITLE
test(stel): add A-029 T2 equivalence spike

### DIFF
--- a/docs/research/A-029-t2-spike.md
+++ b/docs/research/A-029-t2-spike.md
@@ -1,0 +1,99 @@
+# A-029 — T2 equivalence spike (Phase 2 P2-S5)
+
+**Spike ID:** A-029-phase2-2026-06-14  
+**Surface:** `compact` (`SYMFORGE_SURFACE=compact`)  
+**Baseline commit:** `061583cbc8bc87d9a133a3a44ff24d44e03a1abd` (post-#309 H3 remediation)  
+**Machine-readable results:** [`a029-t2-results.json`](./a029-t2-results.json)  
+**Task definitions:** [`tests/fixtures/a029-t2/tasks.jsonl`](../../tests/fixtures/a029-t2/tasks.jsonl)
+
+## Verdict
+
+| Field | Value |
+|-------|-------|
+| **A-029 verdict** | **PIVOT** |
+| **t2_equiv_pass** | 0 / 4 |
+| **Pivot policy** | **P-T2** — T2 reference tasks bypass-only (grep envelope; `eligible_h6=false`) |
+| **H6 impact** | Remove 4 T2 rows from H6 eligible denominator when P-T2 registered (per gap plan §6.1) |
+
+**PASS threshold not met** (requires ≥2/4 T2 equivalence on tokio+django). Spike does **not** claim T2 reference parity; registers P-T2 pivot per binding gap plan §4.2.
+
+## Method (T040)
+
+1. Clone shallow **tokio** + **django** per [`tests/fixtures/a029-t2/README.md`](../../tests/fixtures/a029-t2/README.md).
+2. Define **4 T2 tasks** (`find_references` routing) in `tasks.jsonl` — 2 per repo.
+3. For each task:
+   - Build **rg baseline**: unique `.rs`/`.py` files referencing symbol (sidecar-parity proxy).
+   - `index_folder` corpus; one compact **`symforge`** call per query.
+   - Extract cited file paths from response; compute **baseline_recall** = matched / baseline_paths.
+   - **EQUIVALENT** iff `decision=serve`, `find_references` routed, recall ≥ task `min_baseline_recall`.
+4. Verdict: `PASS` if ≥2 equiv; else `PIVOT` if tasks measured; else `KILL`.
+
+**Operator command:**
+
+```bash
+cargo build -p symforge
+node scripts/a029-t2-spike.cjs target/debug/symforge docs/research/a029-t2-results.json
+```
+
+**Deterministic verdict math:** `src/stel/a029.rs` + `tests/stel_a029_spike.rs`
+
+## Target set (T041)
+
+| ID | Repo | Query | Symbol | min recall |
+|----|------|-------|--------|------------|
+| `tokio/t2_spawn` | tokio | who references spawn | spawn | 35% |
+| `tokio/t2_block_on` | tokio | references to block_on | block_on | 35% |
+| `django/t2_queryset` | django | who references QuerySet | QuerySet | 35% |
+| `django/t2_model` | django | references to Model | Model | 25% |
+
+## Results (T042)
+
+| Row | decision | tool | baseline files | matched | recall | equiv |
+|-----|----------|------|----------------|---------|--------|-------|
+| `tokio/t2_spawn` | serve | find_references | 252 | 18 | 7.1% | SYMFORGE-LESS |
+| `tokio/t2_block_on` | serve | find_references | 141 | 20 | 14.2% | SYMFORGE-LESS |
+| `django/t2_queryset` | serve | find_references | 71 | 7 | 9.9% | SYMFORGE-LESS |
+| `django/t2_model` | serve | find_references | 354 | 17 | 4.8% | SYMFORGE-LESS |
+
+**Observations:**
+
+- **Routing correct:** all 4 rows `decision=serve` with `find_references` (H5 preserved; no runtime changes in this slice).
+- **Reference parity gap:** index-backed `find_references` surfaces a small fraction of rg baseline files (markdown, benches, cross-module imports likely missing — aligns with gap plan §6.1 root-cause hypothesis).
+- **Not a compact-surface regression:** in-repo phase0 golden `t4_refs` rows remain EQUIVALENT on small corpora (see P2-S4 battery).
+
+## P-T2 pivot recommendation
+
+Per [`docs/v8-gap-closure-plan.md`](../v8-gap-closure-plan.md) §6.1:
+
+1. Register **P-T2**: T2 reference tasks become mandatory **bypass** with host grep envelope + line window.
+2. Set `eligible_h6=false` on T2 golden rows when policy lands (4 rows).
+3. **Next program work (8.1, out of P2-S5):** index ref-source audit (`live_index/query.rs`), markdown/bench/import reference capture — do **not** mask with runtime hacks in Phase 2 spike slice.
+
+## T043 — T3 large-row degrade (A-014 note)
+
+**Deferred in this spike run.** In-repo golden `t2_context` outline rows serve on small corpora; full T3-large degrade vs competent-manual window validation remains **A-014 OPEN** for Phase 3 / 8.1 program. No degrade regression introduced in P2-S5 (no runtime changes).
+
+## H3/H4/H5 preservation
+
+P2-S5 does not modify gate math or compact runtime. Post-#309 evidence unchanged:
+
+- **H3 PASS** (0 violations; `records/t8_explore` S=929, M=1000, ~71-token margin noted)
+- **H4 PASS** (`session_net_accepted = +13753`)
+- **H5 PASS**
+
+Re-verify:
+
+```bash
+node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json --report docs/research/phase2-gate-report.generated.md
+```
+
+## Scope boundaries (confirmed)
+
+- No A-029 runtime remediation (no index/planner changes)
+- No persistence / SQLite / EMA→L2
+- No B-RESULTS / §8.7 / H6–H8 claims
+- No new MCP tools; compact-3 names unchanged
+
+## Assumption register (A-029)
+
+**Status:** **PIVOT** — T2 reference parity not validated on tokio+django; P-T2 bypass-only policy recommended before H6 eligibility claims on T2 rows.

--- a/docs/research/a029-t2-results.json
+++ b/docs/research/a029-t2-results.json
@@ -1,0 +1,82 @@
+{
+  "measuredAt": "2026-06-14T17:32:00.876Z",
+  "surface": "compact",
+  "method": "symforge compact + rg baseline file recall",
+  "baselineCommit": "061583cbc8bc87d9a133a3a44ff24d44e03a1abd",
+  "rows": [
+    {
+      "id": "django/t2_model",
+      "repo": "django",
+      "query": "references to Model",
+      "symbol": "Model",
+      "decision": "serve",
+      "tools_called": [
+        "find_references"
+      ],
+      "equivalence": "SYMFORGE-LESS",
+      "baseline_paths": 354,
+      "matched_paths": 17,
+      "baseline_recall": 0.048,
+      "min_baseline_recall": 0.25,
+      "chain_failed": false,
+      "diagnostics": "recall=4.8% need >=25%; tools=find_references"
+    },
+    {
+      "id": "django/t2_queryset",
+      "repo": "django",
+      "query": "who references QuerySet",
+      "symbol": "QuerySet",
+      "decision": "serve",
+      "tools_called": [
+        "find_references"
+      ],
+      "equivalence": "SYMFORGE-LESS",
+      "baseline_paths": 71,
+      "matched_paths": 7,
+      "baseline_recall": 0.0986,
+      "min_baseline_recall": 0.35,
+      "chain_failed": false,
+      "diagnostics": "recall=9.9% need >=35%; tools=find_references"
+    },
+    {
+      "id": "tokio/t2_block_on",
+      "repo": "tokio",
+      "query": "references to block_on",
+      "symbol": "block_on",
+      "decision": "serve",
+      "tools_called": [
+        "find_references"
+      ],
+      "equivalence": "SYMFORGE-LESS",
+      "baseline_paths": 141,
+      "matched_paths": 20,
+      "baseline_recall": 0.1418,
+      "min_baseline_recall": 0.35,
+      "chain_failed": false,
+      "diagnostics": "recall=14.2% need >=35%; tools=find_references"
+    },
+    {
+      "id": "tokio/t2_spawn",
+      "repo": "tokio",
+      "query": "who references spawn",
+      "symbol": "spawn",
+      "decision": "serve",
+      "tools_called": [
+        "find_references"
+      ],
+      "equivalence": "SYMFORGE-LESS",
+      "baseline_paths": 252,
+      "matched_paths": 18,
+      "baseline_recall": 0.0714,
+      "min_baseline_recall": 0.35,
+      "chain_failed": false,
+      "diagnostics": "recall=7.1% need >=35%; tools=find_references"
+    }
+  ],
+  "t2_equiv_pass": 0,
+  "t2_tasks_total": 4,
+  "verdict": "PIVOT",
+  "pivot_policy": "P-T2 bypass-only for reference tasks (grep envelope; eligible_h6=false)",
+  "skippedTasks": [],
+  "notes": "A-029 T2 spike PIVOT: register P-T2 bypass-only policy for reference tasks; adjust H6 denominator."
+}

--- a/docs/research/phase2-evidence-index.md
+++ b/docs/research/phase2-evidence-index.md
@@ -1,6 +1,6 @@
 # Phase 2 STEL evidence index
 
-**Status:** P2-S4 battery gates + H3 remediation — H3/H4/H5 PASS (2026-06-14)
+**Status:** P2-S5 A-029 T2 spike complete — **PIVOT** (0/4 T2 equiv); H3/H4/H5 PASS preserved (2026-06-14)
 
 **Created**: 2026-06-14
 
@@ -22,7 +22,7 @@
 - Phase 1 shipped: [`phase1-stel-checkpoint.md`](../phase1-stel-checkpoint.md)
 - Phase 2 Slice 1 merged: `3d64b96` (multi-hop golden closure)
 - Phase 2 Slice 2 merged: PR #306 / `896840f` (L2 admission hardening)
-- Phase 2 Slice 4 merged: PR #308 / `b1f6019` (battery gate evidence)
+- Phase 2 Slice 4.1 merged: PR #309 / H3 remediation on `records/t8_explore`
 
 ## T002 spec reviewer sign-off
 
@@ -45,7 +45,10 @@
 | Gate computation (Rust) | [`src/stel/gates.rs`](../../src/stel/gates.rs) | **COMPLETE** |
 | Gate test fixtures | [`tests/fixtures/phase2-gate/`](../../tests/fixtures/phase2-gate/) | **COMPLETE** |
 | Gate integration tests | [`tests/stel_battery_gates.rs`](../../tests/stel_battery_gates.rs) | **COMPLETE** |
-| A-029 spike | `docs/research/A-029-t2-spike.md` | NOT STARTED (P2-S5 blocked) |
+| A-029 spike | [`A-029-t2-spike.md`](./A-029-t2-spike.md) | **COMPLETE** — PIVOT (0/4 T2 equiv; P-T2 registered) |
+| A-029 results JSON | [`a029-t2-results.json`](./a029-t2-results.json) | **COMPLETE** |
+| A-029 spike script | [`scripts/a029-t2-spike.cjs`](../../scripts/a029-t2-spike.cjs) | **COMPLETE** |
+| A-029 verdict (Rust) | [`src/stel/a029.rs`](../../src/stel/a029.rs) | **COMPLETE** |
 | Phase 2 checkpoint | `docs/phase2-stel-checkpoint.md` | NOT STARTED (P2-S6) |
 | Exit record | per gate evidence contract | IN_PROGRESS |
 
@@ -58,6 +61,16 @@ node scripts/compare-results.cjs docs/research/results-v8-phase2-candidate.json 
 cargo test --test stel_battery_gates -- --test-threads=1
 ```
 
+## P2-S5 A-029 commands (operator)
+
+```bash
+cargo build -p symforge
+node scripts/a029-t2-spike.cjs target/debug/symforge docs/research/a029-t2-results.json
+cargo test --test stel_a029_spike -- --test-threads=1
+```
+
+Requires tokio + django clones per [`tests/fixtures/a029-t2/README.md`](../../tests/fixtures/a029-t2/README.md). Exit 0 on PASS; exit 1 on PIVOT/KILL (truthful non-pass).
+
 Curated reviewer narrative lives in [`phase2-gate-report.md`](./phase2-gate-report.md); re-running compare-results writes only [`phase2-gate-report.generated.md`](./phase2-gate-report.generated.md).
 
 ## Local corpus note (golden replay)
@@ -69,4 +82,4 @@ Curated reviewer narrative lives in [`phase2-gate-report.md`](./phase2-gate-repo
 - Calibration / ledger persistence → Phase 3
 - B-RESULTS / RESULTS.md §8.7 → post–8.0 tag (A-024)
 - H6/H7/H8 PASS → Phase 3–4
-- A-029 T2 spike → P2-S5 (blocked until P2-S4 merge)
+- A-029 T2 spike → **PIVOT** (P-T2); see [`A-029-t2-spike.md`](./A-029-t2-spike.md)

--- a/docs/stel-assumptions.md
+++ b/docs/stel-assumptions.md
@@ -127,7 +127,7 @@ Status as of branch `v8/stel-architecture`. **Most are OPEN.**
 | **A-026** | **H4** uses **`session_net_accepted`** (accepted serve rows only); `session_net_all36` reported separately | RESULTS.md §8.2 + compare-results.js | **OPEN** |
 | **A-027** | Battery schema divisor (**÷50**) is harness-only until **A-006** host-validated | Document in sf-bench spec; controller uses conservative max | **OPEN** |
 | **A-028** | Golden rows include **`expected_equiv`** and **`expected_decision`**, not route shape alone | routes.golden.jsonl schema | **VALIDATED** |
-| **A-029** | T2 spike: ≥**2/4** equiv on tokio+django **or** bypass-only policy registered for reference tasks | Spike artifact in research log | **OPEN** |
+| **A-029** | T2 spike: ≥**2/4** equiv on tokio+django **or** bypass-only policy registered for reference tasks | [`research/A-029-t2-spike.md`](research/A-029-t2-spike.md) | **PIVOT** (0/4 equiv; P-T2 registered 2026-06-14) |
 | **A-031** | Phase 0.12 rmcp Streamable HTTP **compile spike** passes before Phase 4 code | `docs/research/A-031-rmcp-spike.md` | **OPEN** |
 | **A-032** | Full-file review tasks use policy **P-FF** (bypass, `eligible_h6=false`) | 4 rows in `routes.golden.jsonl` | **OPEN** |
 

--- a/scripts/a029-t2-spike.cjs
+++ b/scripts/a029-t2-spike.cjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * A-029 T2 equivalence spike — compact `symforge` on tokio + django reference tasks.
+ *
+ * Usage:
+ *   cargo build -p symforge
+ *   node scripts/a029-t2-spike.cjs [symforge-bin] [output.json]
+ *
+ * Requires cloned corpora under tests/fixtures/a029-t2/{tokio,django}.
+ */
+const { spawn } = require("child_process");
+const readline = require("readline");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const BIN =
+  process.argv[2] ||
+  path.join(
+    REPO_ROOT,
+    "target/debug",
+    process.platform === "win32" ? "symforge.exe" : "symforge"
+  );
+const OUT =
+  process.argv[3] || path.join(REPO_ROOT, "docs/research/a029-t2-results.json");
+const TASKS = path.join(REPO_ROOT, "tests/fixtures/a029-t2/tasks.jsonl");
+const FIXTURE_ROOT = path.join(REPO_ROOT, "tests/fixtures/a029-t2");
+
+function baselineCommit() {
+  try {
+    return execSync("git rev-parse HEAD", { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function loadTasks() {
+  return fs
+    .readFileSync(TASKS, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function corpusDir(repo) {
+  return path.join(FIXTURE_ROOT, repo);
+}
+
+/** Ripgrep baseline: unique source files referencing symbol (sidecar parity proxy). */
+function baselineReferencePaths(corpusDirPath, symbol, repo) {
+  const glob = repo === "django" ? "*.py" : "*.rs";
+  try {
+    const pattern = repo === "django" ? `\\b${symbol}\\b` : `\\b${symbol}\\b`;
+    const out = execSync(
+      `rg -l --glob '${glob}' --glob '!target/**' --glob '!tests/fixtures/**' '${pattern}' .`,
+      { cwd: corpusDirPath, encoding: "utf8", maxBuffer: 10 * 1024 * 1024 }
+    );
+    return out
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((p) => p.replace(/^\.\//, "").replace(/\\/g, "/"));
+  } catch {
+    return [];
+  }
+}
+
+function parseSymforgeOutput(text) {
+  const ledgerLine = text.match(/^ledger: (\{.+})$/m);
+  let ledger = null;
+  if (ledgerLine) {
+    try {
+      ledger = JSON.parse(ledgerLine[1]);
+    } catch {
+      ledger = null;
+    }
+  }
+  const decision = (ledger && ledger.decision) || "serve";
+  const chainFailed = text.includes("Multi-hop chain failed:");
+  const tools =
+    ledger && ledger.route_tool
+      ? ledger.route_tool.includes("+")
+        ? ledger.route_tool.split("+")
+        : [ledger.route_tool]
+      : [];
+  return { decision, ledger, chainFailed, tools_called: tools };
+}
+
+/** Extract indexed file paths cited in find_references compact output. */
+function extractCitedPaths(text) {
+  const paths = new Set();
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (/\.(rs|py)$/.test(trimmed) && !trimmed.startsWith(":")) {
+      paths.add(trimmed.replace(/\\/g, "/"));
+    }
+    const m = trimmed.match(/^([^\s:]+\.(?:rs|py)):/);
+    if (m) paths.add(m[1].replace(/\\/g, "/"));
+  }
+  return [...paths];
+}
+
+function computeRecall(baselinePaths, citedPaths) {
+  if (baselinePaths.length === 0) return { matched: 0, recall: 0 };
+  const baselineSet = new Set(baselinePaths.map((p) => p.toLowerCase()));
+  let matched = 0;
+  for (const cited of citedPaths) {
+    const norm = cited.toLowerCase();
+    if (baselineSet.has(norm)) matched += 1;
+  }
+  return { matched, recall: matched / baselinePaths.length };
+}
+
+async function runRepoBatch(corpusDirPath, tasks) {
+  const results = [];
+  let id = 1;
+  const pending = new Map();
+
+  const proc = spawn(BIN, [], {
+    cwd: corpusDirPath,
+    stdio: ["pipe", "pipe", "ignore"],
+    env: {
+      ...process.env,
+      RUST_LOG: "off",
+      SYMFORGE_SURFACE: "compact",
+      SYMFORGE_NO_DAEMON: "1",
+    },
+  });
+
+  readline.createInterface({ input: proc.stdout }).on("line", (line) => {
+    if (!line.trim()) return;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (msg.id != null && pending.has(msg.id)) {
+      const { resolve, reject } = pending.get(msg.id);
+      pending.delete(msg.id);
+      if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+      else resolve(msg.result);
+    }
+  });
+
+  function request(method, params) {
+    return new Promise((resolve, reject) => {
+      const myId = id++;
+      pending.set(myId, { resolve, reject });
+      proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n");
+      setTimeout(() => {
+        if (pending.has(myId)) {
+          pending.delete(myId);
+          reject(new Error(`timeout ${method}`));
+        }
+      }, 600000);
+    });
+  }
+
+  async function callTool(name, args) {
+    const result = await request("tools/call", { name, arguments: args });
+    return (result.content || [])
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+  }
+
+  await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "a029-t2-spike", version: "1.0" },
+  });
+  proc.stdin.write(
+    JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) + "\n"
+  );
+
+  console.error(`Indexing ${corpusDirPath} ...`);
+  await callTool("index_folder", { path: corpusDirPath });
+
+  for (const task of tasks) {
+    const baselinePaths = baselineReferencePaths(corpusDirPath, task.symbol, task.repo);
+    console.error(`Task ${task.id} (baseline files=${baselinePaths.length}) ...`);
+    const text = await callTool("symforge", { query: task.query });
+    const parsed = parseSymforgeOutput(text);
+    const citedPaths = extractCitedPaths(text);
+    const { matched, recall } = computeRecall(baselinePaths, citedPaths);
+    const equiv =
+      !parsed.chainFailed &&
+      parsed.decision === "serve" &&
+      parsed.tools_called.includes("find_references") &&
+      baselinePaths.length > 0 &&
+      recall >= task.min_baseline_recall
+        ? "EQUIVALENT"
+        : parsed.chainFailed || recall < task.min_baseline_recall
+          ? "SYMFORGE-LESS"
+          : "NOT_EQUIVALENT";
+
+    results.push({
+      id: task.id,
+      repo: task.repo,
+      query: task.query,
+      symbol: task.symbol,
+      decision: parsed.decision,
+      tools_called: parsed.tools_called,
+      equivalence: equiv,
+      baseline_paths: baselinePaths.length,
+      matched_paths: matched,
+      baseline_recall: Number(recall.toFixed(4)),
+      min_baseline_recall: task.min_baseline_recall,
+      chain_failed: parsed.chainFailed,
+      diagnostics:
+        equiv === "EQUIVALENT"
+          ? `recall=${(recall * 100).toFixed(1)}% matched ${matched}/${baselinePaths.length} rg files`
+          : `recall=${(recall * 100).toFixed(1)}% need >=${(task.min_baseline_recall * 100).toFixed(0)}%; tools=${parsed.tools_called.join(",") || "none"}`,
+    });
+  }
+
+  proc.kill();
+  return results;
+}
+
+function evaluateVerdict(rows) {
+  const equiv = rows.filter((r) => r.equivalence === "EQUIVALENT").length;
+  let verdict = "KILL";
+  let pivot_policy = null;
+  if (equiv >= 2) verdict = "PASS";
+  else if (rows.length >= 2) {
+    verdict = "PIVOT";
+    pivot_policy = "P-T2 bypass-only for reference tasks (grep envelope; eligible_h6=false)";
+  }
+  return { equiv, verdict, pivot_policy };
+}
+
+(async () => {
+  const tasks = loadTasks();
+  const skipped = [];
+  const byRepo = new Map();
+  for (const task of tasks) {
+    const dir = corpusDir(task.repo);
+    if (!fs.existsSync(dir)) {
+      skipped.push(task.id);
+      continue;
+    }
+    if (!byRepo.has(task.repo)) byRepo.set(task.repo, []);
+    byRepo.get(task.repo).push(task);
+  }
+
+  if (skipped.length === tasks.length) {
+    console.error(
+      "No A-029 corpora found. Clone per tests/fixtures/a029-t2/README.md before running spike."
+    );
+    process.exit(2);
+  }
+
+  const allRows = [];
+  for (const [repo, repoTasks] of byRepo.entries()) {
+    const dir = corpusDir(repo);
+    console.error(`A-029 corpus ${repo} (${repoTasks.length} tasks)`);
+    const batch = await runRepoBatch(dir, repoTasks);
+    allRows.push(...batch);
+  }
+  allRows.sort((a, b) => a.id.localeCompare(b.id));
+
+  const { equiv, verdict, pivot_policy } = evaluateVerdict(allRows);
+  const output = {
+    measuredAt: new Date().toISOString(),
+    surface: "compact",
+    method: "symforge compact + rg baseline file recall",
+    baselineCommit: baselineCommit(),
+    rows: allRows,
+    t2_equiv_pass: equiv,
+    t2_tasks_total: allRows.length,
+    verdict,
+    pivot_policy,
+    skippedTasks: skipped,
+    notes:
+      verdict === "PASS"
+        ? "A-029 T2 spike PASS: >=2/4 reference tasks achieved sidecar-parity recall threshold."
+        : verdict === "PIVOT"
+          ? "A-029 T2 spike PIVOT: register P-T2 bypass-only policy for reference tasks; adjust H6 denominator."
+          : "A-029 T2 spike KILL: insufficient evidence; expand T2 program before Phase 2 exit claim.",
+  };
+
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n");
+  console.log(JSON.stringify({ verdict, t2_equiv_pass: equiv, t2_tasks_total: allRows.length }, null, 2));
+  console.error(`Wrote ${OUT}`);
+  process.exit(verdict === "PASS" ? 0 : 1);
+})();

--- a/specs/002-v8-phase2-stel-controller/tasks.md
+++ b/specs/002-v8-phase2-stel-controller/tasks.md
@@ -4,7 +4,7 @@
 
 **Prerequisites**: [plan.md](./plan.md) (required), [spec.md](./spec.md) (required), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/phase2-gate-evidence-contract.md](./contracts/phase2-gate-evidence-contract.md)
 
-**Status**: **P2-S4.1 H3 remediation** — H3/H4/H5 PASS on refreshed battery evidence.
+**Status**: **P2-S5 A-029 spike** — PIVOT (0/4 T2 equiv; P-T2 registered); H3/H4/H5 preserved.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -65,12 +65,12 @@
 
 ## P2-S5: A-029 Spike (US4)
 
-- [ ] T040 [US4] Create `docs/research/A-029-t2-spike.md` with method and repos
-- [ ] T041 [US4] Run T2 spike on tokio + django reference tasks (compact surface)
-- [ ] T042 [US4] Record PASS (≥2/4 equiv) or P-T2 pivot or KILL
-- [ ] T043 [P] [US4] Optional T3 large-row degrade validation for A-014 (document pass/pivot)
+- [x] T040 [US4] Create `docs/research/A-029-t2-spike.md` with method and repos
+- [x] T041 [US4] Run T2 spike on tokio + django reference tasks (compact surface)
+- [x] T042 [US4] Record PASS (≥2/4 equiv) or P-T2 pivot or KILL — **PIVOT** (0/4 equiv; P-T2)
+- [x] T043 [P] [US4] Optional T3 large-row degrade validation for A-014 (document pass/pivot) — deferred; noted in spike artifact
 
-**Checkpoint**: A-029 artifact complete; assumption register updated.
+**Checkpoint**: A-029 artifact complete; P-T2 pivot documented; assumption register note in spike + evidence index.
 
 ---
 

--- a/src/stel/a029.rs
+++ b/src/stel/a029.rs
@@ -1,0 +1,229 @@
+//! A-029 T2 equivalence spike — verdict computation (P2-S5 evidence only).
+
+use serde::{Deserialize, Serialize};
+
+/// Minimum T2 equivalence count for A-029 PASS (tokio + django program).
+pub const A029_T2_PASS_THRESHOLD: usize = 2;
+
+/// Spike verdict per gate evidence contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum A029Verdict {
+    Pass,
+    Pivot,
+    Kill,
+}
+
+impl A029Verdict {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Pivot => "PIVOT",
+            Self::Kill => "KILL",
+        }
+    }
+}
+
+/// T2 row equivalence class for A-029 spike rows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum T2Equivalence {
+    Equivalent,
+    #[serde(alias = "SYMFORGE-LESS")]
+    SymforgeLess,
+    NotEquivalent,
+    Bypass,
+    Pending,
+}
+
+impl T2Equivalence {
+    pub const fn is_equiv(self) -> bool {
+        matches!(self, Self::Equivalent)
+    }
+}
+
+/// One measured A-029 T2 spike row.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct A029T2Row {
+    pub id: String,
+    pub repo: String,
+    pub query: String,
+    pub symbol: String,
+    pub decision: String,
+    #[serde(default)]
+    pub tools_called: Vec<String>,
+    pub equivalence: T2Equivalence,
+    #[serde(default)]
+    pub baseline_paths: usize,
+    #[serde(default)]
+    pub matched_paths: usize,
+    #[serde(default)]
+    pub baseline_recall: f32,
+    #[serde(default)]
+    pub min_baseline_recall: f32,
+    #[serde(default)]
+    pub chain_failed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<String>,
+}
+
+/// Machine-readable A-029 spike output (`docs/research/a029-t2-results.json`).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A029SpikeResults {
+    #[serde(default)]
+    pub measured_at: String,
+    #[serde(default)]
+    pub surface: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    pub baseline_commit: String,
+    pub rows: Vec<A029T2Row>,
+    pub t2_equiv_pass: usize,
+    pub t2_tasks_total: usize,
+    pub verdict: A029Verdict,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pivot_policy: Option<String>,
+    #[serde(default)]
+    pub notes: String,
+}
+
+/// Classify one spike row from measured fields (deterministic; no runtime I/O).
+pub fn classify_t2_equivalence(row: &A029T2Row) -> T2Equivalence {
+    if row.decision == "bypass" {
+        return T2Equivalence::Bypass;
+    }
+    if row.chain_failed {
+        return T2Equivalence::SymforgeLess;
+    }
+    if row.decision == "reject" || row.tools_called.is_empty() {
+        return T2Equivalence::NotEquivalent;
+    }
+    let routed_refs = row
+        .tools_called
+        .iter()
+        .any(|tool| tool == "find_references");
+    if !routed_refs {
+        return T2Equivalence::NotEquivalent;
+    }
+    if row.baseline_paths == 0 {
+        return T2Equivalence::Pending;
+    }
+    if row.baseline_recall >= row.min_baseline_recall {
+        T2Equivalence::Equivalent
+    } else {
+        T2Equivalence::SymforgeLess
+    }
+}
+
+/// Recompute equivalence classes and aggregate counts on spike results.
+pub fn normalize_spike_results(mut results: A029SpikeResults) -> A029SpikeResults {
+    for row in &mut results.rows {
+        row.equivalence = classify_t2_equivalence(row);
+    }
+    results.t2_tasks_total = results.rows.len();
+    results.t2_equiv_pass = results
+        .rows
+        .iter()
+        .filter(|row| row.equivalence.is_equiv())
+        .count();
+    results.verdict = evaluate_a029_verdict(results.t2_equiv_pass, results.t2_tasks_total);
+    if results.verdict == A029Verdict::Pivot {
+        results.pivot_policy = Some(
+            "P-T2 bypass-only for reference tasks (grep envelope; eligible_h6=false)".to_string(),
+        );
+    }
+    results
+}
+
+/// Evaluate A-029 verdict from T2 equivalence count.
+pub fn evaluate_a029_verdict(t2_equiv_pass: usize, t2_tasks_total: usize) -> A029Verdict {
+    if t2_equiv_pass >= A029_T2_PASS_THRESHOLD {
+        A029Verdict::Pass
+    } else if t2_tasks_total >= A029_T2_PASS_THRESHOLD {
+        A029Verdict::Pivot
+    } else {
+        A029Verdict::Kill
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_row(id: &str, recall: f32, decision: &str) -> A029T2Row {
+        A029T2Row {
+            id: id.to_string(),
+            repo: id.split('/').next().unwrap_or("").to_string(),
+            query: "who references X".to_string(),
+            symbol: "X".to_string(),
+            decision: decision.to_string(),
+            tools_called: vec!["find_references".to_string()],
+            equivalence: T2Equivalence::Pending,
+            baseline_paths: 10,
+            matched_paths: (recall * 10.0) as usize,
+            baseline_recall: recall,
+            min_baseline_recall: 0.35,
+            chain_failed: false,
+            diagnostics: None,
+        }
+    }
+
+    #[test]
+    fn pass_when_two_of_four_equiv() {
+        let results = A029SpikeResults {
+            measured_at: String::new(),
+            surface: "compact".to_string(),
+            method: "test".to_string(),
+            baseline_commit: String::new(),
+            rows: vec![
+                sample_row("tokio/a", 0.5, "serve"),
+                sample_row("tokio/b", 0.5, "serve"),
+                sample_row("django/a", 0.1, "serve"),
+                sample_row("django/b", 0.1, "serve"),
+            ],
+            t2_equiv_pass: 0,
+            t2_tasks_total: 4,
+            verdict: A029Verdict::Kill,
+            pivot_policy: None,
+            notes: String::new(),
+        };
+        let normalized = normalize_spike_results(results);
+        assert_eq!(normalized.t2_equiv_pass, 2);
+        assert_eq!(normalized.verdict, A029Verdict::Pass);
+    }
+
+    #[test]
+    fn pivot_when_one_of_four_equiv() {
+        let results = A029SpikeResults {
+            measured_at: String::new(),
+            surface: "compact".to_string(),
+            method: "test".to_string(),
+            baseline_commit: String::new(),
+            rows: vec![sample_row("tokio/a", 0.5, "serve")],
+            t2_equiv_pass: 0,
+            t2_tasks_total: 1,
+            verdict: A029Verdict::Kill,
+            pivot_policy: None,
+            notes: String::new(),
+        };
+        let mut results = results;
+        results.rows.extend([
+            sample_row("tokio/b", 0.1, "serve"),
+            sample_row("django/a", 0.1, "serve"),
+            sample_row("django/b", 0.1, "serve"),
+        ]);
+        let normalized = normalize_spike_results(results);
+        assert_eq!(normalized.t2_equiv_pass, 1);
+        assert_eq!(normalized.verdict, A029Verdict::Pivot);
+        assert!(normalized.pivot_policy.is_some());
+    }
+
+    #[test]
+    fn symforge_less_when_routing_misses_find_references() {
+        let mut row = sample_row("tokio/a", 0.9, "serve");
+        row.tools_called = vec!["search_text".to_string()];
+        assert_eq!(classify_t2_equivalence(&row), T2Equivalence::NotEquivalent);
+    }
+}

--- a/src/stel/mod.rs
+++ b/src/stel/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! Deferred: calibration auto-tuning/persistence, symforge_edit apply path.
 
+pub mod a029;
 pub mod calibration;
 pub mod controller;
 pub mod edit_apply;
@@ -29,6 +30,10 @@ pub mod surface;
 pub mod surface_list;
 pub mod types;
 
+pub use a029::{
+    A029_T2_PASS_THRESHOLD, A029SpikeResults, A029T2Row, A029Verdict, T2Equivalence,
+    classify_t2_equivalence, evaluate_a029_verdict, normalize_spike_results,
+};
 pub use calibration::{
     StelCalibrationSummary, TUNING_REVIEW_MIN_EVENTS, format_calibration_section,
     summarize_calibration,

--- a/tests/fixtures/a029-t2/.gitignore
+++ b/tests/fixtures/a029-t2/.gitignore
@@ -1,0 +1,3 @@
+# Cloned on demand — see README.md
+tokio/
+django/

--- a/tests/fixtures/a029-t2/README.md
+++ b/tests/fixtures/a029-t2/README.md
@@ -1,0 +1,20 @@
+# A-029 T2 equivalence spike corpora
+
+External reference repos for Phase 2 P2-S5 / A-029 (not shipped as product fixtures).
+
+## Clone commands
+
+```bash
+root="tests/fixtures/a029-t2"
+git clone --depth 1 https://github.com/tokio-rs/tokio.git "$root/tokio"
+git clone --depth 1 https://github.com/django/django.git "$root/django"
+```
+
+## Run spike
+
+```bash
+cargo build -p symforge
+node scripts/a029-t2-spike.cjs target/debug/symforge docs/research/a029-t2-results.json
+```
+
+Task definitions: [`tasks.jsonl`](./tasks.jsonl)

--- a/tests/fixtures/a029-t2/tasks.jsonl
+++ b/tests/fixtures/a029-t2/tasks.jsonl
@@ -1,0 +1,4 @@
+{"id":"tokio/t2_spawn","repo":"tokio","query":"who references spawn","symbol":"spawn","must_call":["find_references"],"min_baseline_recall":0.35,"notes":"T2 reference trace — tokio spawn API (code + benches)"}
+{"id":"tokio/t2_block_on","repo":"tokio","query":"references to block_on","symbol":"block_on","must_call":["find_references"],"min_baseline_recall":0.35,"notes":"T2 reference trace — block_on runtime entry"}
+{"id":"django/t2_queryset","repo":"django","query":"who references QuerySet","symbol":"QuerySet","must_call":["find_references"],"min_baseline_recall":0.35,"notes":"T2 reference trace — ORM QuerySet (code + docs/tests)"}
+{"id":"django/t2_model","repo":"django","query":"references to Model","symbol":"Model","must_call":["find_references"],"min_baseline_recall":0.25,"notes":"T2 reference trace — django Model base (high fan-out symbol)"}

--- a/tests/stel_a029_spike.rs
+++ b/tests/stel_a029_spike.rs
@@ -1,0 +1,94 @@
+//! A-029 T2 equivalence spike integration tests (P2-S5 evidence).
+#![cfg(feature = "server")]
+
+use std::path::PathBuf;
+
+use symforge::stel::{A029SpikeResults, A029Verdict, T2Equivalence, normalize_spike_results};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_results_path() -> PathBuf {
+    repo_root().join("docs/research/a029-t2-results.json")
+}
+
+fn load_committed_spike_results() -> Option<A029SpikeResults> {
+    let path = fixture_results_path();
+    if !path.is_file() {
+        return None;
+    }
+    let text = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+#[test]
+fn normalize_spike_results_matches_gate_contract_threshold() {
+    let results = A029SpikeResults {
+        measured_at: String::new(),
+        surface: "compact".to_string(),
+        method: "test".to_string(),
+        baseline_commit: String::new(),
+        rows: vec![],
+        t2_equiv_pass: 0,
+        t2_tasks_total: 0,
+        verdict: symforge::stel::A029Verdict::Kill,
+        pivot_policy: None,
+        notes: String::new(),
+    };
+    let normalized = normalize_spike_results(results);
+    assert_eq!(normalized.t2_tasks_total, 0);
+    assert_eq!(normalized.verdict, A029Verdict::Kill);
+}
+
+#[test]
+fn committed_a029_artifact_has_four_rows_and_truthful_verdict() {
+    let Some(results) = load_committed_spike_results() else {
+        eprintln!(
+            "skip committed_a029_artifact: missing {}; run scripts/a029-t2-spike.cjs",
+            fixture_results_path().display()
+        );
+        return;
+    };
+    assert_eq!(results.t2_tasks_total, 4, "A-029 requires 4 T2 tasks");
+    assert_eq!(results.rows.len(), 4);
+    let normalized = normalize_spike_results(results.clone());
+    assert_eq!(normalized.t2_equiv_pass, results.t2_equiv_pass);
+    assert_eq!(normalized.verdict.as_str(), results.verdict.as_str());
+    for row in &normalized.rows {
+        assert!(
+            matches!(
+                row.equivalence,
+                T2Equivalence::Equivalent
+                    | T2Equivalence::SymforgeLess
+                    | T2Equivalence::NotEquivalent
+                    | T2Equivalence::Bypass
+            ),
+            "row {} has classifiable equivalence",
+            row.id
+        );
+    }
+}
+
+#[test]
+fn a029_verdict_is_pass_pivot_or_kill_only() {
+    let Some(results) = load_committed_spike_results() else {
+        eprintln!("skip a029_verdict_is_pass_pivot_or_kill_only: missing artifact");
+        return;
+    };
+    match results.verdict {
+        A029Verdict::Pass => {
+            assert!(
+                results.t2_equiv_pass >= symforge::stel::A029_T2_PASS_THRESHOLD,
+                "PASS requires >=2 equiv"
+            );
+        }
+        A029Verdict::Pivot => {
+            assert!(results.t2_equiv_pass < symforge::stel::A029_T2_PASS_THRESHOLD);
+            assert!(results.pivot_policy.is_some());
+        }
+        A029Verdict::Kill => {
+            assert!(results.t2_equiv_pass < symforge::stel::A029_T2_PASS_THRESHOLD);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 **P2-S5 / A-029 T2 equivalence spike** — evidence slice only. No runtime/planner/index changes.

## A-029 verdict: **PIVOT** (truthful)

| Metric | Result |
|--------|--------|
| T2 equiv | **0 / 4** |
| Verdict | **PIVOT** |
| Pivot policy | **P-T2** — bypass-only for reference tasks; `eligible_h6=false` |

All 4 tasks route correctly (`decision=serve`, `find_references`), but index-backed reference recall vs rg baseline is below threshold (7–14% on tokio, 5–10% on django). Registers P-T2 per gap plan §4.2/§6.1 — does **not** force PASS via runtime hacks.

## Target set

| ID | Repo | Recall | Equiv |
|----|------|--------|-------|
| `tokio/t2_spawn` | tokio | 7.1% | SYMFORGE-LESS |
| `tokio/t2_block_on` | tokio | 14.2% | SYMFORGE-LESS |
| `django/t2_queryset` | django | 9.9% | SYMFORGE-LESS |
| `django/t2_model` | django | 4.8% | SYMFORGE-LESS |

## Artifacts

- [`docs/research/A-029-t2-spike.md`](docs/research/A-029-t2-spike.md)
- [`docs/research/a029-t2-results.json`](docs/research/a029-t2-results.json)
- [`scripts/a029-t2-spike.cjs`](scripts/a029-t2-spike.cjs)
- [`src/stel/a029.rs`](src/stel/a029.rs) — verdict computation
- [`tests/stel_a029_spike.rs`](tests/stel_a029_spike.rs)

## H3/H4/H5 preserved (post-#309)

Unchanged — compare-results still H3/H4/H5 PASS; ~71-token H3 margin on `records/t8_explore` noted in spike artifact.

## Commands

```bash
cargo build -p symforge
node scripts/a029-t2-spike.cjs target/debug/symforge docs/research/a029-t2-results.json
cargo test --test stel_a029_spike -- --test-threads=1
cargo test --test stel_battery_gates -- --test-threads=1
```

## Scope boundaries

- No persistence / SQLite / EMA→L2
- No B-RESULTS / H6–H8 claims
- No new MCP tools; compact-3 unchanged
- T043 T3 degrade note: deferred; documented in spike
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8719bf-bfb5-479c-8c76-e5f2355a0ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

