### PR TITLE
fix(stel): symbol-aware read/impact/orient routing

### DIFF
--- a/docs/reviews/symforge-8.4-facade-friction.md
+++ b/docs/reviews/symforge-8.4-facade-friction.md
@@ -1,0 +1,50 @@
+# SymForge 8.4.0 — compact-3 facade friction (AAP dogfood battery)
+
+**Date**: 2026-06-19  
+**Surface**: `symforge` + `symforge_edit` + `status` (compact-3)  
+**Version tested**: 8.4.0  
+**Source**: AAP agent onboarding battery (8 `symforge` + 1 `symforge_edit`); black-box findings validated against `src/stel/planner.rs`.
+
+## What works well
+
+- **find (symbol)** → `search_symbols` — exact match, helpful fallback docs.
+- **trace (symbol)** → `find_references` — enclosing-symbol context, low prediction error.
+- **symforge_edit preview** — path+symbol honored, exact `replace_symbol_body` dry-run, clear byte diff.
+- **status** — `symforge_version`, index health, STEL wiring (version assertion TC lacks).
+- **STEL per-call trace** — plan / route_tool / decision / tokens / ledger; self-explaining for diagnosis.
+
+## Repro table (pre-fix)
+
+All calls via compact `symforge` unless noted.
+
+| # | intent / call | planner route (8.4.0) | result |
+|---|---------------|----------------------|--------|
+| A | auto · "Orient me: …main crates…" | find → search_files → search_text (prose tokenized) | 350 noise matches ❌ |
+| B | find · `symbol=fail_and_cascade` | search_symbols | exact `dag.rs:255` ✅ |
+| C | read · `symbol` + `path=dag.rs` | get_file_context | file outline, not body ❌ |
+| D | orient · "map of workspace crates" | explore | Workspace* keyword hits, no map ❌ |
+| E | read · `symbol`, no path | get_file_context `{path: query}` | File not found / reject ❌ |
+| F | trace · `symbol=BlockedReason` | find_references `{name}` | 25 refs / 6 files ✅ |
+| G | impact · `symbol=TaskStatus` | find_dependents `{path: query}` | no dependents for question ❌ |
+| H | symforge_edit replace (dry-run) | replace_symbol_body `{dry_run:true}` | clean preview ✅ |
+
+## Root cause
+
+`symbol_lookup_step` was gated to **find/auto only**. Explicit `read` and `impact` buckets fell through to `route_read` / `route_impact`, which ignore `symbol` and shove the natural-language `query` into `path`. **Trace** and **symforge_edit** already consumed `symbol` — hence the asymmetry.
+
+Orientation queries with no literal `"repo map"` routed to `explore` (keyword hits) or find-fusion (OR-literal explosion on auto).
+
+## Fix (branch `fix/stel-symbol-aware-routing`)
+
+1. Extend `symbol_lookup_step` to **read** intent → `get_symbol` (with or without `path`).
+2. Add `symbol_impact_step` → `find_dependents` when `path` set; else `find_references` for symbol-level impact.
+3. Add `orient_lookup_step` + `is_orient_query` → `get_repo_map` before find fusion; default `route_orient` to map.
+
+## Cross-cutting (separate work)
+
+- **Predictor calibration**: `durable_ledger: unavailable` on stdio MCP; errors wild on plan-only floors — documented/deferred (010).
+- **max_tokens**: compact serve caps inject floors; find fusion can exceed budget while read truncates — inconsistent enforcement.
+
+## AAP coordination
+
+`stel` is `#[cfg(feature = "server")]` — planner changes do not affect AAP embed builds. Keep `../symforge` on a tagged release for AAP `path` deps; land this fix on its own branch.

--- a/docs/reviews/symforge-8.4-facade-friction.md
+++ b/docs/reviews/symforge-8.4-facade-friction.md
@@ -47,4 +47,4 @@ Orientation queries with no literal `"repo map"` routed to `explore` (keyword hi
 
 ## AAP coordination
 
-`stel` is `#[cfg(feature = "server")]` — planner changes do not affect AAP embed builds. Keep `../symforge` on a tagged release for AAP `path` deps; land this fix on its own branch.
+`stel` is `#[cfg(feature = "server")]` — planner changes do not affect AAP embed builds. AAP path-deps `../symforge` and can bump `Cargo.lock` to whatever version it needs after symforge releases.

--- a/src/stel/planner.rs
+++ b/src/stel/planner.rs
@@ -32,6 +32,12 @@ pub fn build_plan(request: &StelRequest) -> StelPlan {
     if let Some(step) = symbol_lookup_step(request) {
         return build_plan_from_steps(request, vec![step]);
     }
+    if let Some(step) = symbol_impact_step(request) {
+        return build_plan_from_steps(request, vec![step]);
+    }
+    if let Some(step) = orient_lookup_step(request) {
+        return build_plan_from_steps(request, vec![step]);
+    }
     // US4 find fusion: a multi-word fuzzy find query that matches no explicit
     // routing phrase fans out across BOTH the path/file matcher (with the gated
     // co-change boost) and the symbol-name matcher, merged by the serve
@@ -93,26 +99,30 @@ pub(crate) fn is_bare_identifier(candidate: &str) -> bool {
     })
 }
 
-/// US-symbol-routing: a bare-identifier `symbol` for find/auto intent routes
+/// US-symbol-routing: a bare-identifier `symbol` for find/auto/read intent routes
 /// straight to a symbol lookup rather than letting the query-side text search
 /// own the route. Returns `None` (deferring to the existing pipeline) when:
 ///   - no `symbol` was supplied, or it is prose (the prose case is rejected with
 ///     a corrective error at the facade boundary, before planning), or
-///   - the intent is an explicit non-find/non-auto bucket (that bucket already
-///     consumes `symbol` where it makes sense — e.g. `route_trace`), or
+///   - the intent is an explicit bucket that already consumes `symbol` elsewhere
+///     (`route_trace`, `symbol_impact_step`, …), or
 ///   - an explicit routing phrase in the query already won (its precise
 ///     single-step golden route must stand).
 ///
 /// When it fires it prefers `get_symbol` (the caller named an exact symbol and,
 /// with a `path`, we can fetch its body directly) and otherwise `search_symbols`
-/// (name-ranked symbol discovery), never a full-text search over the prose query.
+/// for find/auto or `get_symbol` by name for read, never a full-text search over
+/// the prose query.
 fn symbol_lookup_step(request: &StelRequest) -> Option<PlannedStep> {
     let symbol = request.symbol.as_deref()?.trim();
     if !is_bare_identifier(symbol) {
         return None;
     }
     let bucket = request.intent.unwrap_or(IntentBucket::Auto);
-    if !matches!(bucket, IntentBucket::Auto | IntentBucket::Find) {
+    if !matches!(
+        bucket,
+        IntentBucket::Auto | IntentBucket::Find | IntentBucket::Read
+    ) {
         return None;
     }
     // An explicit routing phrase in the query is a precise signal that outranks a
@@ -125,8 +135,16 @@ fn symbol_lookup_step(request: &StelRequest) -> Option<PlannedStep> {
             "get_symbol",
             json!({ "path": path, "name": symbol }),
             IntentBucket::Read,
-            RouteConfidence::Inferred,
+            RouteConfidence::Exact,
             "explicit symbol + path lookup",
+        ))
+    } else if bucket == IntentBucket::Read {
+        Some(planned(
+            "get_symbol",
+            json!({ "name": symbol }),
+            IntentBucket::Read,
+            RouteConfidence::Inferred,
+            "read intent symbol body lookup",
         ))
     } else {
         Some(planned(
@@ -137,6 +155,74 @@ fn symbol_lookup_step(request: &StelRequest) -> Option<PlannedStep> {
             "explicit symbol lookup",
         ))
     }
+}
+
+/// Impact intent with a bare `symbol`: resolve to a concrete tool instead of
+/// shoving the natural-language `query` into `find_dependents.path`.
+fn symbol_impact_step(request: &StelRequest) -> Option<PlannedStep> {
+    let symbol = request.symbol.as_deref()?.trim();
+    if !is_bare_identifier(symbol) {
+        return None;
+    }
+    if request.intent != Some(IntentBucket::Impact) {
+        return None;
+    }
+    if route_with_query_patterns(request).is_some() {
+        return None;
+    }
+    if let Some(path) = request.path.as_deref().filter(|p| !p.trim().is_empty()) {
+        return Some(planned(
+            "find_dependents",
+            json!({ "path": path, "compact": true }),
+            IntentBucket::Impact,
+            RouteConfidence::Exact,
+            "impact intent file dependents for explicit path",
+        ));
+    }
+    Some(planned(
+        "find_references",
+        json!({ "name": symbol, "compact": true }),
+        IntentBucket::Impact,
+        RouteConfidence::Inferred,
+        "impact intent symbol-level dependents (callers/usages)",
+    ))
+}
+
+/// Orient phrasing on auto/orient intent routes to `get_repo_map` before find
+/// fusion can tokenize the prose query into OR-literals.
+fn orient_lookup_step(request: &StelRequest) -> Option<PlannedStep> {
+    let bucket = request.intent.unwrap_or(IntentBucket::Auto);
+    if !matches!(bucket, IntentBucket::Auto | IntentBucket::Orient) {
+        return None;
+    }
+    let lower = request.query.trim().to_ascii_lowercase();
+    if !is_orient_query(&lower) {
+        return None;
+    }
+    if route_with_query_patterns(request).is_some() {
+        return None;
+    }
+    Some(planned(
+        "get_repo_map",
+        json!({}),
+        IntentBucket::Orient,
+        RouteConfidence::Inferred,
+        "orient/workspace phrasing",
+    ))
+}
+
+/// True when the query is asking for repository orientation rather than search.
+fn is_orient_query(lower: &str) -> bool {
+    lower.starts_with("orient me")
+        || lower.contains("repo map")
+        || lower.contains("crate map")
+        || lower.contains("map of")
+        || lower.contains("main crates")
+        || lower.contains("workspace layout")
+        || lower.contains("project layout")
+        || lower.contains("overview of the")
+        || lower.contains("overview of this")
+        || lower.contains("orient:")
 }
 
 fn build_plan_from_steps(request: &StelRequest, steps: Vec<PlannedStep>) -> StelPlan {
@@ -374,7 +460,7 @@ fn is_multi_term_fuzzy_find(query: &str) -> bool {
     // "explain Z") are explore intent, not find — never fuse them. This keeps
     // the golden `explore` rows (e.g. "how to use records ORM") routing to
     // explore and mirrors smart_query's Understand/Explore lead-ins.
-    if is_guidance_query(&lower) {
+    if is_guidance_query(&lower) || is_orient_query(&lower) {
         return false;
     }
     let tokens: Vec<&str> = lower
@@ -734,7 +820,8 @@ fn route_impact(request: &StelRequest) -> PlannedStep {
 }
 
 fn route_orient(request: &StelRequest) -> PlannedStep {
-    if request.query.to_ascii_lowercase().contains("repo map") {
+    let lower = request.query.trim().to_ascii_lowercase();
+    if is_orient_query(&lower) {
         planned(
             "get_repo_map",
             json!({}),
@@ -742,13 +829,21 @@ fn route_orient(request: &StelRequest) -> PlannedStep {
             RouteConfidence::Inferred,
             "orient intent repo map",
         )
-    } else {
+    } else if is_guidance_query(&lower) {
         planned(
             "explore",
             json!({ "query": request.query.trim(), "depth": 2 }),
             IntentBucket::Orient,
             RouteConfidence::Inferred,
-            "orient intent explore",
+            "orient intent explore guidance",
+        )
+    } else {
+        planned(
+            "get_repo_map",
+            json!({}),
+            IntentBucket::Orient,
+            RouteConfidence::Inferred,
+            "orient intent default repo map",
         )
     }
 }
@@ -1512,5 +1607,78 @@ mod tests {
             ..Default::default()
         };
         assert!(symbol_contract_violation(&request).is_none());
+    }
+
+    #[test]
+    fn read_intent_symbol_and_path_routes_to_get_symbol() {
+        let plan = build_plan(&StelRequest {
+            query: "show source body".to_string(),
+            intent: Some(IntentBucket::Read),
+            symbol: Some("fail_and_cascade".to_string()),
+            path: Some("dag.rs".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "get_symbol");
+        assert_eq!(plan.steps[0].args["name"], "fail_and_cascade");
+        assert_eq!(plan.steps[0].args["path"], "dag.rs");
+    }
+
+    #[test]
+    fn read_intent_symbol_without_path_routes_to_get_symbol_not_query_as_path() {
+        let plan = build_plan(&StelRequest {
+            query: "Show the source body of fail_and_cascade".to_string(),
+            intent: Some(IntentBucket::Read),
+            symbol: Some("fail_and_cascade".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "get_symbol");
+        assert_eq!(plan.steps[0].args["name"], "fail_and_cascade");
+        assert!(plan.steps[0].args.get("path").is_none());
+    }
+
+    #[test]
+    fn impact_intent_symbol_routes_to_find_references_not_query_as_path() {
+        let plan = build_plan(&StelRequest {
+            query: "What depends on TaskStatus in this workspace?".to_string(),
+            intent: Some(IntentBucket::Impact),
+            symbol: Some("TaskStatus".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "find_references");
+        assert_eq!(plan.steps[0].args["name"], "TaskStatus");
+    }
+
+    #[test]
+    fn impact_intent_symbol_with_path_routes_to_find_dependents() {
+        let plan = build_plan(&StelRequest {
+            query: "what breaks if I change this file".to_string(),
+            intent: Some(IntentBucket::Impact),
+            symbol: Some("TaskStatus".to_string()),
+            path: Some("src/task.rs".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "find_dependents");
+        assert_eq!(plan.steps[0].args["path"], "src/task.rs");
+    }
+
+    #[test]
+    fn orient_intent_map_phrasing_routes_to_get_repo_map() {
+        let plan = build_plan(&StelRequest {
+            query: "map of workspace crates".to_string(),
+            intent: Some(IntentBucket::Orient),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "get_repo_map");
+    }
+
+    #[test]
+    fn auto_orient_me_phrasing_routes_to_get_repo_map_not_find_fusion() {
+        let plan = build_plan(&StelRequest {
+            query: "Orient me: what are the main crates in this workspace?".to_string(),
+            intent: Some(IntentBucket::Auto),
+            ..Default::default()
+        });
+        assert_eq!(plan.steps[0].tool, "get_repo_map");
+        assert_eq!(plan.steps.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- **Read + symbol** → `get_symbol` (fixes C/E: no more `get_file_context` outline or query-as-path)
- **Impact + symbol** → `find_references` (symbol-level) or `find_dependents` when `path` set (fixes G)
- **Orient phrasing** → `get_repo_map` before find-fusion OR explosion (fixes A/D)
- Friction doc: `docs/reviews/symforge-8.4-facade-friction.md` (AAP battery repro table)

## Root cause

`symbol_lookup_step` was gated to find/auto only; `route_read` / `route_impact` ignored `symbol`.

## Test plan

- [ ] `cargo test --lib stel::planner::`
- [ ] AAP battery rows C/E/G/A/D pass on compact `symforge`
- [ ] B/F/H unchanged (find/trace/edit)

## AAP note

`stel` is server-feature only — embed builds unaffected. Keep AAP path-dep on tagged release; this lands on its own branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request-to-tool routing in `build_plan` for multiple intents; behavior is well-covered by new tests but affects every compact symforge call path when `symbol` or orient phrasing is present.
> 
> **Overview**
> Fixes compact **symforge** facade friction where **read**, **impact**, and **orient/auto** ignored a bare `symbol` or mis-routed orientation prose.
> 
> **Read + `symbol`** now hits `get_symbol` (with optional `path`) instead of `get_file_context` treating the NL `query` as a path. **Impact + `symbol`** uses `find_references` for symbol-level impact, or `find_dependents` when `path` is set—no longer stuffing the question into `find_dependents.path`. **Orient/workspace phrasing** (`orient me`, `main crates`, `map of`, etc.) routes to `get_repo_map` via a new early `orient_lookup_step`, and find-fusion skips those queries so auto orient questions do not OR-explode into hundreds of text hits. **`route_orient`** defaults to repo map when the query is not explicit guidance/explore.
> 
> Adds **`docs/reviews/symforge-8.4-facade-friction.md`** (AAP battery repro table) and planner unit tests for the new routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12af5ea4820a02bd45a60adc7ba4fdc8f587676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->