### PR TITLE
fix(stel): fail closed on broken durable calibration status

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -491,9 +491,10 @@ impl SymForgeServer {
     /// reading the artifact straight off the persisted set so the surface never
     /// claims `tuned` without it. Otherwise the verdict reflects the durable
     /// sample count (`Deferred` / `Accumulating(n/min)`). When no durable store is
-    /// wired (or it is `Disabled`/errors), returns `None` so the caller keeps the
-    /// in-memory verdict (which pins `Deferred`/`Accumulating` — never a false
-    /// `Tuned`). Read-only; no frecency bump.
+    /// wired, returns `None` so the caller keeps the in-memory view. When a wired
+    /// store cannot answer the sample query, pins the verdict to `Deferred` so a
+    /// stale in-memory session cannot claim `Tuned` while no validated tuning is
+    /// readable. Read-only; no frecency bump.
     ///
     /// [`CalibrationVerdict`]: crate::stel::calibration::CalibrationVerdict
     #[cfg(feature = "server")]
@@ -504,10 +505,12 @@ impl SymForgeServer {
         use crate::stel::ledger_store::{CURRENT_ESTIMATOR_VERSION, LEDGER_RETENTION_MAX};
 
         let store = self.stel_ledger_store.as_ref()?;
-        // A wired but failing store -> keep the in-memory verdict (None here).
-        let records = store
-            .samples_for_estimator(CURRENT_ESTIMATOR_VERSION, LEDGER_RETENTION_MAX)
-            .ok()?;
+        // A wired but failing store cannot prove any tuning is in force.
+        let records =
+            match store.samples_for_estimator(CURRENT_ESTIMATOR_VERSION, LEDGER_RETENTION_MAX) {
+                Ok(records) => records,
+                Err(_) => return Some(CalibrationVerdict::Deferred),
+            };
         let n = records.len();
 
         // An active, in-force tuning with a real reduction artifact reads `Tuned`.

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -9291,10 +9291,10 @@ impl SymForgeServer {
 
         // T033 / FR-009: override the in-memory verdict with the DURABLE one so
         // `status detail:full` reflects the persisted cross-session calibration
-        // state + active tuning. `None` (no/failed durable store) keeps the
-        // honest in-memory verdict (`Deferred`/`Accumulating`, never a false
-        // `Tuned`). After a reset above, the durable read sees zero samples ->
-        // `Deferred`.
+        // state + active tuning. `None` means no durable store is wired; a wired
+        // store whose sample read fails returns `Deferred` so status never keeps
+        // an in-memory `Tuned` verdict without a readable durable artifact. After
+        // a reset above, the durable read sees zero samples -> `Deferred`.
         if let Some(verdict) = self.durable_calibration_verdict() {
             ctx = ctx.with_calibration_verdict(verdict);
         }
@@ -9343,9 +9343,8 @@ impl SymForgeServer {
         )
         .with_durable_ledger(self.durable_ledger_summary_for_status());
         // Mirror `render_stel_status_body`: override the in-memory verdict with the
-        // DURABLE one (cross-session samples + active tuning). `None` keeps the
-        // honest in-memory verdict (`Deferred`/`Accumulating`, never a false
-        // `Tuned`).
+        // DURABLE one (cross-session samples + active tuning). A wired store whose
+        // sample read fails returns `Deferred`; only no store at all yields `None`.
         if let Some(verdict) = self.durable_calibration_verdict() {
             ctx = ctx.with_calibration_verdict(verdict);
         }
@@ -10200,6 +10199,68 @@ mod tests {
         assert!(
             body.contains(&expected),
             "full status must render the true full-corpus threshold {expected:?}:\n{body}"
+        );
+    }
+
+    #[test]
+    fn broken_durable_store_pins_status_calibration_to_deferred() {
+        use crate::stel::calibration::{CalibrationVerdict, TUNING_MIN_CORPUS};
+        use crate::stel::ledger_store::StelLedgerStore;
+
+        let client = crate::daemon::DaemonSessionClient::new_for_test(
+            "http://127.0.0.1:1".to_string(),
+            "p".to_string(),
+            "s".to_string(),
+            "proj".to_string(),
+        );
+        let repo = tempfile::tempdir().expect("temp repo");
+        let store = StelLedgerStore::open(repo.path(), "proxy-broken");
+        let db_path =
+            crate::paths::symforge_db_path(repo.path(), crate::paths::STEL_LEDGER_DB_NAME);
+        rusqlite::Connection::open(db_path)
+            .expect("open ledger db directly")
+            .execute_batch("DROP TABLE stel_ledger_events;")
+            .expect("break durable sample query");
+
+        let proxy =
+            SymForgeServer::new_daemon_proxy(client).with_stel_ledger_store(Arc::new(store));
+        for i in 0..TUNING_MIN_CORPUS {
+            let mut event = sample_durable_event();
+            event.ts_ms += i as u64;
+            event.plan_id = format!("p-biased-{i}");
+            event.actual_response_tokens = event.predicted_response_tokens * 2;
+            proxy.stel_ledger().lock().push(event);
+        }
+
+        let session_events = proxy.stel_ledger().lock().events();
+        assert!(
+            matches!(
+                crate::stel::summarize_calibration(&session_events).verdict,
+                CalibrationVerdict::Tuned { .. }
+            ),
+            "fixture must prove the in-memory session alone would claim tuned"
+        );
+        assert_eq!(
+            proxy.durable_calibration_verdict(),
+            Some(CalibrationVerdict::Deferred),
+            "a broken wired store cannot prove any tuning is in force"
+        );
+
+        let body = proxy.render_stel_status_body(&crate::stel::StelStatusRequest {
+            detail: Some(crate::stel::StelStatusDetail::Full),
+            reset_calibration: None,
+        });
+        assert!(
+            body.contains("durable_ledger: disabled"),
+            "broken store must be surfaced as disabled:\n{body}"
+        );
+        assert!(
+            body.contains("calibration: deferred"),
+            "status must not keep the in-memory tuned verdict when durable reads fail:\n{body}"
+        );
+        assert!(
+            !body.contains("calibration: tuned"),
+            "status must never claim tuned without a readable durable artifact:\n{body}"
         );
     }
 

--- a/src/stel/status.rs
+++ b/src/stel/status.rs
@@ -133,10 +133,12 @@ impl<'a> StelStatusContext<'a> {
     /// events. Also re-renders the `tuning_note` from the new verdict so the
     /// section's two calibration lines stay consistent.
     ///
-    /// Honesty invariant (data-model): a `Disabled`/`Unavailable` durable store
-    /// pins the state at in-memory-only — callers pass `None` (keeping the
-    /// in-memory verdict, which is `Deferred`/`Accumulating`, never a false
-    /// `Tuned`). Only a `Durable` store with a real artifact yields `Tuned` here.
+    /// Honesty invariant (data-model): the durable verdict is fail-closed. `None`
+    /// is reserved for "no durable store wired" — the caller keeps the in-memory
+    /// verdict (`Deferred`/`Accumulating`, never a false `Tuned`). A wired-but-
+    /// broken store whose sample read fails passes `Some(Deferred)` so status
+    /// never keeps an in-memory `Tuned` without a readable durable artifact. Only
+    /// a readable `Durable` store with a real artifact yields `Tuned` here.
     pub fn with_calibration_verdict(
         mut self,
         verdict: crate::stel::calibration::CalibrationVerdict,


### PR DESCRIPTION
Takes over and lands cursor-bot's #362 (superseded by this PR), with verification + a doc-consistency follow-up. Original fix authored by Cursor Agent (commit authorship preserved).

## Bug & impact
A wired-but-broken STEL durable ledger could make `status detail:full` report `calibration: tuned` from the in-memory session summary even though durable calibration reads were failing — a false "tuned" while live economics had no validated tuning in force.

## Root cause
`SymForgeServer::durable_calibration_verdict()` swallowed durable sample-query failures as `None` (`.ok()?`), so the status renderer kept the in-memory verdict. A sufficiently biased in-memory session independently computes `Tuned`, violating the status honesty contract when the durable store is disabled/broken.

## Fix
Return `CalibrationVerdict::Deferred` when a **wired** durable store cannot answer the sample query, so status **fails closed** — it never keeps an in-memory `Tuned` without a readable durable artifact. `None` is now reserved strictly for "no durable store wired". Regression test `broken_durable_store_pins_status_calibration_to_deferred` corrupts the SQLite ledger table after open, pushes `TUNING_MIN_CORPUS` biased events (so the in-memory session *alone* would be `Tuned`), and asserts status shows `durable_ledger: disabled` + `calibration: deferred`, not `tuned`. Composes cleanly with already-merged #357 (`TUNING_MIN_CORPUS` in the `Accumulating` threshold) on the post-query path.

Follow-up (this PR, doc-only): updated the stale `with_calibration_verdict` doc comment (`src/stel/status.rs`) so the None-vs-Some(Deferred) contract is documented consistently across all four sites.

## Verification
- Full cargo gate **green on Windows**: `fmt --check`, `check`, `clippy --all-targets -- -D warnings`, `test --all-targets -- --test-threads=1` (incl. the new regression), `build --release`, `check --no-default-features --features embed`.
- **3-lens adversarial review → SHIP**: fail-closed ordering airtight (sample-query Err returns `Deferred` *before* the `Tuned` branch; the two queries hit different tables; `active_tuning_for_economics` independently fails safe); both status call sites + the daemon-proxy overlay covered; the regression genuinely fails on the pre-fix `.ok()?` code (table-DROP makes the query `Err`, not `Ok(empty)`); fail-closed under-claims display only (never disables a real in-force tuning, never over-claims).

Cherry-picked onto current `origin/main` so the merged delta is minimal.

Superseding cursor-bot #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fail-closed behavior for calibration status; does not change in-force tuning or economics application, with a targeted regression test.
> 
> **Overview**
> Fixes a **status honesty** bug where `status detail:full` could show **`calibration: tuned`** from the in-memory session when a **wired** durable STEL ledger could not read calibration samples (e.g. corrupted SQLite), even though no validated durable tuning was provable.
> 
> **`durable_calibration_verdict()`** no longer treats sample-query failures as `None` (which left the in-memory verdict in place). On **`Err`** from `samples_for_estimator`, it returns **`Some(Deferred)`**; **`None`** is reserved for **no durable store attached**. The same contract is documented on **`with_calibration_verdict`** and both status render paths (local body + daemon-proxy overlay).
> 
> Adds regression test **`broken_durable_store_pins_status_calibration_to_deferred`**: corrupt the ledger table, bias the session ledger so memory alone would be `Tuned`, assert status shows **`durable_ledger: disabled`** and **`calibration: deferred`**, not **`tuned`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc5b9a2da94ee4c47f768c1de6387415e760eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->