### PR TITLE
feat(stel): default trust envelope to the compact one-liner

### DIFF
--- a/docs/stel-schema.md
+++ b/docs/stel-schema.md
@@ -448,6 +448,21 @@ Every execution **must** populate `totals` for ledger; bypass/cache use zero L3 
 
 Prepended to every `symforge` and `symforge_edit` body (text or structured). Parsed by hosts; displayed to LLM.
 
+**Default is the COMPACT one-liner.** With no env opt-in, every live MCP call
+prepends a single honest line — route, admission decision, and the `(est.)`
+served-token figure — to keep per-call context noise minimal:
+
+```text
+── stel · trace → find_references (exact) · serve · ~420 tok served (est.) ──
+```
+
+Set `SYMFORGE_STEL_FULL=1` to restore the full multi-line economics block (the
+on-request / contract form below). That is the only variable that changes this
+behavior. `SYMFORGE_STEL_COMPACT` is now a no-op — compact is already the
+default, so the variable is neither read nor required. The full block stays the
+normative contract surface (it is what the golden-replay validators and the
+honesty regression assert):
+
 ```text
 ── stel ──
 plan: trace → find_references (exact)
@@ -459,7 +474,10 @@ calibration: deferred
 ──
 ```
 
-All token figures are estimates, never measured: `served`/`predicted` are
+The compact one-liner carries the SAME honesty load it always has: the served
+figure stays `(est.)`-qualified and no measured-saving claim appears; it simply
+drops the per-call economics detail. All token figures are estimates, never
+measured: `served`/`predicted` are
 `chars/4` approximations; the "fewer vs manual" figure is a heuristic
 prediction from the planner `400/800` constants (010 honesty contract,
 FR-001). `session_tokens_served` is a monotonic gross running total of tokens

--- a/scripts/a029-t2-spike.cjs
+++ b/scripts/a029-t2-spike.cjs
@@ -125,6 +125,10 @@ async function runRepoBatch(corpusDirPath, tasks) {
       ...process.env,
       RUST_LOG: "off",
       SYMFORGE_SURFACE: "compact",
+      // The trust envelope is COMPACT by default and drops the per-call
+      // economics lines (`decision:`, `predicted:`, `ledger:`) this spike
+      // regex-parses. Force the FULL block so the economics measurement is real.
+      SYMFORGE_STEL_FULL: "1",
       SYMFORGE_NO_DAEMON: "1",
     },
   });

--- a/scripts/phase2-compact-battery.cjs
+++ b/scripts/phase2-compact-battery.cjs
@@ -179,6 +179,10 @@ async function runCorpusBatch(corpusDir, rows) {
       ...process.env,
       RUST_LOG: "off",
       SYMFORGE_SURFACE: "compact",
+      // The trust envelope is COMPACT by default and drops the per-call
+      // economics lines (`decision:`, `predicted:`, `ledger:`) this battery
+      // regex-parses. Force the FULL block so the economics measurement is real.
+      SYMFORGE_STEL_FULL: "1",
       SYMFORGE_NO_DAEMON: "1",
     },
   });

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -23356,6 +23356,11 @@ mod tests {
         let (dir, server) = setup_loaded_edit_test(&[("src/lib.rs", original)]);
         let file_path = dir.path().join("src/lib.rs");
         let _surface = EnvVarGuard::set("SYMFORGE_SURFACE", "compact");
+        // The live trust envelope is COMPACT by default (no `ledger:` line); this
+        // test legitimately needs the FULL block to parse the ledger metadata and
+        // assert `!legacy_executed`, so force full for its duration. The lib test
+        // suite runs `--test-threads=1` and `EnvVarGuard` restores on drop.
+        let _full = EnvVarGuard::set("SYMFORGE_STEL_FULL", "1");
 
         // A concurrent writer lands inside the guarded window: overwrite the
         // file with a third, divergent body. Captured path keeps the closure

--- a/src/stel/envelope.rs
+++ b/src/stel/envelope.rs
@@ -52,19 +52,32 @@ fn decision_label(decision: AdmissionDecision) -> &'static str {
 /// does not measure real token counts, so presenting any of them as a measured
 /// saving would violate the 010 honesty contract (FR-001/FR-002).
 ///
-/// The full multi-line block is the default. An operator who finds the per-call
-/// block noisy can set `SYMFORGE_STEL_COMPACT=1` to collapse it to one honest
-/// line (route · decision · est. served tokens); the full economics returns by
-/// unsetting the flag. (Plan 009a; a *default*-compact form is a follow-up that
-/// must update the honesty-surface assertions across the test corpus + schema.)
+/// The one-line COMPACT form is the DEFAULT: with no flag set, every live MCP
+/// call prepends a single honest line (route · decision · est. served tokens),
+/// keeping the load-bearing honesty while dropping the per-call economics noise.
+/// An operator who wants the full multi-line economics block back can set
+/// `SYMFORGE_STEL_FULL=1` (the on-request / contract form). That is the ONLY var
+/// that changes behavior here. `SYMFORGE_STEL_COMPACT` is now a no-op — compact is
+/// already the default, so the var is neither read nor required.
+///
+/// The compact one-liner body is UNCHANGED — it always keeps the route, the
+/// admission decision, and the `(est.)`-labeled served-token figure. This
+/// finishes the author-sanctioned default-compact follow-up: the honesty-surface
+/// assertions across the test corpus + schema were updated to force the full
+/// render where they verify the full contract, so no honesty assertion is lost.
 pub fn format_trust_envelope(input: &TrustEnvelopeInput) -> String {
-    format_trust_envelope_inner(input, stel_compact_envelope_enabled())
+    format_trust_envelope_inner(input, !stel_full_envelope_enabled())
 }
 
-/// Whether the operator opted into the one-line envelope via `SYMFORGE_STEL_COMPACT`.
-fn stel_compact_envelope_enabled() -> bool {
+/// Whether the operator opted into the full multi-line block.
+///
+/// Compact is now the default, so the gate is inverted: only an explicit
+/// `SYMFORGE_STEL_FULL=1|true|TRUE` (the on-request / contract form) restores the
+/// full economics block. `SYMFORGE_STEL_COMPACT` is a no-op (compact is already
+/// the default) and is intentionally not read here.
+fn stel_full_envelope_enabled() -> bool {
     matches!(
-        std::env::var("SYMFORGE_STEL_COMPACT").ok().as_deref(),
+        std::env::var("SYMFORGE_STEL_FULL").ok().as_deref(),
         Some("1") | Some("true") | Some("TRUE")
     )
 }
@@ -130,10 +143,52 @@ fn format_trust_envelope_inner(input: &TrustEnvelopeInput, compact: bool) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    #[test]
-    fn envelope_matches_schema_example_shape() {
-        let text = format_trust_envelope(&TrustEnvelopeInput {
+    // Serializes the env-mutating public-entry tests so they are deterministic
+    // even without `--test-threads=1`. The pure `_inner`-based tests never touch
+    // process env and do not need it.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Test-only RAII guard for `SYMFORGE_STEL_FULL`: set or unset on construction,
+    /// restore the prior value on drop. Mirrors the in-crate env-guard convention
+    /// (`cli::update::SymforgeHomeGuard`, the tools.rs `EnvVarGuard`). Callers hold
+    /// `ENV_LOCK` for the guard's lifetime so the env mutation is serialized.
+    struct StelFullEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl StelFullEnvGuard {
+        #[allow(unsafe_code)] // test-only env mutation, serialized under ENV_LOCK.
+        fn set(value: &str) -> Self {
+            let previous = std::env::var_os("SYMFORGE_STEL_FULL");
+            // SAFETY: serialized under ENV_LOCK; no concurrent env readers.
+            unsafe { std::env::set_var("SYMFORGE_STEL_FULL", value) };
+            Self { previous }
+        }
+
+        #[allow(unsafe_code)] // test-only env mutation, serialized under ENV_LOCK.
+        fn unset() -> Self {
+            let previous = std::env::var_os("SYMFORGE_STEL_FULL");
+            // SAFETY: serialized under ENV_LOCK; no concurrent env readers.
+            unsafe { std::env::remove_var("SYMFORGE_STEL_FULL") };
+            Self { previous }
+        }
+    }
+
+    impl Drop for StelFullEnvGuard {
+        #[allow(unsafe_code)] // test-only env restore, serialized under ENV_LOCK.
+        fn drop(&mut self) {
+            // SAFETY: see `StelFullEnvGuard::set`.
+            match &self.previous {
+                Some(previous) => unsafe { std::env::set_var("SYMFORGE_STEL_FULL", previous) },
+                None => unsafe { std::env::remove_var("SYMFORGE_STEL_FULL") },
+            }
+        }
+    }
+
+    fn sample_input() -> TrustEnvelopeInput {
+        TrustEnvelopeInput {
             plan_summary: "trace → find_references (exact)".to_string(),
             decision: AdmissionDecision::Serve,
             response_tokens: 420,
@@ -143,9 +198,31 @@ mod tests {
             predicted_tokens: 400,
             predict_error_pct: 5.0,
             session_tokens_served: 1240,
-            calibration: "ok",
-            ledger_line: None,
-        });
+            calibration: "deferred",
+            ledger_line: Some("ledger: {}".to_string()),
+        }
+    }
+
+    #[test]
+    fn envelope_matches_schema_example_shape() {
+        // Asserts the FULL contract shape: route through the pure full path so the
+        // assertion is deterministic regardless of the (now compact) live default.
+        let text = format_trust_envelope_inner(
+            &TrustEnvelopeInput {
+                plan_summary: "trace → find_references (exact)".to_string(),
+                decision: AdmissionDecision::Serve,
+                response_tokens: 420,
+                est_net_vs_manual: 380,
+                schema_tokens: 45,
+                invoke_tokens: 80,
+                predicted_tokens: 400,
+                predict_error_pct: 5.0,
+                session_tokens_served: 1240,
+                calibration: "ok",
+                ledger_line: None,
+            },
+            false,
+        );
 
         assert!(text.starts_with("── stel ──\n"));
         assert!(text.contains("plan: trace → find_references (exact)"));
@@ -162,20 +239,24 @@ mod tests {
     #[test]
     fn reject_decision_never_prints_a_positive_saving() {
         // TR-11: a positive predicted net must not read as a saving on a reject,
-        // because SymForge did not deliver a serve result.
-        let text = format_trust_envelope(&TrustEnvelopeInput {
-            plan_summary: "trace → find_references (exact)".to_string(),
-            decision: AdmissionDecision::Reject,
-            response_tokens: 100,
-            est_net_vs_manual: 213,
-            schema_tokens: 45,
-            invoke_tokens: 80,
-            predicted_tokens: 400,
-            predict_error_pct: 0.0,
-            session_tokens_served: 213,
-            calibration: "deferred",
-            ledger_line: None,
-        });
+        // because SymForge did not deliver a serve result. Asserts the FULL block
+        // through the pure full path (deterministic vs the compact live default).
+        let text = format_trust_envelope_inner(
+            &TrustEnvelopeInput {
+                plan_summary: "trace → find_references (exact)".to_string(),
+                decision: AdmissionDecision::Reject,
+                response_tokens: 100,
+                est_net_vs_manual: 213,
+                schema_tokens: 45,
+                invoke_tokens: 80,
+                predicted_tokens: 400,
+                predict_error_pct: 0.0,
+                session_tokens_served: 213,
+                calibration: "deferred",
+                ledger_line: None,
+            },
+            false,
+        );
 
         assert!(text.contains("decision: reject"));
         assert!(text.contains("n/a (rejected) vs manual"));
@@ -221,5 +302,154 @@ mod tests {
             full.lines().count() > 1 && full.contains("session_tokens_served:"),
             "full form stays the multi-line block: {full}"
         );
+    }
+
+    #[test]
+    fn default_render_is_the_compact_one_liner() {
+        // Default-compact follow-up: with no env opt-in, the live default render
+        // is the single honest one-liner. Asserted through the pure compact path
+        // (`_inner(.., true)`) — this IS what `format_trust_envelope` returns when
+        // `SYMFORGE_STEL_FULL` is unset — so the assertion is deterministic and
+        // never touches process env.
+        let input = TrustEnvelopeInput {
+            plan_summary: "trace → find_references (exact)".to_string(),
+            decision: AdmissionDecision::Serve,
+            response_tokens: 420,
+            est_net_vs_manual: 380,
+            schema_tokens: 45,
+            invoke_tokens: 80,
+            predicted_tokens: 400,
+            predict_error_pct: 5.0,
+            session_tokens_served: 1240,
+            calibration: "deferred",
+            ledger_line: Some("ledger: {}".to_string()),
+        };
+        let default_render = format_trust_envelope_inner(&input, true);
+
+        assert_eq!(
+            default_render.lines().count(),
+            1,
+            "default render is a single line: {default_render}"
+        );
+        // Load-bearing honesty survives the default: the decision label and the
+        // `(est.)`-qualified served-token figure are present.
+        assert!(
+            default_render.contains("serve"),
+            "default render keeps the decision label: {default_render}"
+        );
+        assert!(
+            default_render.contains("(est.)"),
+            "default render keeps the est. served-token label: {default_render}"
+        );
+        // The per-call economics detail and any measured-savings phrasing are
+        // dropped — never a measured saving, never the gross session counter.
+        for forbidden in [
+            "session_tokens_served",
+            "predicted:",
+            " saved ",
+            "fewer vs manual",
+            "vs manual",
+        ] {
+            assert!(
+                !default_render.contains(forbidden),
+                "default render must drop `{forbidden}`: {default_render}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_entry_default_is_compact_full_is_opt_in() {
+        // Exercises the PUBLIC `format_trust_envelope` (not `_inner`), so it pins
+        // the shipped gate at envelope.rs: with `SYMFORGE_STEL_FULL` UNSET the live
+        // default render is the single compact line; with it set to `1` the full
+        // multi-line `── stel ──` economics block returns. Reverting the gate would
+        // fail this. Serialized under ENV_LOCK so it is deterministic even without
+        // `--test-threads=1`; the guards restore the prior env on drop.
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let input = sample_input();
+
+        {
+            let _unset = StelFullEnvGuard::unset();
+            let default_render = format_trust_envelope(&input);
+            assert_eq!(
+                default_render.lines().count(),
+                1,
+                "unset SYMFORGE_STEL_FULL must yield the compact one-liner: {default_render}"
+            );
+            assert!(
+                default_render.contains("(est.)"),
+                "compact default keeps the est. served-token label: {default_render}"
+            );
+            assert!(
+                !default_render.contains("session_tokens_served:"),
+                "compact default drops the gross session counter: {default_render}"
+            );
+        }
+
+        {
+            let _full = StelFullEnvGuard::set("1");
+            let full_render = format_trust_envelope(&input);
+            assert!(
+                full_render.lines().count() > 1,
+                "SYMFORGE_STEL_FULL=1 must restore the multi-line block: {full_render}"
+            );
+            assert!(
+                full_render.starts_with("── stel ──\n"),
+                "full render is the `── stel ──` block: {full_render}"
+            );
+            assert!(
+                full_render.contains("session_tokens_served:"),
+                "full render carries the per-call economics: {full_render}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_entry_compact_flag_is_a_noop() {
+        // Documents that `SYMFORGE_STEL_COMPACT` is now a NO-OP: compact is already
+        // the default, the var is never read, so setting it alone (with
+        // SYMFORGE_STEL_FULL unset) still yields the compact one-liner. Only
+        // SYMFORGE_STEL_FULL changes behavior.
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _unset_full = StelFullEnvGuard::unset();
+        let compact_guard = CompactEnvGuard::set("1");
+        let render = format_trust_envelope(&sample_input());
+        drop(compact_guard);
+        assert_eq!(
+            render.lines().count(),
+            1,
+            "SYMFORGE_STEL_COMPACT alone is a no-op; compact stays the default: {render}"
+        );
+    }
+
+    /// Test-only RAII guard for the (no-op) `SYMFORGE_STEL_COMPACT` var, used only
+    /// to prove it does not change behavior. Serialized under ENV_LOCK by callers.
+    struct CompactEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl CompactEnvGuard {
+        #[allow(unsafe_code)] // test-only env mutation, serialized under ENV_LOCK.
+        fn set(value: &str) -> Self {
+            let previous = std::env::var_os("SYMFORGE_STEL_COMPACT");
+            // SAFETY: serialized under ENV_LOCK; no concurrent env readers.
+            unsafe { std::env::set_var("SYMFORGE_STEL_COMPACT", value) };
+            Self { previous }
+        }
+    }
+
+    impl Drop for CompactEnvGuard {
+        #[allow(unsafe_code)] // test-only env restore, serialized under ENV_LOCK.
+        fn drop(&mut self) {
+            // SAFETY: see `CompactEnvGuard::set`.
+            match &self.previous {
+                Some(previous) => unsafe { std::env::set_var("SYMFORGE_STEL_COMPACT", previous) },
+                None => unsafe { std::env::remove_var("SYMFORGE_STEL_COMPACT") },
+            }
+        }
     }
 }

--- a/src/stel/handler.rs
+++ b/src/stel/handler.rs
@@ -140,6 +140,40 @@ mod tests {
     use super::*;
     use crate::stel::types::IntentBucket;
 
+    /// Test-only RAII guard forcing the FULL trust envelope.
+    ///
+    /// The live envelope is COMPACT by default; this unit verifies that the L2
+    /// decision and economics (schema/invoke tokens) flow into the FULL block, so
+    /// it opts back into full via `SYMFORGE_STEL_FULL`. Restored on drop. Matches
+    /// the in-crate env-guard convention (`cli::update::SymforgeHomeGuard`): the
+    /// lib test suite runs `--test-threads=1` and this is the only test that sets
+    /// the variable, so there is no concurrent env access.
+    struct StelFullEnvelopeGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl StelFullEnvelopeGuard {
+        #[allow(unsafe_code)] // test-only env mutation under --test-threads=1.
+        fn set() -> Self {
+            let prev = std::env::var_os("SYMFORGE_STEL_FULL");
+            // SAFETY: the lib test suite runs single-threaded and this is the sole
+            // setter of SYMFORGE_STEL_FULL, so no other thread reads/writes env.
+            unsafe { std::env::set_var("SYMFORGE_STEL_FULL", "1") };
+            Self { prev }
+        }
+    }
+
+    impl Drop for StelFullEnvelopeGuard {
+        #[allow(unsafe_code)] // test-only env restore under --test-threads=1.
+        fn drop(&mut self) {
+            // SAFETY: see `StelFullEnvelopeGuard::set`.
+            match &self.prev {
+                Some(prev) => unsafe { std::env::set_var("SYMFORGE_STEL_FULL", prev) },
+                None => unsafe { std::env::remove_var("SYMFORGE_STEL_FULL") },
+            }
+        }
+    }
+
     #[test]
     fn prepend_envelope_places_header_before_body() {
         let envelope = "── stel ──\nplan: auto → ask (inferred)\n──";
@@ -170,6 +204,10 @@ mod tests {
     fn envelope_reflects_l2_decision_and_economics() {
         use crate::stel::controller::{COMPACT_INVOKE_TOKENS, COMPACT_SCHEMA_TOKENS};
         use crate::stel::planner::build_plan;
+        // Verifies the FULL block carries the L2 decision + economics; force full
+        // because the live default is now the compact one-liner (which has no
+        // `decision:`/`schema`/`invoke` fields).
+        let _full = StelFullEnvelopeGuard::set();
         let request = StelRequest {
             query: "who references cfg_if".to_string(),
             ..Default::default()

--- a/tests/stel_find_fusion.rs
+++ b/tests/stel_find_fusion.rs
@@ -144,6 +144,9 @@ fn row(anchor: &str, partner: &str, shared: u32, weighted: f64) -> CouplingRow {
 async fn run_find(server: &SymForgeServer, query: &str) -> String {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: this suite verifies the `── stel ──` header
+    // and the per-step economics, which the (now default) compact one-liner omits.
+    let _full = stel_surface_env::force_full_stel_envelope();
     let request = symforge::stel::StelRequest {
         query: query.to_string(),
         intent: None,
@@ -363,6 +366,9 @@ async fn fused_find_is_deterministic() {
 async fn run_find_outcome(server: &SymForgeServer, query: &str) -> String {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: this suite verifies the `── stel ──` header
+    // and the per-step economics, which the (now default) compact one-liner omits.
+    let _full = stel_surface_env::force_full_stel_envelope();
     let request = symforge::stel::StelRequest {
         query: query.to_string(),
         intent: None,

--- a/tests/stel_golden_replay.rs
+++ b/tests/stel_golden_replay.rs
@@ -147,6 +147,10 @@ async fn s4_minimum_subset_replays_on_compact_symforge() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: the replay validators assert the full
+    // contract (`── stel ──`, `decision: serve|bypass`, `ledger:`), which the
+    // live serve path generates only in full mode.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("load golden fixture");
     let exit_rows = stel::s4_exit_rows(&rows);
@@ -157,6 +161,10 @@ async fn s4_minimum_subset_replays_on_compact_symforge() {
 async fn multi_hop_golden_rows_replay_on_compact_symforge() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: the replay validators assert the full
+    // contract (`── stel ──`, `decision: serve|bypass`, `ledger:`), which the
+    // live serve path generates only in full mode.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("load golden fixture");
     let mut missing = Vec::new();
@@ -225,6 +233,10 @@ async fn supported_serve_rows_replay_with_envelope_and_ledger() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: the replay validators assert the full
+    // contract (`── stel ──`, `decision: serve|bypass`, `ledger:`), which the
+    // live serve path generates only in full mode.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("load golden fixture");
     let serve_rows: Vec<_> = stel::supported_serve_rows(&rows)
@@ -247,6 +259,10 @@ async fn supported_pff_rows_bypass_without_legacy_execution() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: the replay validators assert the full
+    // contract (`── stel ──`, `decision: serve|bypass`, `ledger:`), which the
+    // live serve path generates only in full mode.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("load golden fixture");
     let pff_rows: Vec<_> = stel::supported_pff_rows(&rows)

--- a/tests/stel_l2_admission.rs
+++ b/tests/stel_l2_admission.rs
@@ -178,6 +178,9 @@ async fn cache_hit_dispatch_skips_legacy_tools_after_session_prefetch() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L2 admission asserts `decision:` lines that
+    // appear only in the full block (the compact one-liner has no `decision:`).
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let server = server_for_corpus(stel::S4_REPLAY_CORPUS, "l2-cache-hit");
     let request = StelRequest {
@@ -221,6 +224,9 @@ async fn grounded_predictions_differ_by_real_file_size_end_to_end() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L2 admission asserts `decision:` lines that
+    // appear only in the full block (the compact one-liner has no `decision:`).
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let small_server = server_for_corpus(small_corpus, "ground-small");
     let large_server = server_for_corpus(large_corpus, "ground-large");
@@ -284,6 +290,9 @@ async fn grounded_small_file_reaches_bypass_end_to_end() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L2 admission asserts `decision:` lines that
+    // appear only in the full block (the compact one-liner has no `decision:`).
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let server = server_for_corpus(small_corpus, "ground-bypass");
     let output = dispatch_symforge(

--- a/tests/stel_l3_enforcement.rs
+++ b/tests/stel_l3_enforcement.rs
@@ -87,6 +87,9 @@ async fn pff_golden_rows_bypass_without_legacy_tool_execution() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L3 enforcement asserts the `── stel ──`
+    // header, `decision: bypass|serve`, and validator-strict full contract.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let pff_ids = [
@@ -157,6 +160,9 @@ async fn serve_golden_row_still_executes_legacy_tool() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L3 enforcement asserts the `── stel ──`
+    // header, `decision: bypass|serve`, and validator-strict full contract.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/t4_refs");

--- a/tests/stel_l4_ledger.rs
+++ b/tests/stel_l4_ledger.rs
@@ -135,6 +135,9 @@ async fn serve_row_records_ledger_with_legacy_execution() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L4 ledger tests parse the `ledger:` line,
+    // which exists only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/t4_refs");
@@ -166,6 +169,9 @@ async fn pff_row_records_ledger_without_legacy_execution() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L4 ledger tests parse the `ledger:` line,
+    // which exists only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/pff_whole_lib");
@@ -199,6 +205,9 @@ async fn serve_invocation_writes_through_to_durable_store() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L4 ledger tests parse the `ledger:` line,
+    // which exists only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/t4_refs");
@@ -252,6 +261,9 @@ async fn durable_write_is_offloaded_off_the_request_path() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L4 ledger tests parse the `ledger:` line,
+    // which exists only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/t4_refs");
@@ -299,6 +311,9 @@ async fn serve_without_durable_store_keeps_in_memory_ledger_only() {
 
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: L4 ledger tests parse the `ledger:` line,
+    // which exists only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let rows = stel::load_golden_rows(&golden_fixture_path()).expect("golden fixture");
     let row = row_by_id(&rows, "cfg-if/t4_refs");

--- a/tests/stel_multi_hop_chain.rs
+++ b/tests/stel_multi_hop_chain.rs
@@ -40,6 +40,9 @@ fn server_for_corpus(relative: &str, project: &str) -> SymForgeServer {
 async fn multi_hop_chain_rejects_when_inner_step_fails() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: the chain regression asserts `decision:
+    // serve|reject` lines that appear only in the full block.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let corpus = repo_root().join("tests/fixtures/stel_multi_hop/cfg-if-rust");
     assert!(

--- a/tests/stel_symforge_edit.rs
+++ b/tests/stel_symforge_edit.rs
@@ -110,6 +110,9 @@ async fn symforge_edit_rejects_non_compact_surface() {
 async fn symforge_edit_rejects_unsafe_path() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let (dir, _) = temp_rust_repo("fn foo() {}\n");
     let server = server_for_repo(dir.path(), "edit-unsafe-path");
@@ -133,6 +136,9 @@ async fn symforge_edit_rejects_unsafe_path() {
 async fn symforge_edit_rejects_missing_symbol_and_body() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let (dir, _) = temp_rust_repo("fn foo() {}\n");
     let server = server_for_repo(dir.path(), "edit-missing-fields");
@@ -154,6 +160,9 @@ async fn symforge_edit_rejects_missing_symbol_and_body() {
 async fn symforge_edit_preview_includes_envelope_ledger_and_dry_run_without_writes() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { old }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -191,6 +200,9 @@ async fn symforge_edit_preview_includes_envelope_ledger_and_dry_run_without_writ
 async fn symforge_edit_explicit_apply_false_matches_preview_no_write() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { old }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -218,6 +230,9 @@ async fn symforge_edit_explicit_apply_false_matches_preview_no_write() {
 async fn symforge_edit_rejects_missing_symbol_on_apply() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // No FULL-envelope opt-in here: this is a pre-apply reject that emits NO
+    // trust envelope at all (asserted below via `!output.contains("── stel ──")`),
+    // so the envelope render mode is irrelevant to what this test checks.
 
     let (dir, file_path) = temp_rust_repo("fn foo() { old }\n");
     let before = std::fs::read(&file_path).expect("read file");
@@ -250,6 +265,9 @@ async fn symforge_edit_rejects_missing_symbol_on_apply() {
 async fn symforge_edit_rejects_if_match_mismatch_on_apply() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { old }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -280,6 +298,9 @@ async fn symforge_edit_rejects_if_match_mismatch_on_apply() {
 async fn symforge_edit_apply_already_applied_is_idempotent_without_rewrite() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { same }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -313,6 +334,9 @@ async fn symforge_edit_apply_already_applied_is_idempotent_without_rewrite() {
 async fn symforge_edit_preview_then_apply_writes_once() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { old }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -370,6 +394,9 @@ async fn symforge_edit_preview_then_apply_writes_once() {
 async fn symforge_edit_apply_idempotency_key_replays_without_double_write() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn foo() { old }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -400,6 +427,9 @@ async fn symforge_edit_apply_idempotency_key_replays_without_double_write() {
 async fn symforge_edit_rejects_absolute_and_scheme_paths() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let (dir, file_path) = temp_rust_repo("fn foo() {}\n");
     let before = std::fs::read(&file_path).expect("read file");
@@ -439,6 +469,9 @@ async fn symforge_edit_rejects_absolute_and_scheme_paths() {
 async fn symforge_edit_insert_after_preview_then_apply_adds_new_symbol() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "fn anchor() { 1 }\n";
     let (dir, file_path) = temp_rust_repo(original);
@@ -496,6 +529,9 @@ async fn symforge_edit_insert_after_preview_then_apply_adds_new_symbol() {
 async fn symforge_edit_edit_within_amends_import_inside_module() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     // A file-level `use` is NOT an indexed symbol in Rust, but a `use` inside a
     // `mod` block IS reachable via edit_within scoped to the enclosing module.
@@ -538,6 +574,9 @@ async fn symforge_edit_completes_full_refactor_through_facade_only() {
     // committing, with NO native file-tool fallback.
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "\
 mod imports {
@@ -632,6 +671,9 @@ fn anchor() { 1 }
 async fn symforge_edit_failed_guarded_apply_is_not_classified_as_found() {
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("compact");
+    // Force the FULL trust envelope: these apply/preview tests assert the
+    // `── stel ──` header and parse the `ledger:` line, both full-block only.
+    let _full = stel_surface_env::force_full_stel_envelope();
 
     let original = "# foo\n\nOld section body.\n";
     let (dir, file_path) = temp_markdown_repo(original);

--- a/tests/support/stel_surface_env.rs
+++ b/tests/support/stel_surface_env.rs
@@ -6,6 +6,12 @@ use std::sync::LazyLock;
 
 use tokio::sync::Mutex;
 
+// Serializes the process-global env mutation so the FULL-envelope opt-in is
+// deterministic even without `--test-threads=1`. `surface_honesty` holds it
+// around `force_full_stel_envelope` on its live-render path; the compact/replay
+// harnesses hold it around the surface-select guard. Some including binaries do
+// not reference it, so the dead-code allow stays.
+#[allow(dead_code)]
 pub static COMPACT_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub struct EnvVarGuard {
@@ -47,6 +53,9 @@ impl Drop for EnvVarGuard {
     }
 }
 
+// Unused in the `surface_honesty` binary (which only forces the full envelope);
+// used by the surface/replay harnesses that select the compact surface.
+#[allow(dead_code)]
 pub fn set_symforge_surface(value: &str) -> EnvVarGuard {
     EnvVarGuard::set("SYMFORGE_SURFACE", value)
 }
@@ -54,4 +63,17 @@ pub fn set_symforge_surface(value: &str) -> EnvVarGuard {
 #[allow(dead_code)]
 pub fn clear_symforge_surface() -> EnvVarGuard {
     EnvVarGuard::unset("SYMFORGE_SURFACE")
+}
+
+/// Force the FULL multi-line trust envelope for the duration of a test.
+///
+/// The live trust envelope is COMPACT by default (the one-line form). Integration
+/// surfaces that verify the full contract — `── stel ──` header, `decision:`,
+/// `ledger:`, the per-call economics block — must opt back into FULL via
+/// `SYMFORGE_STEL_FULL`. Like the surface guard this is process-global, so callers
+/// hold `COMPACT_ENV_LOCK` and rely on the RAII restore (the suite runs
+/// `--test-threads=1`). Returns a guard; keep it bound for the test's lifetime.
+#[allow(dead_code)]
+pub fn force_full_stel_envelope() -> EnvVarGuard {
+    EnvVarGuard::set("SYMFORGE_STEL_FULL", "1")
 }

--- a/tests/surface_honesty.rs
+++ b/tests/surface_honesty.rs
@@ -22,10 +22,26 @@ use symforge::stel::{
     metrics_for_decision, plan_summary_line, summarize_calibration,
 };
 
+// Shared env guard: `force_full_stel_envelope` opts these honesty regressions
+// back into the FULL trust envelope (the live default is now COMPACT). The
+// module carries `#![allow(unsafe_code)]` and an RAII restore-on-drop guard; the
+// suite runs `--test-threads=1`, so there is no cross-test env bleed.
+#[path = "support/stel_surface_env.rs"]
+mod stel_surface_env;
+
 /// Build the trust envelope exactly as the live `symforge` handler does, using
 /// the real planner + L2 controller (so the `400/800`-derived heuristic figures
 /// flow through unmodified) and a gross session running total.
+///
+/// Forces the FULL envelope: this exercises the live env-gated path and the
+/// honesty assertions target the full block, which compact (the new default)
+/// omits by design. The render runs on the live env-gated path, so it holds
+/// `COMPACT_ENV_LOCK` for the env-mutation window — deterministic even without
+/// `--test-threads=1`. The env guard and lock drop together once the (now
+/// immutable) `String` is captured for assertion.
 fn render_live_envelope(query: &str, session_tokens_served: i64) -> String {
+    let _env_lock = stel_surface_env::COMPACT_ENV_LOCK.blocking_lock();
+    let _full = stel_surface_env::force_full_stel_envelope();
     let request = symforge::stel::StelRequest {
         query: query.to_string(),
         ..Default::default()
@@ -112,6 +128,12 @@ fn envelope_calibration_is_deferred_not_pending() {
 #[test]
 fn rejected_decision_never_prints_a_positive_saving() {
     // TR-11: a positive predicted net on a reject must not read as a saving.
+    // This asserts the FULL block (`n/a (rejected) vs manual`), so force full —
+    // the compact default omits the per-call comparison. Live env-gated path, so
+    // hold `COMPACT_ENV_LOCK` for the env-mutation window (deterministic even
+    // without `--test-threads=1`); lock + env guard drop after the render.
+    let _env_lock = stel_surface_env::COMPACT_ENV_LOCK.blocking_lock();
+    let _full = stel_surface_env::force_full_stel_envelope();
     let envelope = format_trust_envelope(&TrustEnvelopeInput {
         plan_summary: "trace → find_references (exact)".to_string(),
         decision: AdmissionDecision::Reject,


### PR DESCRIPTION
## What
The full ~8-line STEL economics block printed on **every** `symforge`/`symforge_edit` MCP response. This makes the **compact one-liner the default**; the full block returns with `SYMFORGE_STEL_FULL=1`.

Per-call envelope: **8 lines / 257 chars → 1 line / 77 chars**, keeping the load-bearing honesty (served tokens stay `(est.)`, no measured-savings claim, no gross session counter). `SYMFORGE_STEL_COMPACT` is now a no-op (compact is the default). `calibration: deferred` unchanged; no auto-tune wired; durable ledger store untouched.

## Why it's safe
Finishes the author-sanctioned follow-up noted in `envelope.rs` ("a default-compact form is a follow-up that must update the honesty-surface assertions"). Contract surfaces (golden replay, honesty regressions, edit-ledger parsers, the two Node economics batteries) are pinned to the full render so they keep verifying the full block; a public-entry test guards the default so a gate revert fails loudly.

## Review + verification
Two independent adversarial reviews + an independent full-gate run caught a real lib-test the implementing sweep missed (`tools.rs` parsed `ledger:` from the now-compact envelope) plus 5 other findings — **all fixed**.

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --all-targets -- --test-threads=1` → **3109 passed / 0 failed** ✅ (was 1 failed)
- embed `--lib` build/clippy/test ✅

No honesty assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-format default change only; admission, ledger, and honesty rules are unchanged, and regressions are guarded by explicit full-envelope opt-in in contract tests.
> 
> **Overview**
> **Live MCP responses now prepend a single-line STEL trust envelope by default** (route · decision · `(est.)` served tokens), shrinking per-call header noise while keeping the honesty labels on the compact form.
> 
> **Env gate is inverted:** `SYMFORGE_STEL_FULL=1` restores the full multi-line economics block (`decision:`, `predicted:`, `ledger:`, session totals). **`SYMFORGE_STEL_COMPACT` is no longer read** — compact is already the default.
> 
> **Contract tests and batteries opt into full mode** where they parse `decision:`, `ledger:`, or the `── stel ──` block: shared `force_full_stel_envelope()` in integration harnesses, `SYMFORGE_STEL_FULL` in Node spike/battery scripts, env guards in `tools.rs` / `handler.rs`, and new unit tests that pin default-compact vs full opt-in. **`docs/stel-schema.md`** documents the new default and full opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5327b75f6ba3c9c4db73c16868a2055bbb7db9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->