### PR TITLE
Feat/010 v8 trust remediation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,5 +57,5 @@ When merging tools A into B:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/007-intelligence-pattern-ports/plan.md
+at specs/010-v8-trust-remediation/plan.md
 <!-- SPECKIT END -->

--- a/docs/reviews/skeptical-senior-review-2026-06-17.md
+++ b/docs/reviews/skeptical-senior-review-2026-06-17.md
@@ -1,0 +1,277 @@
+# SymForge v8 — Skeptical Senior Engineer Review
+
+**Reviewer:** Cursor agent (independent pass; parallel review running elsewhere)  
+**Target:** `feat/009-operator-setup-wizard` / shipped **8.0.0** binary via `user-symforge` MCP  
+**Date:** 2026-06-17  
+**Method:** Dogfood deployed MCP (`status`, `symforge`), cross-read assumptions register + gap-closure docs, trace compact-surface dispatch, compare public docs vs `src/stel/` + `src/protocol/`, reconcile with prior review artifacts in `docs/reviews/`.
+
+---
+
+## Executive verdict
+
+The **internal engineering discipline is stronger than the external product story**. The assumptions register, deferred-work list, and calibration “observational only” labeling are unusually honest for a v1 economics layer. That honesty mostly **does not propagate** to README, AGENTS.md, agent init allow-lists, or runtime error text — where an LLM or user still sees “32 tools,” “trust envelope,” and “call `index_folder`” as if v7 semantics apply.
+
+**Shipped 8.0.0 is architecturally real** (STEL L1–L4 code exists, compact-3 dispatch gate is enforced, operator server hardening landed). **Shipped 8.0.0 is not yet trustworthy as a self-describing agent product** until: (1) cold-start indexing works reliably on the default compact surface, (2) error/recovery paths name actions agents can actually take, and (3) public docs match the default surface.
+
+**Overall:** Proceed with the rework, but treat **LLM-facing honesty and onboarding** as blocking for “production agent default,” not as polish.
+
+---
+
+## Live dogfood evidence (deployed MCP, 8.0.0)
+
+### `status` (compact)
+
+```
+symforge_version: 8.0.0
+index_ready: false
+index_files: 0
+index_symbols: 0
+deferred: b_results,calibration_auto_tune,ledger_persistence,multi_step_planner
+l1_planner: active … l4_ledger: active
+handler_symforge_edit: preview-and-apply
+```
+
+### `status` (full)
+
+```
+project: project
+durable_ledger: unavailable
+last_ledger_decision: reject
+last_ledger_route: search_files
+calibration: insufficient: 2 events (<5); observational only
+predicted_response_tokens: 1200
+actual_response_tokens: 204
+```
+
+### `symforge` query (`intent=find`, repo architecture question)
+
+```
+decision: reject
+error: 85.1%
+Index not loaded. Call index_folder to index a directory.
+Multi-hop chain failed … outcome=internal_failure
+```
+
+**Interpretation:** The trust envelope is working *mechanically* (reject, calibration pending, ledger line present) but **economics numbers are not yet meaningful** (predicted 1200 vs actual 204; error ~85%). The index is empty in this session, so the primary read path fails — yet the error tells the agent to call a tool **not available on the default surface** (see P0-1).
+
+---
+
+## Critical findings (act before calling the product “agent-ready”)
+
+### P0-1 — Compact-surface recovery dead-end
+
+| What | Detail |
+|------|--------|
+| **Symptom** | `symforge` / legacy formatters emit: *“Index not loaded. Call index_folder to index a directory.”* |
+| **Reality** | Default surface is compact-3 only (`symforge`, `symforge_edit`, `status`). `index_folder` is **not** in `COMPACT_TOOL_NAMES` and is rejected by `enforce_compact_surface`. |
+| **Evidence** | `src/protocol/format.rs` (message), `src/stel/surface.rs` (tool set), `src/protocol/surface_probe.rs` (default = Compact), `src/protocol/mod.rs` (dispatch gate) |
+| **LLM impact** | Agent enters an **unrecoverable loop**: status says not ready → symforge says call index_folder → index_folder unavailable → no documented escape on compact surface except env opt-out (`SYMFORGE_SURFACE=full`) agents do not know about. |
+| **Fix direction** | (a) Auto-index reliably before first symforge call; **or** (b) expose indexing on compact surface (`status` subcommand, `symforge intent=meta`, or bundled bootstrap in MCP startup); **or** (c) change all compact-path errors to name the real fix (`SYMFORGE_SURFACE=full`, operator `serve` attach, daemon rebind) — not `index_folder`. |
+
+### P0-2 — Cold start with empty index in real MCP sessions
+
+| What | Detail |
+|------|--------|
+| **Symptom** | Live MCP: `index_ready: false`, `index_files: 0`, generic `project: project`. |
+| **Code intent** | `main.rs` auto-indexes when `SYMFORGE_AUTO_INDEX` ≠ false and `discovery::find_project_root()` succeeds. |
+| **Likely gaps** | Daemon-backed stdio (`new_daemon_proxy`) may attach to a session without the workspace root indexed; Claude Desktop wrapper sets CWD to `%USERPROFILE%` (`init.rs` `create_desktop_wrapper_windows`), not the repo — breaking root discovery. Init registers `"env": {}` — no `SYMFORGE_SURFACE`, no workspace hint. |
+| **LLM impact** | Agent believes SymForge is connected; all symforge queries fail until an invisible operator fixes daemon/root/CWD. |
+| **Fix direction** | Init should set proven env (workspace root, surface profile, auto-index policy). Desktop wrapper should cd to configured workspace or pass `--root`. Status compact view should surface **actionable** empty-index reason (mirror `local_empty_reason` from startup). |
+
+### P1-1 — Public docs still describe v7 (32-tool) as canonical
+
+| Surface | Says | Should say (v8 default) |
+|---------|------|-------------------------|
+| `README.md` | “**32 canonical MCP tools**” (lines 24, 128, 328) | Compact-3 default; 32-tool `SYMFORGE_SURFACE=full` opt-out |
+| `AGENTS.md` | “Current canonical `tools/list` exposes **32 tools**” | Compact-3 + status; legacy table under opt-out |
+| `CHANGELOG` remediation note | “README rewrite” for v8 | README not rewritten at review time |
+| `symforge init` | `SYMFORGE_TOOL_NAMES` lists 32+ legacy `mcp__symforge__*` entries in client allow-lists | Mismatch with MCP `list_tools` (3 tools) — agents granted tools that do not exist on wire |
+
+**LLM impact:** Rules files, wiki links, and client allow-lists **train agents on a surface that is not default**, undermining STEL routing and bypass economics (previously flagged in `docs/reviews/v8-architecture-review-codex-resume.md` §13 Q1).
+
+### P1-2 — Phase gates vs 8.0.0 ship date
+
+`docs/stel-assumptions.md` phase table:
+
+| Phase | Gate |
+|-------|------|
+| **3 executor + 8.0** | **A-015..A-016 validated** (trust envelope ↔ ledger; EMA calibration) |
+| **2 L1 + L2** | A-008..A-014 evidence (many still OPEN/PARTIAL) |
+
+**Reality at 8.0.0 tag:** A-015, A-016, A-011 (±20% predictor), A-008 (95% routing) remain **OPEN or PARTIAL**. Phase 0 GO authorized **`src/stel/` implementation**, not “all Phase 3 assumptions validated.”
+
+**Risk:** Marketing/README “trust envelope” and “token-efficient” reads as **validated product claims**; internal register correctly marks them **hypothesis / observational**.
+
+**Recommendation:** Publish an explicit **“8.0.0 capability matrix”**: Implemented / Measured / Observational / Deferred — aligned with `status` `deferred:` line.
+
+### P1-3 — Status labels overstate subsystems marked deferred
+
+Compact `status` always prints:
+
+```
+l2_economics: active
+l4_ledger: active
+handler_symforge_edit: preview-and-apply
+deferred: …,ledger_persistence,…
+```
+
+But:
+
+- `src/stel/mod.rs` module doc: *“Deferred: calibration auto-tuning/persistence, **symforge_edit apply path**.”*
+- Full status on stdio MCP: `durable_ledger: unavailable` while `l4_ledger: active`.
+- `ledger_persistence` appears in `DEFERRED_ITEMS` while L4 is labeled active.
+
+**LLM impact:** “active” reads as production-ready; “deferred” is easy to miss in compact view. Agents cannot distinguish **in-memory session ledger** vs **durable restart-survival ledger**.
+
+**Fix direction:** Use states like `in_memory_only | durable | disabled` instead of blanket `active`; align module doc with status strings.
+
+---
+
+## High findings (trust / robustness)
+
+### H1 — Token economics envelope is uncalibrated (expected, but oversold externally)
+
+Live session: `predict_error_pct` ~85%, `calibration: pending`, `calibration: insufficient events`. Assumption **A-011** (±20% predictor) is **OPEN**.
+
+The envelope still prints `session_net_vs_manual: +213` alongside `decision: reject` — numerically correct per harness math but **semantically misleading** to LLMs trained to treat “+saved tokens” as success.
+
+**Recommendation:** When `decision != serve`, prefix envelope with `economics_status: uncalibrated_reject` or suppress net-saved line on reject/degrade/bypass failure paths.
+
+### H2 — Routing confidence `inferred` dominates live queries
+
+Dogfood query routed `find → search_files → search_text` with `route_confidence: inferred`, then failed on empty index. Golden corpus (**A-008**) is **PARTIAL** (“95% trajectory metric not numerically measured”).
+
+STEL is honest about confidence in the ledger JSON, but **planner fallbacks** can still burn schema+invoke tokens before failing — bad economics on errors.
+
+### H3 — `symforge_edit` apply path: preview vs apply ambiguity
+
+Status advertises `preview-and-apply`. Module header says apply path deferred. `edit_apply.rs` gates apply on loaded index with message referencing `index_folder` (same P0-1 dead-end).
+
+Agents need a single documented flow: preview → `apply:true` + `if_match` on compact surface, with index readiness preconditions spelled in tool description — not scattered across Rust comments.
+
+### H4 — Daemon IPC bypasses compact gate (documented, still a footgun)
+
+`docs/reviews/external-review-remediation-2026-06-17.md` downgraded P2-4: internal `daemon.rs::execute_tool_call` intentionally reaches full tools for hooks/dogfooding.
+
+**Fine for internal use**; confusing when comparing “SymForge MCP surface” vs “SymForge hooks hitting daemon HTTP.” Document in operator guide: **external contract = gated `/mcp` + stdio `call_tool`; hooks ≠ harness surface.**
+
+### H5 — Init / client configuration not updated for v8 cutover
+
+Observations:
+
+- No `SYMFORGE_SURFACE` in registered MCP env (defaults compact — good — but agents lack escape hatch docs in config).
+- Linux Codex gets `SYMFORGE_NO_DAEMON=1`; Windows/desktop paths differ — uneven cold-start behavior.
+- Allow-lists still enumerate legacy tool names agents will never see on compact wire — **false affordances** in Claude/Codex/Kilo configs.
+
+---
+
+## Medium findings (quality / maintainability)
+
+### M1 — Assumptions register internal inconsistency
+
+Top table marks **A-005 OPEN**; Phase 0 evidence table marks **A-005 VALIDATED** (891 B). Both appear in the same file with different sections — maintainers know why; external readers do not.
+
+**Fix:** Single source of truth per assumption ID; generated table from `docs/stel-assumptions.json` if needed.
+
+### M2 — README trust claims vs STEL maturity
+
+README: *“Every truncation is disclosed with the real cost, never silently applied.”* STEL degrade caps exist (`controller.rs`), but compact serve caps and fusion-empty handling were recently fixed (P3-7). Worth auditing all formatters for silent truncation under `max_tokens` on the **symforge** path specifically.
+
+### M3 — Feature 007 (intelligence ports) — residual open item
+
+`docs/reviews/007-review-focus-2026-06-17.md`: find-fusion both-empty → `Found` was **[OPEN]**; external remediation claims **FIXED** (EmptyResult). Worth one live symforge find-fusion query post-index to confirm on deployed binary.
+
+### M4 — `edition = "2024"` in Cargo.toml
+
+Unusual for ecosystem compatibility; not a functional bug if toolchain pinned — note for downstream packagers.
+
+---
+
+## What is genuinely good (credit where due)
+
+1. **Assumptions register + gap-closure plan** — Rarely seen this explicit; “OPEN assumptions do not unlock phases” is the right doctrine even if 8.0 marketing outran it.
+2. **Compact dispatch enforcement (P1-A)** — `ServerHandler::call_tool` gates before router; not list-only hiding.
+3. **Deferred list in `status`** — `b_results,calibration_auto_tune,ledger_persistence,multi_step_planner` is honest if read carefully.
+4. **Security remediation batch** — Origin gate, admin static/asset auth split, AAP key redaction, ledger drain on shutdown (`external-review-remediation-2026-06-17.md`) traced and tested.
+5. **Embed isolation** — Preserved across v8 operator work; semver story in CHANGELOG is coherent.
+6. **Golden replay + phase2 gate machinery** — Substantial test investment; PARTIAL verdicts are documented with artifact paths.
+7. **Index integrity model** — Byte-exact snapshots, quarantine, idempotency on mutations (7.x layer) remain solid moat; STEL sits on top, does not replace it.
+
+---
+
+## Overstated surfaces (skeptic’s checklist)
+
+| Claim (external or status) | Actual state |
+|----------------------------|--------------|
+| “32 canonical MCP tools” (README) | Default: **3** tools |
+| “Token-efficient” / trust envelope (README hero) | Predictor **OPEN**; live error **~85%**; calibration insufficient |
+| `l4_ledger: active` | Session ledger yes; **durable persistence deferred/unavailable** on stdio |
+| `handler_symforge_edit: preview-and-apply` | Apply path gated; module doc lists apply as **deferred** |
+| Phase 3 gate “A-015/A-016 validated” | Still **OPEN** at ship |
+| “Call index_folder” recovery | **Blocked** on default compact surface |
+| Agent init allow-lists | Legacy 32-tool names **≠** MCP `list_tools` |
+
+---
+
+## Recommended priority queue
+
+### Before declaring “default agent MCP production-ready”
+
+1. **Fix P0-1 + P0-2** — indexing on compact surface without hidden env vars; fix init/CWD/daemon root attachment.
+2. **Rewrite README + AGENTS.md + init allow-lists** for compact-3 default (P1-1).
+3. **Publish 8.0 capability matrix** tied to assumption IDs (P1-2).
+4. **Normalize status vocabulary** — replace misleading `active` labels (P1-3).
+
+### Next hardening tranche
+
+5. Envelope semantics on reject/failure (H1).
+6. Compact-path error messages that only reference **callable** tools (H2/H3).
+7. Reconcile assumptions register tables (M1).
+8. Operator doc: daemon/hook surface ≠ external MCP contract (H4).
+
+### Can defer (already tracked)
+
+- P3 ledger migration forward guard, retention (P3-A/B in 004 review).
+- rmcp version pin drift (P3-C).
+- A-020..A-022 transport/unification assumptions (Phase 4).
+
+---
+
+## Overlap with parallel reviewer
+
+If the other session reported:
+
+- **index_ready false vs working explore** — consistent with **session/root mismatch** (empty index in this MCP attach; explore may hit a different code path or cached daemon project). Root cause cluster: P0-2.
+- **104% / 85% predict error** — consistent; economics layer is **observational**, not calibrated (A-011 OPEN).
+- **durable_ledger unavailable** — confirmed on stdio MCP full status.
+- **Assumptions register “damning admissions”** — confirmed; the register is the most trustworthy doc in the repo.
+
+This pass adds emphasis on **compact-surface dead-end errors**, **init/desktop CWD**, and **public doc / allow-list drift** as distinct LLM-trust failures.
+
+---
+
+## Appendix — key code anchors
+
+| Topic | Location |
+|-------|----------|
+| Compact tool set | `src/stel/surface.rs` |
+| Default surface = compact | `src/protocol/surface_probe.rs` |
+| Dispatch gate | `src/protocol/mod.rs` (`call_tool`) |
+| Index-not-loaded message | `src/protocol/format.rs` |
+| Status formatting | `src/stel/status.rs` |
+| STEL deferred note | `src/stel/mod.rs` (module doc) |
+| Phase gates | `docs/stel-assumptions.md` |
+| Prior operator review | `specs/004-v8-operator-serve/review-findings-2026-06-16.md` |
+| v8 remediation | `docs/reviews/external-review-remediation-2026-06-17.md` |
+
+---
+
+## Appendix B — Golden replay test run (2026-06-17)
+
+`cargo test --test stel_golden_replay -- --test-threads=1` → **6 passed, 0 failed** (~5m35s compile + 0.2s test).
+
+Three tests **skipped in-repo corpus fixtures** (`tests/fixtures/phase0-corpus/` not cloned per README): `s4_minimum_subset_replays`, `supported_pff_rows_bypass`, `supported_serve_rows_replay`. In-repo routing/classification tests still pass; full golden battery replay remains operator-dependent.
+
+---
+
+*End of review. No code changes made in this pass — findings only.*

--- a/docs/reviews/stel-v8-remediation-advice-2026-06-17.md
+++ b/docs/reviews/stel-v8-remediation-advice-2026-06-17.md
@@ -1,0 +1,133 @@
+# SymForge v8 (STEL) — Remediation Advice
+
+- **Date:** 2026-06-17
+- **Status:** ADVICE ONLY. No code in this document is a patch. It is a recommended plan for a downstream coding agent. Every item offers options + tradeoffs; the implementer decides.
+- **Pairs with:** `docs/reviews/stel-v8-skeptic-audit-2026-06-17.md` (findings + evidence). IDs below (C1, H1, …) map 1:1 to that audit.
+- **Verification note:** All file:line anchors were verified against source at audit time (commit `3df5210`, v8.0.0). Re-confirm before editing — the index drifts.
+
+---
+
+## How to use this document
+
+Each item has: **root cause** (one line), **advice** (usually a cheap "honest relabel" option AND a real "rewire" option, with a recommendation), **anchors**, **effort** (S < 1h, M a few h, L a day+), **risk**, **depends on**, and **done when** (acceptance + the regression test that should exist so the bug can't silently return).
+
+Two over-arching rules drawn from the codebase's own principles — keep them as the spine of the whole effort:
+
+1. **Honesty contract for LLM-facing surfaces.** Every field in the trust envelope and `status` must be one of: (a) a real measured value, (b) explicitly labeled `est.`/`assumed`/`heuristic`/`mode`, or (c) derived from real wiring state. No literal "active"/"saved" that asserts a fact the code never checked. This single rule resolves the bulk of the findings.
+2. **Relabel is a valid fix.** For a code-intelligence tool the LLM trusts, an honest "estimated, uncalibrated" is strictly better than a dishonest "275 saved". Where the real rewire is expensive, ship the relabel now and track the rewire as a registered assumption. Do **not** the reverse — do not keep the confident label and defer the honesty.
+
+What NOT to do (anti-patterns this effort must avoid): don't raise a threshold to make an OPEN assumption "pass"; don't delete a deferred seam to make the `deferred:` list shorter; don't mark anything `VALIDATED` without an artifact; don't fail a user request to enforce a ledger/calibration nicety (FR-011 stands).
+
+---
+
+## Tier 0 — Trust-critical (advise: do before promoting v8 as "token-economical" or as a guarded editor)
+
+### C1 — Economics numbers are constants surfaced as measurements
+- **Root cause:** `planner.rs:51-53` hardcodes `est_response_tokens: 400`, `est_manual_tokens: 800`, `index_refs: vec![]`; `controller.rs:333-349` just sums them. Single-step net is always `275`.
+- **Advice — two layers, ship both in order:**
+  - **Layer A (relabel, S, do immediately):** In `envelope.rs:33-66`, change `"{saved} saved vs manual"` to mark it estimated and name the baseline as assumed, e.g. `~{saved} est. (assumed manual {manual})`. Same for the ledger field names in `ledger.rs:84-125` (`actual_response_tokens` → `estimated_response_tokens`, `manual_baseline_tokens` → `assumed_manual_tokens`). This removes the dishonesty in under an hour without touching the predictor.
+  - **Layer B (rewire, M-L, the real fix):** Populate `index_refs` with real `raw_chars`/line counts. The executor already resolves the target file/symbol, so the bytes are in hand at plan/serve time — thread them into `StelPlanStep.index_refs` (`types.rs:152-155` is the field, already doc-commented for this) and compute `est_response_tokens`/`est_manual_tokens` from them. Keep a real tokenizer (or a calibrated bytes→tokens ratio per language) instead of `body.len()/4`.
+- **Anchors:** `planner.rs:51-53`; `controller.rs:333-349`; `envelope.rs:34,45`; `types.rs:152-155`; `handler.rs:8-10` (`estimate_tokens`).
+- **Risk:** Low for Layer A (string-only). Medium for Layer B — changing estimates shifts which gate branch fires (see C2); land C2 first or together.
+- **Depends on:** nothing for A; pairs with C2 for B.
+- **Done when:** no envelope/ledger field presents an estimate without an `est./assumed` marker (Layer A); and for Layer B, `index_refs` is non-empty for served plans and `predicted_response_tokens` tracks actual within the A-011 target on a battery run. Add a test asserting `build_plan` populates `index_refs` for a known file, and a golden row asserting predicted-vs-actual error stays under threshold.
+
+### C2 — Serve/degrade/bypass gate runs on the fiction; degrade + economics-bypass are unreachable
+- **Root cause:** With constant net ≥275 > `SERVE_MARGIN_TOKENS`, `evaluate_plan_with_session` (`controller.rs:40-135`) always returns `serve`; the `<=0` bypass and `<=50` degrade branches (`controller.rs:221-235`) can't fire for real planner output.
+- **Advice:** Don't "fix" by tuning constants. After C1-Layer-B grounds the estimate, re-decide what the gate should key on. Recommended: gate degrade/bypass on **cheap real signals** (indexed file byte size, expected result count) rather than the derived net, and treat the economics net as advisory display only until A-011 validates. If the degrade/bypass branches remain unreachable by design, say so — delete or `#[cfg(test)]`-scope the dead branches, or document them as policy-only (P-FF + cache-hit), so the next reader doesn't think a live economics gate exists when it doesn't.
+- **Anchors:** `controller.rs:17,19,21` (margins), `:40-135` (gate), `:221-235` (economics bypass body).
+- **Effort:** M. **Risk:** Medium — bypass changes what the host reads; never bypass into a truncated read when the user asked for a trace (current `economics_bypass_body` reads lines 1-80 — that is silent capability loss; keep it disabled unless a validated signal justifies it). **Depends on:** C1-B.
+- **Done when:** every reachable decision branch is exercised by a test with realistic planner output, OR the unreachable branches are explicitly marked policy/test-only. No live path bypasses a trace/reference query into a line-window read.
+
+### C3 — `status` reports the empty proxy-shell index, not the daemon index that serves
+- **Root cause:** Daemon-proxy production topology (`main.rs:267`). `explore` proxies to the warm daemon (`tools.rs:7284`, served at `daemon.rs:2389`); `status_stel_tool` reads the front-end's own empty `self.index` (`tools.rs:8529-8557`) with no proxy, and the daemon has no `status` arm (`daemon.rs:2435` bails).
+- **Advice — pick one:**
+  - **Preferred (consistent pattern):** add a `status` arm to `daemon.rs::execute_tool_call` (~`:2306`) that runs STEL status against the daemon's loaded `server`, and make `status_stel_tool` call `self.proxy_tool_call("status", …)` first when a daemon client exists — exactly mirroring `explore`.
+  - **Cheaper:** source `index_ready`/`index_files`/`index_symbols`/durable-ledger facts from the already-proxied `health`/`health_compact` (the daemon DOES serve those, `daemon.rs:2354/2369`) and populate the status context from that.
+- **Anchors:** `tools.rs:8529-8557` (status handler), `:7284` (explore proxy); `daemon.rs:2306,2354,2369,2389,2435`; `protocol/mod.rs:274-281` (proxy defaults), `:587-643` (`ensure_local_index`); `main.rs:267`; `status.rs:51-81` (`from_server`).
+- **Effort:** M. **Risk:** Low-Medium (read-path only; watch for added latency on `status` — it's called rarely, so fine). **Depends on:** none.
+- **Done when:** in daemon mode, `status` index counts match what `explore` sees. **Add the regression test** that's currently missing: spin a daemon (pattern at `daemon.rs:4348`), index a project, assert `status detail=full` reports `index_ready: true` and `index_files > 0`. This test would fail today — that's the point.
+
+### H1 — `if_match` guarded-apply is never enforced at the write (TOCTOU)
+- **Root cause:** `if_match` is checked pre-flight in `run_pre_apply_gates` (`edit_apply.rs:73-79`) under a `read()` lock released at function return; the write runs separately via `replace_symbol_body` (`tools.rs:8458` → `edit_tools.rs:517`), which re-freshens disk, re-resolves, and writes with no `if_match` recheck (token exists only in `types.rs` + `edit_apply.rs`).
+- **Advice:** Close the check-to-write gap. Two viable shapes:
+  - **Recommended:** have the STEL edit handler perform the splice+write itself against the *same* `file.content` bytes it validated `if_match` against, under one held lock — instead of delegating to a second independent resolve in `replace_symbol_body`.
+  - **Alternative:** thread `if_match` (and the resolved byte range) into the write path and re-verify the current symbol body byte-for-byte against `if_match` immediately before `atomic_write_file`, in the same critical section as the splice. On mismatch, abort with a clear conflict error (reuse the idempotency `Conflict` shape).
+- **Anchors:** `edit_apply.rs:38-133` (gates; `:73-79` check; `:118-133` index-vs-disk), `tools.rs:8401,8458`, `edit_tools.rs:517-676`.
+- **Effort:** M. **Risk:** Medium — touches the mutation hot path; must not regress idempotency or the tee snapshot. Keep the change minimal and well-tested. **Depends on:** none, but coordinate with whoever owns `replace_symbol_body`.
+- **Done when:** a test simulates concurrent on-disk change between gate and write and asserts the apply **rejects** rather than clobbering, and that the success response is only emitted when the written bytes match the validated bytes. Until landed, advise that the trust-envelope/docs not claim the apply was `if_match`-guarded.
+
+### H2 — `session_net_vs_manual` is a mislabeled gross counter
+- **Root cause:** Fed `session_context.snapshot().total_tokens` (`tools.rs:8142`), which only increases; no manual term subtracted. (`envelope.rs:47`.)
+- **Advice:** Cheapest honest fix — rename the surfaced field to `session_tokens_served`. Real fix — subtract an accumulated assumed-manual baseline from the ledger to produce a true net (depends on C1-B + a real per-call manual estimate). Recommend the rename now; the true-net only becomes meaningful once C1-B lands.
+- **Anchors:** `envelope.rs:47`, `tools.rs:8142`, `session.rs` (`total_tokens +=`).
+- **Effort:** S. **Risk:** Low. **Done when:** the field name matches its semantics; if it claims "net vs manual" it actually subtracts a manual term.
+
+---
+
+## Tier 1 — Honesty cleanup (cheap, high signal, advise as one batched PR)
+
+### M1 — `l1..l4: active` / `handler_*: active` are unconditional literals
+- **Advice:** Derive each from real wiring. For `l4_ledger`, print `durable` / `in-memory` / `in-memory (durable unavailable)` based on `ctx.durable_ledger.is_some()` + ledger health, resolving the self-contradiction with the `durable_ledger: unavailable` line. Reserve bare "active" for the wired+working case. Anchors: `status.rs:110-116,144-154`. Effort: S.
+
+### M2 — `calibration:` envelope field hardcoded `"pending"`
+- **Advice:** Thread the real `tuning_sufficiency_note`/calibration state into the envelope, or rename to a static `mode:` so it stops implying a live status read. Anchors: `handler.rs:44`, `calibration.rs:30-82`. Effort: S.
+
+### M3 — `error: %` is a dead estimate-vs-estimate readout
+- **Advice:** Either label it informational ("est. vs est."), or — once C1-B + a real tokenizer land — make it a true accuracy signal and feed it into calibration. Don't present it as calibration accuracy while it feeds nothing. Anchors: `handler.rs:71-76`. Effort: S (label) / folds into C1-B (real).
+
+### M4 — Ledger fields `actual_/manual_baseline_` carry estimates/constants
+- **Advice:** Rename `actual_response_tokens` → `estimated_response_tokens`, `manual_baseline_tokens` → `assumed_manual_tokens` until a real tokenizer/measured baseline exists. The predicted-vs-actual *shape* is already correct — keep it; just stop lying in the names. Anchors: `ledger.rs:84-125`, `types.rs:275-276`. Effort: S. (Do together with C1-A.)
+
+### H3 — Multi-hop "A-009 VALIDATED" overstates
+- **Advice:** Doc-only honesty fix — demote A-009 in `docs/phase2-stel-checkpoint.md:120` and `docs/stel-assumptions.md` to PARTIAL/DEMONSTRATED: "3 fixed multi-hop fixtures replay; general query decomposition deferred (= `multi_step_planner`)." This makes the doc agree with the honest `status` `deferred:` line. Optional real work (L, separate program): a general "then"/conjunction decomposer — but that's a feature, not a fix; register it as an assumption first. Anchors: `planner.rs:104-161`. Effort: S (doc).
+
+### H4 — Golden replay never grades equivalence; `expected_equiv` is dead
+- **Advice:** Pick one and commit:
+  - **Real:** capture golden output bodies and assert `expected_equiv` against them, turning the replay into an actual accuracy gate (this is what A-008's "95% trajectory" needs to ever be true).
+  - **Honest-minimal:** strip `expected_equiv` from the fixture and the struct so it stops implying a measurement that never runs; keep the route-shape assertions but rename the test/doc to say "route shape", not "trajectory/equivalence".
+  - Either way: purge any "95% trajectory" claim from README/docs until measured. Also note the tautology smell — tests that feed fixture queries back through `build_plan` are change-detectors, not correctness checks; label them as such.
+- **Anchors:** `golden_replay.rs:244-310`, `types.rs:313`, `fixtures/routes.golden.jsonl`. Effort: S (strip) / M (real grading).
+
+### L4 — `deferred:` list is a stale frozen literal
+- **Advice:** It lists `ledger_persistence` as deferred though the durable store ships in `serve` mode. Compute the list from real feature flags / wiring, or at minimum correct the literal. Anchors: `status.rs:15-16`. Effort: S.
+
+---
+
+## Tier 2 — Hardening (deferred-OK, advise tracking each as a registered item)
+
+- **M5 — durable-ledger silent swallow:** distinguish `durable_ledger: disabled (open failed)` from `unavailable (not wired)` so a silent SQLite open-failure is visible without log access. Anchors: `protocol/mod.rs:338-341`, `ledger_store.rs:184-191,210-216`. Effort: S.
+- **M6 — durable-ledger unbounded growth:** add TTL / capped table / archival + an operator maintenance note. Self-documented at `ledger_store.rs:39-41`. Effort: M.
+- **L1 — in-memory ledger panics on lock poison:** swap `.expect(...)` for `unwrap_or_else(|e| e.into_inner())` to match the durable store's never-panic posture. Anchors: `ledger.rs:26-46`. Effort: S.
+- **L2 — tee "backup" is best-effort, not transactional:** fail closed when a *small*-file snapshot can't be written for `apply:true`; document it as best-effort, not guaranteed undo (relevant to H1's clobber recovery). Anchors: `edit.rs:161-166`, `edit_safety/tee.rs`. Effort: S-M.
+- **L3 — keyless-loopback leaves `/api/v1/keys` mint/rotate/revoke open:** optionally always gate the mutating key routes even on keyless loopback, or document the local-user exposure. Anchors: `auth.rs:150-152`, `serve.rs:338`. Effort: S.
+
+---
+
+## Deepest caveat — the premise itself (advise: register, don't ship-as-proven)
+
+The whole compact surface rests on **A-017** ("tool-selection accuracy degrades past ~30-50 tools") — recorded `OPEN`, "cited, not reproduced." Advice: keep A-017 OPEN and frame v8 in README/release notes as a **bet under test**, matching the assumptions register, until an A/B (compact-3 vs full surface on the same tasks with an LLM in the loop) produces an artifact. This is not a code fix; it is a marketing-honesty fix and the most important one for "trustworthy to LLMs." Same applies to A-011 (predictor ±20%) and A-015/A-016 (calibration) — they gate the truth of C1/C2/M3, so a real calibration battery run is the unlock for the whole economics surface.
+
+---
+
+## Suggested sequencing (a campaign the downstream agent can run)
+
+Gate each phase: code → review → test → live-dogfood the MCP (verify-as-user) before the next.
+
+1. **Phase A — Honesty relabel (S, one PR, no behavior change):** C1-A, H2, M1, M2, M4, L4, plus the doc demotions H3 and the H4 "strip or rename" decision. Outcome: every LLM-facing field is honest *today*, even before any rewire. Lowest risk, highest trust-per-hour.
+2. **Phase B — Status truth (M):** C3 + its regression test. Outcome: `status` stops reporting a working index as empty.
+3. **Phase C — Edit safety (M):** H1 + concurrency test. Outcome: guarded apply is actually guarded. Gate the edit feature's "guaranteed" language on this.
+4. **Phase D — Economics grounding (L):** C1-B (populate `index_refs`, real tokenizer) → C2 (re-decide gate signals) → M3 (live error becomes meaningful) → run a real calibration battery to move A-011 toward VALIDATED. Outcome: the economics surface earns its vocabulary.
+5. **Phase E — Hardening (as capacity allows):** M5, M6, L1, L2, L3.
+6. **Phase F — Premise (separate research):** A-017 / A-008 A/B with artifacts; update README framing.
+
+**Quick-win subset** if time is short: Phase A alone removes essentially all the *dishonesty* findings; H1 and C3 are the two that are *bugs* rather than labels and should not wait long.
+
+---
+
+## Cross-cutting advice
+
+- **Add a "surface honesty" test/CI gate:** a small test that scans the rendered envelope + status for forbidden bare claims ("saved" without "est.", "active" not derived) — so the relabel can't silently regress.
+- **Wire the assumptions register to CI** (the doc already proposes this at `docs/stel-assumptions.md:229-235`): every `OPEN` assumption referenced by a shipped surface = FAIL. This structurally prevents the "register says OPEN, README says proven" gap that caused most findings.
+- **One source of truth per number:** the recurring root cause is two surfaces reading two states (status vs daemon; envelope-predicted vs ledger-actual; doc-verdict vs register). Prefer deriving display strings from the same value the gate/ledger uses.
+- **Treat this doc as advice:** where a recommendation conflicts with a constraint the implementer can see and I can't, follow the constraint and note the deviation. None of these fixes should expand scope into a rewrite; they are relabels, one proxy wire-up, one critical-section tightening, and a calibration program.

--- a/docs/reviews/stel-v8-skeptic-audit-2026-06-17.md
+++ b/docs/reviews/stel-v8-skeptic-audit-2026-06-17.md
@@ -1,0 +1,169 @@
+# SymForge v8 (STEL) — Skeptical Senior-Engineer Audit
+
+- **Date:** 2026-06-17
+- **Target:** SymForge `v8.0.0` (commit `3df5210`), the "STEL" rework — compact L0->L1 MCP facade (`symforge`, `status`, `symforge_edit`) plus a token-economics ledger.
+- **Mandate:** Find overstated code surfaces, dishonest status, claim-vs-reality gaps, and technical fallacies that make the tool untrustworthy to the LLMs that call it or fragile for the users who run it.
+- **Method:** Dogfooded the *live installed* v8.0.0 MCP binary, plus 5 parallel read-only specialist audits (economics, status/index, ledger, planner/routing, security), then independently re-verified every load-bearing claim against source.
+- **Not done (honest scope):** No `cargo build`/`test`/`clippy` was run (read-only, parallel-audit constraint). Findings are from source reading + live MCP dogfooding, not from a fresh build or the full test suite. Live observations are from the deployed daemon-proxy topology; a same-process `serve`/stdio run may differ where noted.
+
+---
+
+## Bottom line
+
+**SymForge's *internal* honesty is good — its *LLM-facing* honesty is not.**
+
+The engineering bones are real: a working SQLite ledger, clean L2/L3 separation, constant-time auth, secure-default startup, genuine path-traversal guards, a candid assumptions register that marks most economics claims `OPEN`, and a `status` `deferred:` list that names unfinished work. The team is not lying to *itself*.
+
+But the three surfaces an LLM actually reads on every call — the **trust envelope**, the **status banner**, and the **`symforge_edit` "guarded apply" contract** — each claim more than the code delivers:
+
+1. The "token economics" that is the entire thesis of v8 is **two hardcoded constants** (`400`, `800`) dressed in measurement vocabulary. The live envelope advertised **"275 saved vs manual"** on a call the tool's own calibration then recorded as a **141-token loss**.
+2. `status` reports a **fully-working index as empty and not-ready** (`index_files: 0`, `index_ready: false`) in the default deployment, because it reads the wrong process.
+3. The advertised **`if_match` write-guard is never enforced at the write** — a real (if race-gated) path to silently clobbering user code.
+
+None of these are fatal, and none require a rewrite. They require either wiring the surfaces to reality, or relabeling them honestly. Until then, an LLM that *trusts* SymForge's self-reported numbers is being misled, which is the precise opposite of what a code-intelligence tool for LLMs needs.
+
+---
+
+## Trust scorecard
+
+| Surface | What it tells the LLM | What the code does | Verdict |
+|---|---|---|---|
+| Trust envelope `…saved vs manual` | A realized token saving | `manual` & `response` are fixed constants (`800`/`400`); realized net was **negative** live | **OVERSTATED / mislabeled** |
+| Envelope `predicted · error %` | A calibration accuracy signal | Estimate-vs-estimate readout, fed into nothing | **OVERSTATED (dead readout)** |
+| Envelope `session_net_vs_manual` | Net savings this session | A monotonically-rising gross token counter; no "manual" term subtracted | **DISHONEST (mislabeled field)** |
+| `status` `index_ready/files/symbols` | Index health | Reads empty front-end proxy shell, not the daemon index that serves queries | **DISHONEST / BUG** |
+| `status` `l1..l4: active`, `handler_*: active` | Subsystem liveness | Unconditional literal strings; never probe real wiring | **OVERSTATED** |
+| `status` `l4_ledger: active` + `durable_ledger: unavailable` | Active durable ledger | In-memory ledger works; durable store only wired in `serve` mode | **OVERSTATED (self-contradicting)** |
+| `symforge_edit` "guarded apply" (`if_match`) | Optimistic-concurrency safety | `if_match` checked pre-flight only; write path never re-checks it | **REAL RISK (data integrity)** |
+| "L1 planner" | Intelligent planning/routing | Deterministic keyword/intent dispatch table | **OVERSTATED naming (code is fine)** |
+| Multi-hop chaining ("A-009 VALIDATED") | Validated multi-step planning | Fires only on 3 hardcoded exact-match query strings | **OVERSTATED verdict** |
+| Golden replay / `expected_equiv` | Routing-accuracy / equivalence measurement | Asserts tool-name shape only; `expected_equiv` is never asserted | **OVERSTATED (unmeasured)** |
+| Auth / secrets / path safety | Secure | Constant-time auth, secure defaults, redacted secrets, traversal guards | **GENUINELY SOLID** |
+| In-memory ledger correctness | Records decisions | Confirmed live: `ledger_events` 0 -> 1 after a serve | **HONEST / works** |
+
+---
+
+## Live evidence (dogfooded v8.0.0)
+
+Three sequential calls to the installed MCP server, same session:
+
+**Call 2 — `symforge` explore** returned accurate symbols + cross-refs from `src/stel/controller.rs`, with this envelope:
+```
+tokens: 816 served · 275 saved vs manual · schema 45 · invoke 80
+predicted: 400 · error: 104.0%
+```
+
+**Call 3 — `status detail=full`**, issued *after* that successful explore:
+```
+ledger_events: 1            <- the process DID record the explore
+session_tokens: 944
+last_ledger_route: explore
+index_ready: false          <- ...yet the index it serves from reports empty
+index_files: 0
+index_symbols: 0
+durable_ledger: unavailable
+predicted_response_tokens: 400
+actual_response_tokens: 816   <- 2x the prediction
+predicted_net_total: -141     <- realized a LOSS vs assumed manual baseline
+```
+
+Two contradictions, observed live, not theorized:
+- The envelope said **+275 saved**; the calibration ledger said **-141 net** (a loss) for the same work.
+- The same process that recorded the explore in its ledger reports its serving index as **empty / not ready**.
+
+---
+
+## Findings (by severity)
+
+### CRITICAL
+
+**C1 — The "token economics" is two hardcoded constants wearing a lab coat.**
+`src/stel/planner.rs:51-53` stamps **every** plan step with `est_response_tokens: 400`, `est_manual_tokens: 800`, and `index_refs: vec![]` (the one field — `IndexRef.raw_chars`, `types.rs:152-155` — designed to ground prediction in real file size is *never populated*). `estimate_economics` (`controller.rs:333-349`) merely sums those constants, so a single-step serve **always** yields `predicted_net_vs_manual = 800 - (400+45+80) = 275`, regardless of query, file, tool, or symbol. The live "275 saved / predicted 400" are not data points; they are the only values this code can emit. A-011 ("`raw_chars` + lines predict response tokens within +/-20%") is `OPEN` in the register precisely because no predictor exists to validate. *Classification: OVERSTATED/DISHONEST.* **Fix:** populate `index_refs.raw_chars` from the live index and compute estimates from real bytes/lines, OR rename these `default_*_heuristic` and drop measurement vocabulary until A-011 validates.
+
+**C2 — The serve/degrade/bypass gate decides on the fiction, and most branches are dead.**
+`evaluate_plan_with_session` (`controller.rs:40-135`) branches on `net = predicted_net_vs_manual`: `<=0` bypass, `<=50` degrade, else serve. Because `net` is a positive constant (>=275) for every plan the real planner emits, **degrade and economics-bypass are unreachable** outside the separate P-FF policy path and cache-hit. So the headline "economics gate" is, for normal queries, a decorative computation that always returns `serve`. Worse, where the economics-bypass *could* fire (it can't, in practice), it tells the host to read lines 1-80 of a file *instead of* running the requested tool (`controller.rs:221-235`) — silent capability loss sold as a token win, gated on an unvalidated constant whose live error was 104%. *Classification: OVERSTATED/DISHONEST + latent BUG (unreachable branch).* **Fix:** gate on a validated predictor or cheap real signals (indexed file size, result count); do not bypass on synthetic economics.
+
+**C3 — `status` reports a working index as empty because it reads the wrong process.**
+In the default production topology the MCP server runs as a **daemon-proxy front-end** (`main.rs:267`, `new_daemon_proxy`). Code tools proxy to the warm daemon index (`explore` -> `self.proxy_tool_call("explore", …)`, `tools.rs:7284`; daemon serves it, `daemon.rs:2389`). But `status_stel_tool` (`tools.rs:8529-8557`) reads the front-end's **own** `self.index` directly with **no proxy**, and that index is empty by design in proxy mode (only ever filled by `ensure_local_index` on daemon failure, `protocol/mod.rs:587-643`). The daemon dispatch has no `status` arm anyway (`daemon.rs:2435` bails "unknown tool"). So `status` and `explore` read two different indices; `status`'s zeros measure the wrong process. Live-confirmed: the index stayed `0/not-ready` even after a successful, ledgered explore. The commit that claims to fix status honesty (`e494fe4`, "honest fusion-empty status P3-7") touches `planner.rs`/`tools.rs`, **not** `status.rs`/the index fields — this contradiction was never addressed. *Classification: DISHONEST/BUG.* **Fix:** proxy `status`'s index/ledger facts to the daemon (add a `status` arm to `daemon.rs::execute_tool_call` and `proxy_tool_call("status", …)` first, mirroring `explore`), or source the counts from the already-proxied `health`. Add a daemon-mode regression test asserting `status` index counts match what `explore` sees.
+
+### HIGH
+
+**H1 — `if_match` guarded-apply is pre-flight-only; the write never re-checks it (TOCTOU).**
+`symforge_edit {apply:true, if_match:X}` validates `if_match` against the *indexed* body inside `run_pre_apply_gates` (`edit_apply.rs:73-79`) under a `read()` lock that is **released when that function returns**. The mutation then runs separately via `replace_symbol_body` (`tools.rs:8458` -> `edit_tools.rs:517`), which re-freshens from disk, re-resolves the symbol, and writes — and **never receives or re-checks `if_match`** (confirmed: the token exists only in `types.rs` + `edit_apply.rs`, nowhere in the write path). Between the two freshens, a concurrent writer (another agent, an editor, `git checkout`, a second `symforge_edit`) can change the file; the second freshen splices against the *new* bytes the caller never validated, the write lands, and the response still reports a successful guarded apply. *Classification: REAL RISK (data integrity), HIGH (race-gated, not one-shot).* **Fix:** re-verify the resolved body byte-for-byte against `if_match` immediately before `atomic_write_file`, in the same critical section as the splice — or have the STEL handler perform the splice+write itself against the bytes it validated rather than delegating to an independent re-resolve.
+
+**H2 — `session_net_vs_manual` is a mislabeled gross counter.**
+The envelope's `session_net_vs_manual` (`envelope.rs:47`) is fed `session_context.snapshot().total_tokens` (`tools.rs:8142`), which only ever *increases* (`session.rs` `total_tokens += tokens`). No "manual" term is ever subtracted. It is gross tokens served, labeled as net savings — so the number grows the more SymForge is used, and A-015 ("matches L4 ledger within +/-1%") cannot hold because the value is not a net at all. *Classification: DISHONEST (mislabeled).* **Fix:** subtract an accumulated manual baseline to produce a true net, or rename to `session_tokens_served`.
+
+**H3 — Multi-hop "VALIDATED" is three magic strings.**
+`plan_multi_hop_steps` (`planner.rs:104-161`) emits a multi-step plan only when the query is *exactly* `"search then fetch cfg_if body"`, `"outline then find connection refs"`, or `"find test.js then read it"` — with hardcoded tool args (`json!({"path":"src/lib.rs","name":"cfg_if"})`). Change one word and it falls through to single-step. The production handler genuinely executes multi-step plans end-to-end (`tools.rs:8193-8217`), so the *execution* is real — but the *planning* is a 3-entry lookup, and `docs/phase2-stel-checkpoint.md:120` marks A-009 `VALIDATED` ("multi-hop internal chain on 3 golden rows"). Replaying 3 pre-baked strings against their pre-baked plans demonstrates a hardcoded path; it does not validate a multi-hop *planner*. The honest `status` line (`multi_step_planner` in `deferred:`) tells the truth; the doc verdict does not. *Classification: OVERSTATED verdict.* **Fix:** demote A-009 to PARTIAL/DEMONSTRATED ("3 fixed fixtures replay; general decomposition deferred").
+
+**H4 — Golden replay never grades equivalence; `expected_equiv` is dead data.**
+Every row in `fixtures/routes.golden.jsonl` carries `"expected_equiv":true`, and the struct has the field (`types.rs:313`), but **no code path asserts it.** `validate_serve_replay_output` (`golden_replay.rs:244-310`) checks that the right tool *name* appears and produced a non-error body — route *shape*, not answer correctness. So the corpus claims "STEL's route is equivalent to the manual answer" on every row while nothing measures equivalence. This is exactly the gap A-008 admits ("95% trajectory metric not numerically measured"). Several "accuracy" tests also feed fixture queries back through `build_plan` and assert they match the fixtures — a change-detector/tautology, not a correctness check. *Classification: OVERSTATED (unmeasured).* **Fix:** assert `expected_equiv` against captured golden bodies, or strip the field so it stops implying a measurement that never runs. Any external "95% trajectory" claim is currently unsupported by code.
+
+### MEDIUM
+
+**M1 — `l1..l4: active` / `handler_*: active` are unconditional literals.** `status.rs:110-116` pushes fixed strings that never probe real wiring; `l4_ledger: active` prints even while `durable_ledger: unavailable` and `ledger_persistence` sit in `deferred:` on the same surface. *Fix:* derive labels from real state (`in-memory` vs `durable` vs `unavailable`); reserve "active" for the wired case.
+
+**M2 — `calibration:` envelope field is hardcoded `"pending"`.** `handler.rs:44` always passes `calibration: "pending"`; it is not a live read of the (honestly observational) calibration module. *Fix:* thread the real tuning state, or rename to a static `mode:`.
+
+**M3 — `error: %` is an estimate-vs-estimate dead readout.** `predict_error_pct` (`handler.rs:71-76`) compares the constant `400` against `body.len()/4` (itself a heuristic, not a tokenizer). The live 104% is the honest tell that the predictor is a constant; the value feeds nothing (no margin, no gate, no tuning). *Fix:* mark informational, or wire a real tokenizer + feedback.
+
+**M4 — Ledger `actual_response_tokens` / `manual_baseline_tokens` carry estimates under "actual"/"baseline" names.** `ledger.rs:84-125`: `actual_response_tokens` is `body.len()/4`; `manual_baseline_tokens` is the constant `800`. The persisted ledger — the thing A-016 calibration would learn from — is seeded with constants it can never learn anything real from. The *shape* is right (predicted and actual stored separately); the *labels* overstate. *Fix:* rename to `estimated_*`/`assumed_*` until a real tokenizer/baseline lands.
+
+**M5 — Durable ledger writes are fire-and-forget with two silent-swallow layers.** `protocol/mod.rs:338-341` spawns the write and drops the result; `ledger_store.rs:210-216` logs-and-continues on insert error; `open` failure degrades to `Disabled` (a no-op) with only a `warn`. An operator can't distinguish "ledger working" from "silently disabled" except via the `durable_ledger:` line. Intentional (FR-011 "never fail the request"), but a real durability gap if ever treated as an audit log. *Fix:* surface `durable_ledger: disabled (open failed)` distinct from `unavailable (not wired)`.
+
+**M6 — Durable ledger table has no retention.** Self-documented at `ledger_store.rs:39-41` ("grows unbounded — no TTL/prune"). Honest, deferred; on a long-lived `serve` host the DB grows one row per invocation forever. *Fix (deferred per their note):* TTL/cap + operator maintenance note.
+
+### LOW
+
+- **L1 — In-memory `SessionLedger` panics on lock poison** (`ledger.rs:26-46` `.expect(...)`) while the durable store deliberately recovers poison — a divergence from the stated never-panic invariant. *Fix:* `unwrap_or_else(|e| e.into_inner())` for parity.
+- **L2 — Tee "backup" is best-effort, not a transactional undo** (`edit.rs:161-166`, `edit_safety/tee.rs`): snapshot failure is non-fatal, files >1 MiB are skipped, snapshots prune after 200 files/7 days, restore is a textual hint. Acceptable as defense-in-depth; should not be presented as a guaranteed rollback for H1's clobber. *Fix:* fail closed when a small-file snapshot can't be written for `apply:true`; document as best-effort.
+- **L3 — Keyless loopback `serve` leaves `/api/v1/keys` mint/rotate/revoke unauthenticated** (`auth.rs:150-152`). Intentional secure-default (Origin gate blocks browser CSRF), but on a shared host any local process can mint a key. *Fix:* always gate mutating key routes, or document the exposure.
+- **L4 — `deferred:` list is a frozen string constant** (`status.rs:15-16`) that lists `ledger_persistence` as deferred even though the durable store ships in `serve` mode — stale literal, misreports shipped capability. *Fix:* compute the list from real feature flags.
+
+---
+
+## What is genuinely good (don't lose this in the noise)
+
+- **The assumptions register (`docs/stel-assumptions.md`) is exemplary.** It marks the economics predictor (A-011), trust-envelope/calibration (A-015/A-016), and the founding premise (A-017) as `OPEN`, and refuses to "raise the threshold to make it pass." The dishonesty is in the shipped surfaces, **not** in the team's record of what's proven.
+- **The ledger is real engineering**, not a Potemkin facade: SQLite with WAL + busy_timeout, idempotent migration, control-char sanitization + field caps (injection/DoS hygiene), poison-recovery on every lock, off-hot-path `spawn_blocking` writes, a bounded shutdown drain that can't hang the server, and a file-reopen test proving rows survive. In-memory recording is confirmed working live (`ledger_events` 0 -> 1).
+- **Security fundamentals are solid:** constant-time bearer auth with length-fold + regression test, refuse-to-start without a key off-loopback, refuse inline `--api-key` (argv leak), fail-closed Origin gating, SHA-256 key store with one-time reveal, redacted AAP preset secret on the surfaced path, and genuine two-layer path-traversal guards (lexical reject of `..`/absolute/scheme, then canonicalized containment check).
+- **Idempotency is genuinely enforcing**, not advisory: `create_dir` atomic create-once reservation, request-hash replay, hard `Conflict` on key+different-request, per-project store (no cross-session bleed), dry-runs don't reserve.
+- **L2/L3 separation and find-fusion semantics show taste:** an empty UNION is correctly downgraded to `EmptyResult` rather than a lying `Found`, and a failed inner multi-hop step becomes `reject` with a failure footer, not a fake serve. The error paths most teams skip are tested.
+- **The planner-is-a-dispatch-table is arguably the right call** for a token gateway — small, deterministic, auditable. The problem is only the word "planner" and the unmeasured accuracy verdicts, not the design.
+
+---
+
+## The deepest caveat
+
+The entire reason-for-being of the v8 compact surface — "LLM tool-selection accuracy degrades past ~30-50 exposed tools, so replace 32 tools with 3" — is **A-017, recorded as `OPEN`, "cited, not reproduced."** Every overstated surface above sits on top of a foundational premise the project itself has not validated on its own corpus. That doesn't make the premise wrong (it's a reasonable industry prior), but it means the whole rework should be framed as a *bet under test*, not a *proven win* — which is exactly how the assumptions register frames it, and exactly how the README/envelope/status do **not**.
+
+---
+
+## Prioritized remediation
+
+**Trust-critical (do before promoting v8 as "token-economical"):**
+1. **C1/C2** — Stop surfacing constant-derived numbers as measured savings. Either ground the predictor in real index data or relabel everything `est.`/`assumed`/`heuristic`. Fix the `session_net_vs_manual` mislabel (H2). This is the #1 LLM-trust issue: the tool currently advertises savings it can post-hoc contradict by 416 tokens (+275 claimed vs -141 realized).
+2. **C3** — Make `status` proxy to the daemon so a working index doesn't report empty; add the daemon-mode regression test.
+3. **H1** — Enforce `if_match` at the write, in the same critical section as the splice. This is a code-mutation safety guarantee that is currently advertised but not kept.
+
+**Honesty cleanup (cheap, high signal-to-noise):**
+4. **M1/M2/M4/L4** — Derive `l1..l4`/`handler_*`/`calibration:`/`deferred:` from real state instead of literals; rename ledger `actual_/manual_` fields.
+5. **H3/H4** — Demote A-009 to PARTIAL; either assert `expected_equiv` or remove it; purge any "95% trajectory" claim from docs/README until measured.
+
+**Hardening (deferred-OK, but track):**
+6. **M5/M6/L1/L2/L3** — distinguish `disabled` vs `unavailable` durable ledger; add ledger retention; panic-harden the in-memory ledger; document tee as best-effort; gate keyless-loopback key routes.
+
+---
+
+## What I could NOT verify
+
+- **No fresh build / full test run** (read-only audit). Whether the suite is currently green is unverified; assertions were read, not executed.
+- **Live topology assumption:** the `index_files: 0` + `durable_ledger: unavailable` cluster is the exact fingerprint of `new_daemon_proxy` (`main.rs:267`) and was reproduced live, but I did not instrument the binary to *prove* daemon mode vs a stdio/`serve` run; a same-process `serve` run would change the durable-ledger and possibly index observations (the C3 status/index split is structural to proxy mode regardless).
+- **Symlink/junction TOCTOU on the write target** (Windows): lexical guards + canonicalize make it low-likelihood, but a post-canonicalize symlink swap before `persist` was not dynamically tested (no live exploitation).
+- **`smart_query::classify_intent` internals** (the `Auto` fallback) were out of scope; likely also rule-based, unconfirmed.
+- The exact wall-clock width of the H1 race window (structural defect confirmed regardless of size).
+
+---
+
+*Audit conducted by dogfooding the live v8.0.0 MCP server and 5 parallel specialist code audits, with every CRITICAL/HIGH claim re-verified against source by the lead. Treat specialist findings as inputs verified here, not as independent gospel.*

--- a/docs/reviews/v8-trust-remediation-advice-2026-06-17.md
+++ b/docs/reviews/v8-trust-remediation-advice-2026-06-17.md
@@ -1,0 +1,414 @@
+# SymForge v8 Trust Remediation — Advisory Effort Document
+
+**Status:** Advice only — no implementation mandate in this file  
+**Audience:** Implementing agent / maintainer on `feat/010-v8-trust-remediation` (or successor)  
+**Date:** 2026-06-17  
+**Scope:** Consolidate all June 2026 review findings into one remediation program  
+**Goal:** Make SymForge **trustworthy to LLMs and robust for users** without rewriting the v8 architecture
+
+---
+
+## 1. How to use this document
+
+This is **guidance**, not a spec kit task list. The implementing agent should:
+
+1. Read the **source reviews** (§2) and **finding registry** (§3).
+2. Pick workstreams in **phase order** (§5); do not start Phase 2 honesty relabeling before Phase 1 index/status truth — agents will still hit dead-end errors.
+3. For each work item, choose an **approach option** (§6) based on time budget and product stance (*honest-heuristic now* vs *real predictor later*).
+4. Close each item with **acceptance checks** (§7) and update **`docs/stel-assumptions.md`** where assumptions move (PARTIAL → VALIDATED or new OPEN).
+5. **Do not** re-litigate items marked FIXED in `external-review-remediation-2026-06-17.md` unless a regression test fails.
+
+If a finding here conflicts with `docs/stel-assumptions.md` phase gates, **the assumptions register wins for “what is proven”**; this doc wins for **“what to fix for agent trust.”**
+
+---
+
+## 2. Source review index
+
+| Document | Role |
+|----------|------|
+| [`stel-v8-skeptic-audit-2026-06-17.md`](./stel-v8-skeptic-audit-2026-06-17.md) | Deepest STEL/economics/status audit; C1–C3, H1–H4, live contradictions |
+| [`skeptical-senior-review-2026-06-17.md`](./skeptical-senior-review-2026-06-17.md) | Compact-surface dead-end, init/CWD, doc drift, dogfood evidence |
+| [`external-review-remediation-2026-06-17.md`](./external-review-remediation-2026-06-17.md) | **Already fixed** security/operator items (do not redo) |
+| [`specs/004-v8-operator-serve/review-findings-2026-06-16.md`](../specs/004-v8-operator-serve/review-findings-2026-06-16.md) | Operator spine; P1-A/B resolved; P3-A/B/C deferred |
+| [`007-review-focus-2026-06-17.md`](./007-review-focus-2026-06-17.md) | Intelligence ports; fusion-empty fixed; footer sentinel sync |
+| [`v8-architecture-review-codex-resume.md`](./v8-architecture-review-codex-resume.md) | Layering rationale; init allow-list undermines STEL |
+| [`agent-review-plan-2026-06-17.md`](./agent-review-plan-2026-06-17.md) | Orchestration template for future verification passes |
+| [`docs/stel-assumptions.md`](../stel-assumptions.md) | Canonical proof state (A-001…A-032) |
+
+**Golden replay baseline:** `cargo test --test stel_golden_replay` → 6/6 pass; 3 tests skip without `tests/fixtures/phase0-corpus/` clone.
+
+---
+
+## 3. Consolidated finding registry
+
+Crosswalk IDs unify reviews. Severity is **agent-trust** severity, not CVE severity.
+
+| ID | Sev | Title | Primary sources | Status |
+|----|-----|-------|-----------------|--------|
+| **TR-01** | P0 | `status` reads empty proxy index while tools serve from daemon index | C3, P0-2 | OPEN |
+| **TR-02** | P0 | Compact surface tells agents to call `index_folder` (blocked on default surface) | P0-1 | OPEN |
+| **TR-03** | P0 | Cold start: MCP sessions with `index_ready: false` / wrong CWD / no root | P0-2, init | OPEN |
+| **TR-04** | P0 | Token economics uses hardcoded 400/800; envelope claims “saved” while ledger shows loss | C1, C2, H1 | OPEN |
+| **TR-05** | P0 | `session_net_vs_manual` is gross tokens, mislabeled as net savings | H2 | OPEN |
+| **TR-06** | P0 | `if_match` checked pre-flight only; write path can TOCTOU-clobber | H1 | OPEN |
+| **TR-07** | P1 | README / AGENTS.md / wiki still say “32 canonical tools” as default | P1-1 | OPEN |
+| **TR-08** | P1 | `symforge init` allow-lists 32+ legacy tools not on compact wire | P1-1, H5 | OPEN |
+| **TR-09** | P1 | Public claims outrun assumptions register (A-011, A-015, A-016 OPEN at 8.0) | P1-2 | OPEN |
+| **TR-10** | P1 | `status` literals (`l*_active`, `handler_*`, `deferred:`) overstate or contradict reality | P1-3, M1, L4 | OPEN |
+| **TR-11** | P2 | Envelope shows positive `session_net` on `decision: reject` | H1 (skeptical) | OPEN |
+| **TR-12** | P2 | A-009 “VALIDATED” vs 3 magic-string multi-hop fixtures | H3 | OPEN (doc) |
+| **TR-13** | P2 | Golden replay checks route shape, not `expected_equiv` | H4 | OPEN |
+| **TR-14** | P2 | `symforge_edit` apply contract vs module “deferred” doc | H3 (skeptical) | OPEN |
+| **TR-15** | P2 | Daemon IPC vs external MCP contract undocumented for operators | H4, P2-4 | DOC |
+| **TR-16** | P3 | Assumptions register duplicate tables (A-005 OPEN vs VALIDATED) | M1 | OPEN |
+| **TR-17** | P3 | Durable ledger: `unavailable` vs `disabled` vs `disabled (open failed)` | M5 | OPEN |
+| **TR-18** | P3 | Ledger retention, migration forward guard, rmcp pin (004 P3-A/B/C) | 004 review | DEFERRED |
+| **TR-19** | — | Security batch (Origin, compact gate, key redaction, ledger drain) | external remediation | **FIXED** |
+| **TR-20** | — | Find-fusion empty union → `EmptyResult` | external remediation | **FIXED** |
+
+---
+
+## 4. North star (definition of done)
+
+Remediation is **complete enough to promote v8 default MCP** when all of the following hold:
+
+1. **Observable truth:** After a successful `symforge` query, `status` reports the **same** index counts the query used (daemon-proxy regression test).
+2. **Recoverable cold start:** Fresh MCP attach to a repo reaches `index_ready: true` **or** returns a compact-surface error that names **only callable** recovery steps.
+3. **Honest economics:** Envelope fields distinguish `heuristic` vs `measured`; no field named `saved` or `net` unless the formula matches the label (or field is renamed).
+4. **Safe apply:** `symforge_edit apply:true` with `if_match` cannot succeed if on-disk body diverged after pre-flight (test with concurrent write simulation).
+5. **Aligned docs:** README + AGENTS.md + init allow-lists describe **compact-3 default**; legacy 32-tool surface documented as opt-out.
+6. **Capability matrix published:** One page mapping features → assumption IDs → Implemented / Heuristic / Observational / Deferred.
+7. **CI green:** Full repo gate per `CLAUDE.md`; golden replay passes; new regression tests for TR-01, TR-02, TR-06.
+
+Partial completion is acceptable for **8.0.1** if TR-01–TR-03 and TR-07–TR-10 ship first; TR-04–TR-06 can follow in **8.0.2** only if economics relabeling ships before any “token savings” marketing.
+
+---
+
+## 5. Phased delivery (recommended)
+
+```text
+Phase 1 — Truth & recovery (agent can use the tool)
+  WS-A Status/index proxy
+  WS-B Compact cold-start & error messages
+  WS-C Init / onboarding / CWD
+
+Phase 2 — Honest surfaces (agent can trust labels)
+  WS-D Status vocabulary & deferred list
+  WS-E Public docs & capability matrix
+  WS-F Envelope & ledger field honesty (relabel before recalibrate)
+
+Phase 3 — Safety & measurement (agent can mutate safely; team can prove claims)
+  WS-G if_match write-path enforcement
+  WS-H Predictor grounding OR explicit heuristic mode
+  WS-I Golden replay & assumption register cleanup
+
+Phase 4 — Operator & deferred hardening (optional 8.1)
+  WS-J Operator docs, ledger retention, P3 items
+```
+
+**Rule:** Do not ship Phase 2 README “token-efficient” language until Phase 2F relabeling lands, or you repeat TR-09.
+
+---
+
+## 6. Workstream advice
+
+### WS-A — Status/index truth (TR-01)
+
+**Problem:** `status_stel_tool` reads `self.index` on the daemon-proxy front-end; proxied tools use the daemon’s warm index. Live: explore works, `index_files: 0`.
+
+**Approach options (pick one):**
+
+| Option | Effort | Pros | Cons |
+|--------|--------|------|------|
+| **A1 — Proxy `status` to daemon** | Medium | Single source of truth; matches explore | Requires new daemon RPC arm + `proxy_tool_call("status", …)` |
+| **A2 — Reuse proxied `health` / `health_compact` fields** | Low–medium | Health already aggregates index facts | Compact surface blocks legacy `health*` unless you embed subset in `status` |
+| **A3 — Populate front-end index in proxy mode** | High | Local reads stay fast | Duplicates daemon state; sync hazard |
+
+**Recommendation:** **A1** first, with **A2** as fallback for index counts only (not full health payload).
+
+**Touch:** `src/protocol/tools.rs` (`status_stel_tool`), `src/protocol/mod.rs` (`proxy_tool_call`), `src/daemon.rs` (`execute_tool_call`), tests mirroring `test_get_repo_map` daemon-proxy patterns.
+
+**Acceptance:** Integration test: daemon-proxy server, successful `symforge` serve, then `status` → `index_files > 0`, `index_ready: true`.
+
+---
+
+### WS-B — Compact recovery & error messages (TR-02, TR-03)
+
+**Problem:** `format.rs` index-not-loaded message references `index_folder`; compact gate rejects it.
+
+**Approach options:**
+
+| Option | Effort | Pros | Cons |
+|--------|--------|------|------|
+| **B1 — Fix root cause: auto-index before first tool** | Medium | Best UX; no new surface | Daemon/CWD/init must be fixed (WS-C) |
+| **B2 — Compact-safe bootstrap via `symforge intent=meta`** | Medium | Keeps 3-tool surface | New routing + docs |
+| **B3 — Surface-aware error strings** | Low | Fast; stops dead-end loop | Doesn’t index by itself |
+| **B4 — Expose `index_folder` on compact** | Low | Minimal code | Violates STEL surface doctrine; re-expands schema story |
+
+**Recommendation:** **B1 + B3** together. **Avoid B4** unless product explicitly abandons compact-3 purity.
+
+**B3 message guidance (compact surface):**
+
+- If index empty and auto-index will run: *“Index loading; retry symforge or call status.”*
+- If auto-index disabled: *“Index empty. Operator: set SYMFORGE_AUTO_INDEX=1 and restart, or SYMFORGE_SURFACE=full for index_folder.”*
+- Never mention a tool name not in `COMPACT_TOOL_NAMES` without naming the env opt-out.
+
+**Touch:** `src/protocol/format.rs`, `src/stel/edit_apply.rs`, STEL chain failure footers in `src/protocol/tools.rs`, `src/main.rs` (`local_empty_reason` → expose via `status` full detail).
+
+---
+
+### WS-C — Init, onboarding, CWD (TR-03, TR-08)
+
+**Problem:** Claude Desktop wrapper `cd`s to `%USERPROFILE%`; MCP env `{}`; allow-lists grant nonexistent tools.
+
+**Advice:**
+
+1. **`symforge init`** should write MCP `env` with documented keys, e.g.:
+   - `SYMFORGE_SURFACE=compact` (explicit, even if default)
+   - Optional `SYMFORGE_PROJECT_ROOT` or pass `--root` in args where client supports it
+   - Platform policy: document why Linux Codex gets `SYMFORGE_NO_DAEMON=1` and Windows does not
+2. **Desktop wrapper:** cd to configured workspace (init prompt) or project root discovered at init time — not `%USERPROFILE%`.
+3. **Allow-lists:** Replace `SYMFORGE_TOOL_NAMES` default with compact-3 names + `status`; move legacy list to a **`--surface full`** init path or separate “legacy client profile.”
+4. **Branch `feat/009-operator-setup-wizard`:** If setup wizard lands, it should become the **single** source of env + root + surface — avoid duplicating init logic.
+
+**Acceptance:** Init integration test: after `init --client codex` in temp repo, simulated MCP env discovers project root; dogfood `status` shows non-zero files without manual `index_folder`.
+
+---
+
+### WS-D — Status vocabulary (TR-10, TR-11)
+
+**Problem:** Unconditional `l4_ledger: active` while `durable_ledger: unavailable`; frozen `DEFERRED_ITEMS` string.
+
+**Advice — replace boolean “active” with enumerated states:**
+
+```text
+l4_ledger: in_memory | in_memory+durable | unavailable
+handler_symforge_edit: preview_only | preview_and_apply
+calibration: observational_insufficient | observational | tuned
+index_state: ready | empty | loading | degraded
+empty_index_reason: <mirror startup local_empty_reason>
+deferred: <computed from feature flags, not const string>
+```
+
+**Touch:** `src/stel/status.rs`, `StelStatusContext` construction in `tools.rs`, update compact/full golden strings in tests.
+
+**Do not:** Remove the deferred concept — it is one of the honest parts; make it **accurate**.
+
+---
+
+### WS-E — Public docs & capability matrix (TR-07, TR-09)
+
+**Deliverables (docs only, but blocking for trust):**
+
+1. **`docs/v8-capability-matrix.md`** (new) — table:
+
+   | Capability | Shipped code | Measured (assumption) | Agent-facing tool |
+   |------------|--------------|------------------------|-------------------|
+   | Compact-3 surface | Yes | A-005 VALIDATED | symforge, status, symforge_edit |
+   | Token predictor ±20% | Heuristic constants | A-011 OPEN | envelope `predicted` |
+   | … | … | … | … |
+
+2. **README.md** — Lead with compact-3; move 32-tool table under “Full surface (`SYMFORGE_SURFACE=full`)”.
+3. **AGENTS.md** + **CLAUDE.md** — Same split; point agents to `status` before bulk symforge.
+4. **CHANGELOG** — Note doc alignment (not a semver break).
+
+**Tone rule:** Use *“heuristic economics (observational)”* not *“proven token savings”* until A-011 closes.
+
+---
+
+### WS-F — Envelope & ledger honesty (TR-04, TR-05, TR-11)
+
+**Two product stances — pick explicitly:**
+
+#### Stance F-Short (recommended for 8.0.1)
+
+**Relabel, don’t recalibrate yet.**
+
+- Rename envelope fields: `estimated_saved_vs_manual_heuristic`, `session_tokens_served` (not `session_net_vs_manual`).
+- Prefix body when `decision != serve`: `economics: observational_heuristic; not_served`.
+- Ledger DB columns: `estimated_response_tokens`, `assumed_manual_baseline` until real tokenizer lands (TR M4).
+- `calibration:` thread real `summarize_calibration` state, not hardcoded `"pending"` (`handler.rs`).
+- Update `docs/stel-assumptions.md`: A-011 remains OPEN but **surfaces no longer imply validation**.
+
+#### Stance F-Long (8.0.2+ / 8.1)
+
+**Ground predictor in index.**
+
+- Populate `IndexRef.raw_chars` in `planner.rs` from live index for path-scoped plans.
+- Derive `est_response_tokens` from bytes/lines + tool-specific caps (start with explore/search_text).
+- Re-run sf-bench subset; move A-011 toward PARTIAL with artifact path.
+
+**Critical:** Stance F-Long without F-Short first **extends the lie window**. Do F-Short first even if F-Long is planned.
+
+**C2 economics gate:** Until predictor is real, consider:
+
+- Narrowing `SERVE_MARGIN` test to use **post-hoc** caps only, or
+- Documenting that L2 gate is **nominal** and serve-always for non-P-FF rows (honest status line: `l2_economics: pass_through_heuristic`).
+
+---
+
+### WS-G — `if_match` write safety (TR-06)
+
+**Problem:** Pre-flight under `read()` lock; `replace_symbol_body` re-resolves from disk without `if_match`.
+
+**Approach options:**
+
+| Option | Effort | Notes |
+|--------|--------|-------|
+| **G1 — Re-check immediately before `atomic_write_file`** | Medium | Minimal API change; keep delegation |
+| **G2 — STEL handler owns splice+write** | Higher | Strongest guarantee; less reuse of edit_tools |
+| **G3 — Pass validated body hash into edit_tools** | Medium | Single hash compare at write |
+
+**Recommendation:** **G1 + test** with temp file mutated between pre-flight and write (must fail apply).
+
+**Also:** Tee snapshot remains best-effort (L2 in skeptic audit); document in tool description — do not claim “transactional undo.”
+
+---
+
+### WS-H — Measurement & assumptions (TR-12, TR-13, TR-16)
+
+**Advice:**
+
+1. **Demote A-009** in `stel-assumptions.md` to **PARTIAL (3 fixture strings; general planner deferred)** — align with `status` `multi_step_planner` deferred.
+2. **Golden replay:** Either implement `expected_equiv` assertion against pinned golden bodies, or remove field from JSONL to stop implying measurement.
+3. **Clone phase0 corpora** into CI (or document mandatory submodule) so skipped tests run in CI.
+4. **Deduplicate assumptions register** — one row per A-ID; generate Phase 0 evidence links from JSON if needed.
+
+**Do not:** Mark A-008 “95% trajectory” VALIDATED without `compare-results.js` + numeric artifact.
+
+---
+
+### WS-I — Operator & deferred (TR-15, TR-17, TR-18)
+
+**Doc-only (quick):**
+
+- Operator guide section: **External MCP contract** = stdio/`/mcp` `call_tool` + compact gate. **Internal** = daemon hook IPC (full tools OK).
+- Distinguish `durable_ledger: unavailable` (stdio/embed) vs `disabled (reason)` (serve open failed).
+
+**Deferred (8.1):** P3-A migration guard, P3-B retention, P3-C rmcp pin — track in `live-code-backlog.md`; don’t block 8.0.1.
+
+---
+
+## 7. Verification gates (mandatory before merge)
+
+Run after **each phase**, not only at end:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo check --all-targets
+cargo test --all-targets -- --test-threads=1
+cargo build --release
+cargo check --no-default-features --features embed
+cd npm && npm test   # if MCP/npm touched
+```
+
+**New tests to add (minimum):**
+
+| Test | Covers |
+|------|--------|
+| `status_index_matches_daemon_proxy_after_symforge_serve` | TR-01 |
+| `compact_surface_index_not_loaded_message_never_mentions_blocked_tools` | TR-02 |
+| `symforge_edit_if_match_rejected_after_concurrent_disk_change` | TR-06 |
+| `envelope_reject_does_not_claim_net_savings` (or renamed fields) | TR-11 |
+| `init_compact_allow_list_matches_list_tools` | TR-08 |
+| `surface_default_compact` (extend existing) | regression TR-19 |
+
+**Dogfood checklist (manual, deployed binary):**
+
+1. Reconnect MCP; `status` compact → note index fields.
+2. `symforge` orient query → succeeds.
+3. `status` full → index counts **match** step 2.
+4. `symforge_edit` preview on known symbol → envelope honest.
+5. Compare envelope `session_*` field names to capability matrix.
+
+---
+
+## 8. Sequencing & dependencies
+
+```mermaid
+flowchart TD
+  A[WS-A Status proxy] --> D[WS-D Status vocabulary]
+  B[WS-B Error messages] --> E[WS-E Docs matrix]
+  C[WS-C Init/CWD] --> B
+  A --> F[WS-F Envelope relabel]
+  D --> E
+  G[WS-G if_match] --> E
+  F --> H[WS-H Measurement]
+  E --> Release[8.0.1 tag candidate]
+  H --> Release2[8.0.2+ optional]
+```
+
+**Parallelizable:** WS-C (init) and WS-A (daemon status) in parallel by different owners; WS-E (docs) can start after WS-D field names are frozen.
+
+**Blockers:** WS-F Stance F-Long **depends on** WS-A (need real index bytes in planner).
+
+---
+
+## 9. Effort sizing (rough, advisory)
+
+| Phase | Workstreams | Person-days (1 senior Rust) | Risk |
+|-------|-------------|----------------------------|------|
+| 1 | A + B + C | 4–7 | Daemon RPC design |
+| 2 | D + E + F-short | 3–5 | Doc churn across wiki |
+| 3 | G + H | 5–10 | Predictor scope creep |
+| 4 | I | 1–2 doc; 3–5 if P3 code | Low urgency |
+
+**Total to “agent-trust MVP” (Phases 1–2):** ~1–2 weeks focused.  
+**Total including predictor + golden equiv (Phase 3):** +2–3 weeks.
+
+---
+
+## 10. What NOT to do
+
+1. **Do not** revert compact-3 default or re-expose 32 tools on the wire “to fix indexing.”
+2. **Do not** mark A-011/A-015/A-016 VALIDATED because labels improved — relabeling ≠ validation.
+3. **Do not** gate daemon hook IPC on compact surface (breaks dogfooding; see TR-19 doc path).
+4. **Do not** run a README “token savings” campaign until WS-F-short ships.
+5. **Do not** conflate **8.0 architecture ship** with **economics proof ship** — the assumptions register already separates these; keep it that way.
+6. **Do not** fix TR-01 by hiding index fields from compact `status` — that trades one lie for another.
+
+---
+
+## 11. Suggested branch / spec structure (for implementing agent)
+
+Optional structure — not prescriptive:
+
+```text
+feat/010-v8-trust-remediation
+├── Phase 1 commits (WS-A,B,C) — "fix(status): proxy index facts in daemon mode"
+├── Phase 2 commits (WS-D,E,F-short) — "docs: v8 capability matrix; relabel envelope"
+├── Phase 3 commits (WS-G,H) — "fix(edit): enforce if_match at write"
+└── specs/010-v8-trust-remediation/  (if using Spec Kit: plan.md + tasks.md mirroring §5–§6)
+```
+
+Merge strategy: **stacked PRs per phase** or single PR with phase labels in commit messages — maintainer preference.
+
+Release: **8.0.1** after Phase 1+2; **8.0.2** after Phase 3 if predictor/heuristic split needs time.
+
+---
+
+## 12. Success metrics (post-remediation)
+
+| Metric | Before | Target |
+|--------|--------|--------|
+| Live `status` index vs served query | Contradictory (0 vs N) | Always consistent |
+| Compact error mentions blocked tools | Yes (`index_folder`) | Never |
+| Envelope field mislabel incidents | `session_net_vs_manual` | Renamed or formula-correct |
+| README default surface | 32 tools | Compact-3 |
+| Open TR-critical items | 6 P0-class | 0 |
+| A-011 status | OPEN (hidden by UI) | OPEN (explicit in matrix) or PARTIAL with artifact |
+
+---
+
+## 13. Closing advice
+
+The v8 rework’s **architecture bet is defensible**; the **trust debt is in the presentation layer** — status, envelope, errors, init, and public docs — not in LiveIndex, auth, or ledger engineering.
+
+The cheapest high-leverage move is **make every LLM-visible string either true or explicitly labeled heuristic**. The most dangerous lingering bug is **TR-01 (status vs daemon index)** because it teaches agents the tool is broken even when it works, and **TR-06 (`if_match`)** because it teaches agents a safety guarantee that is not kept.
+
+Prioritize **truth → recovery → labels → safety → measurement**. The implementing agent has full reports; this document is the map, not the territory.
+
+---
+
+*Advisory document only. No code changes implied by this file.*

--- a/docs/reviews/v8-trust-remediation-ledger.md
+++ b/docs/reviews/v8-trust-remediation-ledger.md
@@ -1,0 +1,132 @@
+# v8 Trust Remediation — Discovery Ledger (seed)
+
+**Status:** SEED — discovery phase, accumulating. Feeds `/speckit-specify` for the
+v8 trust-remediation feature (working dir: `specs/010-v8-trust-remediation/`).
+
+**Keystone:** LLM trust in the tools. Every finding and fix is judged by one
+question — *does this make SymForge more trustworthy and more indispensable for
+real cross-project use, or is it motion?* (See the constitution: III Trust
+Envelopes, VIII Verification Before Done.)
+
+**North-star pillars (ordered):** easy onboarding · proper server architecture ·
+intelligent tools · **above all, LLM trust**.
+
+## Method
+
+- **Two independent external reviews** + live dogfood + the project's own
+  assumptions register. Two-reviewer agreement on a finding = high confidence.
+- **Code is gospel.** Every reviewer claim is re-verified against live code
+  BEFORE any fix. Reviewers' traces are inputs, not verdicts — several came from
+  source-reading without a fresh build.
+- **No ad-hoc fixes.** The remediation runs the full speckit lifecycle
+  (discovery → specify → clarify → plan → tasks → implement → review), gated.
+- **Tool surface + STEL layers are IN SCOPE** (not frozen): the compact-3 rework
+  rests on A-017, which the register marks OPEN / cited-not-reproduced. Surface
+  changes are the highest blast radius — evidence-led only, no hidden capability
+  cliffs.
+
+## Sources
+
+| ID | Source | State |
+|----|--------|-------|
+| R1 | `docs/reviews/skeptical-senior-review-2026-06-17.md` (Cursor skeptical-senior pass) | **IN** ✓ |
+| R2 | second external reviewer | **PENDING** (slot reserved below) |
+| DF | operator live dogfood (parallel run) | partial signals folded as corroboration |
+| REG | `docs/stel-assumptions.md` assumptions register | reference |
+
+> A separate WIP audit file exists in `docs/reviews/` but is **in-the-making and
+> deliberately excluded** from this ledger until finalized — do not build on it.
+
+## Status legend
+
+`CLAIMED` reviewer-asserted, not yet re-verified here · `VERIFIED` re-traced
+against live code · `CORROBORATED` independently seen in dogfood (still pending
+code-trace) · `BY-DESIGN` · `WONTFIX` · `FIXED-ALREADY` · `DEFERRED` ·
+`DUPLICATE`.
+
+---
+
+## Findings (from R1 — pending my code-verification + R2 overlap)
+
+| L-ID | R1 | Sev | Title | Status | Trust impact | Proposed disposition | Anchors (R1-claimed) |
+|------|----|-----|-------|--------|--------------|----------------------|----------------------|
+| L-001 | P0-1 | P0 | Compact-surface recovery dead-end: error says "Call `index_folder`" but it isn't on compact-3 → unrecoverable agent loop | CORROBORATED (DF saw `index_ready:false`) | **Severe** — tool instructs an action it forbids; agent stuck | FIX. Make indexing reachable on compact surface and/or rewrite every compact-path error to name a *callable* recovery (never `index_folder`) | `format.rs`, `surface.rs`, `surface_probe.rs`, `mod.rs` |
+| L-002 | P0-2 | P0 | Cold start with empty index in real MCP sessions (daemon-proxy root not attached; Desktop wrapper CWD=`%USERPROFILE%`; init `env:{}`) | CORROBORATED | **Severe** — agent believes SymForge is connected; all queries fail until invisible operator fix | FIX. Init sets proven env (workspace root, surface, auto-index); desktop wrapper cd/`--root`; compact `status` surfaces actionable empty-index reason | `main.rs`, `init.rs` (`create_desktop_wrapper_windows`), `new_daemon_proxy` |
+| L-003 | P1-1 | P1 | Public docs describe v7 32-tool surface as canonical (README, AGENTS.md, init allow-lists, CHANGELOG "README rewrite" not actually done) | CLAIMED | **High** — trains agents + allow-lists on a non-default surface; false affordances | FIX. Rewrite README + AGENTS.md for compact-3 default + `SYMFORGE_SURFACE=full` opt-out; reconcile init allow-lists with on-wire tools | `README.md`, `AGENTS.md`, `init.rs` (`SYMFORGE_TOOL_NAMES`) |
+| L-004 | P1-2 | P1 | Phase gates vs ship date: A-015/A-016/A-011/A-008 OPEN/PARTIAL at 8.0.0, but surfaces read as validated product claims | CLAIMED | **High** — "trust envelope"/"token-efficient" implied proven | FIX (honesty). Publish an explicit **8.0.0 capability matrix**: Implemented / Measured / Observational / Deferred, tied to assumption IDs + `status` `deferred:` | `docs/stel-assumptions.md` |
+| L-005 | P1-3 | P1 | `status` labels overstate deferred subsystems (`l4_ledger: active` while `durable_ledger: unavailable`; `ledger_persistence` deferred) | CORROBORATED | **High** — "active" reads production-ready; agent can't tell in-memory vs durable | FIX. Vocabulary `in_memory_only \| durable \| disabled \| unavailable`; align module doc ↔ status strings | `status.rs`, `mod.rs` (module doc) |
+| L-006 | H1 | High | Token-economics envelope uncalibrated (predict error ~85% live; A-011 OPEN); `session_net_vs_manual:+N` printed alongside `decision: reject` reads as success | CORROBORATED (DF 104% error) | **High** — LLM trained to read "+saved" as success is misled on a reject | FIX. On `decision != serve`, prefix `economics_status: uncalibrated_*` or suppress net-saved line on reject/degrade/bypass-fail | economics envelope formatter |
+| L-007 | H2 | High | Routing confidence `inferred` dominates; planner fallbacks burn schema+invoke tokens before failing on empty index | CLAIMED | Med-High — bad economics on errors; A-008 PARTIAL | VERIFY then decide (cheap-fail on low-confidence empty-index path) | planner / routing |
+| L-008 | H3 | High | `symforge_edit` apply path: `status` advertises `preview-and-apply`; module doc says apply deferred; apply gates on index with the P0-1 `index_folder` message | CLAIMED | High — agents lack a single documented edit flow | FIX. One documented flow (preview → `apply:true`+`if_match`), readiness preconditions in the tool description; reconcile status vs module doc | `edit_apply.rs`, module doc, `status.rs` |
+| L-009 | H4 | High→P3 | Daemon IPC bypasses compact gate (already documented/by-design for hooks/dogfooding) | BY-DESIGN (per `external-review-remediation-2026-06-17.md` P2-4) | Low (internal) — confusing externally | DOC only: operator guide — external contract = gated `/mcp` + stdio `call_tool`; hooks ≠ harness surface | `daemon.rs::execute_tool_call` |
+| L-010 | H5 | High | Init/client config not updated for v8 cutover: no `SYMFORGE_SURFACE` escape doc; uneven cold-start (Linux Codex `SYMFORGE_NO_DAEMON=1`); legacy allow-list names = false affordances | CLAIMED | High — overlaps L-002/L-003 | FIX with L-002/L-003 (init env + allow-list reconciliation) | `init.rs` |
+| L-011 | M1 | Med | Assumptions register internal inconsistency (A-005 OPEN in top table, VALIDATED in Phase-0 table) | CLAIMED | Med — external readers misled | FIX. Single source of truth per assumption ID | `docs/stel-assumptions.md` |
+| L-012 | M2 | Med | README "every truncation disclosed with real cost" vs maturity — audit all formatters for silent truncation under `max_tokens` on the `symforge` path | CLAIMED | Med — trust-envelope claim | VERIFY (audit formatters); fix or hedge the claim | `controller.rs`, formatters |
+| L-013 | M3 | Med | Feature 007 find-fusion both-empty→`Found` was OPEN; external remediation claims FIXED (`EmptyResult`) — confirm live post-index | CLAIMED | Low — likely already FIXED-ALREADY (P3-7 in 010) | VERIFY live on deployed binary | `tools.rs` (`symforge_stel_handler`) |
+| L-014 | M4 | Med | `edition = "2024"` in `Cargo.toml` — note for downstream packagers (not a bug if toolchain pinned) | CLAIMED | Low | NOTE only | `Cargo.toml` |
+
+### Already-tracked / can-defer (from R1's "can defer", reconcile — don't re-find)
+
+- P3-A ledger migration forward guard, P3-B retention — tracked in 004 review; DEFERRED.
+- P3-C rmcp version pin drift — tracked; DEFERRED.
+- A-020..A-022 transport/unification (Phase 4) — out of scope this slice.
+
+---
+
+## Cross-cutting workstream: the claims-honesty sweep
+
+R1's "Overstated surfaces" checklist is the honesty hit-list — these are the
+keystone (trust) items. Each shipped surface must say only what's proven:
+
+| Claim (surface) | R1: actual state | Action |
+|-----------------|------------------|--------|
+| "32 canonical MCP tools" (README/AGENTS) | default = **3** | rewrite for compact-3 default (L-003) |
+| "token-efficient" / trust envelope (README hero) | predictor OPEN; live error ~85%; calibration insufficient | hedge to observational + capability matrix (L-004, L-006) |
+| `l4_ledger: active` | session yes; durable deferred/unavailable on stdio | status vocabulary (L-005) |
+| `handler_symforge_edit: preview-and-apply` | apply gated; module doc says deferred | reconcile + document flow (L-008) |
+| Phase 3 gate "A-015/A-016 validated" | OPEN at ship | capability matrix (L-004) |
+| "Call index_folder" recovery | blocked on compact surface | rewrite error (L-001) |
+| init allow-lists (32 legacy names) | ≠ MCP `list_tools` (3) | reconcile (L-003/L-010) |
+
+**Foundational premise to settle:** A-017 ("tool accuracy degrades past ~30–50
+tools") justifies the entire 32→3 rework and is **OPEN / cited-not-reproduced**.
+The remediation must either (a) reproduce/measure it on our corpus, or (b) frame
+v8 as a *bet under test* (not a proven win) across all surfaces — matching how
+the register already frames it.
+
+## Protect (genuinely-good — must not regress)
+
+R1 credits, and these are load-bearing moat — the refactor must NOT break them:
+compact dispatch enforcement (P1-A, gate before router, not list-only); the
+security remediation batch (Origin gate, admin asset auth split, AAP key
+redaction, ledger drain); embed isolation + coherent semver story; golden-replay
++ phase-2 gate machinery; the byte-exact snapshot / quarantine / idempotency
+index-integrity model (7.x moat STEL sits on top of); and the assumptions
+register itself (the most trustworthy doc in the repo — keep it the source of
+truth).
+
+## Proposed remediation tranches (from R1's queue — becomes the spec's breakdown)
+
+1. **P0 trust-critical (block "agent-ready default"):** L-001 + L-002 — indexing
+   reachable on the compact surface without hidden env; fix init/CWD/daemon root.
+2. **Honesty of shipped surfaces:** L-003 (README/AGENTS/allow-lists), L-004
+   (capability matrix), L-005 (status vocabulary), L-006 (envelope on reject).
+3. **Edit-flow + routing clarity:** L-008, L-007.
+4. **Doc + register hygiene:** L-009 (operator-guide note), L-011, L-012.
+5. **Verify-not-fix:** L-013 (find-fusion live), L-014 (note).
+
+---
+
+## Reserved: Reviewer 2 (PENDING)
+
+> When R2 lands: enter its findings here, **dedup against L-001..L-014** (same
+> file/symptom → merge, take highest severity, mark two-reviewer agreement =
+> high confidence), then re-verify each surviving finding against live code
+> before it enters the remediation spec.
+
+## Next step
+
+1. Await R2; fold + dedup into this ledger.
+2. Re-verify every surviving finding against live code (code is gospel).
+3. `/speckit-specify` the remediation from this verified set → clarify → plan →
+   tasks → implement → review, gated. P0 trust items + the honesty sweep lead.

--- a/docs/reviews/v8-trust-remediation-ledger.md
+++ b/docs/reviews/v8-trust-remediation-ledger.md
@@ -1,132 +1,134 @@
-# v8 Trust Remediation — Discovery Ledger (seed)
+# v8 Trust Remediation — Discovery Ledger
 
-**Status:** SEED — discovery phase, accumulating. Feeds `/speckit-specify` for the
-v8 trust-remediation feature (working dir: `specs/010-v8-trust-remediation/`).
+**Status:** DISCOVERY COMPLETE (both reviews in) — pending code-verification of
+load-bearing findings before `/speckit-specify` into `specs/010-v8-trust-remediation/`.
 
-**Keystone:** LLM trust in the tools. Every finding and fix is judged by one
-question — *does this make SymForge more trustworthy and more indispensable for
-real cross-project use, or is it motion?* (See the constitution: III Trust
-Envelopes, VIII Verification Before Done.)
+**Keystone:** LLM trust in the tools. Every finding/fix judged by — *does this make
+SymForge more trustworthy and more indispensable for real cross-project use, or is
+it motion?* (Constitution: III Trust Envelopes, VIII Verification Before Done.)
 
 **North-star pillars (ordered):** easy onboarding · proper server architecture ·
 intelligent tools · **above all, LLM trust**.
 
 ## Method
 
-- **Two independent external reviews** + live dogfood + the project's own
-  assumptions register. Two-reviewer agreement on a finding = high confidence.
-- **Code is gospel.** Every reviewer claim is re-verified against live code
-  BEFORE any fix. Reviewers' traces are inputs, not verdicts — several came from
-  source-reading without a fresh build.
-- **No ad-hoc fixes.** The remediation runs the full speckit lifecycle
-  (discovery → specify → clarify → plan → tasks → implement → review), gated.
-- **Tool surface + STEL layers are IN SCOPE** (not frozen): the compact-3 rework
-  rests on A-017, which the register marks OPEN / cited-not-reproduced. Surface
-  changes are the highest blast radius — evidence-led only, no hidden capability
-  cliffs.
+- **Two independent external reviews** + a consolidated advisory + live dogfood +
+  the assumptions register. **Two-reviewer agreement = high confidence.**
+- **Code is gospel.** Every claim re-verified against live code BEFORE any fix.
+  Both reviews are source-reading + live dogfood, NO fresh build/test — so the
+  load-bearing CRITICALs get a code-trace pass here first.
+- **No ad-hoc fixes.** Full speckit lifecycle (discovery → specify → clarify →
+  plan → tasks → implement → review), gated each phase.
+- **Surface + STEL layers IN SCOPE** but evidence-led; **no hidden capability
+  cliffs**; do NOT revert compact-3 to "fix" indexing (see Do-Not list).
 
 ## Sources
 
 | ID | Source | State |
 |----|--------|-------|
-| R1 | `docs/reviews/skeptical-senior-review-2026-06-17.md` (Cursor skeptical-senior pass) | **IN** ✓ |
-| R2 | second external reviewer | **PENDING** (slot reserved below) |
-| DF | operator live dogfood (parallel run) | partial signals folded as corroboration |
-| REG | `docs/stel-assumptions.md` assumptions register | reference |
+| R1 | `skeptical-senior-review-2026-06-17.md` (compact dead-end, init/CWD, doc drift) | **IN** ✓ |
+| R2 | `stel-v8-skeptic-audit-2026-06-17.md` (economics-constants, status-wrong-process, if_match TOCTOU) | **IN** ✓ |
+| ADV | `v8-trust-remediation-advice-2026-06-17.md` (consolidated TR-01..TR-20, phases, DoD) | **IN** ✓ |
+| REG | `docs/stel-assumptions.md` (A-001..A-032 proof state) | reference |
+| FIXED | `external-review-remediation-2026-06-17.md` (security batch + fusion-empty already shipped) | do-not-redo |
 
-> A separate WIP audit file exists in `docs/reviews/` but is **in-the-making and
-> deliberately excluded** from this ledger until finalized — do not build on it.
+## Verification legend
 
-## Status legend
-
-`CLAIMED` reviewer-asserted, not yet re-verified here · `VERIFIED` re-traced
-against live code · `CORROBORATED` independently seen in dogfood (still pending
-code-trace) · `BY-DESIGN` · `WONTFIX` · `FIXED-ALREADY` · `DEFERRED` ·
-`DUPLICATE`.
+`AGREED` both reviewers (high confidence) · `CLAIMED` one reviewer, not yet
+code-traced · `VERIFIED` re-traced here against live code · `BY-DESIGN` ·
+`FIXED-ALREADY` · `DEFERRED` · `DOC`.
 
 ---
 
-## Findings (from R1 — pending my code-verification + R2 overlap)
+## Canonical finding crosswalk (TR-01..TR-20 from ADV; the register of record)
 
-| L-ID | R1 | Sev | Title | Status | Trust impact | Proposed disposition | Anchors (R1-claimed) |
-|------|----|-----|-------|--------|--------------|----------------------|----------------------|
-| L-001 | P0-1 | P0 | Compact-surface recovery dead-end: error says "Call `index_folder`" but it isn't on compact-3 → unrecoverable agent loop | CORROBORATED (DF saw `index_ready:false`) | **Severe** — tool instructs an action it forbids; agent stuck | FIX. Make indexing reachable on compact surface and/or rewrite every compact-path error to name a *callable* recovery (never `index_folder`) | `format.rs`, `surface.rs`, `surface_probe.rs`, `mod.rs` |
-| L-002 | P0-2 | P0 | Cold start with empty index in real MCP sessions (daemon-proxy root not attached; Desktop wrapper CWD=`%USERPROFILE%`; init `env:{}`) | CORROBORATED | **Severe** — agent believes SymForge is connected; all queries fail until invisible operator fix | FIX. Init sets proven env (workspace root, surface, auto-index); desktop wrapper cd/`--root`; compact `status` surfaces actionable empty-index reason | `main.rs`, `init.rs` (`create_desktop_wrapper_windows`), `new_daemon_proxy` |
-| L-003 | P1-1 | P1 | Public docs describe v7 32-tool surface as canonical (README, AGENTS.md, init allow-lists, CHANGELOG "README rewrite" not actually done) | CLAIMED | **High** — trains agents + allow-lists on a non-default surface; false affordances | FIX. Rewrite README + AGENTS.md for compact-3 default + `SYMFORGE_SURFACE=full` opt-out; reconcile init allow-lists with on-wire tools | `README.md`, `AGENTS.md`, `init.rs` (`SYMFORGE_TOOL_NAMES`) |
-| L-004 | P1-2 | P1 | Phase gates vs ship date: A-015/A-016/A-011/A-008 OPEN/PARTIAL at 8.0.0, but surfaces read as validated product claims | CLAIMED | **High** — "trust envelope"/"token-efficient" implied proven | FIX (honesty). Publish an explicit **8.0.0 capability matrix**: Implemented / Measured / Observational / Deferred, tied to assumption IDs + `status` `deferred:` | `docs/stel-assumptions.md` |
-| L-005 | P1-3 | P1 | `status` labels overstate deferred subsystems (`l4_ledger: active` while `durable_ledger: unavailable`; `ledger_persistence` deferred) | CORROBORATED | **High** — "active" reads production-ready; agent can't tell in-memory vs durable | FIX. Vocabulary `in_memory_only \| durable \| disabled \| unavailable`; align module doc ↔ status strings | `status.rs`, `mod.rs` (module doc) |
-| L-006 | H1 | High | Token-economics envelope uncalibrated (predict error ~85% live; A-011 OPEN); `session_net_vs_manual:+N` printed alongside `decision: reject` reads as success | CORROBORATED (DF 104% error) | **High** — LLM trained to read "+saved" as success is misled on a reject | FIX. On `decision != serve`, prefix `economics_status: uncalibrated_*` or suppress net-saved line on reject/degrade/bypass-fail | economics envelope formatter |
-| L-007 | H2 | High | Routing confidence `inferred` dominates; planner fallbacks burn schema+invoke tokens before failing on empty index | CLAIMED | Med-High — bad economics on errors; A-008 PARTIAL | VERIFY then decide (cheap-fail on low-confidence empty-index path) | planner / routing |
-| L-008 | H3 | High | `symforge_edit` apply path: `status` advertises `preview-and-apply`; module doc says apply deferred; apply gates on index with the P0-1 `index_folder` message | CLAIMED | High — agents lack a single documented edit flow | FIX. One documented flow (preview → `apply:true`+`if_match`), readiness preconditions in the tool description; reconcile status vs module doc | `edit_apply.rs`, module doc, `status.rs` |
-| L-009 | H4 | High→P3 | Daemon IPC bypasses compact gate (already documented/by-design for hooks/dogfooding) | BY-DESIGN (per `external-review-remediation-2026-06-17.md` P2-4) | Low (internal) — confusing externally | DOC only: operator guide — external contract = gated `/mcp` + stdio `call_tool`; hooks ≠ harness surface | `daemon.rs::execute_tool_call` |
-| L-010 | H5 | High | Init/client config not updated for v8 cutover: no `SYMFORGE_SURFACE` escape doc; uneven cold-start (Linux Codex `SYMFORGE_NO_DAEMON=1`); legacy allow-list names = false affordances | CLAIMED | High — overlaps L-002/L-003 | FIX with L-002/L-003 (init env + allow-list reconciliation) | `init.rs` |
-| L-011 | M1 | Med | Assumptions register internal inconsistency (A-005 OPEN in top table, VALIDATED in Phase-0 table) | CLAIMED | Med — external readers misled | FIX. Single source of truth per assumption ID | `docs/stel-assumptions.md` |
-| L-012 | M2 | Med | README "every truncation disclosed with real cost" vs maturity — audit all formatters for silent truncation under `max_tokens` on the `symforge` path | CLAIMED | Med — trust-envelope claim | VERIFY (audit formatters); fix or hedge the claim | `controller.rs`, formatters |
-| L-013 | M3 | Med | Feature 007 find-fusion both-empty→`Found` was OPEN; external remediation claims FIXED (`EmptyResult`) — confirm live post-index | CLAIMED | Low — likely already FIXED-ALREADY (P3-7 in 010) | VERIFY live on deployed binary | `tools.rs` (`symforge_stel_handler`) |
-| L-014 | M4 | Med | `edition = "2024"` in `Cargo.toml` — note for downstream packagers (not a bug if toolchain pinned) | CLAIMED | Low | NOTE only | `Cargo.toml` |
+> The advice doc's TR IDs already dedup both reviews + my R1 seed (L-001..L-014).
+> Adopting TR as canonical. **`verify?` = must code-trace before it enters the
+> spec** (load-bearing or could be by-design).
 
-### Already-tracked / can-defer (from R1's "can defer", reconcile — don't re-find)
+| TR | Sev | Title | Confidence | verify? | Disposition |
+|----|-----|-------|-----------|---------|-------------|
+| **TR-01** | P0 | `status` reads empty proxy index while tools serve from the daemon index (root cause of `index_ready:false` + working `explore`) | **AGREED** (R2 C3 + R1 P0-2 + dogfood) | **YES** — trace `status_stel_tool` (tools.rs ~8529), `proxy_tool_call`, daemon `execute_tool_call` | FIX: proxy status index facts to daemon (or reuse proxied health subset) + regression test |
+| **TR-02** | P0 | Compact surface error says "Call `index_folder`" — not on compact-3 → unrecoverable loop | AGREED (R1 P0-1 + dogfood) | YES — `format.rs` msg, `surface.rs` set, gate | FIX: auto-index path + every compact error names only callable recovery |
+| **TR-03** | P0 | Cold start: empty index / wrong CWD (`%USERPROFILE%`) / `env:{}` in real MCP sessions | AGREED (R1+R2) | YES — `main.rs`, `init.rs` desktop wrapper, `new_daemon_proxy` | FIX: init writes proven env (root/surface/auto-index); wrapper cd/`--root` |
+| **TR-04** | P0 | Token economics = hardcoded 400/800; `index_refs` always empty → `predicted_net` always 275; envelope "saved" while ledger shows loss | **AGREED** (R2 C1/C2 + R1 H1 + dogfood −141 vs +275) | **YES** — `planner.rs:51-53`, `controller.rs:333-349`, `evaluate_plan_with_session` | FIX (honesty-first): relabel `est_/heuristic`; later ground predictor in real bytes (do NOT relabel=validate) |
+| **TR-05** | P0 | `session_net_vs_manual` is a gross rising counter mislabeled as net savings | AGREED (R2 H2) | YES — `envelope.rs`, `session.rs` total_tokens | FIX: subtract manual baseline OR rename `session_tokens_served` |
+| **TR-06** | P0 | `if_match` checked pre-flight only; write path re-resolves + writes with NO recheck → TOCTOU clobber | **AGREED** (R2 H1) — **real data-integrity bug** | **YES** — `edit_apply.rs:73-79` → `tools.rs:8458` → `edit_tools.rs:517` | FIX: re-verify bytes vs `if_match` in the same critical section as the splice + concurrent-write test |
+| TR-07 | P1 | README/AGENTS/wiki say "32 canonical tools" as default | AGREED (R1 P1-1) | low (doc) | FIX: compact-3 default, 32 under `SYMFORGE_SURFACE=full` |
+| TR-08 | P1 | `init` allow-lists 32+ legacy tools not on compact wire (false affordances) | AGREED (R1 P1-1/H5) | YES — `init.rs` `SYMFORGE_TOOL_NAMES` | FIX: compact-3 allow-list default; legacy under `--surface full` |
+| TR-09 | P1 | Public claims outrun register (A-011/A-015/A-016 OPEN at 8.0) | AGREED | doc | FIX: publish 8.0 capability matrix (Implemented/Heuristic/Observational/Deferred) |
+| TR-10 | P1 | `status` literals (`l*_active`, `handler_*`, `deferred:`) overstate/contradict | AGREED (R1 P1-3 + R2 M1/L4) | YES — `status.rs` | FIX: enumerated states (`in_memory\|durable\|unavailable`); compute `deferred:` from flags |
+| TR-11 | P2 | Envelope shows positive `session_net` on `decision: reject` | AGREED | YES | FIX: suppress/relabel net on non-serve |
+| TR-12 | P2 | A-009 "VALIDATED" = 3 magic-string multi-hop fixtures | AGREED (R2 H3) | YES — `planner.rs:104-161` | FIX (doc): demote A-009 → PARTIAL |
+| TR-13 | P2 | Golden replay checks route shape, not `expected_equiv` (dead field) | AGREED (R2 H4) | YES — `golden_replay.rs:244-310` | FIX: assert `expected_equiv` vs golden bodies OR remove field; purge "95%" claims |
+| TR-14 | P2 | `symforge_edit` apply contract vs module "deferred" doc | AGREED (R1 H3) | YES | FIX: one documented flow + reconcile status/module doc |
+| TR-15 | P2 | Daemon IPC vs external MCP contract undocumented | BY-DESIGN (P2-4) | DOC | DOC: operator guide — external = gated `/mcp`+stdio; hooks ≠ harness surface |
+| TR-16 | P3 | Assumptions register duplicate tables (A-005 OPEN vs VALIDATED) | CLAIMED (R1 M1) | low | FIX: single source per A-ID |
+| TR-17 | P3 | Durable ledger `unavailable` vs `disabled (open failed)` indistinguishable | CLAIMED (R2 M5) | YES — `ledger_store.rs` | FIX: distinguish states |
+| TR-18 | P3 | Ledger retention / migration guard / rmcp pin (004 P3-A/B/C) | DEFERRED | — | track in backlog; not 8.0.1-blocking |
+| TR-19 | — | Security batch (Origin/compact gate/key redaction/ledger drain) | **FIXED-ALREADY** | regression-only | do not redo (010 remediation) |
+| TR-20 | — | Find-fusion empty union → `EmptyResult` | **FIXED-ALREADY** | verify live | confirm on deployed binary (TR-13 covers equiv) |
 
-- P3-A ledger migration forward guard, P3-B retention — tracked in 004 review; DEFERRED.
-- P3-C rmcp version pin drift — tracked; DEFERRED.
-- A-020..A-022 transport/unification (Phase 4) — out of scope this slice.
-
----
-
-## Cross-cutting workstream: the claims-honesty sweep
-
-R1's "Overstated surfaces" checklist is the honesty hit-list — these are the
-keystone (trust) items. Each shipped surface must say only what's proven:
-
-| Claim (surface) | R1: actual state | Action |
-|-----------------|------------------|--------|
-| "32 canonical MCP tools" (README/AGENTS) | default = **3** | rewrite for compact-3 default (L-003) |
-| "token-efficient" / trust envelope (README hero) | predictor OPEN; live error ~85%; calibration insufficient | hedge to observational + capability matrix (L-004, L-006) |
-| `l4_ledger: active` | session yes; durable deferred/unavailable on stdio | status vocabulary (L-005) |
-| `handler_symforge_edit: preview-and-apply` | apply gated; module doc says deferred | reconcile + document flow (L-008) |
-| Phase 3 gate "A-015/A-016 validated" | OPEN at ship | capability matrix (L-004) |
-| "Call index_folder" recovery | blocked on compact surface | rewrite error (L-001) |
-| init allow-lists (32 legacy names) | ≠ MCP `list_tools` (3) | reconcile (L-003/L-010) |
-
-**Foundational premise to settle:** A-017 ("tool accuracy degrades past ~30–50
-tools") justifies the entire 32→3 rework and is **OPEN / cited-not-reproduced**.
-The remediation must either (a) reproduce/measure it on our corpus, or (b) frame
-v8 as a *bet under test* (not a proven win) across all surfaces — matching how
-the register already frames it.
-
-## Protect (genuinely-good — must not regress)
-
-R1 credits, and these are load-bearing moat — the refactor must NOT break them:
-compact dispatch enforcement (P1-A, gate before router, not list-only); the
-security remediation batch (Origin gate, admin asset auth split, AAP key
-redaction, ledger drain); embed isolation + coherent semver story; golden-replay
-+ phase-2 gate machinery; the byte-exact snapshot / quarantine / idempotency
-index-integrity model (7.x moat STEL sits on top of); and the assumptions
-register itself (the most trustworthy doc in the repo — keep it the source of
-truth).
-
-## Proposed remediation tranches (from R1's queue — becomes the spec's breakdown)
-
-1. **P0 trust-critical (block "agent-ready default"):** L-001 + L-002 — indexing
-   reachable on the compact surface without hidden env; fix init/CWD/daemon root.
-2. **Honesty of shipped surfaces:** L-003 (README/AGENTS/allow-lists), L-004
-   (capability matrix), L-005 (status vocabulary), L-006 (envelope on reject).
-3. **Edit-flow + routing clarity:** L-008, L-007.
-4. **Doc + register hygiene:** L-009 (operator-guide note), L-011, L-012.
-5. **Verify-not-fix:** L-013 (find-fusion live), L-014 (note).
+**6 P0-class trust items (TR-01..TR-06).** TR-01, TR-04, TR-06 are the most
+load-bearing: status that lies about a working index, economics that contradicts
+itself by 416 tokens, and a safety guarantee (`if_match`) that isn't kept.
 
 ---
 
-## Reserved: Reviewer 2 (PENDING)
+## Phased plan (from ADV §5 — becomes the spec breakdown)
 
-> When R2 lands: enter its findings here, **dedup against L-001..L-014** (same
-> file/symptom → merge, take highest severity, mark two-reviewer agreement =
-> high confidence), then re-verify each surviving finding against live code
-> before it enters the remediation spec.
+```
+Phase 1 — Truth & recovery   : WS-A status/index proxy (TR-01) · WS-B compact errors (TR-02) · WS-C init/CWD (TR-03/08)
+Phase 2 — Honest surfaces    : WS-D status vocab (TR-10/11) · WS-E docs+capability matrix (TR-07/09) · WS-F envelope/ledger relabel (TR-04/05)
+Phase 3 — Safety & measure   : WS-G if_match at write (TR-06) · WS-H predictor grounding OR explicit heuristic (TR-04 long) · WS-I golden equiv + register cleanup (TR-12/13/16)
+Phase 4 — Operator/deferred  : WS-J operator docs (TR-15/17) + deferred P3 (TR-18)
+```
+
+**Hard rule:** do NOT ship Phase 2 README "token-efficient" language before WS-F
+relabel lands (else you re-open TR-09). **Truth → recovery → labels → safety →
+measurement.** Likely **8.0.1** after Phase 1+2; **8.0.2** after Phase 3.
+
+## Definition of done (ADV §4 — acceptance bar)
+
+1. `status` index counts == what the served query used (daemon-proxy regression test).
+2. Fresh attach reaches `index_ready:true` OR a compact error naming only callable recovery.
+3. Envelope fields distinguish `heuristic` vs `measured`; no `saved`/`net` unless the formula matches.
+4. `symforge_edit apply:true` + `if_match` cannot succeed if on-disk body diverged (concurrent-write test).
+5. README/AGENTS/init allow-lists describe compact-3 default; 32-tool = opt-out.
+6. Capability matrix published (features → assumption IDs → Implemented/Heuristic/Observational/Deferred).
+7. Full gate green + golden replay + new regression tests for TR-01, TR-02, TR-06.
+
+## Do NOT (ADV §10 — guardrails)
+
+1. Do NOT revert compact-3 / re-expose 32 tools on the wire to "fix indexing".
+2. Do NOT mark A-011/A-015/A-016 VALIDATED because labels improved — **relabel ≠ validate**.
+3. Do NOT gate daemon hook IPC on compact surface (breaks dogfooding).
+4. Do NOT run a "token savings" doc campaign until WS-F relabel ships.
+5. Do NOT conflate 8.0 architecture-ship with economics-proof-ship.
+6. Do NOT "fix" TR-01 by hiding index fields from compact `status` (one lie for another).
+
+## Protect (must NOT regress)
+
+Compact dispatch enforcement (gate-before-router); the security remediation batch
+(TR-19); embed isolation + semver coherence; golden-replay/phase-2 gate machinery;
+the byte-exact snapshot / quarantine / idempotency index-integrity moat; and the
+assumptions register itself (keep it the source of truth — it's the most honest
+doc in the repo and the reason these reviews could even be written).
+
+## A-017 — the premise under the whole rework
+
+"Tool accuracy degrades past ~30–50 tools" justifies 32→3 and is **OPEN /
+cited-not-reproduced**. Remediation must either reproduce/measure it on our corpus
+OR frame v8 as a *bet under test* across all surfaces (as the register already
+does). Not a blocker for the honesty fixes; it IS the frame for the capability matrix.
+
+---
 
 ## Next step
 
-1. Await R2; fold + dedup into this ledger.
-2. Re-verify every surviving finding against live code (code is gospel).
-3. `/speckit-specify` the remediation from this verified set → clarify → plan →
-   tasks → implement → review, gated. P0 trust items + the honesty sweep lead.
+1. **Verify the load-bearing CRITICALs against live code** (code is gospel, `verify?=YES`):
+   TR-01 (status wrong-process), TR-04 (economics constants), TR-06 (if_match TOCTOU)
+   first — confirm file:line claims, rule out by-design, before they enter the spec.
+2. `/speckit-specify` 010 from the verified set → clarify → plan → tasks →
+   implement → review, gated. Phase 1 (truth/recovery) + the honesty sweep lead.
+3. Update `docs/stel-assumptions.md` where assumptions move; never relabel=validate.

--- a/docs/reviews/v8-trust-remediation-ledger.md
+++ b/docs/reviews/v8-trust-remediation-ledger.md
@@ -1,134 +1,139 @@
-# v8 Trust Remediation — Discovery Ledger
+# v8 Trust Remediation — Discovery Ledger (VERIFIED)
 
-**Status:** DISCOVERY COMPLETE (both reviews in) — pending code-verification of
-load-bearing findings before `/speckit-specify` into `specs/010-v8-trust-remediation/`.
+**Status:** DISCOVERY COMPLETE. Two external reviews + two advisory programs +
+a 5-agent code-verification panel, all converged. Ready for `/speckit-specify`
+into `specs/010-v8-trust-remediation/`.
 
-**Keystone:** LLM trust in the tools. Every finding/fix judged by — *does this make
-SymForge more trustworthy and more indispensable for real cross-project use, or is
-it motion?* (Constitution: III Trust Envelopes, VIII Verification Before Done.)
-
-**North-star pillars (ordered):** easy onboarding · proper server architecture ·
+**Keystone:** LLM trust in the tools. (Constitution III Trust Envelopes, VIII
+Verification Before Done.) Pillars: easy onboarding · proper server architecture ·
 intelligent tools · **above all, LLM trust**.
 
-## Method
+## Convergence
 
-- **Two independent external reviews** + a consolidated advisory + live dogfood +
-  the assumptions register. **Two-reviewer agreement = high confidence.**
-- **Code is gospel.** Every claim re-verified against live code BEFORE any fix.
-  Both reviews are source-reading + live dogfood, NO fresh build/test — so the
-  load-bearing CRITICALs get a code-trace pass here first.
-- **No ad-hoc fixes.** Full speckit lifecycle (discovery → specify → clarify →
-  plan → tasks → implement → review), gated each phase.
-- **Surface + STEL layers IN SCOPE** but evidence-led; **no hidden capability
-  cliffs**; do NOT revert compact-3 to "fix" indexing (see Do-Not list).
+The load-bearing findings are **triple-confirmed**: two independent skeptical
+reviews flagged them, and a 5-agent read-only panel re-traced every claim against
+live 8.0.0 code (`feat/010` @ 711ee68) — confirming all CRITICAL/HIGH items, with
+**several worse than reported** and a few corrected. This is high-confidence
+discovery, not report-trust.
 
 ## Sources
 
 | ID | Source | State |
 |----|--------|-------|
-| R1 | `skeptical-senior-review-2026-06-17.md` (compact dead-end, init/CWD, doc drift) | **IN** ✓ |
-| R2 | `stel-v8-skeptic-audit-2026-06-17.md` (economics-constants, status-wrong-process, if_match TOCTOU) | **IN** ✓ |
-| ADV | `v8-trust-remediation-advice-2026-06-17.md` (consolidated TR-01..TR-20, phases, DoD) | **IN** ✓ |
-| REG | `docs/stel-assumptions.md` (A-001..A-032 proof state) | reference |
-| FIXED | `external-review-remediation-2026-06-17.md` (security batch + fusion-empty already shipped) | do-not-redo |
+| R1 | `skeptical-senior-review-2026-06-17.md` | IN ✓ |
+| R2 | `stel-v8-skeptic-audit-2026-06-17.md` | IN ✓ |
+| ADV1 | `v8-trust-remediation-advice-2026-06-17.md` (R1 program: TR phases) | IN ✓ |
+| ADV2 | `stel-v8-remediation-advice-2026-06-17.md` (R2 program: T0/T1/T2 tiers, CI gates, relabel-spine) | IN ✓ |
+| PANEL | 5-agent verification (status, economics, edit-safety, surface/init, measurement) | IN ✓ |
+| REG | `docs/stel-assumptions.md` | reference |
 
-## Verification legend
+## Two spine rules (from ADV2 — adopt)
 
-`AGREED` both reviewers (high confidence) · `CLAIMED` one reviewer, not yet
-code-traced · `VERIFIED` re-traced here against live code · `BY-DESIGN` ·
-`FIXED-ALREADY` · `DEFERRED` · `DOC`.
-
----
-
-## Canonical finding crosswalk (TR-01..TR-20 from ADV; the register of record)
-
-> The advice doc's TR IDs already dedup both reviews + my R1 seed (L-001..L-014).
-> Adopting TR as canonical. **`verify?` = must code-trace before it enters the
-> spec** (load-bearing or could be by-design).
-
-| TR | Sev | Title | Confidence | verify? | Disposition |
-|----|-----|-------|-----------|---------|-------------|
-| **TR-01** | P0 | `status` reads empty proxy index while tools serve from the daemon index (root cause of `index_ready:false` + working `explore`) | **AGREED** (R2 C3 + R1 P0-2 + dogfood) | **YES** — trace `status_stel_tool` (tools.rs ~8529), `proxy_tool_call`, daemon `execute_tool_call` | FIX: proxy status index facts to daemon (or reuse proxied health subset) + regression test |
-| **TR-02** | P0 | Compact surface error says "Call `index_folder`" — not on compact-3 → unrecoverable loop | AGREED (R1 P0-1 + dogfood) | YES — `format.rs` msg, `surface.rs` set, gate | FIX: auto-index path + every compact error names only callable recovery |
-| **TR-03** | P0 | Cold start: empty index / wrong CWD (`%USERPROFILE%`) / `env:{}` in real MCP sessions | AGREED (R1+R2) | YES — `main.rs`, `init.rs` desktop wrapper, `new_daemon_proxy` | FIX: init writes proven env (root/surface/auto-index); wrapper cd/`--root` |
-| **TR-04** | P0 | Token economics = hardcoded 400/800; `index_refs` always empty → `predicted_net` always 275; envelope "saved" while ledger shows loss | **AGREED** (R2 C1/C2 + R1 H1 + dogfood −141 vs +275) | **YES** — `planner.rs:51-53`, `controller.rs:333-349`, `evaluate_plan_with_session` | FIX (honesty-first): relabel `est_/heuristic`; later ground predictor in real bytes (do NOT relabel=validate) |
-| **TR-05** | P0 | `session_net_vs_manual` is a gross rising counter mislabeled as net savings | AGREED (R2 H2) | YES — `envelope.rs`, `session.rs` total_tokens | FIX: subtract manual baseline OR rename `session_tokens_served` |
-| **TR-06** | P0 | `if_match` checked pre-flight only; write path re-resolves + writes with NO recheck → TOCTOU clobber | **AGREED** (R2 H1) — **real data-integrity bug** | **YES** — `edit_apply.rs:73-79` → `tools.rs:8458` → `edit_tools.rs:517` | FIX: re-verify bytes vs `if_match` in the same critical section as the splice + concurrent-write test |
-| TR-07 | P1 | README/AGENTS/wiki say "32 canonical tools" as default | AGREED (R1 P1-1) | low (doc) | FIX: compact-3 default, 32 under `SYMFORGE_SURFACE=full` |
-| TR-08 | P1 | `init` allow-lists 32+ legacy tools not on compact wire (false affordances) | AGREED (R1 P1-1/H5) | YES — `init.rs` `SYMFORGE_TOOL_NAMES` | FIX: compact-3 allow-list default; legacy under `--surface full` |
-| TR-09 | P1 | Public claims outrun register (A-011/A-015/A-016 OPEN at 8.0) | AGREED | doc | FIX: publish 8.0 capability matrix (Implemented/Heuristic/Observational/Deferred) |
-| TR-10 | P1 | `status` literals (`l*_active`, `handler_*`, `deferred:`) overstate/contradict | AGREED (R1 P1-3 + R2 M1/L4) | YES — `status.rs` | FIX: enumerated states (`in_memory\|durable\|unavailable`); compute `deferred:` from flags |
-| TR-11 | P2 | Envelope shows positive `session_net` on `decision: reject` | AGREED | YES | FIX: suppress/relabel net on non-serve |
-| TR-12 | P2 | A-009 "VALIDATED" = 3 magic-string multi-hop fixtures | AGREED (R2 H3) | YES — `planner.rs:104-161` | FIX (doc): demote A-009 → PARTIAL |
-| TR-13 | P2 | Golden replay checks route shape, not `expected_equiv` (dead field) | AGREED (R2 H4) | YES — `golden_replay.rs:244-310` | FIX: assert `expected_equiv` vs golden bodies OR remove field; purge "95%" claims |
-| TR-14 | P2 | `symforge_edit` apply contract vs module "deferred" doc | AGREED (R1 H3) | YES | FIX: one documented flow + reconcile status/module doc |
-| TR-15 | P2 | Daemon IPC vs external MCP contract undocumented | BY-DESIGN (P2-4) | DOC | DOC: operator guide — external = gated `/mcp`+stdio; hooks ≠ harness surface |
-| TR-16 | P3 | Assumptions register duplicate tables (A-005 OPEN vs VALIDATED) | CLAIMED (R1 M1) | low | FIX: single source per A-ID |
-| TR-17 | P3 | Durable ledger `unavailable` vs `disabled (open failed)` indistinguishable | CLAIMED (R2 M5) | YES — `ledger_store.rs` | FIX: distinguish states |
-| TR-18 | P3 | Ledger retention / migration guard / rmcp pin (004 P3-A/B/C) | DEFERRED | — | track in backlog; not 8.0.1-blocking |
-| TR-19 | — | Security batch (Origin/compact gate/key redaction/ledger drain) | **FIXED-ALREADY** | regression-only | do not redo (010 remediation) |
-| TR-20 | — | Find-fusion empty union → `EmptyResult` | **FIXED-ALREADY** | verify live | confirm on deployed binary (TR-13 covers equiv) |
-
-**6 P0-class trust items (TR-01..TR-06).** TR-01, TR-04, TR-06 are the most
-load-bearing: status that lies about a working index, economics that contradicts
-itself by 416 tokens, and a safety guarantee (`if_match`) that isn't kept.
+1. **Honesty contract for LLM-facing surfaces:** every string an LLM reads
+   (`status`, the economics envelope, error/recovery text, tool descriptions,
+   README/AGENTS) is **either true or explicitly labeled heuristic/observational/
+   deferred**. No field named `saved`/`net`/`active`/`validated` unless the code
+   matches the word.
+2. **Relabel is a valid fix.** Cheap-honest beats dishonest-confident. Relabeling
+   a constant `est_/heuristic` (zero behavior change) is a legitimate, shippable
+   remediation — but **relabel ≠ validate** (never mark A-011/A-015/A-016/A-028
+   VALIDATED because a label improved).
 
 ---
 
-## Phased plan (from ADV §5 — becomes the spec breakdown)
+## Verified crosswalk (panel verdicts)
 
-```
-Phase 1 — Truth & recovery   : WS-A status/index proxy (TR-01) · WS-B compact errors (TR-02) · WS-C init/CWD (TR-03/08)
-Phase 2 — Honest surfaces    : WS-D status vocab (TR-10/11) · WS-E docs+capability matrix (TR-07/09) · WS-F envelope/ledger relabel (TR-04/05)
-Phase 3 — Safety & measure   : WS-G if_match at write (TR-06) · WS-H predictor grounding OR explicit heuristic (TR-04 long) · WS-I golden equiv + register cleanup (TR-12/13/16)
-Phase 4 — Operator/deferred  : WS-J operator docs (TR-15/17) + deferred P3 (TR-18)
-```
+`sev*` = panel-corrected agent-trust severity.
 
-**Hard rule:** do NOT ship Phase 2 README "token-efficient" language before WS-F
-relabel lands (else you re-open TR-09). **Truth → recovery → labels → safety →
-measurement.** Likely **8.0.1** after Phase 1+2; **8.0.2** after Phase 3.
+| TR | Verdict | sev* | Confirmed (one-line) | Anchor |
+|----|---------|------|----------------------|--------|
+| **TR-01** | **CONFIRMED — worse** | P0 | `status_stel_tool` reads the empty front-end `self.index`; every other reader proxies; daemon has **no `status` arm**; `health` proxies but is full-surface-only → **no honest compact index-health tool exists**. Fix: proxy `status` to daemon + add daemon arm + regression test. | tools.rs ~8529/8541, mod.rs:266, daemon.rs ~2435 |
+| **TR-02** | **CONFIRMED — worse** | P0 | "Call index_folder" reaches the agent via **37 `loading_guard!`** sites through the `symforge` facade, and **4 distinct compact-reachable strings** name `index_folder`. Fix: one surface-aware `empty_index_recovery_hint(profile)` (never name a gated tool). | format.rs:4774, edit_apply.rs:48, tools.rs:6033, edit_tools.rs:263 |
+| **TR-03** | **CONFIRMED — root-cause corrected** | P0 | Root cause is the Desktop wrapper `cd /d "%USERPROFILE%"` → `find_project_root()`=None → no root → no daemon → empty index (NOT the daemon-attach path). The **default** Desktop cold-start trap; init writes `env:{}`. | init.rs:837, main.rs:217-248, init.rs:761 |
+| **TR-04** | **CONFIRMED** | P0 | `400/800` stamped on every step (planner ~51-53), `index_refs`/`raw_chars` structurally inert → predicted_net always 275. **A real byte-grounded estimator already exists in `format.rs:4925-5029` and is simply not wired** — grounding is wiring, not building. | planner.rs:44-55, controller.rs:333-348, types.rs:152 |
+| **TR-04b** | **CONFIRMED** | P1 | Gate decides on the constant → `degrade`/economics-`bypass` unreachable from the live planner (not dead code — dead from real input). **+ a 3rd dead branch: `mandatory_degrade`** (Fallback confidence) never fires → low-confidence routes get no economic guardrail. | controller.rs:40-135 (55-128, 75-76) |
+| **TR-05** | **CONFIRMED** | P0 | `session_net_vs_manual` = `session_context.total_tokens` (monotonic gross, only `+=`), no manual subtracted, printed with `+`. Most misleading line (never negative). | tools.rs:8142, session.rs:69, envelope.rs:47 |
+| **TR-06** | **CONFIRMED — worse** | P0(High) | `if_match` is **structurally absent** from the write path (`ReplaceSymbolBodyInput` has no field; planner drops it). Two separate read locks; wide async window with disk re-read. **Real data-integrity bug** (silent clobber + success receipt); repo's 5-agent model hits it normally. Tee = zero protection. | edit_apply.rs:73-91, edit_planner.rs:72, edit.rs:1160, edit_tools.rs:570-676 |
+| TR-07 | CONFIRMED — line fix | P1 | README "32 canonical tools" at **L24 + L328** (not L128); AGENTS.md:125; **CLAUDE.md:34 also stale**. Default is 3. | README.md:24,328 · AGENTS.md:125 |
+| TR-08 | **CONFIRMED — cosmetic** | P2 | Allow-list has **35** names (deliberately pinned to the full router, init.rs:1877); the 3 compact tools ARE present so the user is **not blocked** — 32 are dead grants/false affordances. Downgrade "blocks users". | init.rs:430-466, 1867-1883 |
+| TR-09 | CONFIRMED | P1 | A-011/A-015/A-016 OPEN at ship; surfaces imply validation. Fix: capability matrix. | stel-assumptions.md |
+| **TR-10** | **PARTIAL — corrected** | P2 | All **7** `l*/handler_*` literals are unprobed (not just l4); `l4_ledger:active` is literally true for the always-on in-memory layer (reframe: compact omits durable state); `ledger_persistence` stale in `deferred:` (durable ships in serve). **+ `summary()` swallows DB errors as None → disabled≡broken.** | status.rs:15-16,104-122; ledger_store.rs:230 |
+| TR-11 | CONFIRMED | P2 | Positive `session_net` on `decision:reject` (sub-case of TR-05). | executor.rs:347-366, envelope.rs:47 |
+| **TR-12** | **PARTIAL — doc only** | P2 | Planner IS a 3-magic-string lookup, **but multi-step plans DO execute in production**. Real defect = doc vs status: A-009 "VALIDATED" vs `multi_step_planner` deferred. Fix: demote A-009 → PARTIAL (doc). | planner.rs:104-161, phase2-checkpoint.md:120 |
+| TR-13 | CONFIRMED | P2 | `expected_equiv` is write-only dead data; replay grades route-shape only; "accuracy" tests are tautologies (fixture query → build_plan → assert fixture). **+ A-028 falsely VALIDATED** ("not route shape alone" — but it is). Fix: assert or remove `expected_equiv`; demote A-028; purge "95% trajectory". | golden_replay.rs:244-310, types.rs:313, stel-assumptions.md:129 |
+| TR-14 | **PARTIAL — Low** | P3 | `status` "preview-and-apply" is the TRUTHFUL line; `mod.rs:14` module doc is **stale** (apply IS wired); status output internally consistent. Doc drift only. (But it advertises a guard TR-06 doesn't keep.) | status.rs:116, mod.rs:14 |
+| TR-15 | BY-DESIGN | DOC | Daemon hook IPC ≠ external MCP contract. Operator-guide note. | daemon.rs |
+| TR-16 | CONFIRMED | P3 | A-005 OPEN (line 77) vs VALIDATED (line 146); evidence (891B) supports VALIDATED but vs draft shapes. Single-source. | stel-assumptions.md:77,146 |
+| TR-17 | CONFIRMED | P3 | `unavailable` (not wired) vs `disabled (open failed)` indistinguishable. | ledger_store.rs |
+| TR-18 | DEFERRED | — | P3-A/B/C (migration guard, retention, rmcp pin). Backlog. | 004 review |
+| **TR-19** | FIXED-ALREADY | — | Security batch — do not redo; regression-only. | external-remediation |
+| **TR-20** | **VERIFIED FIXED** | — | P3-7 empty-union → `EmptyResult` present + correctly placed on the live handler. | tools.rs:8219-8233 |
 
-## Definition of done (ADV §4 — acceptance bar)
+## New findings (panel-discovered, beyond both reviews)
 
-1. `status` index counts == what the served query used (daemon-proxy regression test).
-2. Fresh attach reaches `index_ready:true` OR a compact error naming only callable recovery.
-3. Envelope fields distinguish `heuristic` vs `measured`; no `saved`/`net` unless the formula matches.
-4. `symforge_edit apply:true` + `if_match` cannot succeed if on-disk body diverged (concurrent-write test).
-5. README/AGENTS/init allow-lists describe compact-3 default; 32-tool = opt-out.
+- **N-1 — `CalibrationState` is fully dead** (types.rs:292-298): `ema_predict_error`/`fudge_multiplier` constructed/read **nowhere**. `calibration: "pending"` will never resolve — it's permanently inert, not transient. Label `deferred`/`observational`.
+- **N-2 — `mandatory_degrade` 3rd dead branch** (controller.rs:75-76): low-confidence Fallback routes get **no** economic guardrail (served at full budget).
+- **N-3 — `summary()` error-swallow** (ledger_store.rs:230 `.ok()`): a wired-but-failing durable store reports identical to a never-configured one. Distinguish `disabled(reason)` vs `unavailable`.
+- **N-4 — bytes/4 conflated with "tokens"** everywhere (handler.rs:8-10): every "tokens" figure (envelope, ledger `actual_response_tokens`, session) is `len/4`, an unstated approximation — even the "honest" actuals.
+- **N-5 — 4 dead-end recovery strings** (not 1): TR-02 anchors above; centralize.
+- **N-6 — batch-edit `if_match` gap**: batch executors have no `if_match` plumbing; if extended, same TOCTOU. `verify_index_matches_disk` is also pre-flight-only (false safety control).
+- **N-7 — A-028 falsely VALIDATED** (stel-assumptions.md:129): contradicted by the validator's own source.
+
+## The good news (leverage + protect — do NOT regress)
+
+- **The real estimator exists** (`format.rs:4925-5029`, `competent_manual_baseline_chars` / `saved_tokens_vs_competent_manual`) — TR-04 grounding is one import away.
+- **The compact gate is clean** — pure `(profile,name)->bool`, single chokepoint (`mod.rs:935`), shared stdio+HTTP, conformance test against the real gate. The dead-end is a *message* defect on a *correct* gate.
+- **Find-fusion union semantics + P3-7 (TR-20)** correctly shaped + live. Security batch (TR-19), embed isolation, idempotency, path guards, the SQLite ledger engineering, and the **assumptions register itself** are genuinely solid moat. The trust debt is in the **presentation layer**, not the engine.
+
+---
+
+## Consolidated remediation program (ADV1 phases ∪ ADV2 tiers)
+
+**Tiers (ADV2):** T0 trust-critical = TR-04/04b (economics constants+gate), TR-01
+(status proxy), TR-06 (if_match TOCTOU), TR-05 (mislabel). T1 honesty cleanup
+(one batched, zero-behavior PR) = TR-10/N-1/N-3/M-labels + TR-12/13 doc demotions +
+TR-07/08/09 docs+matrix. T2 hardening = TR-17/N-6/TR-18 + ledger retention.
+
+**Phase order (ADV2 sequencing — truth → recovery → labels → safety → measure):**
+- **Phase A — Relabel** (1 PR, zero behavior): kills *all* dishonesty today — envelope `est_/heuristic`, `session_tokens_served`, `calibration: deferred`, status enumerated states, drop stale `ledger_persistence`/demote A-009/A-028. Quick-win.
+- **Phase B — Status truth**: TR-01 proxy + N-3, regression test.
+- **Phase C — Edit safety**: TR-06 `if_match` at write (+ N-6 note), concurrent-write test.
+- **Phase D — Recovery + onboarding**: TR-02 surface-aware errors + TR-03 wrapper-CWD/init-env (+ overlaps the parked 009 wizard).
+- **Phase E — Grounding + measurement**: TR-04 wire the real estimator (reuse format.rs) → reopens degrade/bypass legitimately; TR-13 assert-or-remove `expected_equiv`.
+- **Phase F — Premise + matrix + CI gates**: capability matrix; frame v8 as *bet under test* (A-017/A-011 stay OPEN); cross-cutting CI.
+
+**Hard rule:** Phase A (relabel) ships BEFORE any README "token-efficient"
+language (else re-open TR-09). The two **real bugs** (TR-01, TR-06) + Phase A are
+the highest-leverage quick-win.
+
+**Cross-cutting CI (ADV2):** a surface-honesty gate; wire the assumptions register
+to CI (**OPEN + shipped-claim = FAIL**); one-source-of-truth per number.
+
+## Definition of done (acceptance bar)
+
+1. `status` index counts == the served query's (daemon-proxy regression test).
+2. Fresh attach → `index_ready:true` OR a compact error naming only callable recovery.
+3. Envelope distinguishes `heuristic` vs `measured`; no `saved`/`net` unless the formula matches.
+4. `symforge_edit apply:true`+`if_match` cannot succeed if on-disk body diverged (concurrent-write test).
+5. README/AGENTS/CLAUDE.md/init allow-lists describe compact-3 default; 32 = opt-out.
 6. Capability matrix published (features → assumption IDs → Implemented/Heuristic/Observational/Deferred).
 7. Full gate green + golden replay + new regression tests for TR-01, TR-02, TR-06.
 
-## Do NOT (ADV §10 — guardrails)
+## Do NOT (guardrails)
 
-1. Do NOT revert compact-3 / re-expose 32 tools on the wire to "fix indexing".
-2. Do NOT mark A-011/A-015/A-016 VALIDATED because labels improved — **relabel ≠ validate**.
-3. Do NOT gate daemon hook IPC on compact surface (breaks dogfooding).
-4. Do NOT run a "token savings" doc campaign until WS-F relabel ships.
-5. Do NOT conflate 8.0 architecture-ship with economics-proof-ship.
-6. Do NOT "fix" TR-01 by hiding index fields from compact `status` (one lie for another).
-
-## Protect (must NOT regress)
-
-Compact dispatch enforcement (gate-before-router); the security remediation batch
-(TR-19); embed isolation + semver coherence; golden-replay/phase-2 gate machinery;
-the byte-exact snapshot / quarantine / idempotency index-integrity moat; and the
-assumptions register itself (keep it the source of truth — it's the most honest
-doc in the repo and the reason these reviews could even be written).
-
-## A-017 — the premise under the whole rework
-
-"Tool accuracy degrades past ~30–50 tools" justifies 32→3 and is **OPEN /
-cited-not-reproduced**. Remediation must either reproduce/measure it on our corpus
-OR frame v8 as a *bet under test* across all surfaces (as the register already
-does). Not a blocker for the honesty fixes; it IS the frame for the capability matrix.
+1. Don't revert compact-3 / re-expose 32 tools to "fix indexing".
+2. **Relabel ≠ validate** — don't mark A-011/A-015/A-016/A-028 VALIDATED for a label.
+3. Don't gate daemon hook IPC on compact (breaks dogfooding).
+4. Don't run a "token savings" doc campaign until Phase A ships.
+5. Don't conflate 8.0 architecture-ship with economics-proof-ship.
+6. Don't "fix" TR-01 by hiding index fields (one lie for another).
+7. Don't delete dead seams (CalibrationState) — relabel honestly; don't fail a request for a ledger nicety.
 
 ---
 
 ## Next step
 
-1. **Verify the load-bearing CRITICALs against live code** (code is gospel, `verify?=YES`):
-   TR-01 (status wrong-process), TR-04 (economics constants), TR-06 (if_match TOCTOU)
-   first — confirm file:line claims, rule out by-design, before they enter the spec.
-2. `/speckit-specify` 010 from the verified set → clarify → plan → tasks →
-   implement → review, gated. Phase 1 (truth/recovery) + the honesty sweep lead.
-3. Update `docs/stel-assumptions.md` where assumptions move; never relabel=validate.
+Discovery is **done and verified**. `/speckit-specify` 010 from this set →
+clarify → plan → tasks → implement → review, gated. Phase A (relabel) +
+TR-01/TR-06 (the two real bugs) lead. Surface/STEL-layer changes stay evidence-led
+(A-017 OPEN → bet-under-test framing, never a proven-win claim).

--- a/specs/010-v8-trust-remediation/checklists/requirements.md
+++ b/specs/010-v8-trust-remediation/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: v8 Trust Remediation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec is value-level (honest surfaces, true status, safe apply, recoverable
+  start, grounded/labeled economics, published capability record + enforced
+  honesty). The HOW (code anchors, fix shapes, the TR-01..TR-20 crosswalk) lives
+  in `docs/reviews/v8-trust-remediation-ledger.md` and is deliberately kept out of
+  the spec.
+- Zero `[NEEDS CLARIFICATION]` markers: discovery is complete + verified, so
+  informed defaults (phasing, relabel-first, premise-stays-OPEN, fixture-based
+  verification) are documented in Assumptions rather than left open. `/speckit-clarify`
+  may still refine the economics relabel-vs-ground sequencing and the if_match
+  enforcement shape — those are plan-level, not spec blockers.
+- All checklist items PASS on first iteration.

--- a/specs/010-v8-trust-remediation/contracts/capability-matrix.md
+++ b/specs/010-v8-trust-remediation/contracts/capability-matrix.md
@@ -1,0 +1,24 @@
+# Contract: `docs/v8-capability-matrix.md` (US6, NEW)
+
+**Surface**: the published capability record an operator / evaluating agent reads.
+
+## Schema (one row per capability)
+| Column | Rule |
+|--------|------|
+| Feature | A user-visible capability (e.g. "token economics prediction", "if_match guard", "status index health"). |
+| Proof state | `Implemented \| Heuristic \| Observational \| Deferred` — what the code delivers. |
+| Assumption ID | `A-0NN` from `docs/stel-assumptions.md`; one source of truth (FR-017). |
+| Surface claim | What the shipped surface says — MUST NOT exceed Proof state. |
+| Evidence | Artifact ref (test, measurement) for `Implemented`; none required for the others (they are honestly labeled, not proven). |
+
+## Guarantees
+1. Each capability maps to exactly one assumption ID and one proof state (FR-017, US6 AC-2).
+2. The premise is framed as a **bet under test**: A-017 (surface premise) and A-011
+   (predictor accuracy) stay OPEN — never presented as a proven win.
+3. No row's Surface claim asserts validation while its Assumption is OPEN (feeds FR-018 /
+   the CI gate).
+
+## Source-of-truth rule
+The matrix references assumption IDs; it does NOT restate proof states that could drift
+from `stel-assumptions.md`. The register is authoritative; the matrix is the human-readable
+projection.

--- a/specs/010-v8-trust-remediation/contracts/economics-envelope.md
+++ b/specs/010-v8-trust-remediation/contracts/economics-envelope.md
@@ -1,0 +1,26 @@
+# Contract: economics envelope (US1, US5)
+
+**Surface**: the token-economics envelope emitted with tool responses (planner +
+envelope formatter).
+
+## Field labeling (US1, Phase A — zero behavior)
+| Field | Proof state | Rule |
+|-------|-------------|------|
+| predicted figures | `Heuristic` until grounded | Labeled `est_`/`heuristic`; a `400/800` constant is never presented as measured (FR-001, TR-04). |
+| session running total | n/a (gross) | Named `session_tokens_served`; never `session_net_vs_manual`; no `+net` implying savings (FR-002, TR-05/TR-11). |
+| any chars/4 value | approximation | Labeled "estimated tokens (chars/4)" (N-4). |
+| `calibration` | `Deferred` | `CalibrationState` relabeled, seam kept (N-1, Do-Not #7). |
+
+## Grounding (US5, Phase E — ground now)
+1. Predicted figures are derived from real request/result size via the existing estimator
+   `format.rs:4925-5029` (`competent_manual_baseline_chars` /
+   `saved_tokens_vs_competent_manual`), wired into `planner.rs:44-55` (FR-014, D2).
+2. Two materially different file sizes ⟹ two different predictions (SC-005, US5 AC-1).
+3. At least one non-serve economics branch (`degrade`/`bypass`/`mandatory_degrade`) is
+   reachable for an appropriately small/cheap request (US5 AC-2, TR-04b, N-2).
+4. `expected_equiv` golden data is asserted by a test or removed (FR-015, TR-13).
+
+## Invariant
+No envelope field presents a constant or a gross counter as a measured saving. A figure
+is `Measured` only if computed from real bytes at call time; otherwise it is explicitly
+`Heuristic` (SC-001).

--- a/specs/010-v8-trust-remediation/contracts/honesty-ci-gate.md
+++ b/specs/010-v8-trust-remediation/contracts/honesty-ci-gate.md
@@ -1,0 +1,26 @@
+# Contract: honesty CI gate (US6, FR-018)
+
+**Surface**: a CI check (`.github/workflows/...`) that fails the build on a dishonest
+claim. Runs on PR + push, alongside the existing gates.
+
+## Inputs
+- `docs/stel-assumptions.md` (assumption IDs + proof states).
+- `docs/v8-capability-matrix.md` (feature → assumption ID → surface claim).
+- The shipped LLM-facing surfaces / docs that assert capabilities.
+
+## Failure conditions (build FAILS)
+1. A shipped surface or doc asserts a capability as **validated/measured** while its
+   backing assumption is `OPEN` (FR-018, US6 AC-3).
+2. A number/figure has **two divergent definitions** across surfaces (one-source-of-truth
+   violation, FR-017).
+3. A `VALIDATED` verdict in the register has no `artifact_ref` (FR-004).
+
+## Must NOT fail on (allowed)
+- A change that correctly **labels** a still-OPEN assumption as heuristic/observational/
+  deferred. The gate keys on "claim of validation ⇒ proof exists", NOT on the presence of
+  the word OPEN (spec edge case; relabel ≠ validate).
+
+## Determinism
+The gate is a static parse + cross-reference (no network, no flake). It is part of the
+per-phase verification (FR-019) once Phase F lands, and guards against future regression of
+the honesty work.

--- a/specs/010-v8-trust-remediation/contracts/if-match-guard.md
+++ b/specs/010-v8-trust-remediation/contracts/if-match-guard.md
@@ -1,0 +1,31 @@
+# Contract: `if_match` guarded apply (US3)
+
+**Surface**: `symforge_edit` / `replace_symbol_body` apply path.
+
+## Input
+- `if_match`: expected pre-edit body (or its hash) the apply is conditioned on. Threaded
+  through `ReplaceSymbolBodyInput` (`edit_tools.rs`) → planner (`edit_planner.rs`) → write
+  (`edit_apply.rs`/`edit.rs`). MUST NOT be dropped by the planner (TR-06).
+
+## Enforcement (FR-009, D1)
+1. The guard is re-verified against the **bytes actually being written**, in the **same
+   critical section** as the splice + `atomic_write` (re-check-at-write, single lock).
+2. On divergence (on-disk body changed after the agent's read): **reject, no write**; the
+   divergent on-disk content is left intact (US3 AC-1).
+3. Negative control (no concurrent change): the guarded apply succeeds and matches the
+   request (US3 AC-2).
+
+## Response honesty (FR-010)
+- The response claims a successful guarded apply **only** when the guard was enforced at
+  the write (US3 AC-3).
+- The best-effort tee backup is NOT described as transactional rollback.
+
+## Regression
+`symforge_edit_if_match_rejected_after_concurrent_disk_change`: apply a guarded edit;
+via a **deterministic injected interleave point** (test hook, NOT a sleep) mutate the file
+between guard-read and write; assert reject + on-disk change preserved + no false success.
+
+## N-6 boundary
+Batch executors carry no `if_match` today; the batch path is marked "no `if_match` (same
+TOCTOU if extended)" — never a silent false-safety control. `verify_index_matches_disk`
+stays pre-flight-only and is not advertised as a write guard.

--- a/specs/010-v8-trust-remediation/contracts/recovery-hint.md
+++ b/specs/010-v8-trust-remediation/contracts/recovery-hint.md
@@ -1,0 +1,26 @@
+# Contract: `empty_index_recovery_hint(profile)` (US4)
+
+**Surface**: every empty-index / not-loaded error reachable by an agent (the message
+fanned through 37 `loading_guard!` sites + 4 distinct dead-end strings — TR-02, N-5).
+
+## Function
+`empty_index_recovery_hint(profile) -> String` — one centralized, surface-aware source.
+
+## Guarantees
+1. On the **compact** surface, the hint names ONLY actions callable on that surface:
+   re-launch from the project root, or the documented opt-out (`SYMFORGE_SURFACE=full`).
+   It MUST NOT name `index_folder` or any gated capability (FR-012, US4 AC-2).
+2. On the **full** surface, it MAY name `index_folder`.
+3. The hint is computed from the **active** surface, never a fixed string (edge case:
+   recovery callable on full but not compact).
+4. All 4 dead-end strings + the 37 guard sites route through this one function (N-5) — no
+   residual hardcoded "Call index_folder" on a compact-reachable path.
+
+## Regression
+`compact_surface_index_not_loaded_message_never_mentions_blocked_tools`: on the compact
+profile, assert no empty-index message mentions a tool the compact gate forbids.
+
+## Pairing with cold start (TR-03)
+Recovery text is the *fallback*; the primary fix is that a fresh default attach indexes a
+discoverable workspace automatically (D5). The hint covers the case where it genuinely
+cannot.

--- a/specs/010-v8-trust-remediation/contracts/status-readout.md
+++ b/specs/010-v8-trust-remediation/contracts/status-readout.md
@@ -1,0 +1,33 @@
+# Contract: `status` readout (US2, US1)
+
+**Surface**: the `status` MCP tool output (compact + full), shared formatter.
+
+## Inputs
+- Active surface profile (compact | full).
+- The **daemon** index facts (readiness, symbol/file counts) — via the existing proxy
+  channel (TR-01 fix). NOT the front-end `self.index`.
+- `ledger_store.summary()` real result (including the open-error, not swallowed — N-3).
+
+## Output guarantees
+1. `index_state ∈ {Ready, Empty, Loading, Unavailable}` reflects the index that **serves
+   queries**. After any successful query, `index_state == Ready` and counts > 0 (FR-006,
+   SC-002).
+2. `source == Daemon` in the proxy topology; a `FrontEnd`-sourced empty read while serving
+   is a contract violation.
+3. On compact, `status` is present and reports real index health — there is no gap where
+   "no honest index-health tool exists" (FR-007).
+4. Subsystem states are enumerated (E4): `InMemory | Durable | Disabled(reason) |
+   Unavailable`. `Disabled(open_failed)` ≠ `Unavailable` (FR-008, TR-17).
+5. No unconditional `active`/`pending` literal (TR-10); `calibration: deferred` not
+   `pending` (N-1); `empty_index_reason` present when empty (US4 input).
+6. `deferred:` list is derived from real state — `ledger_persistence` removed when the
+   durable store ships in serve mode (FR-004).
+
+## Regression
+`status_index_matches_daemon_proxy_after_symforge_serve`: start serve, run a query that
+populates the index, read `status`, assert reported counts == the served index's counts
+(non-zero, Ready).
+
+## Non-goals
+- Do NOT hide index fields to "fix" the mismatch (ledger Do-Not #6).
+- Do NOT widen the compact wire surface beyond the targeted `status` proxy.

--- a/specs/010-v8-trust-remediation/data-model.md
+++ b/specs/010-v8-trust-remediation/data-model.md
@@ -1,0 +1,129 @@
+# Phase 1 Data Model: v8 Trust Remediation
+
+The "data" of this feature is the set of **LLM-facing surfaces** and the honest **proof
+state** each must carry. These are not new persistent entities — they are the state
+machines that govern how existing fields are labeled and reported. Validation rules trace
+to the spec's Functional Requirements.
+
+---
+
+## E1 — LLM-facing surface (string)
+
+Any string an agent reads on a call: status banner field, economics-envelope field,
+error/recovery text, tool description, public doc line.
+
+| Field | Type | Rule |
+|-------|------|------|
+| `text` | string | The literal surfaced to the agent. |
+| `proof_state` | enum `Measured \| Heuristic \| Observational \| Deferred` | Every figure/claim carries one (FR-001, FR-003). |
+| `label_matches_code` | invariant | A field named `saved`/`net`/`active`/`validated` MUST satisfy the word in code, else it is renamed or qualified (FR-001/002/003). |
+
+**Invariant (honesty contract)**: `proof_state == Measured` ⟹ the value is derived from a
+real measurement at call time; otherwise the surface is explicitly qualified.
+
+---
+
+## E2 — Economics figure
+
+| Field | Type | Rule |
+|-------|------|------|
+| `value` | integer (estimated tokens) | Derived from real bytes once grounded (FR-014); chars/4 is labeled "estimated tokens (chars/4)" (N-4). |
+| `source` | enum `Measured \| Heuristic` | A `400/800` constant is `Heuristic`; a byte-grounded estimate is `Measured`-from-size (still an estimate, labeled as such). |
+| `name` | string | Names what it is. A monotonic running total is `session_tokens_served`, never `session_net_vs_manual` (FR-002, TR-05). |
+| `sign_semantics` | rule | A figure that can only grow MUST NOT be printed as `+net` implying savings (TR-05, TR-11). |
+
+**State transition (US5)**: `Heuristic(constant 400/800)` → *[Phase E wiring]* →
+`Measured-from-size(format.rs estimator)`. Until transitioned, stays `Heuristic` and the
+adaptive behavior is described as not-yet-active (FR-014).
+
+---
+
+## E3 — Index health readout
+
+| Field | Type | Rule |
+|-------|------|------|
+| `index_state` | enum `Ready \| Empty \| Loading \| Unavailable` | Reflects the index that **serves queries** (FR-006). |
+| `symbol_count` / `file_count` | integer | Non-zero and matching the served index after a successful query (SC-002). |
+| `source` | enum `Daemon \| FrontEnd` | MUST be `Daemon` in the proxy topology (TR-01); a `FrontEnd` empty read while serving is the bug. |
+| `empty_index_reason` | enum `NoRoot \| NotIndexedYet \| Disabled \| n/a` | Distinguishes why empty, drives recovery (US4). |
+
+**Invariant (US2)**: a successful query ⟹ `index_state == Ready` ∧ counts > 0 on the
+next status read. No "Empty/not-ready while serving."
+
+---
+
+## E4 — Subsystem state (status banner: ledger / handlers / layers)
+
+Replaces the unconditional `active`/`pending` literals (TR-10, N-1, N-3).
+
+| State | Meaning |
+|-------|---------|
+| `InMemory` | Layer is the always-on in-memory implementation (true today for l4 cache). |
+| `Durable` | Durable store is open and writable (serve mode, ledger). |
+| `Disabled(reason)` | Configured off, or open failed — **with the reason** (N-3, TR-17). |
+| `Unavailable` | Not wired in this build/surface. |
+
+**Invariant (FR-008)**: `Disabled(open_failed)` and `Unavailable` are **distinct** — a
+wired-but-failing store never reports identically to a never-configured one. `summary()`
+must not swallow the DB error into `None` (N-3).
+
+---
+
+## E5 — Guard condition (`if_match`)
+
+| Field | Type | Rule |
+|-------|------|------|
+| `expected_body` | string \| hash | The pre-edit body the apply is conditioned on. |
+| `enforced_at` | enum `Write` (only valid value) | The guard is verified against the bytes actually written, in the splice's critical section (FR-009, D1). |
+| `on_divergence` | action `Reject` | No write; divergent on-disk content left intact (US3 AC-1). |
+| `claim_rule` | invariant | The response claims a guarded apply only when `enforced_at == Write` succeeded (FR-010, US3 AC-3). |
+
+**State machine**: `Requested` → re-read on-disk under lock → `Match` → splice +
+`atomic_write` → `AppliedGuarded`; or `Diverged` → `RejectedNoWrite`. No path reports
+`AppliedGuarded` without passing through write-time `Match`.
+
+---
+
+## E6 — Assumption record entry (`docs/stel-assumptions.md`)
+
+| Field | Type | Rule |
+|-------|------|------|
+| `id` | `A-0NN` | Stable identifier. |
+| `proof_state` | enum `OPEN \| PARTIAL \| VALIDATED` | Exactly one, single source of truth per id (TR-16; A-005, A-016 deduped). |
+| `artifact_ref` | path/link \| none | `VALIDATED` REQUIRES a backing artifact; a verdict with no artifact is demoted (FR-004, TR-12 A-009→PARTIAL, TR-13 A-028 demoted). |
+| `claimed_by` | list of surfaces | Surfaces that assert this capability; the CI gate cross-checks (FR-018). |
+
+**Invariant (relabel ≠ validate)**: a label change never moves `proof_state` to
+`VALIDATED`. A-011/A-015/A-016/A-028 stay OPEN/PARTIAL until reproduced with an artifact.
+
+---
+
+## E7 — Capability matrix entry (`docs/v8-capability-matrix.md`, NEW)
+
+| Field | Type | Rule |
+|-------|------|------|
+| `feature` | string | A user-visible capability. |
+| `proof_state` | enum `Implemented \| Heuristic \| Observational \| Deferred` | Maps the feature to what the code delivers. |
+| `assumption_id` | `A-0NN` | The backing assumption; one source of truth (FR-017). |
+| `surface_claim` | string \| none | What the shipped surface says — must not exceed `proof_state` (FR-018, the CI gate's input). |
+
+**Invariant (FR-018)**: `surface_claim` asserts a validated capability ∧
+`assumption.proof_state == OPEN` ⟹ **CI fails**.
+
+---
+
+## Relationships
+
+```text
+LLM-facing surface (E1) ──carries──▶ proof_state
+   economics field (E2) ──is-a──▶ E1
+   index readout  (E3) ──is-a──▶ E1, ──reads──▶ Daemon index (Principle I)
+   subsystem state(E4) ──is-a──▶ E1, ──derived-from──▶ ledger_store.summary()
+   recovery text       ──is-a──▶ E1, ──computed-from──▶ active surface profile
+Guard condition (E5) ──enforced-at──▶ Write critical section
+Assumption (E6) ──backs──▶ Capability matrix entry (E7) ──claimed-by──▶ surfaces (E1)
+                          └──enforced-by──▶ honesty CI gate (FR-018)
+```
+
+Every entity reduces to one rule: **the surface never asserts more than the code
+delivers** (SC-008, keystone).

--- a/specs/010-v8-trust-remediation/plan.md
+++ b/specs/010-v8-trust-remediation/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: v8 Trust Remediation
+
+**Branch**: `010-v8-trust-remediation` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/010-v8-trust-remediation/spec.md`
+
+**Discovery source of truth**: `docs/reviews/v8-trust-remediation-ledger.md` (TR-01..TR-20
++ panel findings N-1..N-7 + code anchors). Triple-confirmed against live 8.0.0 code
+(`feat/010` @ 711ee68). Not re-litigated here.
+
+## Summary
+
+Make SymForge trustworthy to the LLMs that call it without rewriting the v8
+architecture. The engine is sound (single in-process index, constant-time auth,
+path guards, SQLite ledger, candid assumptions register); the trust debt is in the
+**presentation layer** — `status`, the economics envelope, error/recovery text, tool
+descriptions, public docs — which overstate what the code delivers, plus **two real
+bugs**: `status` reads the empty front-end proxy index instead of the warm daemon
+index (reports a working index as empty), and `if_match` guarded-apply is structurally
+absent from the write path (silent clobber under concurrency with a success receipt).
+
+**Approach**: six independently-shippable phases sequenced truth → recovery → labels →
+safety → measure, every LLM-facing string made true or explicitly labeled
+heuristic/observational/deferred. Two design forks are locked: (1) `if_match` is
+re-verified against the bytes actually written, **in the same critical section as the
+splice** (re-check-at-write, not a second pre-flight); (2) economics is **grounded now**
+(clarified 2026-06-17) by wiring the existing byte-grounded estimator
+(`format.rs:4925-5029`) into the planner, which legitimately reopens the
+degrade/bypass branches. The full verification gate (incl. the network-free embed
+build) runs after **each** phase, and three named regression tests are added.
+
+## Technical Context
+
+**Language/Version**: Rust 2024, single crate `symforge`.
+
+**Primary Dependencies**: tree-sitter (parsing); `axum` + `rmcp` (server transport,
+`server` feature only); `rusqlite`/SQLite (durable ledger, serve mode); `tokio` (async
+runtime). No new dependency is introduced by this feature.
+
+**Storage**: in-process LiveIndex (authoritative read path) + local `.symforge/`
+snapshots (warm-start/recovery) + SQLite ledger (`serve` mode, durable write metadata).
+No new store. The `status` fix **reuses** the existing daemon index via the existing
+proxy channel — it does not add a second index (Constitution Principle I).
+
+**Testing**: `cargo test --all-targets -- --test-threads=1`; golden replay suite; three
+new named regressions — `status_index_matches_daemon_proxy_after_symforge_serve`
+(TR-01), `compact_surface_index_not_loaded_message_never_mentions_blocked_tools`
+(TR-02), `symforge_edit_if_match_rejected_after_concurrent_disk_change` (TR-06, via a
+deterministic injected interleave point, **not** a timing sleep).
+
+**Target Platform**: local MCP server, Windows/Linux/macOS, stdio + `symforge serve`
+`/mcp` transports.
+
+**Project Type**: MCP code-intelligence server (single Rust project).
+
+**Performance Goals**: none added; this is presentation + correctness. No regression to
+index-query latency; the economics grounding reuses an O(bytes) estimator already on the
+response path.
+
+**Constraints**: Phase A is **zero behavior change** (relabel only). All changes are
+`server`-feature-gated; the `embed` build stays network/server-free
+(`cargo check --no-default-features --features embed`). Shared protocol formatters keep
+stdio↔serve parity. Regression tests use injected interleave points, not sleeps. No
+mutation of real operator configs (fixtures only).
+
+**Scale/Scope**: ~12 source files across `src/stel/` and `src/protocol/` + `src/cli/init.rs`
++ `src/main.rs` + `src/daemon.rs`; docs (README/AGENTS/CLAUDE + new capability matrix +
+assumptions register); one CI honesty gate. No architectural surface change on the wire
+(compact-3 default stays).
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.0.0 (8 principles).*
+
+| # | Principle | Verdict | Note |
+|---|-----------|---------|------|
+| I | Local-First In-Process Index | **PASS (strengthened)** | `status` is fixed to read the **same** authoritative daemon index that serves queries — it removes a "two truths" reporting split. No second index introduced. |
+| II | MCP-Native Surface | **PASS** | `status`/`health` stay MCP tools; the daemon gains a `status` arm reached via the existing proxy (no chat injection, no client-tool shadowing). Compact-3 wire surface unchanged. |
+| III | Trust Envelopes | **PASS (core alignment)** | This feature *is* the trust-envelope honesty work: enumerated subsystem states, heuristic-vs-measured labels, "map orients / tools prove" preserved. |
+| IV | Determinism & Recovery | **PASS (strengthened)** | `if_match` enforcement implements IV's "mutations reject stale-state edits"; surface-aware recovery hints support resumability. Best-effort backup is **not** relabeled as transactional. |
+| V | Frecency Invariant | **PASS** | No frecency writes; `status`/economics/recovery are read-side surfaces. |
+| VI | Embed Isolation (G-045) | **PASS** | Every change is `server`-gated (status proxy, daemon arm, economics planner, init wrapper). `cargo check --no-default-features --features embed` is in the per-phase gate (FR-019). |
+| VII | Transport Parity | **PASS** | Honesty labels live in shared formatters → apply to stdio and serve identically; parity covered when formatters are touched. |
+| VIII | Verification Before Done | **PASS** | Per-phase full gate + golden replay + three named regression tests (FR-019, SC-007). |
+
+**Result**: no violations. **Complexity Tracking**: empty (nothing to justify).
+
+**Re-check after Phase 1 design**: still PASS — the design artifacts (data-model,
+contracts, quickstart) introduce no new index, no new wire tool, no new feature flag, no
+chat injection, no frecency write. Recorded at the end of this plan.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-v8-trust-remediation/
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions + anchors (discovery already done)
+├── data-model.md        # Phase 1: trust entities + their honest state machines
+├── quickstart.md        # Phase 1: dogfood + regression run guide
+├── contracts/           # Phase 1: the LLM-facing surface contracts
+│   ├── status-readout.md
+│   ├── economics-envelope.md
+│   ├── if-match-guard.md
+│   ├── recovery-hint.md
+│   ├── capability-matrix.md
+│   └── honesty-ci-gate.md
+├── checklists/requirements.md   # (from /speckit-specify)
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root) — touch map by phase
+
+```text
+src/stel/
+├── status.rs            # A: enumerated states; B: distinguish disabled/unavailable (N-3)
+├── planner.rs           # A: rename est_ fields; E: wire real estimator (TR-04)
+├── controller.rs        # E: degrade/bypass/mandatory_degrade reachable (TR-04b, N-2)
+├── session.rs           # A: session_tokens_served rename (TR-05)
+├── envelope.rs          # A: heuristic-vs-measured labels (TR-05, TR-11)
+├── types.rs             # A: CalibrationState relabel (N-1); E: economics types
+├── executor.rs          # A: reject-path session figure (TR-11)
+├── golden_replay.rs     # E: assert-or-remove expected_equiv (TR-13)
+└── ledger_store.rs      # A/B: summary() error surface, disabled vs unavailable (N-3, TR-17)
+
+src/protocol/
+├── tools.rs             # B: status_stel_tool proxies daemon (TR-01); A: session line (TR-05)
+├── format.rs            # D: empty_index_recovery_hint(profile) (TR-02); E: estimator reuse
+├── mod.rs               # B: daemon status arm wiring; compact gate (unchanged chokepoint)
+├── edit_apply.rs        # C: if_match re-verify at write (TR-06)
+├── edit_planner.rs      # C: thread if_match through plan (TR-06)
+├── edit_tools.rs        # C: ReplaceSymbolBodyInput.if_match field (TR-06, N-6 note)
+├── edit.rs              # C: critical-section write guard (TR-06)
+└── handler.rs           # A: bytes/4 "estimated" labeling note (N-4)
+
+src/daemon.rs            # B: daemon-side status arm (TR-01)
+src/cli/init.rs          # D: wrapper CWD + proven env (TR-03); A: doc string (TR-07)
+src/main.rs              # D: cold-start root discovery (TR-03)
+
+docs/
+├── stel-assumptions.md  # A: demote A-009/A-028; single-source A-005/A-016 (TR-12/13/16)
+├── v8-capability-matrix.md   # F: NEW — features → assumption IDs → proof state (TR-09)
+└── reviews/...          # ledger (reference)
+
+README.md, AGENTS.md, CLAUDE.md   # F: compact-3 default + 32-tool opt-out (TR-07)
+.github/workflows/...     # F: surface-honesty + OPEN-assumption CI gate (FR-018)
+tests/                    # B/C/D: three named regressions + status/recovery coverage
+```
+
+**Structure Decision**: single Rust crate, no new modules. Changes are localized to the
+STEL controller/status/economics layer and the protocol edit/format/status handlers, plus
+init/main for cold-start and docs/CI for the public record. No new directory beyond the
+new `docs/v8-capability-matrix.md` and the spec's own `contracts/`.
+
+## Phase mapping (user stories → phases → anchors)
+
+| Phase | Story | Pri | Findings | Behavior change? |
+|-------|-------|-----|----------|------------------|
+| **A** Relabel | US1 | P1 | TR-05, TR-10, TR-11, N-1, N-4 + doc demotes TR-07/12/13/16 | **No** (labels only) |
+| **B** Status truth | US2 | P1 | TR-01, N-3, TR-17 | Yes (read path) |
+| **C** Edit safety | US3 | P1 | TR-06, N-6 | Yes (write guard) |
+| **D** Recovery + onboarding | US4 | P2 | TR-02, TR-03, N-5 | Yes (error text + init) |
+| **E** Economics grounding | US5 | P2 | TR-04, TR-04b, TR-13, N-2 | Yes (planner; reopens branches) |
+| **F** Matrix + CI | US6 | P2 | TR-07/08/09, FR-017/018 | Docs + CI only |
+
+**Sequencing rule (ledger)**: Phase A ships **before** any README "token-efficient"
+language. The two real bugs (TR-01 status, TR-06 if_match) + Phase A are the
+highest-leverage quick-win. Phases are independently shippable; each runs the full gate
+before the next begins (FR-019).
+
+## Complexity Tracking
+
+No constitution violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| — | — | — |

--- a/specs/010-v8-trust-remediation/quickstart.md
+++ b/specs/010-v8-trust-remediation/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: v8 Trust Remediation — validation guide
+
+How to prove 010 works end-to-end. Two layers: the **per-phase gate** (mechanical, run
+after every phase) and the **acceptance checks** (per user story). Implementation detail
+lives in `tasks.md`; this is the run/verify guide.
+
+## Prerequisites
+- Repo on `010-v8-trust-remediation`, `target/` kept warm across the campaign.
+- The dev MCP harness binary version is irrelevant to correctness (currently 7.27.0);
+  010 is verified by `cargo` against the on-disk 8.0.0 source. Live STEL-surface dogfood
+  uses the **locally-built** 8.0.0 binary.
+
+## Per-phase gate (FR-019 / SC-007) — run after EACH of phases A–F
+
+```sh
+cargo fmt --check
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets -- --test-threads=1
+cargo build --release
+cargo check --no-default-features --features embed   # embed stays network/server-free
+```
+
+All six MUST pass before the next phase starts. A check that cannot run is reported
+unverified with the reason (Constitution VIII).
+
+## The three named regression tests (must exist + pass)
+| Test | Story | Proves |
+|------|-------|--------|
+| `status_index_matches_daemon_proxy_after_symforge_serve` | US2 | status counts == served index (TR-01). |
+| `compact_surface_index_not_loaded_message_never_mentions_blocked_tools` | US4 | no compact recovery string names a gated tool (TR-02). |
+| `symforge_edit_if_match_rejected_after_concurrent_disk_change` | US3 | guarded apply rejects a concurrent divergence via injected interleave (TR-06). |
+
+## Acceptance checks (per story)
+
+### US1 — honest labels (Phase A, zero behavior)
+- Read every status + envelope field; confirm each is `Measured` or carries
+  heuristic/observational/deferred (SC-001). Grep the surfaces for `net`/`saved`/`active`/
+  `pending`/`validated`; each survivor must satisfy its word in code.
+- Confirm golden replay still passes (zero behavior change).
+
+### US2 — status truth (Phase B)
+- Locally build + run `symforge serve`; run a query that populates the index; read
+  `status`; confirm `index_state: Ready` with counts matching the served query (SC-002).
+- Confirm a wired-but-failing ledger reports `Disabled(reason)`, distinct from
+  `Unavailable` (FR-008).
+
+### US3 — edit safety (Phase C)
+- Run the TR-06 regression: guarded apply + injected concurrent change ⟹ rejected, on-disk
+  change intact, no false "guarded apply succeeded" (SC-003). Negative control succeeds.
+
+### US4 — recoverable cold start (Phase D)
+- Simulate a fresh default attach with no pre-indexed workspace: confirm either auto-index
+  populates, or the recovery message names only callable actions on the active surface
+  (SC-004). Confirm the desktop launch path discovers the project root (not `%USERPROFILE%`).
+
+### US5 — economics grounded (Phase E)
+- Run the same op over a small and a large file; confirm predicted figures differ in
+  proportion to size (SC-005); confirm a non-serve branch becomes reachable for a small
+  request. Confirm `expected_equiv` is asserted or removed.
+
+### US6 — public record + enforced honesty (Phase F)
+- Read README / AGENTS.md / CLAUDE.md / init allow-list: confirm they describe the
+  compact-3 default with the 32-tool surface as a documented opt-out (SC-006).
+- Confirm `docs/v8-capability-matrix.md` maps each capability → assumption ID → proof state.
+- Force a violation (a surface claiming a capability whose assumption is OPEN) on a scratch
+  branch; confirm the honesty CI gate FAILS (FR-018). Confirm honest OPEN-labeling passes.
+
+## Keystone (SC-008)
+Final dogfood with the locally-built 8.0.0 binary: reconnect MCP; `status` compact reports
+the real index; `symforge` orient query succeeds; `status` full → counts MATCH the served
+query; `symforge_edit` preview is honest. An agent trusting the self-reported numbers/status
+is no longer misled — no surface asserts more than the code delivers.

--- a/specs/010-v8-trust-remediation/research.md
+++ b/specs/010-v8-trust-remediation/research.md
@@ -1,0 +1,188 @@
+# Phase 0 Research: v8 Trust Remediation
+
+Discovery is **already complete and verified** in
+`docs/reviews/v8-trust-remediation-ledger.md` (two external skeptical reviews + two
+advisory programs + a 5-agent code-verification panel, triple-confirmed against live
+8.0.0 code @ 711ee68). This file records the **decisions** that resolve every design
+fork; there are no open `NEEDS CLARIFICATION` markers.
+
+Format per decision: **Decision / Rationale / Alternatives rejected**.
+
+---
+
+## D1 — `if_match` enforcement shape (US3 / TR-06)
+
+**Decision**: Re-verify the guard **at the write**, inside the same critical section
+that performs the splice and `atomic_write`. Thread an `if_match` field through
+`ReplaceSymbolBodyInput` (`edit_tools.rs:570-676`) → the edit planner
+(`edit_planner.rs:72`) → the write path (`edit_apply.rs:73-91`, `edit.rs:1160`). The
+write path re-reads the on-disk bytes under the lock, compares against the supplied
+guard, and rejects (no write) on divergence; the response only claims a guarded apply
+when the guard was honored at the write.
+
+**Rationale**: The TOCTOU window exists precisely because the only check today is a STEL
+pre-flight (`edit_apply.rs:73`) with the guard never reaching the write. A second
+pre-flight would leave the same window. Closing it requires the comparison to happen
+against the *exact bytes about to be written*, under the write lock — the splice and the
+verify cannot be separated by an async boundary.
+
+**Alternatives rejected**:
+- *Second pre-flight before write* — still a TOCTOU; a writer between pre-flight and
+  splice clobbers silently. Rejected.
+- *Advisory `if_match` (warn, write anyway)* — violates the honesty contract and US3's
+  "guard actually guards". Rejected.
+- *Tee-snapshot as the safety net* — the tee is best-effort recovery, "zero protection"
+  against the clobber (ledger). It must NOT be presented as transactional rollback
+  (FR-010).
+
+**N-6 note**: batch executors have no `if_match` plumbing today; the single-edit fix
+lands first, and the batch path carries a documented "no `if_match` (same TOCTOU if
+extended)" marker rather than a silent false-safety control. `verify_index_matches_disk`
+is also pre-flight-only and must not be advertised as a write-time guard.
+
+---
+
+## D2 — Economics grounding: ground now, reuse the existing estimator (US5 / TR-04)
+
+**Decision**: Wire the existing byte-grounded estimator
+(`format.rs:4925-5029`, `competent_manual_baseline_chars` /
+`saved_tokens_vs_competent_manual`) into the STEL planner (`planner.rs:44-55`) so the
+predicted figures derive from real request/result size instead of the hardcoded
+`400/800`. This reopens the `degrade` / `bypass` / `mandatory_degrade` branches
+(`controller.rs:40-135`) on real input. Confirmed in clarify (2026-06-17): grounding is
+**in-scope for 010**, not deferred.
+
+**Rationale**: The estimator already exists and runs on the response path; grounding is a
+**wiring** effort, not new science. US5's acceptance scenarios (predictions vary by size;
+a non-serve branch reachable) are binding. Until a given figure is grounded, the honest
+heuristic label (FR-001, Phase A) is the floor — never a substitute.
+
+**Alternatives rejected**:
+- *Defer grounding, label-only* — explicitly declined in clarify. Rejected.
+- *Build a new estimator* — duplicates `format.rs:4925-5029`; violates single-source.
+  Rejected.
+- *Keep the `400/800` constant but relabel `est_`* — that is Phase A's interim floor, not
+  the US5 deliverable; leaving it there permanently fails US5's "predictions vary".
+  Rejected as the end state.
+
+---
+
+## D3 — Status truth: proxy to the daemon + add a daemon `status` arm (US2 / TR-01)
+
+**Decision**: `status_stel_tool` (`tools.rs:8529`) must read the **daemon** index facts
+via the existing proxy channel, not the empty front-end `self.index`. The daemon has no
+`status` arm today (`daemon.rs ~2435`) — add one that returns index readiness + counts +
+ledger state, and route `status` through it like every other proxying reader
+(`mod.rs:266`).
+
+**Rationale**: Constitution Principle I — one authoritative index. The bug is that
+`status` reads a *different* index than the one serving queries. Proxying makes the
+readout reflect the served index. The compact surface currently has **no** honest
+index-health tool (`health` is full-surface-only), so this also closes FR-007.
+
+**Alternatives rejected**:
+- *Read the front-end `self.index`* — it is structurally empty in the daemon-proxy
+  topology. That is the bug. Rejected.
+- *Hide the index fields on compact* — "one lie for another" (ledger Do-Not #6); leaves
+  the agent with no health signal. Rejected.
+- *Expose `health` on compact* — would widen the wire surface; the targeted `status`
+  proxy is sufficient and respects compact-3. Rejected.
+
+---
+
+## D4 — Recovery: one surface-aware `empty_index_recovery_hint(profile)` (US4 / TR-02)
+
+**Decision**: Replace the 4 distinct compact-reachable dead-end strings (and the message
+fanned through 37 `loading_guard!` sites) with a single surface-aware
+`empty_index_recovery_hint(profile)` that **never names a gated tool**. On the compact
+surface it names only callable recovery (re-launch from project root, or the documented
+opt-out); on the full surface it may name `index_folder`.
+
+**Rationale**: The compact gate itself is correct (pure `(profile,name)->bool`, single
+chokepoint `mod.rs:935`); the dead-end is a *message* defect, not a gate defect. The
+message must be computed from the **active** surface, never a fixed string (FR-012).
+
+**Alternatives rejected**:
+- *Per-site string edits* — 37 sites + 4 strings drift; centralization is the only
+  durable fix. Rejected.
+- *Allow `index_folder` on compact to make the message true* — reverts compact-3 / widens
+  the surface (ledger Do-Not #1). Rejected.
+
+---
+
+## D5 — Cold start populates the index (US4 / TR-03)
+
+**Decision**: Fix the default Desktop wrapper so it does **not** `cd /d "%USERPROFILE%"`
+(`init.rs:837`) before launch — the CWD must allow `find_project_root()` (`main.rs:217-248`)
+to discover the project workspace. Write a proven init `env` (root / `SYMFORGE_SURFACE` /
+auto-index hint) instead of `env:{}` (`init.rs:761`).
+
+**Rationale**: Root cause (panel-corrected) is the wrapper CWD → `find_project_root()`
+returns None → no root → no daemon → empty index → the agent then hits TR-02. Fixing CWD +
+init env makes cold start actually index. Overlaps the parked 009 setup-wizard but is
+self-contained here.
+
+**Alternatives rejected**:
+- *Auto-index `%USERPROFILE%`* — indexes the wrong (home) tree; expensive and useless.
+  Rejected.
+- *Only fix the error message (D4) without the CWD* — leaves cold start permanently empty;
+  D4 alone is recovery, not a populated start. Both are needed. Rejected as sufficient.
+
+---
+
+## D6 — Honest labels are enumerated, behavior-preserving (US1 / Phase A)
+
+**Decision**: Phase A is a single **zero-behavior** pass. Concretely:
+`session_net_vs_manual` → `session_tokens_served` (TR-05, drop the `+`-only framing);
+envelope figures gain `est_`/`heuristic` vs `measured` qualifiers (TR-11);
+`calibration: "pending"` → `calibration: deferred` and `CalibrationState` relabeled
+`deferred`/`observational` (do **not** delete the seam — ledger Do-Not #7, N-1); status
+`l1..l4`/`handler_*` literals become enumerated states
+(`l4_ledger: in_memory|durable|unavailable`, `index_state`, `empty_index_reason`);
+drop the stale `ledger_persistence` from `deferred:`; bytes/4 figures labeled
+"estimated tokens (chars/4)" (N-4). Docs demote A-009 → PARTIAL and A-028 (TR-12/13),
+single-source A-005/A-016 (TR-16).
+
+**Rationale**: Cheap-honest beats dishonest-confident; relabel is a valid, shippable fix.
+**Relabel ≠ validate**: no OPEN assumption (A-011/A-015/A-016/A-028) is promoted to
+VALIDATED by a label change.
+
+**Alternatives rejected**:
+- *Mark figures VALIDATED now that they're labeled* — violates relabel≠validate. Rejected.
+- *Delete `CalibrationState` dead seam* — ledger Do-Not #7; relabel instead. Rejected.
+
+---
+
+## D7 — Enforced honesty CI (US6 / FR-018)
+
+**Decision**: Add a CI honesty gate that (a) parses the assumptions register and **fails
+the build** when a shipped surface claims a capability whose assumption is OPEN, and
+(b) enforces one-source-of-truth per number (no figure with two divergent definitions).
+Publish `docs/v8-capability-matrix.md` mapping feature → assumption ID → proof state
+(Implemented / Heuristic / Observational / Deferred).
+
+**Rationale**: Closes the loop so the honesty work cannot silently rot; frames v8 as a
+*bet under test* (A-017/A-011 stay OPEN, never a proven-win claim).
+
+**Alternatives rejected**:
+- *Manual review only* — regresses over time; the spec requires automation (FR-018).
+  Rejected.
+- *Block honest OPEN-labeling changes* — the gate must allow correctly labeling a
+  still-OPEN assumption; it only fails on *claimed validation* of an OPEN one (spec edge
+  case). Rejected as written; the gate keys on "claim ⇒ proof", not on the word OPEN.
+
+---
+
+## Cross-cutting decisions
+
+- **Per-phase verification** (FR-019): after each phase run `cargo fmt --check`,
+  `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`,
+  `cargo test --all-targets -- --test-threads=1`, `cargo build --release`, and
+  `cargo check --no-default-features --features embed`. Not only at the end.
+- **Regression determinism**: the TR-06 test uses an injected interleave point (a test
+  hook that mutates the file between guard-read and write), **not** a timing sleep.
+- **Harness note**: the dev MCP binary may be any version (currently downgraded to
+  7.27.0 for full-surface comfort); 010 correctness is proven by `cargo` against the
+  on-disk 8.0.0 source. Live STEL-surface dogfood uses the **locally-built** 8.0.0 binary
+  at verify time.
+- **No new dependency, no new feature flag, no new index** — Constitution I/VI preserved.

--- a/specs/010-v8-trust-remediation/spec.md
+++ b/specs/010-v8-trust-remediation/spec.md
@@ -23,6 +23,12 @@ spine rules govern every change:
    **relabel ≠ validate**: a label change never promotes an OPEN assumption to
    VALIDATED.
 
+## Clarifications
+
+### Session 2026-06-17
+
+- Q: Phase E (economics) — does 010 ground the estimator now (real behavior change) or ship only the honest heuristic label and defer grounding? → A: Ground now. 010 wires the existing byte-grounded estimator into the planner so predictions vary with real request/result size and the adaptive economics branches (degrade/bypass) become reachable; the honest heuristic label (US1) remains the interim floor for any figure not yet grounded, but grounding is in-scope for this feature, not deferred. US5's acceptance scenarios (predictions differ by size; a non-serve branch reachable) are binding for 010.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Every reported number/label is honest (Priority: P1)
@@ -217,7 +223,7 @@ unproven assumption.
 
 **Economics grounding (US5)**
 
-- **FR-014**: Economics predictions MUST be derived from real request/result size so that predictions vary with the work, and the adaptive economics outcomes are reachable for appropriate requests — OR, until grounded, every economics figure MUST be labeled heuristic (FR-001) and the adaptive behavior described as not-yet-active.
+- **FR-014**: Economics predictions MUST be derived from real request/result size so that predictions vary with the work, and the adaptive economics outcomes (degrade/bypass) MUST be reachable for appropriate requests. Grounding is in-scope for this feature (clarified 2026-06-17, ground-now). The honest heuristic label (FR-001) is the interim floor for any figure not yet grounded, never a substitute for delivering grounding in 010.
 - **FR-015**: Any equivalence/accuracy figure presented as measured MUST be backed by an actual assertion in the test corpus, or be removed.
 
 **Public record & enforced honesty (US6)**

--- a/specs/010-v8-trust-remediation/spec.md
+++ b/specs/010-v8-trust-remediation/spec.md
@@ -1,0 +1,264 @@
+# Feature Specification: v8 Trust Remediation
+
+**Feature Branch**: `010-v8-trust-remediation`
+
+**Created**: 2026-06-17
+
+**Status**: Draft
+
+**Input**: User description: "Make SymForge trustworthy to the LLMs that call it (the keystone), without rewriting the v8 architecture. Discovery verified in docs/reviews/v8-trust-remediation-ledger.md (two external skeptical reviews + two advisory programs + a 5-agent code-verification panel). The surfaces an LLM reads on every call — status, the economics envelope, error/recovery text, tool descriptions, public docs — overstate what the code delivers. Make every LLM-facing string true or explicitly labeled heuristic/observational/deferred; fix the two real bugs (status reports a working index as empty; the if_match write-guard never enforces). The trust debt is in the presentation layer, not the engine."
+
+## Guiding principle
+
+**LLM trust is the keystone.** A code-intelligence tool exists to be *believed* by
+the model that calls it. Every overstated surface teaches the agent the tool is
+unreliable; once caught overstating, the model discounts everything after. Two
+spine rules govern every change:
+
+1. **Honesty contract** — every LLM-facing string is **true**, or **explicitly
+   labeled** heuristic / observational / deferred. No field named `saved`, `net`,
+   `active`, or `validated` survives unless the code matches the word.
+2. **Relabel is a valid fix** — making a number honest (e.g. renaming a constant
+   to `estimated`/`heuristic`) is a legitimate, shippable remediation. But
+   **relabel ≠ validate**: a label change never promotes an OPEN assumption to
+   VALIDATED.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every reported number/label is honest (Priority: P1)
+
+An agent (or operator) reads the tool's self-reported status banner and
+economics envelope and can take every field at face value: a number labeled
+"saved" reflects a real saving; a subsystem labeled "active" is wired; anything
+not yet proven is plainly marked heuristic, observational, or deferred.
+
+**Why this priority**: This is the keystone and the highest-leverage, lowest-risk
+move — it can be delivered with **zero behavior change** (relabeling only), and it
+removes the single largest source of agent mistrust today. Shippable alone as the
+quick-win.
+
+**Independent Test**: Read every field the status banner and economics envelope
+emit; confirm each is either provably accurate against the underlying state or
+carries an explicit heuristic/observational/deferred qualifier — and that no field
+named "saved"/"net"/"validated" presents a constant or a gross counter as a
+measured result.
+
+**Acceptance Scenarios**:
+
+1. **Given** the economics envelope, **When** it reports a savings/prediction figure that is not derived from real measurement, **Then** that figure is explicitly labeled heuristic/estimated (not presented as a measured saving).
+2. **Given** a cumulative session figure, **When** it is a running total of work done (not a true net of savings), **Then** its name reflects what it is (e.g. "tokens served"), never an unqualified "net savings" that can only ever grow.
+3. **Given** the status banner's subsystem and calibration labels, **When** a subsystem is in-memory-only, deferred, or unwired, **Then** the label says so (enumerated state), not a blanket "active"/"pending" that implies more.
+4. **Given** the assumptions/capability record, **When** an assumption is OPEN, **Then** no shipped surface claims it as validated, and any prior "VALIDATED" verdict not backed by an artifact is demoted.
+
+---
+
+### User Story 2 - Status tells the truth about the index (Priority: P1)
+
+An agent checks index health and gets the truth: if the tool just answered a
+query from a populated index, the health readout reports that same populated
+index — never "empty / not ready" while the tool demonstrably serves results.
+
+**Why this priority**: This is a real bug, not a label: in the default deployment
+the health readout reads a different (empty) index than the one serving queries,
+so it reports a fully working system as broken. That actively teaches agents the
+tool is down when it is up — the most corrosive possible trust failure.
+
+**Independent Test**: In the default deployment topology, run a query that
+succeeds against the live index, then read the health/status; confirm the reported
+index readiness and counts match what the query actually used (non-zero, ready).
+
+**Acceptance Scenarios**:
+
+1. **Given** the default deployment where queries are served from a warm index, **When** a query succeeds, **Then** a subsequent status read reports that index as ready with matching counts (not empty / not-ready).
+2. **Given** a health readout has no honest path to the real index, **When** the agent is on the default (compact) surface, **Then** there is still a status readout that reports the real index health (no "no honest tool exists" gap).
+3. **Given** a durable subsystem that failed to open versus one that is simply not wired, **When** status reports it, **Then** the two states are distinguishable (not both collapsed to a single ambiguous "unavailable").
+
+---
+
+### User Story 3 - A guarded edit actually guards (Priority: P1)
+
+An agent applies a symbol edit with an optimistic-concurrency guard ("only apply
+if the body still matches what I saw"). If another writer changed the file in the
+meantime, the apply is rejected — the agent's stale edit never silently overwrites
+the concurrent change, and the response never reports a successful guarded apply
+when the guard was not honored.
+
+**Why this priority**: This is a data-integrity bug: the guard is advertised but
+never enforced at the write, so under concurrency (including this project's own
+multi-agent workflow) a stale edit can silently clobber another writer's change
+while reporting success. A safety guarantee that isn't kept is worse than none.
+
+**Independent Test**: Apply a guarded edit; deterministically mutate the file on
+disk between the guard check and the write; confirm the apply is **rejected** (no
+write), the on-disk concurrent change is preserved, and the response does not
+claim a successful guarded apply. Control: same flow without the concurrent change
+succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a guarded apply whose target body matched at check time, **When** the on-disk body diverges before the write, **Then** the apply is rejected and the divergent on-disk content is left intact.
+2. **Given** the negative control (no concurrent change), **When** the guarded apply runs, **Then** it succeeds and the result matches the requested edit.
+3. **Given** any guarded apply, **When** the response is rendered, **Then** it only claims a guarded apply when the guard was actually enforced at the write.
+
+---
+
+### User Story 4 - Recoverable cold start, no dead-end (Priority: P2)
+
+A fresh agent attaching to a freshly installed tool can always make progress: the
+workspace is indexed automatically, or — if it isn't — the error tells the agent a
+recovery step it can actually perform on its current surface. The agent is never
+told to call a capability that its surface forbids.
+
+**Why this priority**: Today a default cold start can bind an empty index and then
+emit an error naming a recovery action unavailable on the default surface — an
+unrecoverable loop. High user/agent impact, but it depends on the truth/recovery
+foundation and is a step beyond the keystone honesty work.
+
+**Independent Test**: Simulate a fresh default attach with no pre-indexed
+workspace; confirm either the workspace gets indexed automatically, or the agent
+receives a recovery message that names only actions callable on its current
+surface (and never a forbidden capability).
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh default attach, **When** the workspace can be discovered, **Then** it is indexed automatically and queries work without manual intervention.
+2. **Given** an empty index on the default surface, **When** a query fails, **Then** the recovery text names only steps available on that surface (re-launch from the project root, or the documented opt-out) and never a forbidden capability.
+3. **Given** the default desktop launch path, **When** it starts, **Then** it discovers the project workspace (not an unrelated home directory) so the index is populated.
+
+---
+
+### User Story 5 - Economics grounded in reality (or honestly labeled) (Priority: P2)
+
+The economics figures an agent sees reflect the actual work — predictions derived
+from real file/response size, so the adaptive economics behavior (serve / degrade
+/ bypass) is genuinely driven by the request rather than parked permanently in one
+branch by a constant. Until grounded, every figure is labeled heuristic.
+
+**Why this priority**: The headline "token economics" is currently constant-driven,
+so its adaptive branches never fire on real traffic and its numbers can contradict
+the recorded outcome. Grounding makes the feature real; but the honest label
+(US1) ships first so nothing waits on this.
+
+**Independent Test**: Run the same operation over a small file and a large file;
+confirm the predicted figures differ in proportion to the real size, and that at
+least one non-default economics branch becomes reachable for an appropriately
+small/cheap request.
+
+**Acceptance Scenarios**:
+
+1. **Given** two operations over materially different file sizes, **When** predictions are produced, **Then** the predicted figures differ (not a fixed constant for every request).
+2. **Given** a sufficiently small/cheap request, **When** the economics gate evaluates it, **Then** a non-serve economics outcome is reachable (the adaptive behavior is no longer decorative).
+3. **Given** any equivalence/accuracy claim in the test corpus, **When** it is presented as measured, **Then** it is actually asserted by a test, or the claim is removed.
+
+---
+
+### User Story 6 - Honest public record + enforced honesty (Priority: P2)
+
+An operator (or evaluating agent) reading the public docs and the capability
+record sees the true default surface and a clear map of what is proven vs.
+heuristic vs. observational vs. deferred — and the project's automation prevents a
+future regression where a shipped claim outruns the evidence.
+
+**Why this priority**: Closes the loop so the honesty work doesn't silently rot:
+the docs match reality, the premise is framed as a bet-under-test, and a guard
+makes "shipped claim with an OPEN assumption" fail automatically. Important for
+durability, but it follows the runtime truth/labels.
+
+**Independent Test**: Read the public docs and the capability record; confirm they
+describe the real default surface and map each capability to its proof state; and
+confirm the automated honesty guard fails when a product claim is paired with an
+unproven assumption.
+
+**Acceptance Scenarios**:
+
+1. **Given** the public docs and client configuration, **When** they describe the tool surface, **Then** they state the real default surface and present the larger legacy surface as a documented opt-out.
+2. **Given** the capability record, **When** an operator reads it, **Then** each capability maps to a proof state (implemented / heuristic / observational / deferred) tied to an assumption identifier.
+3. **Given** the automated honesty guard, **When** a shipped surface claims a capability whose assumption is OPEN, **Then** the guard fails (the regression cannot merge silently).
+
+---
+
+### Edge Cases
+
+- A subsystem is wired but currently failing (vs. never configured) — status must distinguish "broken" from "off"; both must not collapse to one ambiguous label.
+- The reported recovery action is callable on the full surface but not the default surface — recovery text must be computed from the *active* surface, never a fixed string.
+- A guarded edit on a file that grows beyond the best-effort backup threshold, or is deleted mid-apply — the guard must still reject on divergence; the best-effort backup must not be presented as a transactional undo.
+- An assumption has supporting evidence in one place and is marked OPEN in another — the record must have one source of truth per identifier.
+- The honesty guard itself must not block a legitimate change that correctly labels a still-OPEN assumption (labeling honestly is allowed; claiming validation is not).
+- A figure that is a coarse approximation (e.g. derived, not measured) must be labeled as such even where it is "honest-ish", so the agent knows its precision.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Honest surfaces (US1)**
+
+- **FR-001**: Every economics-envelope figure that is not derived from real measurement MUST be explicitly labeled heuristic/estimated; no figure may be presented as a measured saving unless it is one.
+- **FR-002**: A cumulative session figure MUST be named for what it is; a running total of work performed MUST NOT be presented as an unqualified "net savings".
+- **FR-003**: Status subsystem/calibration labels MUST reflect real state via enumerated values (e.g. in-memory-only vs durable vs unavailable; deferred vs observational vs tuned), not blanket "active"/"pending".
+- **FR-004**: The deferred-items and assumption records MUST be derived from real state (no stale frozen list that contradicts what actually shipped), and any "VALIDATED" verdict not backed by an artifact MUST be demoted.
+- **FR-005**: Relabeling MUST NOT change runtime behavior, and MUST NOT promote any OPEN assumption to validated.
+
+**Status truth (US2)**
+
+- **FR-006**: In every deployment topology, the index health a status read reports MUST reflect the same index that serves queries (a successful query implies a ready, non-zero status).
+- **FR-007**: The default (compact) surface MUST provide at least one readout that reports the real index health (no gap where no honest health tool exists on the default surface).
+- **FR-008**: A durable subsystem that failed to initialize MUST be reported distinctly from one that is simply not wired.
+
+**Edit safety (US3)**
+
+- **FR-009**: A guarded apply MUST re-verify the guard condition against the bytes actually being written, in the same critical section as the write; on divergence it MUST reject the apply without writing.
+- **FR-010**: A response MUST claim a successful guarded apply only when the guard was enforced at the write; best-effort backups MUST NOT be described as transactional rollback.
+
+**Recovery & onboarding (US4)**
+
+- **FR-011**: A fresh default attach MUST index a discoverable workspace automatically, or return a recovery message that names only actions callable on the active surface.
+- **FR-012**: No agent-facing error or recovery string MUST name a capability that the active surface forbids.
+- **FR-013**: The default launch path MUST discover the project workspace (not an unrelated default directory) so the index is populated, and the registered client environment MUST carry the configuration needed for a populated, correctly-surfaced start.
+
+**Economics grounding (US5)**
+
+- **FR-014**: Economics predictions MUST be derived from real request/result size so that predictions vary with the work, and the adaptive economics outcomes are reachable for appropriate requests — OR, until grounded, every economics figure MUST be labeled heuristic (FR-001) and the adaptive behavior described as not-yet-active.
+- **FR-015**: Any equivalence/accuracy figure presented as measured MUST be backed by an actual assertion in the test corpus, or be removed.
+
+**Public record & enforced honesty (US6)**
+
+- **FR-016**: Public docs and client configuration MUST describe the real default surface, with the larger legacy surface presented as a documented opt-out.
+- **FR-017**: A published capability record MUST map each capability to a proof state (implemented / heuristic / observational / deferred) tied to an assumption identifier, with one source of truth per identifier.
+- **FR-018**: Automated verification MUST fail when a shipped surface claims a capability whose underlying assumption is OPEN.
+
+**Cross-cutting**
+
+- **FR-019**: The full verification gate (format, type/lint, tests, release build, and the network-free embed build) MUST pass after each delivered phase, not only at the end; the three named regression tests (status-matches-served-index, compact-error-never-names-blocked-tools, guarded-apply-rejects-concurrent-divergence) MUST exist.
+- **FR-020**: No remediation MUST regress the protected foundations (compact dispatch enforcement, the shipped security batch, embed isolation, index-integrity model, the assumptions register as source of truth) or revert the compact-3 default surface to "fix" anything.
+
+### Key Entities *(include if feature involves data)*
+
+- **LLM-facing surface**: any string an agent reads on a call — status banner, economics envelope, error/recovery text, tool description — governed by the honesty contract.
+- **Economics figure**: a predicted/served/saved token quantity, each carrying a proof state (measured vs heuristic) and an honest label.
+- **Index health readout**: the reported readiness + counts of the index, which must reflect the index that actually serves.
+- **Guard condition (if_match)**: the expected pre-edit body an apply is conditioned on; must be honored at the write.
+- **Assumption record entry**: an identified claim (e.g. predictor accuracy, surface premise) with exactly one proof state (OPEN / PARTIAL / VALIDATED-with-artifact), referenced by surfaces and enforced by the honesty guard.
+- **Capability matrix entry**: a feature mapped to its proof state and the assumption identifier backing it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of LLM-facing status/economics fields are either provably accurate or carry an explicit heuristic/observational/deferred label (zero fields present a constant or gross counter as a measured result).
+- **SC-002**: After a successful query in the default deployment, the status index readiness and counts match the served index in 100% of runs (never "empty/not-ready" while serving).
+- **SC-003**: A guarded apply rejects 100% of cases where the on-disk body diverged after the guard check, with zero silent clobbers and zero false "guarded apply succeeded" claims (proven by a deterministic concurrent-change test).
+- **SC-004**: From a fresh default attach, the agent reaches a working query OR a recovery message that names only callable actions in 100% of cold-start runs; zero agent-facing strings name a surface-forbidden capability.
+- **SC-005**: Economics predictions vary with real request size (two materially different inputs yield different predictions), or — if grounding is deferred — every economics figure is labeled heuristic; in either case zero figures are presented as measured savings without measurement.
+- **SC-006**: Public docs, client configuration, and the capability record describe the real default surface and proof states with one source of truth per assumption; the automated honesty guard fails any shipped claim paired with an OPEN assumption.
+- **SC-007**: The full verification gate (incl. the embed build) passes after each phase, and the three named regression tests exist and pass.
+- **SC-008 (keystone)**: An LLM that trusts SymForge's self-reported numbers and status is no longer misled — no surface asserts more than the code delivers.
+
+## Assumptions
+
+- Discovery is complete and verified in `docs/reviews/v8-trust-remediation-ledger.md`; that ledger (TR-01..TR-20 + panel findings + anchors) is the authoritative finding set and is not re-litigated here.
+- The v8 architecture is sound; this is a presentation-layer + two-real-bug remediation, **not** a rewrite. The compact-3 default surface stays; the engine (index integrity, auth, ledger storage, path guards) is protected, not changed.
+- Delivery is phased and independently shippable: P1 = honest relabel (US1) + status truth (US2) + edit safety (US3); P2 = recovery/onboarding (US4) + economics grounding (US5) + public record & enforced honesty (US6). The honest relabel (US1) ships before any "token-efficient" public messaging.
+- "Relabel ≠ validate": OPEN assumptions (notably the surface premise and the economics predictor) remain OPEN and are framed as a bet-under-test until reproduced with an artifact.
+- Verification uses fixtures and the project's own test suite (no mutation of real operator configs); regression tests use deterministic injected interleave points, not timing sleeps.
+- A real byte-grounded estimator already exists in the codebase (the economics grounding reuses it rather than building a new one), so grounding is a wiring effort, not new science.
+- Out of scope and tracked separately: the deferred P3 hardening items (ledger migration guard, retention, dependency-pin drift); the separately-tracked update-command robustness and tool-parameter schema-rendering fixes; and the parked operator-setup-wizard (009), whose onboarding overlaps US4 but is its own feature.

--- a/specs/010-v8-trust-remediation/tasks.md
+++ b/specs/010-v8-trust-remediation/tasks.md
@@ -33,11 +33,43 @@ Single Rust crate `symforge`; sources under `src/`, tests under `tests/`, docs u
 
 **Purpose**: establish a green baseline and re-confirm anchors before touching code.
 
-- [ ] T001 Capture baseline green gate: run `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets -- --test-threads=1`, `cargo build --release`, `cargo check --no-default-features --features embed`; record pass/fail in a scratch note. Kill any stray `symforge*` processes first.
-- [ ] T002 [P] Re-confirm the six T0 anchors against live `src/` (TR-01 `tools.rs` status_stel_tool + `daemon.rs`; TR-02 `format.rs`/`edit_apply.rs` dead-end strings + `loading_guard!` sites; TR-03 `cli/init.rs`/`main.rs` cold-start; TR-04 `stel/planner.rs` + `format.rs` estimator; TR-05 `stel/session.rs`/`envelope.rs`; TR-06 `protocol/edit_*`). Note any line drift in this tasks file.
-- [ ] T003 [P] Confirm `target/` is warm and stays warm for the whole campaign (no `cargo clean` until the end).
+- [ ] T001 Capture baseline green gate: run `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets -- --test-threads=1`, `cargo build --release`, `cargo check --no-default-features --features embed`; record pass/fail in a scratch note. Do NOT blanket-kill `symforge*` (the user's live MCP is a global binary; cargo builds to `target/`, no conflict).
+- [X] T002 [P] Re-confirm anchors against live `src/` — DONE 2026-06-17 (45/45 verified, 0 line-drift; 5 divergences below).
+- [X] T003 [P] Confirm `target/` warm and stays warm (no `cargo clean` until campaign end). Confirmed.
 
-**Checkpoint**: baseline known-green; anchors verified live.
+**Checkpoint**: anchors verified live; baseline gate running (T001).
+
+### Live anchor notes (T002 result, 2026-06-17) — read before editing
+
+Current exact lines (no drift): `status_stel_tool` tools.rs:8524-8557 (reads `self.index` @8541);
+daemon match daemon.rs:2306-2435 (NO `status` arm → "unknown tool"); `ReplaceSymbolBodyInput`
+edit.rs:1160-1189 (no `if_match`); `StelEditRequest` types.rs:108-126 (HAS `if_match` @122);
+pre-flight `run_pre_apply_gates` edit_apply.rs:38-90 (if_match check @73-79 under index.read);
+planner 400/800 planner.rs:51-52; estimator format.rs:4930 / 5006; controller branches
+controller.rs:55-134 (bypass@58 net<=0, mandatory_degrade@75, economics_degrade@77, serve@125);
+`summary().ok()` ledger_store.rs:227-231; status literals status.rs:110-116 + DEFERRED_ITEMS@15-16;
+4 dead-end strings format.rs:4774, edit_apply.rs:48, tools.rs:6033, edit_tools.rs:23(macro);
+`loading_guard!` ~26 sites; wrapper init.rs:837 `cd /d %USERPROFILE%`, env:{} @761-765;
+`find_project_root` discovery/mod.rs:483-515; expected_equiv types.rs:313 (write-only/dead);
+A-005 OPEN@77 vs VALIDATED@146; A-009 VALIDATED@86; A-016 OPEN@103; A-028 VALIDATED@129;
+"32 canonical tools" README:24,328 AGENTS:125 CLAUDE:34; CI `.github/workflows/ci.yml` (rust job 55-79, embed 81-103).
+
+**Divergences that change implementation:**
+- **D-a (T014)**: A-005 self-contradicts itself (OPEN@77, VALIDATED@146) — single-source it.
+- **D-b (T023-T025)**: `if_match` is plumbed at L0 (`StelEditRequest`@122) + validated in pre-flight
+  under the read guard, but DROPPED by the planner (edit_planner.rs:72-80) before the legacy write,
+  and `ReplaceSymbolBodyInput` has no field; the write (tools.rs:519) never re-verifies → TOCTOU real.
+  Fix = thread field through to legacy input + re-verify at the write critical section (D1). The pre-flight
+  check stays but is NOT the guarantee.
+- **D-c (T018/T019)**: daemon has NO `status` arm; `status_stel_tool` reads the front-end `self.index`.
+  Add a daemon `status` arm + proxy the front-end read to it.
+- **D-d (T011)**: no `"pending"` literal; `CalibrationState` (types.rs:292-298) is rendered via
+  `format_calibration_section` (status.rs:155) from `src/stel/calibration.rs`. Relabel target is there;
+  first verify the EMA is never meaningfully updated (N-1 dead-seam claim) before labeling `deferred`/
+  `observational`. Keep the seam (Do-Not #7).
+- **D-e (T037/T038)**: controller.rs:55 ALREADY calls `estimate_economics` → the real estimator;
+  the planner just stamps 400/800 with `index_refs`/`raw_chars` inert. Grounding = feed real raw_chars
+  to the already-wired estimator (smaller than "wire a new path").
 
 ---
 

--- a/specs/010-v8-trust-remediation/tasks.md
+++ b/specs/010-v8-trust-remediation/tasks.md
@@ -1,0 +1,273 @@
+---
+description: "Task list for v8 Trust Remediation implementation"
+---
+
+# Tasks: v8 Trust Remediation
+
+**Input**: Design documents from `specs/010-v8-trust-remediation/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: REQUESTED — FR-019 mandates the three named regression tests + the per-phase
+gate; quickstart defines per-story acceptance. Test tasks are included and written before
+the fix where practical.
+
+**Organization**: by user story (US1=Phase A … US6=Phase F), sequenced per the ledger
+(relabel → status truth → edit safety → recovery → economics → matrix+CI). Each story is an
+independently shippable increment; the full gate runs after each.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different file, no dependency on an incomplete task)
+- **[Story]**: US1–US6; Setup/Foundational/Polish carry no story label
+- Anchors (file:line) are from the ledger; **re-confirm against live code at use** (line
+  numbers drift). Harness MCP may be any version; correctness is proven by `cargo`.
+
+## Path Conventions
+
+Single Rust crate `symforge`; sources under `src/`, tests under `tests/`, docs under `docs/`.
+
+---
+
+## Phase 1: Setup (Baseline — goal PHASE 0)
+
+**Purpose**: establish a green baseline and re-confirm anchors before touching code.
+
+- [ ] T001 Capture baseline green gate: run `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets -- --test-threads=1`, `cargo build --release`, `cargo check --no-default-features --features embed`; record pass/fail in a scratch note. Kill any stray `symforge*` processes first.
+- [ ] T002 [P] Re-confirm the six T0 anchors against live `src/` (TR-01 `tools.rs` status_stel_tool + `daemon.rs`; TR-02 `format.rs`/`edit_apply.rs` dead-end strings + `loading_guard!` sites; TR-03 `cli/init.rs`/`main.rs` cold-start; TR-04 `stel/planner.rs` + `format.rs` estimator; TR-05 `stel/session.rs`/`envelope.rs`; TR-06 `protocol/edit_*`). Note any line drift in this tasks file.
+- [ ] T003 [P] Confirm `target/` is warm and stays warm for the whole campaign (no `cargo clean` until the end).
+
+**Checkpoint**: baseline known-green; anchors verified live.
+
+---
+
+## Phase 2: Foundational (Shared honest-label vocabulary)
+
+**Purpose**: the enumerated-state types US1/US2/US5 all consume. BLOCKS the story phases
+that label state. Pure type additions — no behavior, no surface change yet.
+
+**⚠️ CRITICAL**: no labeling story can finish until these types exist.
+
+- [ ] T004 Add a `ProofState` enum (`Measured | Heuristic | Observational | Deferred`) in `src/stel/types.rs` (per data-model E1/E2); no surface wired yet.
+- [ ] T005 Add a `SubsystemState` enum (`InMemory | Durable | Disabled(reason) | Unavailable`) in `src/stel/status.rs` (per data-model E4); no surface wired yet.
+- [ ] T006 [P] Add an `IndexState` enum (`Ready | Empty | Loading | Unavailable`) + `empty_index_reason` field type in `src/stel/status.rs` (per data-model E3); no surface wired yet.
+
+**Checkpoint**: shared vocabulary compiles; `cargo check` green. User stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Every reported number/label is honest (Priority: P1) 🎯 MVP
+
+**Goal**: every status + economics-envelope field is true or explicitly labeled
+heuristic/observational/deferred. **Zero behavior change** (relabel only).
+
+**Independent Test**: read every status/envelope field — each is `Measured` or carries a
+qualifier; no `net`/`saved`/`active`/`validated` presents a constant or gross counter as a
+measured result; golden replay unchanged.
+
+### Tests for User Story 1
+
+- [ ] T007 [P] [US1] Add a surface-honesty unit test in `tests/surface_honesty.rs`: render the status banner + economics envelope over a fixture and assert no field named `net`/`saved`/`validated`/`active`/`pending` presents an ungrounded constant/gross counter (fails before the relabel).
+- [ ] T008 [P] [US1] Add a golden-replay invariance check (reuse existing golden replay) asserting Phase A changes the *labels* only, not route shape / behavior.
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Rename `session_net_vs_manual` → `session_tokens_served` and drop the `+net`-implies-savings framing in `src/protocol/tools.rs` (~8142) and `src/stel/session.rs` (TR-05).
+- [ ] T010 [US1] Label envelope figures `est_`/`heuristic` vs `measured` and fix the reject-path session figure in `src/stel/envelope.rs` (~47) and `src/stel/executor.rs` (~347-366) (TR-05, TR-11).
+- [ ] T011 [US1] Relabel `calibration: "pending"` → `deferred` and mark `CalibrationState` `deferred`/`observational` (KEEP the seam — Do-Not #7) in `src/stel/types.rs` (~292) and the status formatter (N-1).
+- [ ] T012 [US1] Replace the unconditional `l1..l4`/`handler_*` literals with `SubsystemState`/`IndexState` enumerated states + `empty_index_reason` in `src/stel/status.rs` (~104-122) (TR-10); drop stale `ledger_persistence` from the `deferred:` list (FR-004).
+- [ ] T013 [P] [US1] Label every chars/4 figure "estimated tokens (chars/4)" at its source in `src/protocol/handler.rs` (~8-10) and downstream formatters (N-4).
+- [ ] T014 [P] [US1] Docs honesty: demote A-009 → PARTIAL and A-028 (remove false VALIDATED) and single-source A-005/A-016 in `docs/stel-assumptions.md` (TR-12/13/16); **relabel ≠ validate** — do not promote A-011/A-015/A-016/A-028.
+- [ ] T015 [US1] Run the per-phase gate (quickstart 6 commands) + golden replay; confirm zero behavior change. Commit Phase A.
+
+**Checkpoint**: US1 shippable alone — all surfaces honest, behavior identical. MVP done.
+
+---
+
+## Phase 4: User Story 2 — Status tells the truth about the index (Priority: P1)
+
+**Goal**: a working index never reports empty; `status` reads the same index that serves.
+
+**Independent Test**: serve + query to populate the index, read `status`, counts match the
+served index (Ready, non-zero); a failing-open ledger reads `Disabled(reason)` ≠ `Unavailable`.
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] Add the named regression `status_index_matches_daemon_proxy_after_symforge_serve` in `tests/status_truth.rs`: populate via serve, assert `status` counts == served index (fails before the proxy fix) (TR-01, SC-002).
+- [ ] T017 [P] [US2] Add a unit test asserting a wired-but-failing ledger reports `Disabled(reason)`, distinct from a never-configured `Unavailable` (N-3, FR-008).
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Add a `status` arm to the daemon that returns index readiness + counts + ledger state in `src/daemon.rs` (~2435) (TR-01).
+- [ ] T019 [US2] Route `status_stel_tool` through the daemon proxy (like every other proxying reader, `mod.rs:266`) instead of the empty front-end `self.index` in `src/protocol/tools.rs` (~8529-8541) (TR-01); ensure compact `status` reports real health (FR-007).
+- [ ] T020 [US2] Stop `summary()` swallowing the DB error into `None`; surface `Disabled(reason)` vs `Unavailable` in `src/stel/ledger_store.rs` (~227-230) (N-3, TR-17).
+- [ ] T021 [US2] Run the per-phase gate; confirm T016/T017 pass. Commit Phase B.
+
+**Checkpoint**: US1+US2 work independently; status never lies about the index.
+
+---
+
+## Phase 5: User Story 3 — A guarded edit actually guards (Priority: P1)
+
+**Goal**: `if_match` is enforced at the write; a concurrent divergence is rejected, never a
+false success.
+
+**Independent Test**: guarded apply + injected concurrent change ⟹ rejected, on-disk change
+intact, no false "guarded apply succeeded"; negative control succeeds.
+
+### Tests for User Story 3
+
+- [ ] T022 [P] [US3] Add the named regression `symforge_edit_if_match_rejected_after_concurrent_disk_change` in `tests/edit_safety.rs` using a **deterministic injected interleave point** (test hook between guard-read and write, NOT a sleep) (TR-06, SC-003); include the negative control.
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Add an `if_match` field to `ReplaceSymbolBodyInput` in `src/protocol/edit_tools.rs` (~570-676) (TR-06).
+- [ ] T024 [US3] Thread `if_match` through the edit planner so it is not dropped in `src/protocol/edit_planner.rs` (~72) (TR-06).
+- [ ] T025 [US3] Re-verify the guard against the bytes actually written, in the same critical section as the splice + `atomic_write`; reject on divergence in `src/protocol/edit_apply.rs` (~73-91) and `src/protocol/edit.rs` (~1160) (FR-009, D1).
+- [ ] T026 [P] [US3] Honest response + N-6 boundary: claim a guarded apply only when enforced at write; mark the batch path "no if_match (same TOCTOU if extended)" and keep `verify_index_matches_disk` labeled pre-flight-only (FR-010, N-6); ensure the tee backup is not called transactional rollback.
+- [ ] T027 [US3] Run the per-phase gate; confirm T022 passes (both reject + negative control). Commit Phase C.
+
+**Checkpoint**: US1+US2+US3 — the three real-bug/keystone P1s done.
+
+---
+
+## Phase 6: User Story 4 — Recoverable cold start, no dead-end (Priority: P2)
+
+**Goal**: a fresh attach indexes automatically, or the error names only callable recovery on
+the active surface — never a gated tool.
+
+**Independent Test**: fresh default attach with no pre-index ⟹ auto-index OR a recovery
+message naming only surface-callable actions; the desktop launch path discovers the project
+root (not `%USERPROFILE%`).
+
+### Tests for User Story 4
+
+- [ ] T028 [P] [US4] Add the named regression `compact_surface_index_not_loaded_message_never_mentions_blocked_tools` in `tests/recovery.rs`: on the compact profile, assert no empty-index message names a gated tool (TR-02, SC-004).
+- [ ] T029 [P] [US4] Add a test that the cold-start root discovery resolves the project workspace, not the home dir (TR-03).
+
+### Implementation for User Story 4
+
+- [ ] T030 [US4] Add a single surface-aware `empty_index_recovery_hint(profile)` in `src/protocol/format.rs` (~4774) that never names a gated tool (compact: re-launch from root / documented opt-out; full: may name `index_folder`) (TR-02, D4).
+- [ ] T031 [US4] Route all 4 dead-end strings + the `loading_guard!` sites through `empty_index_recovery_hint` in `src/protocol/format.rs`, `edit_apply.rs` (~48), `tools.rs` (~6033), `edit_tools.rs` (~263) (N-5, FR-012).
+- [ ] T032 [US4] Fix the desktop wrapper so it does not `cd /d "%USERPROFILE%"` before launch in `src/cli/init.rs` (~837) so `find_project_root()` discovers the workspace (TR-03).
+- [ ] T033 [US4] Write a proven init `env` (root / `SYMFORGE_SURFACE` / auto-index hint) instead of `env:{}` in `src/cli/init.rs` (~761); verify `find_project_root()` in `src/main.rs` (~217-248) populates the index (TR-03, FR-013).
+- [ ] T034 [US4] Run the per-phase gate; confirm T028/T029 pass. Commit Phase D.
+
+**Checkpoint**: cold start recovers; no dead-end loop.
+
+---
+
+## Phase 7: User Story 5 — Economics grounded in reality (Priority: P2)
+
+**Goal**: predictions derive from real size; the adaptive branches (degrade/bypass) become
+reachable. (Ground-now, clarified 2026-06-17.)
+
+**Independent Test**: same op over small vs large file ⟹ predictions differ proportionally; a
+non-serve branch is reachable for a small request; `expected_equiv` is asserted or removed.
+
+### Tests for User Story 5
+
+- [ ] T035 [P] [US5] Add a test asserting predictions vary with real file size (two materially different inputs ⟹ different predictions) in `tests/economics.rs` (SC-005, US5 AC-1).
+- [ ] T036 [P] [US5] Add a test asserting a non-serve economics branch (`degrade`/`bypass`/`mandatory_degrade`) is reachable for a small/cheap request (TR-04b, N-2, US5 AC-2).
+
+### Implementation for User Story 5
+
+- [ ] T037 [US5] Wire the existing estimator (`competent_manual_baseline_chars` / `saved_tokens_vs_competent_manual`, `src/protocol/format.rs` ~4925-5029) into the planner, replacing the `400/800` constants in `src/stel/planner.rs` (~44-55) (TR-04, D2).
+- [ ] T038 [US5] Make `index_refs`/`raw_chars` carry real values so `predicted_net` varies; verify the economics gate now routes on real input in `src/stel/controller.rs` (~40-135) (TR-04, TR-04b).
+- [ ] T039 [P] [US5] Assert-or-remove `expected_equiv`: either assert it in golden replay or delete the write-only dead data; purge any "95% trajectory" tautology claim in `src/stel/golden_replay.rs` (~244-310) and `src/stel/types.rs` (~313) (TR-13, FR-015).
+- [ ] T040 [US5] Run the per-phase gate + golden replay; confirm T035/T036 pass. Commit Phase E.
+
+**Checkpoint**: economics is real (or honestly heuristic where a figure isn't yet grounded).
+
+---
+
+## Phase 8: User Story 6 — Honest public record + enforced honesty (Priority: P2)
+
+**Goal**: docs describe the real default surface; a capability matrix maps proof states; CI
+fails a claim that outruns the evidence.
+
+**Independent Test**: docs state compact-3 default + 32-tool opt-out; `v8-capability-matrix.md`
+maps feature → assumption ID → proof state; the honesty CI gate fails a surface claiming an
+OPEN-assumption capability, and passes honest OPEN-labeling.
+
+### Tests for User Story 6
+
+- [ ] T041 [P] [US6] Add a test/lint asserting `docs/v8-capability-matrix.md` exists and every row has feature + proof state + assumption ID (FR-017).
+- [ ] T042 [P] [US6] Add a test for the honesty gate: a fixture surface claiming a capability whose assumption is OPEN ⟹ gate FAILS; an honest OPEN-labeled fixture ⟹ passes (FR-018, US6 AC-3).
+
+### Implementation for User Story 6
+
+- [ ] T043 [P] [US6] Publish `docs/v8-capability-matrix.md` (feature → assumption ID → Implemented/Heuristic/Observational/Deferred), framing A-017/A-011 as bet-under-test (TR-09, FR-017).
+- [ ] T044 [P] [US6] Update README.md (L24, L328), AGENTS.md (L125), CLAUDE.md (L34) to describe the compact-3 default with the 32-tool surface as a documented opt-out (TR-07, FR-016). Ship only AFTER Phase A (Do-Not #4).
+- [ ] T045 [US6] Implement the honesty CI gate (static parse + cross-reference: OPEN-assumption + validated-claim = FAIL; one-source-of-truth per number; VALIDATED requires artifact) as a `.github/workflows/` check (FR-018).
+- [ ] T046 [US6] Run the per-phase gate + the new honesty gate; confirm T041/T042 pass. Commit Phase F.
+
+**Checkpoint**: public record honest; regression of the honesty work is CI-blocked.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: campaign-level verification and integration.
+
+- [ ] T047 Run the full quickstart acceptance pass for all six stories (SC-001..SC-007).
+- [ ] T048 Live keystone dogfood (SC-008): build the local 8.0.0 binary (`cargo build --release`), run `symforge serve`, reconnect a client; `status` compact reports real index; orient query succeeds; `status` full counts MATCH the served query; `symforge_edit` preview honest. Record evidence.
+- [ ] T049 [P] Confirm Constitution VI/VII: `cargo check --no-default-features --features embed` green and stdio↔serve parity for any touched formatter.
+- [ ] T050 git-master: integrate all phase commits onto a review branch; HARD-STOP before any push/merge (await explicit human approval).
+- [ ] T051 Write the honest results doc (objective / changes / verification / evidence / known gaps) under `docs/reviews/`; `cargo clean` only now (campaign end).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (P1)**: no deps — start immediately.
+- **Foundational (P2)**: depends on Setup — BLOCKS the labeling stories (US1, US2, US5 use the enums).
+- **US1 (P3)**: after Foundational. The relabel; ships first (Do-Not #4 — before any "token-efficient" doc in US6/T044).
+- **US2 (P4)**: after Foundational. Uses `SubsystemState`/`IndexState`; otherwise independent of US1.
+- **US3 (P5)**: after Setup only (edit path — no enum dep); independent.
+- **US4 (P6)**: after Setup; independent (recovery text + init).
+- **US5 (P7)**: after Foundational (proof-state labels); reopens economics branches.
+- **US6 (P8)**: docs/CI; T044 (README "token-efficient") MUST follow US1; the gate (T045) can land last.
+- **Polish (P9)**: after all desired stories.
+
+### Within Each Story
+
+- Tests written before the fix (assert they fail), then implement, then the per-phase gate, then commit.
+- Each story ends green on the full gate before the next begins (FR-019).
+
+### Parallel Opportunities
+
+- Setup T002/T003 [P]; Foundational T006 [P] (T004/T005 touch shared files first).
+- The two **real-bug** stories US2 (status) and US3 (edit safety) touch disjoint files (`daemon.rs`/`tools.rs`/`status.rs` vs `edit_*`) → can be implemented in parallel by separate agents after Foundational.
+- US4 (init/format recovery) is disjoint from US2/US3 → parallelizable.
+- Within a story, `[P]` test tasks run together; doc tasks (T014, T043, T044) are file-disjoint.
+- **Throttle**: each phase's gate is a heavy `cargo` run — serialize the gates (do not run 3 phase-gates concurrently); keep `target/` warm.
+
+---
+
+## Implementation Strategy
+
+### MVP First (P1 trio)
+
+1. Setup + Foundational.
+2. US1 (relabel, zero-behavior) → **STOP, validate** (the keystone honesty quick-win, shippable alone).
+3. US2 (status truth) + US3 (edit safety) — the two real bugs. These three P1s are the highest-leverage delivery.
+
+### Incremental Delivery
+
+US1 → US2 → US3 (P1 done) → US4 → US5 → US6 (P2 done) → Polish. Each story is a green,
+independently-testable increment; integrate to a review branch and STOP for human approval
+before any push/merge (T050).
+
+---
+
+## Notes
+
+- Anchors are ledger line numbers; re-confirm live before editing (Step-0 / EDIT INTEGRITY).
+- Phase A (US1) ships before any README "token-efficient" language (Do-Not #4).
+- relabel ≠ validate — never promote A-011/A-015/A-016/A-028 for a label change.
+- Do NOT revert compact-3 / re-expose 32 tools, gate daemon IPC on compact, or delete the
+  `CalibrationState` seam (Do-Not #1/#3/#7).
+- No push/merge without explicit human approval — commit to a review branch and stop.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and planning only; no production code paths change. Risk is process/scope clarity until implementation PRs land the P0 bugs (status proxy, `if_match` write guard).
> 
> **Overview**
> This PR **does not change Rust or MCP behavior** — it lands the discovery → specify package for **v8 trust remediation** (feature `010`).
> 
> **`CLAUDE.md`** now points Speckit readers at `specs/010-v8-trust-remediation/plan.md` instead of the 007 intelligence-ports plan.
> 
> **New review corpus** under `docs/reviews/` consolidates June 2026 skeptical audits and advisory write-ups: compact-surface recovery dead-ends (`index_folder` on a 3-tool default), status vs daemon index mismatch, economics envelope overstated as measured, `if_match` TOCTOU, init/CWD/onboarding gaps, and doc/allow-list drift vs compact-3. **`v8-trust-remediation-ledger.md`** is the verified TR-01..TR-20 crosswalk and phased remediation spine (relabel → status truth → edit safety → recovery → economics grounding → matrix/CI).
> 
> **New `specs/010-v8-trust-remediation/`** turns that ledger into an implementable program: **`spec.md`** (six user stories, FR/SC), **`plan.md`** / **`research.md`** (locked decisions, e.g. proxy `status` to daemon, ground economics via existing `format.rs` estimator), **`tasks.md`** (T001–T051 with named regressions), **`data-model.md`**, **`quickstart.md`**, **`contracts/`** (status, envelope, `if_match`, recovery hints, capability matrix, honesty CI), and a passing requirements checklist.
> 
> Follow-on work is explicitly scoped in tasks (e.g. daemon `status` arm, `empty_index_recovery_hint`, init env/CWD) — to be delivered in later PRs on this branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe35755de6ec8639d2eec9a6190db49995356b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->