### PR TITLE
feat(stel): honor cross-project scoping on the engine read path (B1)

### DIFF
--- a/docs/reviews/HANDOFF-symforge-trust-campaign.md
+++ b/docs/reviews/HANDOFF-symforge-trust-campaign.md
@@ -1,0 +1,53 @@
+# HANDOFF — SymForge trust campaign (resume here)
+
+**As of:** 2026-06-23. **Branch state:** everything below is merged to `main` (released as **v8.6.0**).
+**Mission:** make SymForge trustworthy for the LLMs that call it and robust for users — by attacking ROOT causes of its trust defects, not patching symptoms. Engine-first: the facade is a thin honest layer; AAP consumes the engine via the `embed` feature (NOT the MCP server).
+
+## How we work (durable rules — honor these)
+- **A defect is a defect, not an "honest gap"** (now in global `~/.claude/CLAUDE.md` §0). Found an issue → name it plainly → add to the ledger → decide on the spot if it's a symptom of a larger root → if so, investigate + attack the root. Don't plug holes endlessly.
+- **Deferral policy** (global CLAUDE.md §0): defer *scope/capability* (with a loud, tracked, owned refusal), never *defects*.
+- **Never leave open PRs for the user** — process/merge them all yourself via **git-master** with the push mandate; carry through to merge+delete with the release-please guard `gh pr merge <N> --merge --delete-branch --body "PR #<N>"`. (agentmemory `mem_mqpbsq29`.) Still surface (don't execute) destructive ops on another lane's *live* branch.
+- **Verify as user**, not "tests passed": the full cargo gate (`fmt --check`, `check`, `clippy --all-targets -D warnings`, `test --all-targets --test-threads=1`, `build --release`, `check --no-default-features --features embed`) AND behavioral/live evidence before claiming done. Full gate green before ANYTHING merges to main.
+- **Ultracode** was on: use Workflow for substantive design/investigation; adversarially verify load-bearing work.
+
+## THE source of truth
+- **`docs/reviews/symforge-defect-ledger.md`** — every defect, named plainly, ROOT vs SYMPTOM, clustered to 3 culprits + the vetted attack sequence with owners. READ THIS FIRST.
+- `specs/012-harness-agnostic-mcp/{spec,research,plan,integration-plan}.md` — the engine-first design + the adversarially-vetted integration plan.
+- `docs/reviews/stel-v8-skeptic-audit-2026-06-17.md` + `stel-v8-field-confirmation-2026-06-19.md` — the original audit + 3-agent field evidence (where the defects came from).
+
+## The 3 root culprits
+- **A — lossy/fabricating facade**: silently drops caller params + emits unmeasured numbers. Fix = `lossless-or-loud` + `honest-envelope` contracts, enforced by conformance tests.
+- **B — engine multi-view search has no per-view derived index / no live rebase**: cross-project search is scoping-less, stale, low-recall.
+- **C — `/mcp` is a stateless single-index singleton**: no per-connection session.
+
+## DONE + on main (v8.6.0)
+- Engine **base+overlay `IndexView` primitive** (`src/live_index/view.rs`): immutable base shared by `Arc` keyed `(canonical-root, commit)` + per-consumer CoW overlay; O(K) rebase (spike-proven); `WorkingSet` cross-project query w/ source attribution. `embed` contract unchanged.
+- **US1 cross-project query**: `index_folder(add:true)` opens projects additively; `search_symbols/search_text/find_references` + `StelRequest` gain `project`/`projects` → `Targets`; single-project path byte-identical. Daemon-only (stdio refuses honestly). Proven by a real daemon-HTTP integration test.
+- **C4** wrong-repo fix: per-connection retarget + bound `project_root` in every response.
+- **Honesty hardening**: facade refuses cross-project params it can't route; cross-project output bounded+disclosed; `if_match` normalized pre-flight; clean `query`-required error; glossary MCP resource.
+- **A1a** — `ParamDisposition` choke point (`src/stel/planner.rs`) + conformance test (`tests/stel_param_disposition.rs`): every `StelRequest` field resolves to an explicit disposition; silent-drop class non-regressable. Zero behavior change.
+- **D17** — atomic open (`src/daemon.rs register_session_for_existing_project`): eliminates the open-vs-close TOCTOU; open is fail-never (8-thread stress test asserts it).
+
+## REMAINING — the attack sequence (do in this order)
+
+**B1 — DONE** (implemented, full-gate-green, adversarially reviewed; D11 scoping **FIXED**, D14 ranking **PARTIAL** — per-project ranked+bounded, global cross-project interleave deferred). **NEXT = A1b** (gated per-tool forwarding). The original B1 recipe is retained below for reference:
+- The empty-overlay fast path `IndexView::search_symbols` (`view.rs:341`) calls the **preset-only** `base_search_symbols(... usize::MAX)` (hardcodes path_scope=Any, language=None). The option-honoring `search_symbols_with_options` / `search_text_with_options` (`search.rs:808/943`) ALREADY EXIST.
+- Thread the caller's scoping/limit options through `IndexView`'s search methods → `WorkingSet` cross-project query passes them down → daemon `execute_cross_project_read` builds the options from `SearchSymbolsInput/SearchTextInput/FindReferencesInput` AND **removes `reject_unsupported_cross_project_scoping`** (the honesty-pass guard that loudly refuses path/language/etc.).
+- Overlays are EMPTY in US1 (no-overlay-writes invariant) so the empty-overlay path is the cross-project path. Per-overlay derived index for NON-empty overlays is the deferred large item **D-B0**.
+- Update the rejection tests (they assert refusal) → assert honoring; add scoping-honored cross-project tests.
+
+Then: **A1b** (gated per-tool forwarding: `max_tokens`→args, `path`→`path_prefix`; golden re-baselined) · **C-stopgap** (`/mcp` loudly refuses `project`/`projects`) · **B2/D12** (republish→rebase on HEAD/watcher advance; mechanism `Overlay::rebase` + `StaleOverlay` fence exist).
+
+**Tracked-large (OPEN, owners, blocked-on — NOT deferred-as-acceptable):** D-B0 (per-view derived index, after cross-project writes) · D15 (overlay edits in ordinary reads — Phase 5 read-path flip, ~64 `self.index.read()` + ~20 `capture_*`) · D16 (`/mcp` per-connection daemon session) · D13 (xref recall ~29% — `parsing/xref.rs` qualified-call extraction, NOT a view defect) · D2 (gate decides on estimated economics — owner 013 lane) · serve_port test-fragility (local Docker-Desktop port collisions).
+
+## Working environment + gotchas
+- **`E:\project\symforge-012`** worktree is now on **`main`** (clean). Branch the next attack from here. (`feat/012` was merged + deleted.)
+- **`E:\project\symforge`** = the **013 predictor-calibration lane's** worktree (branch `013-stel-predictor-calibration-spec`) — has **unpushed commits**; DO NOT disturb. Its remote branch isn't pruned for that reason.
+- **`E:\project\symforge-perl`** = perl-grammar lane.
+- AAP repo: `E:\project\Agent_Army_Professionals` (consumes symforge via `embed`, git dep on main; diagrams in `docs/`).
+- Symforge MCP/daemon can disconnect/flake mid-session; cross-project is **daemon-only**; verify behaviorally via a built binary, not just unit tests.
+- Subagent rate limit historically resets ~2pm Europe/Ljubljana.
+- A2 (`Figure` provenance enum) was DEMOTED to regression-guard (envelope already honest); don't prioritize it.
+
+## Immediate first action for the next session
+B1 is landed (cross-project `path_prefix`/`language`/noise scoping honored via the engine's option path; reject guard narrowed to `structural` + find_references selectors; per-project ranked+bounded). Read `docs/reviews/symforge-defect-ledger.md`, branch a fresh `feat/012c-a1b-gated-forwarding` (or similar) off `main` in `E:\project\symforge-012`, and implement **A1b** (gated per-tool forwarding: `max_tokens`→args, `path`→`path_prefix`; golden re-baselined) → full gate → PR → merge yourself. Then C-stopgap/D16, then B2/D12.

--- a/docs/reviews/symforge-defect-ledger.md
+++ b/docs/reviews/symforge-defect-ledger.md
@@ -31,10 +31,10 @@ Last updated: 2026-06-22.
 | ID | Defect (plain) | Root/Symptom | Status | Owner |
 |----|----------------|--------------|--------|-------|
 | D-B0 | `WorkingSet`/`IndexView` `search_text`/`find_references` run base-only + overlay post-filter; no per-view derived (trigram/reverse) index; no live rebase on change. | **ROOT (Culprit B)** | OPEN | new |
-| D11 | Cross-project scoping (`path`/`language`/`symbol_kind`/`direction`/`structural`) is broken — currently **loudly refused**, not honored. | SYMPTOM(B) | LOUD-ONLY | 012 |
+| D11 | Cross-project scoping — `path_prefix`/`language`/noise now **HONORED** (B1): threaded through the engine's option-honoring `search_*_with_options` on the empty-overlay cross-project path, built via the SAME helpers as single-project (identical behavior; proven by engine unit test + live daemon-HTTP test). `structural` (separate ast-grep pipeline) and `find_references` `path`/`symbol_kind`/`direction` (selectors / implementations-mode) remain honest capability-refusals — no cross-project entry point. Cross-project rendering of display params (`context`/`group_by`/`follow_refs`) is deferred to A1b (display, NOT scoping). | SYMPTOM(B) | FIXED | 012 |
 | D12 | Cross-project base is a frozen snapshot from open time; results go stale after ANY watched change (not just commits). No republish→rebase. | SYMPTOM(B) | OPEN | 012 |
 | D13 | Reference trace recall ~29% on type/value usages (`find_references` misses value sites). | SYMPTOM(B) | OPEN | new |
-| D14 | Cross-project output ranking is working-set/tier order, not real relevance ranking (capped, but not ranked). | SYMPTOM(B) | LOUD-ONLY | 012 |
+| D14 | Cross-project results are now per-project `result_limit`-bounded + tier-RANKED before the cap (B1; was an unbounded `usize::MAX` dump then truncate). Output stays grouped-by-project in working-set order; a single GLOBAL relevance interleave across projects is still deferred (adversarial review wf a2eac32 — honest scope). | SYMPTOM(B) | PARTIAL | 012 |
 | D15 | Single-project overlay edits are NOT visible in ordinary reads (read path uses `self.index`, not `IndexView`). | SYMPTOM(B) | OPEN | 012 |
 
 ## Defects — CULPRIT C (transport) + independent
@@ -56,6 +56,7 @@ Last updated: 2026-06-22.
 - close_session multi-project leak → reaper + regression test.
 - Strict-MCP-client schema rejection of Phase 3 `projects` fields → `schemars(with=...)`.
 - Base+overlay engine primitive + cross-project query (US1) — live-verified.
+- B1 cross-project scoping HONORED (D11): `path_prefix`/`language`/noise threaded through the option-honoring engine search via the single-project helpers; reject guard narrowed to the genuinely-unsupported params (`structural`, `find_references` selectors). Per-project ranked+bounded (D14 PARTIAL — global interleave deferred). Aligns cross-project text defaults with single-project (`include_vendor=false`); `ranked` is churn-blind cross-project (noted). Engine unit test + live daemon-HTTP scoping assertions (symbols + text); adversarial review wf a2eac32.
 
 ## Attack plan (roots, not holes)
 
@@ -71,7 +72,7 @@ This ledger lives on `feat/012` (worktree); A1/A2/B1 all land here (the superset
 Sequence by (defects-killed ÷ effort), gated by file independence:
 1. **A1a** — `ParamDisposition` choke point in `build_plan_from_steps` + conformance test. Every `StelRequest` field resolves to `Routed|Forwarded|Refused|NotApplicable`; silent-absent is asserted-against. **Zero behavior change — `routes.golden.jsonl` does NOT move.** Erects the non-regressable guard against the silent-drop class (D-A0) at zero risk. **ATTACK FIRST.** Owner 012.
 2. **D17** — collapse the open-vs-close TOCTOU (single `projects.write()` entry). S/LOW, isolated. Owner 012.
-3. **B1** — thread caller options through the empty-overlay search path (`search_*_with_options` already exist) → honors D11 scoping + D14 ranking on the cross-project read path. S-M/LOW. Owner 012.
+3. **B1** — DONE (implemented, gate-green): threaded caller options through the empty-overlay search path → D11 scoping FIXED, D14 ranking PARTIAL (per-project ranked+bounded; global interleave deferred). Owner 012.
 4. **A1b** — gated per-tool forwarding (`max_tokens`→args, `path`→`path_prefix`); golden re-baselined. Owner 012.
 5. **C-stopgap** — `/mcp` loudly refuses `project`/`projects` (contain D16's silent-wrong half). Owner 012.
 6. **B2** — republish→rebase on HEAD/watcher advance (D12). Owner 012.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -34,6 +34,7 @@ use crate::protocol::tools::{
     GetRepoMapInput, GetSymbolContextInput, GetSymbolInput, HealthInput, IndexFolderInput,
     InspectMatchInput, InvestigationInput, SearchFilesInput, SearchSymbolsInput, SearchTextInput,
     SmartQueryInput, TraceSymbolInput, ValidateFileSyntaxInput, WhatChangedInput,
+    search_symbols_options_from_input, search_text_options_from_input,
 };
 use crate::sidecar::{SidecarState, SymbolSnapshot, TokenStats};
 use crate::watcher::{self, WatcherInfo};
@@ -2856,17 +2857,21 @@ fn apply_cross_project_token_budget(body: String, max_tokens: Option<u64>) -> St
     truncated
 }
 
-/// Honest refusal of the DEFERRED per-project derived-index scoping when combined
-/// with cross-project targeting (Principle VII). The cross-project read serves
-/// from each project's interned base via the overlay-aware `WorkingSet` search,
-/// which does NOT honor the per-project derived-index scoping params
-/// (`path`/`path_prefix`/`language`/`symbol_kind`/`direction`/`structural`).
-/// Rather than silently ignore such a param (handing back results that look
-/// scoped but are not), return a clear error naming the offending param. Returns
-/// `Err(message)` for the FIRST unsupported scoping param present, else `Ok(())`.
+/// Honest refusal of the cross-project params that are genuinely NOT supported
+/// on the cross-project read path — as distinct from the scoping that IS now
+/// honored. B1 threads `path_prefix`/`language`/noise/`limit` through the
+/// engine's option-honoring `search_*_with_options` (so cross-project scoping
+/// behaves identically to single-project; D11 + D14), and those are NO LONGER
+/// refused here. What remains unsupported, and is therefore still refused
+/// loudly rather than silently ignored:
+/// * `search_text` `structural` — ast-grep runs a separate single-project
+///   pipeline, not `search_text_with_options`, so it has no cross-project path;
+/// * `find_references` `path`/`symbol_kind`/`direction` — single-project symbol
+///   SELECTORS / implementations-mode direction, which have no cross-project
+///   meaning and no option-honoring engine entry point.
 ///
-/// `kind` (symbol/reference kind filter) IS honored cross-project and is NOT
-/// rejected here; only the deferred derived-index scoping is refused.
+/// Returns `Err(message)` for the FIRST still-unsupported param present, else
+/// `Ok(())`. `kind`, `path_prefix`, and `language` are honored and not rejected.
 fn reject_unsupported_cross_project_scoping(
     tool_name: &str,
     params: &serde_json::Value,
@@ -2877,17 +2882,13 @@ fn reject_unsupported_cross_project_scoping(
              query a single project for scoped results."
         );
     }
-    // A lenient peek of ONLY the deferred scoping fields; unrelated/invalid
+    // A lenient peek of ONLY the still-unsupported fields; unrelated/invalid
     // sibling fields must not make this check fail (the real decode happens in
     // the per-tool branch). `null`/absent fields deserialize to `None`.
     #[derive(serde::Deserialize, Default)]
     struct ScopePeek {
         #[serde(default)]
         path: Option<String>,
-        #[serde(default)]
-        path_prefix: Option<String>,
-        #[serde(default)]
-        language: Option<String>,
         #[serde(default)]
         symbol_kind: Option<String>,
         #[serde(default)]
@@ -2899,21 +2900,7 @@ fn reject_unsupported_cross_project_scoping(
     let present = |v: &Option<String>| v.as_deref().is_some_and(|s| !s.trim().is_empty());
 
     match tool_name {
-        "search_symbols" => {
-            if present(&peek.path_prefix) {
-                return refuse("path_prefix");
-            }
-            if present(&peek.language) {
-                return refuse("language");
-            }
-        }
         "search_text" => {
-            if present(&peek.path_prefix) {
-                return refuse("path_prefix");
-            }
-            if present(&peek.language) {
-                return refuse("language");
-            }
             if peek.structural == Some(true) {
                 return refuse("structural");
             }
@@ -2943,14 +2930,18 @@ fn reject_unsupported_cross_project_scoping(
 /// Read-only by construction: it calls the overlay-aware `WorkingSet` search
 /// methods, which never mutate an overlay (the no-overlay-writes invariant).
 ///
-/// HONESTY (012 hardening): unlike the single-project path, the cross-project
-/// path does NOT honor the per-project derived-index scoping params
-/// (`path`/`path_prefix`/`language`/`symbol_kind`/`direction`/`structural`).
-/// Rather than silently drop them, every such param is REFUSED up front
-/// ([`reject_unsupported_cross_project_scoping`]). The output is also BOUNDED: a
-/// total-hit cap (caller `limit`, else [`CROSS_PROJECT_DEFAULT_RESULT_CAP`]) and
-/// the caller's optional `max_tokens` budget are applied by the formatters, which
-/// disclose any truncation.
+/// SCOPING (B1): the cross-project path builds the SAME `SymbolSearchOptions`/
+/// `TextSearchOptions` the single-project path builds (via
+/// `search_symbols_options_from_input` / `search_text_options_from_input`) and
+/// threads them through the engine's option-honoring `WorkingSet` search, so
+/// `path_prefix`/`language`/noise/`limit` ARE honored cross-project (D11) and
+/// each project's hits are `result_limit`-bounded and tier-ranked (D14). The
+/// params that genuinely have no cross-project path are still REFUSED up front
+/// ([`reject_unsupported_cross_project_scoping`]): `search_text` `structural`
+/// and `find_references` `path`/`symbol_kind`/`direction`. The output is also
+/// BOUNDED: a total-hit cap (caller `limit`, else
+/// [`CROSS_PROJECT_DEFAULT_RESULT_CAP`]) and the caller's optional `max_tokens`
+/// budget are applied by the formatters, which disclose any truncation.
 fn execute_cross_project_read(
     tool_name: &str,
     params: serde_json::Value,
@@ -2981,14 +2972,31 @@ fn execute_cross_project_read(
                      (browse mode is single-project only)."
                 );
             }
+            // Build the SAME options the single-project path builds, so cross-
+            // project scoping (path_prefix, language, noise) + per-project
+            // result_limit ranking behave identically (B1: D11 + D14). An unknown
+            // language is an honest error, not a silent drop.
+            let options = search_symbols_options_from_input(&input)
+                .map_err(|message| anyhow::anyhow!(message))?;
             let cap = cross_project_result_cap(input.limit);
-            let hits = working_set.search_symbols(&targets, query, input.kind.as_deref());
+            let hits = working_set.search_symbols(&targets, query, input.kind.as_deref(), &options);
             let body = format_cross_project_symbols(&hits, query, multi, cap);
             Ok(apply_cross_project_token_budget(body, input.max_tokens))
         }
         "search_text" => {
             let input: SearchTextInput = decode_params(params)?;
             let regex = input.regex.unwrap_or(false);
+            // Same options the single-project path builds (path_prefix, language,
+            // noise, max_per_file, case/word, glob, ranked) so cross-project text
+            // scoping is honored (B1: D11). `structural` was already refused above
+            // (it runs a separate ast-grep pipeline).
+            let mut options = search_text_options_from_input(&input)
+                .map_err(|message| anyhow::anyhow!(message))?;
+            // `context` (surrounding lines) is NOT rendered by the cross-project
+            // text formatter, so drop it rather than compute-and-discard it or
+            // imply it is honored. Rendering context / group_by / follow_refs
+            // cross-project is a display concern tracked under A1b, not B1 scoping.
+            options.context = None;
             let cap = cross_project_result_cap(input.limit);
             let results = working_set
                 .search_text(
@@ -2996,6 +3004,7 @@ fn execute_cross_project_read(
                     input.query.as_deref(),
                     input.terms.as_deref(),
                     regex,
+                    &options,
                 )
                 .map_err(|error| anyhow::anyhow!("text search failed: {error:?}"))?;
             let body = format_cross_project_text(&results, multi, cap);
@@ -5230,6 +5239,134 @@ mod tests {
             "single-active query must render flat (no project header): {active_only}"
         );
 
+        // (5) B1 — cross-project scoping is now HONORED over the wire, not
+        // refused (D11). These params previously returned a 400 "scoping is not
+        // supported with cross-project targeting"; now they filter the results.
+        //
+        // 5a — a path_prefix matching NEITHER project's files scopes BOTH out
+        //      (honored as a real filter, not silently ignored, not refused).
+        let scoped_out = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_symbols",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({
+                "query": "xproj_marker",
+                "projects": ["*"],
+                "path_prefix": "no_such_dir"
+            }))
+            .send()
+            .await
+            .expect("scoped query request")
+            .error_for_status()
+            .expect("B1: path_prefix must NOT be refused (HTTP 200, not 400)")
+            .text()
+            .await
+            .expect("scoped query body");
+        assert!(
+            !scoped_out.contains("xproj_marker_alpha") && !scoped_out.contains("xproj_marker_beta"),
+            "B1: a non-matching path_prefix must scope BOTH projects out \
+             (honored, not ignored): {scoped_out}"
+        );
+
+        // 5b — language=Python excludes both Rust symbols (honored language filter).
+        let lang_python = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_symbols",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({
+                "query": "xproj_marker",
+                "projects": ["*"],
+                "language": "Python"
+            }))
+            .send()
+            .await
+            .expect("python query request")
+            .error_for_status()
+            .expect("B1: language must NOT be refused (HTTP 200, not 400)")
+            .text()
+            .await
+            .expect("python query body");
+        assert!(
+            !lang_python.contains("xproj_marker_alpha")
+                && !lang_python.contains("xproj_marker_beta"),
+            "B1: language=Python must scope out the Rust symbols cross-project: {lang_python}"
+        );
+
+        // 5c — language=Rust keeps BOTH (the filter scopes; it does not break the
+        // query) — proves the scope-outs above are real filtering, not breakage.
+        let lang_rust = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_symbols",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({
+                "query": "xproj_marker",
+                "projects": ["*"],
+                "language": "Rust"
+            }))
+            .send()
+            .await
+            .expect("rust query request")
+            .error_for_status()
+            .expect("rust query status")
+            .text()
+            .await
+            .expect("rust query body");
+        assert!(
+            lang_rust.contains("xproj_marker_alpha") && lang_rust.contains("xproj_marker_beta"),
+            "B1: language=Rust keeps both Rust symbols cross-project: {lang_rust}"
+        );
+
+        // (6) B1 — cross-project search_text scoping is ALSO honored over the wire
+        // (closes the symbols-only coverage gap from the adversarial review). The
+        // source text "xproj_marker_*" lives in both projects' .rs files.
+        // 6-control: an unscoped cross-project text search finds BOTH.
+        let text_all = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_text",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({ "query": "xproj_marker", "projects": ["*"] }))
+            .send()
+            .await
+            .expect("text all request")
+            .error_for_status()
+            .expect("text all status")
+            .text()
+            .await
+            .expect("text all body");
+        assert!(
+            text_all.contains("xproj_marker_alpha") && text_all.contains("xproj_marker_beta"),
+            "B1 control: unscoped cross-project text search finds both projects: {text_all}"
+        );
+        // 6-scoped: a non-matching path_prefix scopes BOTH out — honored as a
+        // filter (HTTP 200), not refused (this was HTTP 400 before B1).
+        let text_scoped = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_text",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({
+                "query": "xproj_marker",
+                "projects": ["*"],
+                "path_prefix": "no_such_dir"
+            }))
+            .send()
+            .await
+            .expect("text scoped request")
+            .error_for_status()
+            .expect("B1: search_text path_prefix must NOT be refused (200, not 400)")
+            .text()
+            .await
+            .expect("text scoped body");
+        assert!(
+            !text_scoped.contains("xproj_marker_alpha")
+                && !text_scoped.contains("xproj_marker_beta"),
+            "B1: non-matching path_prefix must scope BOTH projects' text out (honored): {text_scoped}"
+        );
+
         let _ = handle.shutdown_tx.send(());
         wait_for_path_absent(&daemon_home.path().join(LEGACY_DAEMON_PORT_FILE)).await;
     }
@@ -5345,35 +5482,35 @@ mod tests {
         );
     }
 
-    // ── Feature 012 hardening — cross-project REFUSES deferred scoping params ─────
+    // ── B1 — cross-project HONORS path_prefix/language, still REFUSES the params
+    // with no cross-project path ─────────────────────────────────────────────
     //
-    // The per-project derived-index scoping (path/path_prefix/language/symbol_kind/
-    // direction/structural) is NOT honored cross-project. Prove each is REFUSED
-    // (honest, not silently dropped) with the corrective message, and that `kind`
-    // (which IS honored) is NOT refused.
+    // `path_prefix`/`language`/noise/`limit` are now threaded through the
+    // engine's option-honoring search (D11 + D14), so they are NO LONGER refused.
+    // `structural` (search_text) and `path`/`symbol_kind`/`direction`
+    // (find_references) have no cross-project entry point and are still refused
+    // (honest, not silently dropped).
     #[test]
     fn test_reject_unsupported_cross_project_scoping_per_tool() {
         use serde_json::json;
 
-        // search_symbols: path_prefix + language refused; kind allowed.
-        let err = reject_unsupported_cross_project_scoping(
-            "search_symbols",
-            &json!({ "query": "x", "path_prefix": "src/" }),
-        )
-        .expect_err("path_prefix must be refused");
-        let msg = err.to_string();
+        // search_symbols: path_prefix + language are now HONORED (not refused);
+        // kind always allowed.
         assert!(
-            msg.contains("path_prefix scoping is not supported with cross-project targeting")
-                && msg.contains("query a single project for scoped results"),
-            "refusal message must name the param + corrective hint: {msg}"
+            reject_unsupported_cross_project_scoping(
+                "search_symbols",
+                &json!({ "query": "x", "path_prefix": "src/" }),
+            )
+            .is_ok(),
+            "path_prefix is now honored cross-project and must NOT be refused"
         );
         assert!(
             reject_unsupported_cross_project_scoping(
                 "search_symbols",
                 &json!({ "query": "x", "language": "Rust" }),
             )
-            .is_err(),
-            "language must be refused on search_symbols"
+            .is_ok(),
+            "language is now honored cross-project and must NOT be refused"
         );
         assert!(
             reject_unsupported_cross_project_scoping(
@@ -5384,19 +5521,32 @@ mod tests {
             "kind IS honored cross-project and must NOT be refused"
         );
 
-        // search_text: structural refused.
+        // search_text: path_prefix/language honored; structural still refused.
         assert!(
             reject_unsupported_cross_project_scoping(
                 "search_text",
-                &json!({ "query": "x", "structural": true }),
+                &json!({ "query": "x", "path_prefix": "src/", "language": "Rust" }),
             )
-            .unwrap_err()
-            .to_string()
-            .contains("structural scoping is not supported"),
-            "structural must be refused on search_text"
+            .is_ok(),
+            "search_text path_prefix/language are now honored cross-project"
+        );
+        let structural_err = reject_unsupported_cross_project_scoping(
+            "search_text",
+            &json!({ "query": "x", "structural": true }),
+        )
+        .expect_err("structural must be refused");
+        assert!(
+            structural_err
+                .to_string()
+                .contains("structural scoping is not supported")
+                && structural_err
+                    .to_string()
+                    .contains("query a single project for scoped results"),
+            "structural refusal must name the param + corrective hint: {structural_err}"
         );
 
-        // find_references: path / symbol_kind / direction refused.
+        // find_references: path / symbol_kind / direction still refused (no
+        // cross-project meaning).
         for (field, value) in [
             ("path", json!("src/db.rs")),
             ("symbol_kind", json!("fn")),
@@ -5414,14 +5564,14 @@ mod tests {
             );
         }
 
-        // Blank/empty values are treated as not-set (no false refusal).
+        // A blank still-refused value is treated as not-set (no false refusal).
         assert!(
             reject_unsupported_cross_project_scoping(
-                "search_symbols",
-                &json!({ "query": "x", "path_prefix": "  " }),
+                "find_references",
+                &json!({ "name": "x", "path": "  " }),
             )
             .is_ok(),
-            "blank scoping value must not trip the refusal"
+            "blank path value must not trip the refusal"
         );
     }
 
@@ -5443,17 +5593,21 @@ mod tests {
         let mut ws = WorkingSet::new();
         ws.add("proj-x", base);
 
+        // A still-unsupported param (find_references `direction`) is refused up
+        // front, before any query runs. (`path_prefix`/`language` are now honored,
+        // so they no longer exercise this guard — `direction` still has no
+        // cross-project path.)
         let err = execute_cross_project_read(
-            "search_symbols",
-            json!({ "query": "anything", "language": "Rust" }),
+            "find_references",
+            json!({ "name": "anything", "direction": "trait" }),
             Targets::Subset(vec!["proj-x".to_string()]),
             &ws,
         )
         .expect_err("scoping param must be refused");
         assert!(
             err.to_string()
-                .contains("language scoping is not supported with cross-project targeting"),
-            "cross-project read must refuse the deferred scoping param: {err}"
+                .contains("direction scoping is not supported with cross-project targeting"),
+            "cross-project read must refuse the unsupported scoping param: {err}"
         );
     }
 

--- a/src/live_index/view.rs
+++ b/src/live_index/view.rs
@@ -31,9 +31,9 @@ use std::sync::Arc;
 use crate::domain::{ReferenceKind, ReferenceRecord};
 
 use super::search::{
-    DEFAULT_MAX_PER_FILE, SymbolMatchTier, TextSearchError, TextSearchResult, compute_test_ranges,
-    current_code_search_keeps_file, search_symbols as base_search_symbols,
-    search_text as base_search_text, truncate_display_line,
+    DEFAULT_MAX_PER_FILE, SymbolMatchTier, SymbolSearchOptions, TextSearchError, TextSearchOptions,
+    TextSearchResult, compute_test_ranges, current_code_search_keeps_file,
+    search_symbols_with_options, search_text_with_options, truncate_display_line,
 };
 use super::store::{IndexedFile, LiveIndex};
 use crate::live_index::query::is_filtered_name;
@@ -318,28 +318,40 @@ impl<'a> IndexView<'a> {
     /// Symbol-name search resolved THROUGH the overlay (research D1: symbol-name
     /// search resolves through the overlay, not via the base's derived indices).
     ///
-    /// For a base-only view this delegates straight to the engine's
-    /// [`base_search_symbols`] over the base index (byte-for-byte today's
-    /// behavior). When an overlay is present we cannot call the base function
-    /// (it would scan the stale base file map), so we scan the OVERLAY-RESOLVED
-    /// file set ([`all_files`]) directly with the same name-match + tiering rules
-    /// the engine search uses, then sort and bound identically. Correctness over
-    /// speed: this is a linear scan of the resolved file set.
+    /// For a view with NO live deltas (base-only, OR an empty overlay — the US1
+    /// cross-project case, since overlays are never written there) this delegates
+    /// straight to the engine's option-honoring [`search_symbols_with_options`]
+    /// over the base, so the caller's `options` (path scope, language filter,
+    /// noise policy, and the `result_limit` ranking) ARE honored on the
+    /// cross-project read path (D11 scoping + D14 ranking). When live overlay
+    /// deltas ARE present we cannot call the base function (it would scan the
+    /// stale base file map), so we scan the OVERLAY-RESOLVED file set
+    /// ([`all_files`]) directly with the name-match + tiering rules the engine
+    /// uses. Correctness over speed: this is a linear scan of the resolved set.
     ///
-    /// `// DEFERRED (012 full tier):` the engine's richer
-    /// `search_symbols_with_options` (noise policy, test-module suppression,
-    /// path scope, language filter) is intentionally NOT reproduced here — the
-    /// overlay path applies only the name/kind tiering needed for cross-project
-    /// attribution. Wiring the full option surface through the overlay is the
-    /// deferred derived-index work; until then the overlay symbol search is a
-    /// minimal, correct superset (it may include hits the option-filtered base
-    /// path would suppress).
+    /// `// DEFERRED (D-B0):` the overlay-present scan applies only the name/kind
+    /// tiering needed for cross-project attribution; honoring the full option
+    /// surface (path scope, language, noise) over the dirty set is the deferred
+    /// per-overlay derived-index work. That branch is unreached on the US1
+    /// cross-project path (overlays are empty there); until then the overlay
+    /// symbol search is a minimal, correct superset.
     ///
     /// [`all_files`]: IndexView::all_files
-    pub fn search_symbols(&self, query: &str, kind_filter: Option<&str>) -> Vec<ViewSymbolHit> {
-        // Fast path: no overlay -> reuse the engine search verbatim over the base.
-        if self.overlay.is_none() {
-            let result = base_search_symbols(self.base, query, kind_filter, usize::MAX);
+    pub fn search_symbols(
+        &self,
+        query: &str,
+        kind_filter: Option<&str>,
+        options: &SymbolSearchOptions,
+    ) -> Vec<ViewSymbolHit> {
+        // No live deltas (absent OR empty overlay) -> reuse the engine's
+        // option-honoring search verbatim over the base. This IS the US1
+        // cross-project path; caller scoping + result_limit ranking are honored.
+        let no_deltas = match self.overlay_deltas() {
+            None => true,
+            Some(deltas) => deltas.is_empty(),
+        };
+        if no_deltas {
+            let result = search_symbols_with_options(self.base, query, kind_filter, options);
             return result
                 .hits
                 .into_iter()
@@ -403,7 +415,9 @@ impl<'a> IndexView<'a> {
     /// `search_text` depends on the base's repo-wide `trigram_index`, which the
     /// overlay does NOT re-derive (that is the DEFERRED per-consumer derived
     /// index). So we:
-    /// 1. run the engine [`base_search_text`] against the immutable base index;
+    /// 1. run the engine [`search_text_with_options`] against the immutable base
+    ///    index (honoring the caller's `options` — path scope, language, noise,
+    ///    limits — so cross-project text scoping is honored, D11);
     /// 2. DROP every base file-result whose path is a live overlay delta — its
     ///    base content is stale (the consumer edited or deleted that file);
     /// 3. directly SCAN each overlay `Upsert`'s current content for the same
@@ -440,8 +454,9 @@ impl<'a> IndexView<'a> {
         query: Option<&str>,
         terms: Option<&[String]>,
         regex: bool,
+        options: &TextSearchOptions,
     ) -> Result<TextSearchResult, TextSearchError> {
-        let mut result = base_search_text(self.base, query, terms, regex)?;
+        let mut result = search_text_with_options(self.base, query, terms, regex, options)?;
 
         let Some(deltas) = self.overlay_deltas() else {
             return Ok(result);
@@ -958,6 +973,7 @@ impl WorkingSet {
         targets: &Targets,
         query: &str,
         kind_filter: Option<&str>,
+        options: &SymbolSearchOptions,
     ) -> Vec<ProjectHit<ViewSymbolHit>> {
         let mut out = Vec::new();
         for entry in self
@@ -968,7 +984,7 @@ impl WorkingSet {
             let Ok(view) = Self::view_for(entry) else {
                 continue;
             };
-            for hit in view.search_symbols(query, kind_filter) {
+            for hit in view.search_symbols(query, kind_filter, options) {
                 out.push(ProjectHit {
                     project_id: entry.project_id.clone(),
                     hit,
@@ -988,6 +1004,7 @@ impl WorkingSet {
         query: Option<&str>,
         terms: Option<&[String]>,
         regex: bool,
+        options: &TextSearchOptions,
     ) -> Result<Vec<ProjectHit<TextSearchResult>>, TextSearchError> {
         let mut out = Vec::new();
         for entry in self
@@ -998,7 +1015,7 @@ impl WorkingSet {
             let Ok(view) = Self::view_for(entry) else {
                 continue;
             };
-            let result = view.search_text(query, terms, regex)?;
+            let result = view.search_text(query, terms, regex, options)?;
             out.push(ProjectHit {
                 project_id: entry.project_id.clone(),
                 hit: result,
@@ -1540,7 +1557,12 @@ mod tests {
             base_with_symbol("/c", "c0", "shared_c", "fn shared_c() {}"),
         );
 
-        let hits = ws.search_symbols(&Targets::All, "shared", None);
+        let hits = ws.search_symbols(
+            &Targets::All,
+            "shared",
+            None,
+            &SymbolSearchOptions::for_current_code_search(usize::MAX),
+        );
         assert_eq!(hits.len(), 3, "one hit per project");
 
         // Every hit is attributed to its source project, and the project's own
@@ -1572,7 +1594,12 @@ mod tests {
         );
 
         // Single.
-        let one = ws.search_symbols(&Targets::One("B".to_string()), "shared", None);
+        let one = ws.search_symbols(
+            &Targets::One("B".to_string()),
+            "shared",
+            None,
+            &SymbolSearchOptions::for_current_code_search(usize::MAX),
+        );
         assert_eq!(one.len(), 1);
         assert_eq!(one[0].project_id, "B");
         assert_eq!(one[0].hit.name, "shared_b");
@@ -1582,6 +1609,7 @@ mod tests {
             &Targets::Subset(vec!["A".to_string(), "C".to_string()]),
             "shared",
             None,
+            &SymbolSearchOptions::for_current_code_search(usize::MAX),
         );
         let projects: std::collections::BTreeSet<&str> =
             subset.iter().map(|h| h.project_id.as_str()).collect();
@@ -1595,7 +1623,12 @@ mod tests {
         // A target naming a project not in the set yields no hits (the caller
         // layer turns "project not open" into an explicit error; the primitive
         // simply does not match it).
-        let none = ws.search_symbols(&Targets::One("Z".to_string()), "shared", None);
+        let none = ws.search_symbols(
+            &Targets::One("Z".to_string()),
+            "shared",
+            None,
+            &SymbolSearchOptions::for_current_code_search(usize::MAX),
+        );
         assert!(none.is_empty());
     }
 
@@ -1634,7 +1667,12 @@ mod tests {
         // Sanity: base-only view finds the base hit.
         let base_view = IndexView::new(&base, None).unwrap();
         let base_hits = base_view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("base text search");
         assert_eq!(base_hits.total_matches, 1);
         assert_eq!(base_hits.files.len(), 1);
@@ -1646,7 +1684,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("overlay text search");
 
         let paths: std::collections::BTreeSet<&str> =
@@ -1673,7 +1716,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("text search");
         assert_eq!(
             result.total_matches, 0,
@@ -1767,7 +1815,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("overlay text search");
 
         let added = result
@@ -1818,7 +1871,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("overlay text search");
         let paths: std::collections::BTreeSet<&str> =
             result.files.iter().map(|f| f.path.as_str()).collect();
@@ -1857,7 +1915,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("overlay text search");
         let code = result
             .files
@@ -1934,7 +1997,12 @@ mod tests {
 
         let view = IndexView::new(&base, Some(&overlay)).unwrap();
         let result = view
-            .search_text(Some("NEEDLE"), None, false)
+            .search_text(
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("overlay text search");
         let ordered: Vec<&str> = result.files.iter().map(|f| f.path.as_str()).collect();
         let mut expected = names.to_vec();
@@ -1976,7 +2044,13 @@ mod tests {
         ws.add("C", base_with_symbol("/c", "c0", "h", "let NEEDLE = 3;"));
 
         let results = ws
-            .search_text(&Targets::All, Some("NEEDLE"), None, false)
+            .search_text(
+                &Targets::All,
+                Some("NEEDLE"),
+                None,
+                false,
+                &TextSearchOptions::for_current_code_search(),
+            )
             .expect("cross-project text search");
         // Only projects whose content has NEEDLE produce non-empty results, but
         // every targeted project yields a (possibly empty) attributed result.
@@ -2000,10 +2074,108 @@ mod tests {
         // rebase). The query must SKIP it (never serve stale) rather than panic.
         ws.get_mut("A").unwrap().overlay.base_generation = 999;
 
-        let hits = ws.search_symbols(&Targets::All, "shared", None);
+        let hits = ws.search_symbols(
+            &Targets::All,
+            "shared",
+            None,
+            &SymbolSearchOptions::for_current_code_search(usize::MAX),
+        );
         assert!(
             hits.is_empty(),
             "a stale-overlay entry must be skipped, not served"
+        );
+    }
+
+    /// Build a base from explicit (path, language, symbol_name) tuples, each file
+    /// defining one function named `symbol_name`. Used to prove the cross-project
+    /// search HONORS caller options (path scope, language, result_limit) on the
+    /// empty-overlay path (B1 / D11 + D14).
+    fn base_with_files(
+        root: &str,
+        commit: &str,
+        files: &[(&str, LanguageId, &str)],
+    ) -> Arc<IndexBase> {
+        let mut idx = LiveIndex::empty_live_index();
+        idx.is_empty = false;
+        idx.loaded_at = Instant::now();
+        let mut map: HashMap<String, Arc<IndexedFile>> = HashMap::new();
+        for (path, lang, sym) in files {
+            let mut file = make_file_with_symbol(path, sym, &format!("fn {sym}() {{}}"));
+            file.language = lang.clone();
+            map.insert((*path).to_string(), Arc::new(file));
+        }
+        idx.trigram_index = crate::live_index::trigram::TrigramIndex::build_from_files(&map);
+        idx.files = map;
+        idx.rebuild_reverse_index();
+        Arc::new(IndexBase::new(
+            BaseKey::new(root, CommitId::Sha(commit.to_string())),
+            Arc::new(idx),
+            1,
+        ))
+    }
+
+    // ── B1: cross-project search HONORS caller scoping + limit (D11 + D14) ─────
+    // These options were previously LOUDLY REFUSED at the daemon guard; now they
+    // are threaded through the engine's option-honoring search.
+    #[test]
+    fn cross_project_search_honors_scoping_options() {
+        use crate::live_index::search::PathScope;
+
+        let mut ws = WorkingSet::new();
+        // One project; three files all defining `widget`: two Rust (src/, other/)
+        // and one Python under src/.
+        ws.add(
+            "A",
+            base_with_files(
+                "/a",
+                "c0",
+                &[
+                    ("src/keep.rs", LanguageId::Rust, "widget"),
+                    ("other/skip.rs", LanguageId::Rust, "widget"),
+                    ("src/also.py", LanguageId::Python, "widget"),
+                ],
+            ),
+        );
+
+        // path_scope = src/ -> the other/ file is EXCLUDED (D11 path scoping).
+        let mut scoped = SymbolSearchOptions::for_current_code_search(usize::MAX);
+        scoped.path_scope = PathScope::prefix("src");
+        let hits = ws.search_symbols(&Targets::All, "widget", None, &scoped);
+        let paths: std::collections::BTreeSet<&str> =
+            hits.iter().map(|h| h.hit.path.as_str()).collect();
+        assert!(
+            paths.contains("src/keep.rs") && paths.contains("src/also.py"),
+            "src/-scoped search must include the src/ hits: {paths:?}"
+        );
+        assert!(
+            !paths.contains("other/skip.rs"),
+            "src/-scoped search must EXCLUDE other/ hits (path scoping honored): {paths:?}"
+        );
+
+        // language = Rust -> the Python file is EXCLUDED (D11 language scoping).
+        let mut rust_only = SymbolSearchOptions::for_current_code_search(usize::MAX);
+        rust_only.language_filter = Some(LanguageId::Rust);
+        let rust_hits = ws.search_symbols(&Targets::All, "widget", None, &rust_only);
+        let rust_paths: std::collections::BTreeSet<&str> =
+            rust_hits.iter().map(|h| h.hit.path.as_str()).collect();
+        assert!(
+            rust_paths.contains("src/keep.rs") && rust_paths.contains("other/skip.rs"),
+            "Rust-filtered search keeps the Rust files: {rust_paths:?}"
+        );
+        assert!(
+            !rust_paths.contains("src/also.py"),
+            "Rust-filtered search must EXCLUDE the Python file (language scoping honored): {rust_paths:?}"
+        );
+
+        // result_limit = 1 -> the per-project hits are bounded + tier-ranked, not
+        // an unbounded usize::MAX dump (D14).
+        let bounded = SymbolSearchOptions::for_current_code_search(1);
+        let bounded_hits = ws.search_symbols(&Targets::All, "widget", None, &bounded);
+        assert_eq!(
+            bounded_hits.len(),
+            1,
+            "result_limit=1 bounds the per-project hits (D14): got {}",
+            bounded_hits.len()
         );
     }
 }


### PR DESCRIPTION
## B1 — cross-project scoping honored (ledger D11/D14)

Flips cross-project `path_prefix`/`language`/noise scoping from **LOUD-refused -> honored**, attacking Culprit B (engine multi-view search ignored caller scoping) at the root.

### What changed
- **Engine** (`live_index/view.rs`): `IndexView::search_symbols`/`search_text` + `WorkingSet` take caller `SymbolSearchOptions`/`TextSearchOptions` and, on the no-live-deltas path (the US1 cross-project path — overlays are always empty there), route through the engine's option-honoring `search_*_with_options`. The single-project read path is untouched (`IndexView` is reached **only** via the cross-project `WorkingSet`).
- **Daemon** (`daemon.rs`): `execute_cross_project_read` builds those options via the **same helpers the single-project path uses**, so cross-project scoping behaves identically to single-project. `reject_unsupported_cross_project_scoping` narrowed to the params with no cross-project entry point — `structural` (separate ast-grep pipeline) and `find_references` `path`/`symbol_kind`/`direction` (selectors/implementations-mode) stay honest capability-refusals. `context` is dropped from cross-project text options (the formatter can't render surrounding lines; deferred to A1b) rather than accepted-and-ignored.

### Honesty (per adversarial review wf a2eac32)
- **D11 -> FIXED**: `path_prefix`/`language`/noise honored for both `search_symbols` and `search_text`.
- **D14 -> PARTIAL**: per-project results are now `result_limit`-bounded + tier-ranked before the cap (was an unbounded `usize::MAX` dump then truncate); a single **global** relevance interleave across projects is deferred (results stay grouped-by-project). Not overstated as FIXED.

### Verification (full gate green on the merged state)
- `fmt --check`, `clippy --all-targets -D warnings`, `test --all-targets --test-threads=1`, `build --release`, `check --no-default-features --features embed` — all green.
- Engine unit test (path/language/limit honored), daemon guard tests flipped refusal->honoring, and a live daemon-HTTP test asserting **symbols + text** scoping honored over the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-project search behavior and API semantics (400 refusals become filtered 200s); risk is mitigated by parity with single-project option builders and expanded integration tests.
> 
> **Overview**
> **B1** makes cross-project `search_symbols` and `search_text` honor the same scoping as single-project reads instead of refusing `path_prefix` and `language` up front.
> 
> The daemon’s `execute_cross_project_read` now builds `SymbolSearchOptions` / `TextSearchOptions` via the existing single-project helpers and passes them into `WorkingSet`. `reject_unsupported_cross_project_scoping` only blocks params with no cross-project implementation (`structural`, `find_references` selectors). On the empty-overlay path, `IndexView` routes through `search_*_with_options` so **path_prefix**, **language**, noise, and **result_limit** (per-project tier ranking) apply; cross-project text drops `context` because the formatter does not render it.
> 
> Tests and docs flip from “must refuse” to “must honor,” add engine and live HTTP scoping coverage, and mark ledger **D11** fixed and **D14** partial (global cross-project interleave still deferred).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc486b93e61a3b56449c58b2cde85f308e9bc5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->