### PR TITLE
refactor(stel): centralize edit outcome classification

### DIFF
--- a/src/protocol/edit_format.rs
+++ b/src/protocol/edit_format.rs
@@ -251,6 +251,27 @@ pub(crate) fn symforge_edit_apply_write_mode(output: &str) -> &'static str {
     }
 }
 
+/// Whether a `symforge_edit` body reports an internal failure (as opposed to an
+/// invalid request, classified separately by the caller).
+///
+/// `apply` gates the apply-only failure sentinels (`Write mode: failed` from
+/// `stel::edit_apply::format_apply_metadata`, and `: edit safety blocked` from
+/// [`format_capability_warning`]) so a dry-run preview is never misclassified
+/// as a failed write. `Index not loaded.` is unconditional because the index is
+/// unavailable for previews and applies alike. `tool_body` is the trust/result
+/// envelope text; `full_body` is the complete summary carrying apply metadata.
+pub(crate) fn symforge_edit_internal_failure(
+    tool_body: &str,
+    apply: bool,
+    full_body: &str,
+) -> bool {
+    if tool_body.starts_with("Index not loaded.") {
+        return true;
+    }
+    apply
+        && (full_body.contains("Write mode: failed") || tool_body.contains(": edit safety blocked"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,6 +339,51 @@ mod tests {
         );
         assert!(!edit_output_bytes_committed(&blocked));
         assert_eq!(symforge_edit_apply_write_mode(&blocked), "failed");
+    }
+
+    #[test]
+    fn symforge_edit_internal_failure_gates_apply_only_sentinels() {
+        // Index-unavailable is unconditional: a failure for preview and apply alike.
+        assert!(symforge_edit_internal_failure(
+            "Index not loaded.",
+            false,
+            "Index not loaded."
+        ));
+        assert!(symforge_edit_internal_failure(
+            "Index not loaded.",
+            true,
+            "Index not loaded."
+        ));
+
+        // `Write mode: failed` only counts as a failure on an apply, never a preview.
+        let failed_apply = "Write mode: failed\nChanged file: src/a.rs";
+        assert!(symforge_edit_internal_failure("ok", true, failed_apply));
+        assert!(!symforge_edit_internal_failure("ok", false, failed_apply));
+
+        // `: edit safety blocked` is likewise apply-gated.
+        let blocked = format_capability_warning(
+            "replace_symbol_body",
+            "html",
+            "structural-edit-safe",
+            "text-edit-safe",
+            "use edit_within_symbol",
+        );
+        assert!(symforge_edit_internal_failure(&blocked, true, &blocked));
+        assert!(!symforge_edit_internal_failure(&blocked, false, &blocked));
+
+        // A clean committed apply is not an internal failure.
+        let committed = format!(
+            "{}\nWrite mode: committed",
+            format_edit_envelope(
+                EditSafetyMode::StructuralEditSafe,
+                EditSourceAuthority::DiskRefreshed,
+                EditWriteSemantics::AtomicWriteAndReindex,
+                "src/a.rs:1",
+            )
+        );
+        assert!(!symforge_edit_internal_failure(
+            &committed, true, &committed
+        ));
     }
 
     #[test]

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -8312,13 +8312,10 @@ impl SymForgeServer {
         apply: bool,
         full_body: &str,
     ) -> OutcomeClass {
+        use super::edit_format::symforge_edit_internal_failure;
         if tool_body.starts_with("Error:") || tool_body.starts_with("Invalid") {
             OutcomeClass::InvalidRequest
-        } else if tool_body.starts_with("Index not loaded.")
-            || (apply
-                && (full_body.contains("Write mode: failed")
-                    || tool_body.contains(": edit safety blocked")))
-        {
+        } else if symforge_edit_internal_failure(tool_body, apply, full_body) {
             OutcomeClass::InternalFailure
         } else {
             OutcomeClass::Found


### PR DESCRIPTION
Centralizes symforge_edit outcome classification to reuse edit-format helpers instead of duplicating output/error string checks in tools.rs.

Scope:
- Extends/uses edit-format helpers for symforge_edit error/outcome detection.
- Updates classify_symforge_edit_outcome to delegate to centralized parsing/classification logic.
- Keeps behavior equivalent for committed, dry-run, failed, and blocked edit outputs.

Out of scope:
- No get_file_context/get_symbol changes.
- No client allow-list changes.
- No compact MCP tool-surface changes.
- No golden/replay fixture changes.
- No 8.1 index-recall artifacts.
- No changes to cursor/v8-phase2-stel-controller.

Verification:
- cargo fmt --check
- cargo check
- cargo test --lib protocol::edit_format
- cargo test --test stel_symforge_edit
- cargo clippy --all-targets -- -D warnings
- cargo build --release

Note:
- Local full-suite is not used as a blocker here because partial optional replay corpora can make corpus-gated stel_golden_replay tests fail locally while they skip/pass in CI.
- PR CI is source of truth for full cargo test --all-targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that preserves existing outcome classification for symforge_edit; logic is covered by new unit tests.
> 
> **Overview**
> Moves **`symforge_edit` internal-failure detection** out of `classify_symforge_edit_outcome` in `tools.rs` into a shared **`symforge_edit_internal_failure`** helper in `edit_format.rs`, alongside other edit-output parsing.
> 
> Classification rules are unchanged: **`Error:` / `Invalid`** still map to invalid requests in the tool layer; **`Index not loaded.`** always counts as internal failure; **`Write mode: failed`** and **`: edit safety blocked`** only count when **`apply`** is true so dry-run previews are not treated as failed writes.
> 
> Adds unit tests in `edit_format` that lock in those apply-gated and committed-success cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42096559f0750976176e1fadea62e1f53c164ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->