### PR TITLE
feat(stel): forward caller `path` into scoped search routes (A1b)

### DIFF
--- a/docs/reviews/symforge-defect-ledger.md
+++ b/docs/reviews/symforge-defect-ledger.md
@@ -25,6 +25,7 @@ Last updated: 2026-06-22.
 | D7 | `symbol` param ignored on read/impact/orient (query token taken as the symbol name). | SYMPTOM(A) | VERIFY | 012/branch |
 | D8 | `path:` reads as a project selector but is a within-project filter; vocabulary trap. Glossary + error added (loud), facade vocabulary still lossy. | SYMPTOM(A) | LOUD-ONLY | new |
 | D9 | The `symforge` facade silently dropped `project`/`projects`. Now **loudly refused** — but the defect (facade does not route cross-project) is unfixed. | SYMPTOM(A) | LOUD-ONLY | new |
+| D20 | `search_files` is planner-reachable + scope-capable but its input has NO `path_prefix` field, so a caller's `path` is silently dropped on `search_files` routes (path/file ranking runs repo-wide despite the caller scoping). A1b's planner forwarding cannot reach it (no arg to forward into). Found by adversarial review wf a9b73e8. Fix path: add `path_prefix` to `SearchFilesInput` + scope the handler, then add `search_files` to `PATH_PREFIX_FORWARD_TOOLS`. | SYMPTOM(A) | OPEN | 012 |
 
 ## Defects — CULPRIT B (engine multi-view search: no per-view derived index, no live rebase)
 
@@ -57,6 +58,7 @@ Last updated: 2026-06-22.
 - Strict-MCP-client schema rejection of Phase 3 `projects` fields → `schemars(with=...)`.
 - Base+overlay engine primitive + cross-project query (US1) — live-verified.
 - B1 cross-project scoping HONORED (D11): `path_prefix`/`language`/noise threaded through the option-honoring engine search via the single-project helpers; reject guard narrowed to the genuinely-unsupported params (`structural`, `find_references` selectors). Per-project ranked+bounded (D14 PARTIAL — global interleave deferred). Aligns cross-project text defaults with single-project (`include_vendor=false`); `ranked` is churn-blind cross-project (noted). Engine unit test + live daemon-HTTP scoping assertions (symbols + text); adversarial review wf a2eac32.
+- A1b `path` forwarding (D-A0 / lossless-or-loud): `forward_caller_path` in the single plan choke point (`src/stel/planner.rs`) threads the caller's `path` into `path_prefix` on the path_prefix-capable search routes (`search_symbols`/`search_text`/`explore`), closing the `path` silent-drop there; `path`-as-selector routes (`get_symbol`/`get_file_content`/`find_references`/`find_dependents`) already carry it (Routed). `max_tokens` left as handler-`Forwarded` (already honored; injecting it would fight the degrade-cap logic and violate the `Forwarded` contract). Golden unaffected (tool-shape unchanged). Conformance test re-baselined NotApplicable→Routed + behavioral forwarding proof. Adversarial review wf a9b73e8 (verdict: correct + honest); newly-found `search_files` scope gap tracked as D20.
 
 ## Attack plan (roots, not holes)
 
@@ -73,7 +75,7 @@ Sequence by (defects-killed ÷ effort), gated by file independence:
 1. **A1a** — `ParamDisposition` choke point in `build_plan_from_steps` + conformance test. Every `StelRequest` field resolves to `Routed|Forwarded|Refused|NotApplicable`; silent-absent is asserted-against. **Zero behavior change — `routes.golden.jsonl` does NOT move.** Erects the non-regressable guard against the silent-drop class (D-A0) at zero risk. **ATTACK FIRST.** Owner 012.
 2. **D17** — collapse the open-vs-close TOCTOU (single `projects.write()` entry). S/LOW, isolated. Owner 012.
 3. **B1** — DONE (implemented, gate-green): threaded caller options through the empty-overlay search path → D11 scoping FIXED, D14 ranking PARTIAL (per-project ranked+bounded; global interleave deferred). Owner 012.
-4. **A1b** — gated per-tool forwarding (`max_tokens`→args, `path`→`path_prefix`); golden re-baselined. Owner 012.
+4. **A1b** — DONE (implemented, gate-green, adversarially reviewed wf a9b73e8): `forward_caller_path` threads caller `path`→`path_prefix` on path_prefix-capable search routes (the real `path` silent-drop). HONEST refinement of the forecast: `max_tokens` was already honored (handler CCR `Forwarded`), so it is NOT forwarded into plan args (would violate the `Forwarded` contract); golden needed NO re-baseline (it asserts tool-shape only). New defect found: D20 (`search_files` unscoped). Owner 012.
 5. **C-stopgap** — `/mcp` loudly refuses `project`/`projects` (contain D16's silent-wrong half). Owner 012.
 6. **B2** — republish→rebase on HEAD/watcher advance (D12). Owner 012.
 

--- a/src/stel/planner.rs
+++ b/src/stel/planner.rs
@@ -76,9 +76,11 @@ impl ParamDisposition {
 /// - `symbol` → `Refused` for prose (the handler's `symbol_contract_violation`
 ///   precedent), `Routed` when a bare identifier reaches a plan step, else
 ///   `NotApplicable` (set but not consumed on this route today).
-/// - `path`   → `Routed` when the finalized plan's args carry the path value,
-///   else `NotApplicable` (the planner does not forward it on this route yet —
-///   A1b is the forwarding step; A1a only records the gap).
+/// - `path`   → `Routed` when the finalized plan's args carry the path value
+///   (A1b forwards it into `path_prefix` on scoped search routes), else
+///   `NotApplicable` (a route whose tool has no path scope, e.g. `get_repo_map`
+///   or `search_files`; NOT `get_symbol`/`get_file_content`, which DO consume
+///   `path` as a selector and are therefore `Routed`).
 /// - `max_tokens` / `preview` → `Forwarded`: consumed by the handler AFTER the
 ///   planner (CCR budget / preview-estimate branch), not by plan steps.
 /// - `project` / `projects` → `Refused` when meaningfully set: the handler
@@ -122,8 +124,11 @@ pub fn classify_param_dispositions(
     let path = if path_set && plan_carries_path(plan, request) {
         ParamDisposition::Routed
     } else {
-        // Set-but-unconsumed `path` (the A1b forwarding target) or absent: the
-        // planner does not thread it into this route's args today.
+        // `path` absent, or a route whose tool carries no path scope and no path
+        // selector (so neither A1b's forwarding nor a target arg applies — e.g.
+        // `get_repo_map`, `context_inventory`, or `search_files`, which has no
+        // `path_prefix` field at all; tracked as D20): explicit NotApplicable,
+        // not a silent drop.
         ParamDisposition::NotApplicable
     };
 
@@ -421,12 +426,50 @@ fn is_orient_query(lower: &str) -> bool {
         || lower.contains("orient:")
 }
 
+/// Tools whose schema accepts a `path_prefix` SCOPE argument — the caller's
+/// `path` forwards into it (A1b gated per-tool forwarding). Tools where `path`
+/// is a TARGET/selector (e.g. `get_file_content`, `find_references`) are
+/// intentionally excluded: there the target comes from the query, not a scope
+/// hint, so forwarding the caller's `path` would be wrong.
+const PATH_PREFIX_FORWARD_TOOLS: &[&str] = &["search_symbols", "search_text", "explore"];
+
+/// A1b gated per-tool forwarding: thread the caller's `path` into each plan
+/// step's `path_prefix` arg where that tool accepts a path scope (and the caller
+/// supplied a non-blank `path`), UNLESS the route already set `path_prefix`
+/// (idempotent — a route that parsed its own scope from the query is left
+/// untouched). This closes the `path` silent-drop on scoped search routes
+/// (lossless-or-loud, root D-A0): after this pass `plan_carries_path` is true on
+/// those routes, so [`classify_param_dispositions`] records `path` as `Routed`.
+///
+/// `max_tokens` is deliberately NOT forwarded here: it is already honored as a
+/// handler-layer CCR budget on the final envelope (`Forwarded`), so it is not a
+/// silent drop, and pushing it into plan-step args would violate the `Forwarded`
+/// disposition contract ("consumed downstream of the planner, not by the plan
+/// steps").
+fn forward_caller_path(request: &StelRequest, steps: &mut [StelPlanStep]) {
+    let Some(path) = request
+        .path
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+    else {
+        return;
+    };
+    for step in steps.iter_mut() {
+        if PATH_PREFIX_FORWARD_TOOLS.contains(&step.tool.as_str())
+            && step.args.get("path_prefix").is_none()
+        {
+            step.args["path_prefix"] = json!(path);
+        }
+    }
+}
+
 fn build_plan_from_steps(request: &StelRequest, steps: Vec<PlannedStep>) -> StelPlan {
     let primary = steps.first().expect("plan must have at least one step");
     let intent = primary.intent;
     let confidence = primary.confidence;
     let confidence_rationale = primary.rationale.to_string();
-    let stel_steps: Vec<StelPlanStep> = steps
+    let mut stel_steps: Vec<StelPlanStep> = steps
         .into_iter()
         .enumerate()
         .map(|(index, step)| StelPlanStep {
@@ -438,6 +481,9 @@ fn build_plan_from_steps(request: &StelRequest, steps: Vec<PlannedStep>) -> Stel
             index_refs: vec![],
         })
         .collect();
+    // A1b gated per-tool forwarding: thread the caller's `path` into scoped
+    // search routes' `path_prefix`, closing the `path` silent-drop (root D-A0).
+    forward_caller_path(request, &mut stel_steps);
     let plan = StelPlan {
         plan_id: new_plan_id(request),
         intent,
@@ -447,13 +493,16 @@ fn build_plan_from_steps(request: &StelRequest, steps: Vec<PlannedStep>) -> Stel
         suggested_followup: None,
     };
 
-    // A1a lossless-or-loud guard (root D-A0): every `StelRequest` field MUST
-    // resolve to an explicit `ParamDisposition` at this single choke point — no
-    // field may be silently unaccounted-for. Assertion-only: this neither reads
-    // into nor mutates the returned plan, so output is byte-identical. The
-    // `debug_assert!` compiles out of release; the conformance test
-    // (`tests/stel_param_disposition.rs`) enforces the same invariant across the
-    // emittable surface in every build.
+    // Lossless-or-loud STRUCTURAL guard (root D-A0): every `StelRequest` field
+    // MUST resolve to an explicit `ParamDisposition` at this single choke point —
+    // no field may be silently unaccounted-for. This is a COMPILE-TIME / TEST-TIME
+    // completeness invariant over field accounting, NOT a runtime loud refusal:
+    // the `debug_assert!` compiles out of release, the conformance test
+    // (`tests/stel_param_disposition.rs`) enforces it in every build, and only
+    // `Refused` params (project/projects) reach the caller loudly — via a separate
+    // handler path (D9), not this classifier. `classify_param_dispositions` is
+    // pure (it audits the finalized `plan`, never mutates it); the behavioral
+    // change is the `forward_caller_path` pass above (A1b), which the guard audits.
     debug_assert!(
         classify_param_dispositions(request, &plan)
             .iter()

--- a/tests/stel_param_disposition.rs
+++ b/tests/stel_param_disposition.rs
@@ -177,13 +177,15 @@ fn disposition_of(
         .unwrap_or_else(|| panic!("field `{field}` must be classified"))
 }
 
-/// Records the CURRENT disposition of each field, pinning today's behavior so a
-/// future increment that CHANGES routing (e.g. A1b forwarding `path` /
-/// `max_tokens` into plan args) updates this deliberately rather than drifting
-/// silently. Documents the A1a baseline; it is the behavior-change tripwire, not
-/// a behavioral claim about which tool a route picks.
+/// Records the CURRENT disposition of each field, pinning behavior so a future
+/// routing change updates this deliberately rather than drifting silently. Now
+/// reflects A1b: the caller's `path` is forwarded into scoped search routes'
+/// `path_prefix` (Routed). `max_tokens` stays handler-`Forwarded` (already
+/// honored; intentionally NOT pushed into plan-step args, which would violate the
+/// `Forwarded` contract). The behavior-change tripwire, not a claim about which
+/// tool a route picks.
 #[test]
-fn current_dispositions_pin_the_a1a_baseline() {
+fn current_dispositions_pin_the_post_a1b_baseline() {
     // Constant across routes: query/intent are always consumed; max_tokens /
     // preview are handler-forwarded (post-planner); project / projects are
     // loudly refused (D9).
@@ -226,11 +228,11 @@ fn current_dispositions_pin_the_a1a_baseline() {
         ParamDisposition::Routed
     );
 
-    // A1a BASELINE GAP (the A1b target): a multi-word fuzzy find with NO
-    // `symbol` routes through find-fusion, which does NOT thread `path` into its
-    // args today. `path` is therefore explicitly NotApplicable — the planner saw
-    // it and did not consume it on this route — NOT a silent drop. A1b will flip
-    // this to Routed/Forwarded and must re-baseline this exact assertion.
+    // A1b (the re-baselined assertion): a multi-word fuzzy find with NO `symbol`
+    // routes through find-fusion to a scoped search tool, and A1b now forwards
+    // the caller's `path` into that route's `path_prefix`. So `path` is Routed —
+    // this was `NotApplicable` at the A1a baseline and was the documented A1b
+    // re-baseline target.
     let no_symbol = StelRequest {
         query: "stel planner find helper".to_string(),
         intent: Some(IntentBucket::Find),
@@ -241,13 +243,41 @@ fn current_dispositions_pin_the_a1a_baseline() {
     let no_symbol_d = classify_param_dispositions(&no_symbol, &no_symbol_plan);
     assert_eq!(
         disposition_of(&no_symbol_d, "path"),
-        ParamDisposition::NotApplicable,
-        "A1a baseline: fuzzy-find route does not consume `path` yet (A1b target)"
+        ParamDisposition::Routed,
+        "A1b: fuzzy-find route now forwards `path` into `path_prefix` (Routed)"
     );
     // The unset `symbol` on this route is NotApplicable, never silent.
     assert_eq!(
         disposition_of(&no_symbol_d, "symbol"),
         ParamDisposition::NotApplicable
+    );
+}
+
+/// A1b behavioral proof: a search-intent request with `path` set yields a plan
+/// whose scoped-search step actually carries `path_prefix == path` (the
+/// forwarding lands in the args, not merely in the disposition record). Every
+/// route funnels through `build_plan_from_steps`, so this holds for single-step
+/// routes too.
+#[test]
+fn a1b_forwards_path_into_path_prefix_arg() {
+    let request = StelRequest {
+        query: "find Database class".to_string(),
+        intent: Some(IntentBucket::Find),
+        path: Some("src/db".to_string()),
+        ..Default::default()
+    };
+    let plan = build_plan(&request);
+    let forwarded = plan
+        .steps
+        .iter()
+        .any(|step| step.args.get("path_prefix").and_then(Value::as_str) == Some("src/db"));
+    assert!(
+        forwarded,
+        "A1b: a scoped search route must forward `path` into `path_prefix`; got {:?}",
+        plan.steps
+            .iter()
+            .map(|s| s.args.clone())
+            .collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## A1b — forward caller `path` into scoped search routes (lossless-or-loud)

Closes the `path` silent-drop on the `symforge` compact facade (root D-A0). A new `forward_caller_path` pass in the single plan choke point `build_plan_from_steps` threads the caller's `path` into `path_prefix` on the path_prefix-capable search routes (`search_symbols`/`search_text`/`explore`), idempotently. Every route funnels through that choke point, so single- and multi-step routes are all covered.

### Honest scope (per adversarial review wf a9b73e8 — verdict: correct + honest)
- **`path` forwarding** closes the silent-drop on the path_prefix-capable routes. `path`-as-selector routes (`get_symbol`/`get_file_content`/`find_references`) already carry it (Routed).
- **`max_tokens` is NOT forwarded** — it is already honored as a handler-layer CCR budget (`Forwarded`); injecting it into plan-step args would fight the degrade-cap logic and violate the `Forwarded` contract. (Honest refinement of the handoff forecast.)
- **Golden unchanged** — `classify_golden_row` asserts tool-shape only; A1b adds an arg, not a tool.
- **New defect found + ledgered (D20):** `search_files` is scope-capable but has no `path_prefix` field, so caller `path` is dropped there — A1b's planner pass cannot reach it. Tracked with an owner + fix path, not called acceptable.

### Verification (full gate green)
- `fmt --check`, `clippy --all-targets -D warnings`, `test --all-targets --test-threads=1`, `build --release`, `check --no-default-features --features embed` — all green.
- Conformance test's documented A1b-target assertion re-baselined NotApplicable→Routed; behavioral forwarding proof added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planner-only routing change with idempotent forwarding and conformance tests; golden routes unchanged (tool-shape only).
> 
> **Overview**
> **A1b** closes part of the symforge facade **lossless-or-loud** work (root D-A0): when callers set `path`, it is no longer dropped on scoped search plans.
> 
> `forward_caller_path` runs in `build_plan_from_steps` and copies the caller's `path` into `path_prefix` on `search_symbols`, `search_text`, and `explore` when that arg is not already set. Selector-style tools (`get_symbol`, `get_file_content`, etc.) are unchanged. **`max_tokens` is not** injected into plan args—it stays handler-`Forwarded` (CCR budget).
> 
> Conformance tests re-baseline fuzzy-find `path` from `NotApplicable` to `Routed` and add a test that `path_prefix` matches the caller path. The defect ledger marks A1b done and adds **D20**: `search_files` still has no `path_prefix`, so caller `path` can drop on file-search routes until schema/handler work lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb67abcd37de425aed62ddb1afaf8c862e5e739f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->