### PR TITLE
refactor(stel): parse symforge edit write semantics

### DIFF
--- a/src/protocol/edit_format.rs
+++ b/src/protocol/edit_format.rs
@@ -198,6 +198,59 @@ pub(crate) fn format_batch_summary(results: &[String], file_count: usize) -> Str
     out
 }
 
+const WRITE_SEMANTICS_LINE_PREFIX: &str = "Write semantics: ";
+
+/// Parse the normative `Write semantics:` envelope line from legacy edit tool output.
+pub(crate) fn parse_write_semantics_from_output(output: &str) -> Option<EditWriteSemantics> {
+    output.lines().find_map(|line| {
+        let label = line.strip_prefix(WRITE_SEMANTICS_LINE_PREFIX)?.trim();
+        Some(match label {
+            "dry run (no writes)" => EditWriteSemantics::DryRunNoWrites,
+            "atomic write + reindex" => EditWriteSemantics::AtomicWriteAndReindex,
+            "transactional write + rollback + reindex" => {
+                EditWriteSemantics::TransactionalWriteRollbackAndReindex
+            }
+            _ => return None,
+        })
+    })
+}
+
+fn edit_output_is_error(output: &str) -> bool {
+    output.starts_with("Error:")
+        || output.starts_with("Invalid")
+        || output.contains(": edit safety blocked")
+        || output.starts_with("Index not loaded.")
+        || output.starts_with("Index is loading")
+        || output.starts_with("Index degraded:")
+        || output.starts_with("File not found:")
+        || output.starts_with("Symbol not found:")
+}
+
+/// Whether legacy edit output indicates a committed write (not dry-run preview).
+pub(crate) fn edit_output_bytes_committed(output: &str) -> bool {
+    if edit_output_is_error(output) {
+        return false;
+    }
+    matches!(
+        parse_write_semantics_from_output(output),
+        Some(EditWriteSemantics::AtomicWriteAndReindex)
+            | Some(EditWriteSemantics::TransactionalWriteRollbackAndReindex)
+    )
+}
+
+/// Write mode for compact `symforge_edit` apply metadata (`committed` / `dry_run` / `failed`).
+pub(crate) fn symforge_edit_apply_write_mode(output: &str) -> &'static str {
+    if edit_output_is_error(output) {
+        return "failed";
+    }
+    match parse_write_semantics_from_output(output) {
+        Some(EditWriteSemantics::DryRunNoWrites) => "dry_run",
+        Some(EditWriteSemantics::AtomicWriteAndReindex)
+        | Some(EditWriteSemantics::TransactionalWriteRollbackAndReindex) => "committed",
+        None => "failed",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,6 +283,55 @@ mod tests {
         assert!(result.contains("Required safety: structural-edit-safe"));
         assert!(result.contains("Available safety: text-edit-safe"));
         assert!(result.contains("Language: html"));
+    }
+
+    #[test]
+    fn edit_output_bytes_committed_uses_write_semantics_not_summary_wording() {
+        let envelope = format_edit_envelope(
+            EditSafetyMode::StructuralEditSafe,
+            EditSourceAuthority::DiskRefreshed,
+            EditWriteSemantics::AtomicWriteAndReindex,
+            "src/lib.rs:1",
+        );
+        let committed = format!("{envelope}\nsrc/lib.rs — updated function `foo` (10 → 12 bytes)");
+        assert!(edit_output_bytes_committed(&committed));
+        assert_eq!(symforge_edit_apply_write_mode(&committed), "committed");
+
+        let dry = format!(
+            "{}\n[DRY RUN] Would replace `foo` in src/lib.rs",
+            format_edit_envelope(
+                EditSafetyMode::StructuralEditSafe,
+                EditSourceAuthority::DiskRefreshed,
+                EditWriteSemantics::DryRunNoWrites,
+                "src/lib.rs:1",
+            )
+        );
+        assert!(!edit_output_bytes_committed(&dry));
+        assert_eq!(symforge_edit_apply_write_mode(&dry), "dry_run");
+
+        let blocked = format_capability_warning(
+            "replace_symbol_body",
+            "html",
+            "structural-edit-safe",
+            "text-edit-safe",
+            "use edit_within_symbol",
+        );
+        assert!(!edit_output_bytes_committed(&blocked));
+        assert_eq!(symforge_edit_apply_write_mode(&blocked), "failed");
+    }
+
+    #[test]
+    fn parse_write_semantics_from_output_reads_envelope_line() {
+        let output = format_edit_envelope(
+            EditSafetyMode::StructuralEditSafe,
+            EditSourceAuthority::CurrentIndex,
+            EditWriteSemantics::TransactionalWriteRollbackAndReindex,
+            "src/a.rs:3",
+        );
+        assert_eq!(
+            parse_write_semantics_from_output(&output),
+            Some(EditWriteSemantics::TransactionalWriteRollbackAndReindex)
+        );
     }
 
     #[test]

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -8280,22 +8280,14 @@ impl SymForgeServer {
         );
         let mut body = format!("{routing_meta}\n\n{tool_body}");
         if apply && let Some(symbol) = resolved_symbol.as_ref() {
-            let write_mode = if tool_body.contains("replaced") {
-                "committed"
-            } else if tool_body.contains("[DRY RUN]") {
-                "dry_run"
-            } else {
-                "failed"
-            };
+            let write_mode = super::edit_format::symforge_edit_apply_write_mode(&tool_body);
             body = format!(
                 "{routing_meta}\n\n{}\n\n{tool_body}",
                 format_apply_metadata(symbol, write_mode)
             );
         }
 
-        let legacy_executed = apply
-            && tool_body.contains("replaced")
-            && tool_body.contains("Write semantics: atomic write + reindex");
+        let legacy_executed = apply && super::edit_format::edit_output_bytes_committed(&tool_body);
         let output = self.finalize_symforge_with_ledger(
             "symforge_edit",
             &crate::stel::StelRequest::default(),

--- a/tests/stel_symforge_edit.rs
+++ b/tests/stel_symforge_edit.rs
@@ -74,6 +74,15 @@ async fn dispatch_symforge_edit(server: &SymForgeServer, request: &StelEditReque
     tool_result_text(&dispatch_symforge_edit_result(server, request).await).to_string()
 }
 
+fn ledger_meta_from_output(output: &str) -> symforge::stel::LedgerEnvelopeMeta {
+    let ledger_json = output
+        .lines()
+        .find(|line| line.starts_with("ledger: "))
+        .expect("ledger line in envelope")
+        .trim_start_matches("ledger: ");
+    serde_json::from_str(ledger_json).expect("ledger json")
+}
+
 #[tokio::test]
 async fn symforge_edit_rejects_non_compact_surface() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
@@ -289,14 +298,14 @@ async fn symforge_edit_apply_already_applied_is_idempotent_without_rewrite() {
     )
     .await;
 
-    for needle in [
-        "── stel ──",
-        "already applied",
-        "Write mode: already_applied",
-        "ledger:",
-    ] {
+    for needle in ["already applied", "Write mode: already_applied", "ledger:"] {
         assert!(output.contains(needle), "missing `{needle}` in:\n{output}");
     }
+    let meta = ledger_meta_from_output(&output);
+    assert!(
+        !meta.legacy_executed,
+        "already-applied must not count as committed write"
+    );
     assert_eq!(before, std::fs::read(&file_path).unwrap());
 }
 
@@ -343,11 +352,15 @@ async fn symforge_edit_preview_then_apply_writes_once() {
         "Write mode: committed",
         "Byte range:",
         "Line range:",
-        "replaced",
         "Write semantics: atomic write + reindex",
     ] {
         assert!(apply.contains(needle), "missing `{needle}` in:\n{apply}");
     }
+    let meta = ledger_meta_from_output(&apply);
+    assert!(
+        meta.legacy_executed,
+        "successful apply must record legacy_executed from write-semantics envelope"
+    );
     let on_disk = std::fs::read_to_string(&file_path).unwrap();
     assert!(on_disk.contains("new"), "disk after apply: {on_disk}");
     assert!(!on_disk.contains("old"), "disk after apply: {on_disk}");


### PR DESCRIPTION
Refactors symforge_edit ledger/write-mode detection to parse the typed Write semantics envelope instead of relying on fragile output substring checks.

Scope:
- Adds typed parsing helpers in src/protocol/edit_format.rs.
- Replaces inline output substring heuristics in src/protocol/tools.rs.
- Updates symforge_edit integration tests to assert ledger metadata through parsed output semantics.

Out of scope:
- No get_file_context/get_symbol changes.
- No client allow-list changes.
- No compact MCP tool-surface changes.
- No 8.1 index-recall artifacts.

Verification:
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib protocol::edit_format
- cargo test --test stel_symforge_edit
- cargo build --release

Note on local full-suite:
- `cargo test --all-targets -- --test-threads=1` has 2 local failures in `stel_golden_replay`.
- The same 2 failures reproduce on pristine `main`, so they are not introduced by this PR.
- They are corpus-gated tests that skip in CI when optional replay corpora are absent.
- This checkout has partial local replay corpora, which makes the guard enter the replay path and fail on local corpus state.
- PR CI should be treated as source of truth for the full suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how committed writes and ledger legacy_executed are detected for symforge_edit; behavior should be more correct but affects billing/ledger semantics on edit output.
> 
> **Overview**
> **`symforge_edit`** no longer infers write outcome from substrings like `replaced` or `[DRY RUN]`. It now reads the normative **`Write semantics:`** line on legacy edit tool output to set apply metadata (`committed` / `dry_run` / `failed`) and **`legacy_executed`** on the ledger.
> 
> New helpers in **`edit_format.rs`** parse that envelope line, treat common error prefixes as failures, and map atomic/transactional semantics to committed writes. Unit tests cover cases where summary wording (e.g. “updated” instead of “replaced”) would have fooled the old heuristics.
> 
> Integration tests parse the **`ledger:`** JSON and assert **`legacy_executed`** is false for already-applied idempotent applies and true only when the envelope reports a real write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22cb4952943fd5033342fb904f59975328e3d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->