### PR TITLE
fix(012f/d18): loud not-found for missing symbols in get_symbol

### DIFF
--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -812,11 +812,11 @@ pub fn symbol_detail_from_indexed_file(
             )
         }
         SymbolSelectorMatch::NotFound => {
-            if let Some(window) =
-                content_anchored_symbol_window(file, name, COMPETENT_READ_WINDOW_LINES / 2)
-            {
-                return window;
-            }
+            // D18: loud not-found. Do NOT silently substitute a content-anchored
+            // window (a substring hit in comments/strings) for the symbol the
+            // caller asked for. render_not_found_symbol names the symbol + path,
+            // offers near-miss suggestions, and (via "No symbol ") auto-classifies
+            // as OutcomeClass::NotFound in the result envelope.
             render_not_found_symbol(&file.relative_path, &file.symbols, name)
         }
         SymbolSelectorMatch::Ambiguous(lines) => {
@@ -5000,35 +5000,6 @@ pub fn resolve_read_max_tokens(explicit: Option<u64>, raw_chars: usize) -> u64 {
             estimate_tokens_from_chars(baseline).max(64)
         }
     }
-}
-
-/// Grep-then-window fallback when the symbol name is missing from the index but
-/// appears in source (matches sf-bench manual T1: grep hit + ±25-line window).
-pub fn content_anchored_symbol_window(
-    file: &crate::live_index::store::IndexedFile,
-    needle: &str,
-    radius_lines: u32,
-) -> Option<String> {
-    if needle.trim().is_empty() {
-        return None;
-    }
-    let text = std::str::from_utf8(&file.content).ok()?;
-    let lines: Vec<&str> = text.split('\n').collect();
-    if lines.is_empty() {
-        return None;
-    }
-    let needle_lower = needle.to_lowercase();
-    let hit_line = lines
-        .iter()
-        .position(|line| line.to_lowercase().contains(&needle_lower))
-        .map(|idx| (idx + 1) as u32)?;
-    let excerpt = render_numbered_around_line_excerpt(&lines, hit_line, radius_lines);
-    if excerpt.is_empty() {
-        return None;
-    }
-    Some(format!(
-        "{excerpt}\n[content-anchored window around '{needle}' at L{hit_line}; no indexed symbol with that name]"
-    ))
 }
 
 /// Estimated tokens from a character count (`~chars/4` approximation).

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -3847,24 +3847,6 @@ fn test_resolve_read_max_tokens_defaults_to_window() {
 }
 
 #[test]
-fn test_content_anchored_symbol_window_finds_doc_comment_match() {
-    let content = br#"/// Example
-#[tokio::main]
-pub async fn hard_link() {}
-"#;
-    let (_key, file) = make_file("src/fs/hard_link.rs", content, vec![]);
-    let window = content_anchored_symbol_window(&file, "main", 5).expect("window");
-    assert!(
-        window.contains("hard_link"),
-        "window should include nearby source: {window}"
-    );
-    assert!(
-        window.contains("content-anchored"),
-        "should label fallback: {window}"
-    );
-}
-
-#[test]
 fn test_saved_tokens_vs_competent_manual_uses_window() {
     assert_eq!(saved_tokens_vs_competent_manual(200, 500_000), 950);
 }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -11260,6 +11260,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_symbol_missing_symbol_returns_loud_not_found() {
+        // D18: a symbol absent from the file must yield a LOUD not-found that
+        // names the symbol + path — NOT a silent content-anchored window.
+        //
+        // Non-vacuity: the source deliberately contains "TotallyFake" as a
+        // substring (in a comment). On the pre-fix code, content_anchored_symbol_window
+        // would find that substring and return a numbered source window tagged
+        // "content-anchored ...". This test asserts the window is gone, so it
+        // FAILS against the old behavior.
+        let sym = make_symbol("foo", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("// TotallyFake is only in a comment\nfn foo() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("src/lib.rs", "TotallyFake")))
+            .await;
+
+        assert!(
+            result.contains("No symbol TotallyFake in src/lib.rs"),
+            "must name the missing symbol and path; got: {result}"
+        );
+        assert!(
+            !result.contains("content-anchored"),
+            "must NOT silently return a content-anchored window; got: {result}"
+        );
+        // Distinct from the file-not-found message: the file IS indexed.
+        assert!(
+            !result.starts_with("File not found"),
+            "indexed file with absent symbol must not read as file-not-found; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_missing_file_returns_not_found_file() {
+        // D18 boundary: an unindexed/absent file must report file-not-found,
+        // distinct from the symbol-absent message above.
+        let sym = make_symbol("foo", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn foo() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("src/nonexistent.rs", "foo")))
+            .await;
+
+        assert!(
+            result.starts_with("File not found"),
+            "absent file must report file-not-found; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_valid_symbol_still_resolves() {
+        // D18 no-regression: a real symbol must still return its body, never a
+        // false not-found.
+        let sym = make_symbol("foo", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn foo() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("src/lib.rs", "foo")))
+            .await;
+
+        assert!(
+            !result.contains("No symbol"),
+            "valid symbol must not read as not-found; got: {result}"
+        );
+        assert!(
+            result.contains("fn foo"),
+            "valid symbol must return its body; got: {result}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_get_repo_map_full_uses_project_name() {
         let (key, file) = make_file("src/main.rs", b"fn main() {}", vec![]);
         let server = make_server(make_live_index_ready(vec![(key, file)]));


### PR DESCRIPTION
## D18 — loud not-found (silent-wrong family)

`get_symbol(name, path)` for a symbol absent from the file silently returned a **content-anchored source window** (substring-matched around the name — e.g. a comment mention), masquerading as a result. The caller asked for a specific symbol and got something else, with no signal it wasn't found — a silent wrong answer.

### Fix (shared formatter, one site)
- `symbol_detail_from_indexed_file` `NotFound` arm (`format.rs:814`): removed the silent `content_anchored_symbol_window` fallback; route straight to the established `render_not_found_symbol` → `No symbol <name> in <path>. Close matches: <top-5 fuzzy>. Use get_file_context ... (<N> symbols).`
- Because the body starts with `"No symbol "`, `classify_get_symbol_output` auto-classifies the envelope as `OutcomeClass::NotFound` — body **and** machine status fixed, no `result_status.rs` change.
- Fix is in the shared formatter → **both single- and batch-mode** get_symbol corrected.
- Distinctions preserved: file-not-indexed → `File not found`; Tier-2 → `Not indexed ... Tier 2`; symbol-absent → `No symbol ...`.
- Deleted the now-dead `content_anchored_symbol_window` + its stale test (verified no other callers).

### Verification (non-vacuous)
- `test_get_symbol_missing_symbol_returns_loud_not_found` — fixture plants `TotallyFake` **in a comment** so the old substring-window path *would* have fired; **proven non-vacuous** (fails on pre-fix code, returning the content-anchored window — the exact defect).
- `..._missing_file_returns_not_found_file` (boundary) + `..._valid_symbol_still_resolves` (no false not-found regression).
- Gate (`CARGO_INCREMENTAL=0`): `fmt`/`check`/`clippy --all-targets -D warnings`/`test --lib` (2574 pass)/`build --release` — all PASS. `test --all-targets` deferred to CI (local 10m timeout / disk).
- Reviews: skeptic **APPROVE**; code-reviewer's BLOCK was a leftover dirty-working-tree from the non-vacuity experiment (commit itself correct) — resolved, tree clean, lib gate re-run green.

### R3 split out (deliberate)
The recall-confidence caveat is a different surface (`find_references_completeness_label`) with its own over-disclosure design fork; both investigators recommended splitting it. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-visible `get_symbol` outcomes from silent substring windows to explicit not-found messages; correctness fix with intentional behavior change on the shared formatter path.
> 
> **Overview**
> **`get_symbol`** no longer returns a **content-anchored source window** when the requested name is missing from the symbol index but appears as a substring in the file (e.g. in a comment). That path looked like a real symbol body and could mislead callers.
> 
> The **`NotFound`** branch in **`symbol_detail_from_indexed_file`** now always uses **`render_not_found_symbol`** (`No symbol <name> in <path>` plus fuzzy close matches). The shared formatter change applies to single and batch **`get_symbol`**. **`content_anchored_symbol_window`** and its unit test are removed.
> 
> New **`get_symbol`** tests cover the comment-substring case (must not return `content-anchored`), file-not-found vs symbol-not-found, and that valid symbols still resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b750d7a37ac65991c0a0439e3ce72dd351bbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->