### PR TITLE
fix(012f/d20): path_prefix scoping for search_files

### DIFF
--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -1270,6 +1270,7 @@ impl LiveIndex {
             coupling_context,
             true,
             true,
+            &PathScope::Any,
         )
     }
 
@@ -1279,6 +1280,10 @@ impl LiveIndex {
     /// for tests and internal callers. Public tool entry points should call this
     /// variant so advertised vendor/personal-tooling defaults apply before
     /// ranking and total-match counts are computed.
+    // ponytail: 8 positional args on one internal capture API; an options
+    // struct would be the upgrade if a 9th axis appears, but not worth the
+    // churn for one scope param.
+    #[allow(clippy::too_many_arguments)]
     pub fn capture_search_files_view_with_noise(
         &self,
         query: &str,
@@ -1287,14 +1292,21 @@ impl LiveIndex {
         coupling_context: Option<(&str, &SearchFilesCouplingNeighbors)>,
         include_vendor: bool,
         include_personal_tooling: bool,
+        path_scope: &PathScope,
     ) -> SearchFilesView {
         let limit = limit.clamp(1, 50);
         let normalized_query = normalize_path_query(query);
         if normalized_query.is_empty() {
             return SearchFilesView::EmptyQuery;
         }
+        // `path_scope` mirrors the `path_scope` axis of `search_symbols`/`search_text`:
+        // it filters candidates BEFORE counting/limiting, so total_matches,
+        // overflow_count, and hits are all consistently scoped. Folding it into
+        // `path_allowed` reuses the one pre-count predicate every tier funnels
+        // through (strong/basename/prefix/loose/glob/metadata).
         let path_allowed = |path: &str| -> bool {
-            (include_vendor || !is_vendor_path(path))
+            path_scope.matches(path)
+                && (include_vendor || !is_vendor_path(path))
                 && (include_personal_tooling || !is_personal_tooling_path(path))
         };
 
@@ -3527,16 +3539,30 @@ mod tests {
         );
 
         // Default (vendor hidden): the vendored lockfile must NOT surface.
-        let hidden =
-            index.capture_search_files_view_with_noise("package-lock", 20, None, None, false, true);
+        let hidden = index.capture_search_files_view_with_noise(
+            "package-lock",
+            20,
+            None,
+            None,
+            false,
+            true,
+            &super::PathScope::Any,
+        );
         assert!(
             matches!(hidden, SearchFilesView::NotFound { .. }),
             "vendored Tier-2 path must be suppressed by default: {hidden:?}"
         );
 
         // include_vendor=true: now it surfaces as metadata-only.
-        let shown =
-            index.capture_search_files_view_with_noise("package-lock", 20, None, None, true, true);
+        let shown = index.capture_search_files_view_with_noise(
+            "package-lock",
+            20,
+            None,
+            None,
+            true,
+            true,
+            &super::PathScope::Any,
+        );
         match shown {
             SearchFilesView::Found { hits, .. } => {
                 assert_eq!(hits.len(), 1);
@@ -3914,6 +3940,7 @@ mod tests {
             Some(("wiki/notes.md", &neighbors)),
             true,
             false,
+            &super::PathScope::Any,
         );
 
         assert_eq!(

--- a/src/protocol/search_tools.rs
+++ b/src/protocol/search_tools.rs
@@ -208,6 +208,8 @@ pub struct SearchFilesInput {
     /// Default false -- personal sidecars rarely answer codebase path questions.
     #[serde(default, deserialize_with = "lenient_bool")]
     pub include_personal_tooling: Option<bool>,
+    /// Optional relative path prefix scope, for example `src/` or `src/protocol`.
+    pub path_prefix: Option<String>,
 }
 
 /// Input for `find_references`.
@@ -301,7 +303,7 @@ pub(crate) fn parse_language_filter(input: Option<&str>) -> Result<Option<Langua
     })
 }
 
-fn normalize_path_prefix(input: Option<&str>) -> search::PathScope {
+pub(crate) fn normalize_path_prefix(input: Option<&str>) -> search::PathScope {
     let Some(prefix) = input.map(str::trim).filter(|prefix| !prefix.is_empty()) else {
         return search::PathScope::any();
     };

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -53,8 +53,8 @@ pub use super::search_tools::{
     FindReferencesInput, SearchFilesInput, SearchSymbolsInput, SearchTextInput,
 };
 pub(crate) use super::search_tools::{
-    fix_common_double_escapes, parse_language_filter, search_symbols_options_from_input,
-    search_text_options_from_input,
+    fix_common_double_escapes, normalize_path_prefix, parse_language_filter,
+    search_symbols_options_from_input, search_text_options_from_input,
 };
 
 const INDEX_FOLDER_RESET_ENV: &str = "SYMFORGE_INDEX_FOLDER_RESET";
@@ -5485,6 +5485,27 @@ impl SymForgeServer {
             }
             view
         };
+        // Optional path-prefix scoping. Mirrors the `path_scope` axis used by
+        // `search_symbols`/`search_text`: drop hits whose path falls outside the
+        // requested prefix. Applied to the captured hits because `search_files`
+        // uses a dedicated capture API rather than the shared search options.
+        let path_scope = normalize_path_prefix(params.0.path_prefix.as_deref());
+        if !matches!(path_scope, search::PathScope::Any)
+            && let SearchFilesView::Found {
+                hits,
+                total_matches,
+                ..
+            } = &mut view
+        {
+            let before = hits.len();
+            hits.retain(|hit| path_scope.matches(&hit.path));
+            *total_matches = total_matches.saturating_sub(before - hits.len());
+            if hits.is_empty() {
+                view = SearchFilesView::NotFound {
+                    query: params.0.query.clone(),
+                };
+            }
+        }
         // Optional frecency-fusion rerank. Activated when the caller requests
         // `rank_by="frecency"`, independent of the old persistent-collection
         // feature flag. Discovery still never opens a writeable frecency store:
@@ -9573,6 +9594,7 @@ impl SymForgeServer {
                     anchor_path: None,
                     include_vendor: None,
                     include_personal_tooling: None,
+                    path_prefix: None,
                 };
                 self.search_files(Parameters(input)).await
             }
@@ -10956,6 +10978,7 @@ mod tests {
             anchor_path: None,
             include_vendor: None,
             include_personal_tooling: None,
+            path_prefix: None,
         }
     }
 
@@ -14851,6 +14874,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
         assert!(result.contains("2 matching files"), "got: {result}");
@@ -14873,6 +14897,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_search_files_path_prefix_scopes_results() {
+        let server = make_server(make_live_index_ready(vec![
+            make_file("src/protocol/tools.rs", b"fn a() {}", vec![]),
+            make_file("src/sidecar/tools.rs", b"fn b() {}", vec![]),
+        ]));
+
+        // Without path_prefix: both same-basename files are returned.
+        let unscoped = server
+            .search_files(Parameters(super::SearchFilesInput {
+                path_prefix: None,
+                ..search_files_input("tools.rs")
+            }))
+            .await;
+        assert!(
+            unscoped.contains("src/protocol/tools.rs"),
+            "unscoped should include protocol path, got: {unscoped}"
+        );
+        assert!(
+            unscoped.contains("src/sidecar/tools.rs"),
+            "unscoped should include sidecar path, got: {unscoped}"
+        );
+
+        // With path_prefix=src/protocol: only paths under that prefix survive.
+        let scoped = server
+            .search_files(Parameters(super::SearchFilesInput {
+                path_prefix: Some("src/protocol".to_string()),
+                ..search_files_input("tools.rs")
+            }))
+            .await;
+        assert!(
+            scoped.contains("src/protocol/tools.rs"),
+            "scoped should include in-prefix path, got: {scoped}"
+        );
+        assert!(
+            !scoped.contains("src/sidecar/tools.rs"),
+            "scoped must drop out-of-prefix path, got: {scoped}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_search_files_not_found() {
         let server = make_server(make_live_index_ready(vec![]));
         let result = server
@@ -14889,6 +14953,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
         assert!(
@@ -14934,6 +14999,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -14985,6 +15051,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15014,6 +15081,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
         // Without git temporal data, should return informative message (not an error/panic)
@@ -15082,6 +15150,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15134,6 +15203,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15186,6 +15256,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15226,6 +15297,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15265,6 +15337,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15301,6 +15374,7 @@ mod tests {
                 anchor_path: Some("src/missing/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15337,6 +15411,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15376,6 +15451,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15410,6 +15486,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15427,6 +15504,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15466,6 +15544,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15483,6 +15562,7 @@ mod tests {
                 anchor_path: Some("src/auth/routes.rs".to_string()),
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15519,6 +15599,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15557,6 +15638,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: Some(true),
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15587,6 +15669,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15625,6 +15708,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: Some(true),
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15659,6 +15743,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
 
@@ -15694,6 +15779,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
         assert!(
@@ -15727,6 +15813,7 @@ mod tests {
                 anchor_path: None,
                 include_vendor: None,
                 include_personal_tooling: None,
+                path_prefix: None,
             }))
             .await;
         assert!(

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -5427,6 +5427,12 @@ impl SymForgeServer {
                 .as_ref()
                 .and_then(|resolution| resolution.neighbors.as_ref());
             let coupling_context = params.0.anchor_path.as_deref().zip(coupling_neighbors);
+            // Optional path-prefix scoping, mirroring the `path_scope` axis of
+            // search_symbols/search_text: the scope is applied inside the capture
+            // (pre-count predicate), so total_matches/overflow_count/hits are all
+            // consistently scoped — including the overflow set, not just the
+            // visible hits.
+            let path_scope = normalize_path_prefix(params.0.path_prefix.as_deref());
             let view = guard.capture_search_files_view_with_noise(
                 &params.0.query,
                 params.0.limit.unwrap_or(20) as usize,
@@ -5434,13 +5440,19 @@ impl SymForgeServer {
                 coupling_context,
                 include_vendor,
                 include_personal_tooling,
+                &path_scope,
             );
             if !(include_vendor && include_personal_tooling) {
-                let unfiltered = guard.capture_search_files_view(
+                // Same path_scope so hidden_noise_count compares like-for-like
+                // (noise hidden WITHIN the requested prefix, not repo-wide).
+                let unfiltered = guard.capture_search_files_view_with_noise(
                     &params.0.query,
                     params.0.limit.unwrap_or(20) as usize,
                     params.0.current_file.as_deref(),
                     coupling_context,
+                    true,
+                    true,
+                    &path_scope,
                 );
                 hidden_noise_count = search_files_total_matches(&unfiltered)
                     .saturating_sub(search_files_total_matches(&view));
@@ -5485,27 +5497,6 @@ impl SymForgeServer {
             }
             view
         };
-        // Optional path-prefix scoping. Mirrors the `path_scope` axis used by
-        // `search_symbols`/`search_text`: drop hits whose path falls outside the
-        // requested prefix. Applied to the captured hits because `search_files`
-        // uses a dedicated capture API rather than the shared search options.
-        let path_scope = normalize_path_prefix(params.0.path_prefix.as_deref());
-        if !matches!(path_scope, search::PathScope::Any)
-            && let SearchFilesView::Found {
-                hits,
-                total_matches,
-                ..
-            } = &mut view
-        {
-            let before = hits.len();
-            hits.retain(|hit| path_scope.matches(&hit.path));
-            *total_matches = total_matches.saturating_sub(before - hits.len());
-            if hits.is_empty() {
-                view = SearchFilesView::NotFound {
-                    query: params.0.query.clone(),
-                };
-            }
-        }
         // Optional frecency-fusion rerank. Activated when the caller requests
         // `rank_by="frecency"`, independent of the old persistent-collection
         // feature flag. Discovery still never opens a writeable frecency store:
@@ -14933,6 +14924,55 @@ mod tests {
         assert!(
             !scoped.contains("src/sidecar/tools.rs"),
             "scoped must drop out-of-prefix path, got: {scoped}"
+        );
+    }
+
+    /// Regression for D20 review: scoping must hold UNDER overflow truncation.
+    /// The default limit is 20; seeding >20 in-prefix and >20 out-of-prefix
+    /// same-basename files forces the overflow path. If the prefix were applied
+    /// only to the visible (already-truncated) hits, out-of-prefix files in the
+    /// overflow set would escape scoping and the reported total/overflow counts
+    /// would be inflated. We assert: (a) no out-of-prefix path appears at all,
+    /// and (b) the header total equals only the in-prefix count (30), proving
+    /// total_matches is scoped pre-count, not just the rendered view.
+    #[tokio::test]
+    async fn test_search_files_path_prefix_scopes_under_overflow() {
+        let mut files = Vec::new();
+        for i in 0..30 {
+            files.push(make_file(
+                &format!("src/protocol/m{i:02}/tools.rs"),
+                b"fn a() {}",
+                vec![],
+            ));
+            files.push(make_file(
+                &format!("src/sidecar/m{i:02}/tools.rs"),
+                b"fn b() {}",
+                vec![],
+            ));
+        }
+        let server = make_server(make_live_index_ready(files));
+
+        let scoped = server
+            .search_files(Parameters(super::SearchFilesInput {
+                path_prefix: Some("src/protocol".to_string()),
+                ..search_files_input("tools.rs")
+            }))
+            .await;
+
+        // No out-of-prefix path leaks, even from the overflow set.
+        assert!(
+            !scoped.contains("src/sidecar/"),
+            "no out-of-prefix path may appear under overflow, got: {scoped}"
+        );
+        // total_matches reflects ONLY the 30 in-prefix files, not all 60.
+        assert!(
+            scoped.contains("30 matching files"),
+            "scoped header must count only in-prefix matches, got: {scoped}"
+        );
+        // overflow_count is scoped too: 30 matches, limit 20 => "... and 10 more".
+        assert!(
+            scoped.contains("... and 10 more"),
+            "scoped overflow count must be 30-20=10, got: {scoped}"
         );
     }
 

--- a/src/stel/planner.rs
+++ b/src/stel/planner.rs
@@ -126,9 +126,9 @@ pub fn classify_param_dispositions(
     } else {
         // `path` absent, or a route whose tool carries no path scope and no path
         // selector (so neither A1b's forwarding nor a target arg applies — e.g.
-        // `get_repo_map`, `context_inventory`, or `search_files`, which has no
-        // `path_prefix` field at all; tracked as D20): explicit NotApplicable,
-        // not a silent drop.
+        // `get_repo_map` or `context_inventory`): explicit NotApplicable, not a
+        // silent drop. (search_files now has a `path_prefix` field and is in
+        // PATH_PREFIX_FORWARD_TOOLS, so it routes via the branch above.)
         ParamDisposition::NotApplicable
     };
 

--- a/src/stel/planner.rs
+++ b/src/stel/planner.rs
@@ -431,7 +431,8 @@ fn is_orient_query(lower: &str) -> bool {
 /// is a TARGET/selector (e.g. `get_file_content`, `find_references`) are
 /// intentionally excluded: there the target comes from the query, not a scope
 /// hint, so forwarding the caller's `path` would be wrong.
-const PATH_PREFIX_FORWARD_TOOLS: &[&str] = &["search_symbols", "search_text", "explore"];
+const PATH_PREFIX_FORWARD_TOOLS: &[&str] =
+    &["search_symbols", "search_text", "explore", "search_files"];
 
 /// A1b gated per-tool forwarding: thread the caller's `path` into each plan
 /// step's `path_prefix` arg where that tool accepts a path scope (and the caller


### PR DESCRIPTION
## D20 — search_files path_prefix scoping (review-found gap)

`search_files` had no `path_prefix` scoping while sibling tools (`search_symbols`/`search_text`) do.

### Fix (true sibling mirror — pre-count scoping)
- Added `path_prefix: Option<String>` to `SearchFilesInput` (mirrors siblings; `Option` serde, no custom).
- Threaded a `path_scope: &PathScope` param into `capture_search_files_view_with_noise` and folded it into the **single pre-count `path_allowed` predicate** that every tier (strong/basename/prefix/loose/glob/metadata) funnels through — the same predicate that already filters vendor/personal-tooling. So `total_matches`, `overflow_count`, and `hits` are **all** consistently scoped *before* limiting (the genuine mirror of `path_scope` in `SymbolSearchOptions`/`TextSearchOptions`).
- Added `search_files` to `PATH_PREFIX_FORWARD_TOOLS` (`planner.rs`) so the STEL planner forwards a caller's path into the step's `path_prefix`. Daemon path flows automatically via generic serde decode.

### Why the first pass was BLOCKed (and fixed)
The initial implementation applied the prefix as a *post-capture* `hits.retain` on the already-limit-truncated view → out-of-prefix files in the **overflow set escaped scoping** and `overflow_count` went stale (inflated counts). Code-review caught it; the fix moves filtering pre-count into `path_allowed` (above), eliminating both by construction.

### Verification (non-vacuous, incl. the overflow case)
- `test_search_files_path_prefix_scopes_results` (no-overflow) + `test_search_files_path_prefix_scopes_under_overflow` (30 in-prefix + 30 out, >limit 20): asserts no out-of-prefix leak, header `30 matching files`, `... and 10 more`. **Non-vacuous:** neutralizing the scope leaks `src/sidecar/*` into the overflow set and reports `... and 40 more`.
- Gate (`CARGO_INCREMENTAL=0`): `fmt`/`check`/`clippy --all-targets -D warnings`/`test --lib` (2576 pass)/`build --release` — all PASS.
- Also corrected two now-stale comments (the "no path_prefix field — tracked as D20" note in planner.rs, and the overstated mirror comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search behavior extension with pre-count filtering and tests; no auth, persistence, or security-sensitive paths touched.
> 
> **Overview**
> **`search_files` now accepts optional `path_prefix`**, aligned with `search_symbols` and `search_text`, so callers can limit path lookup to a directory subtree.
> 
> Scoping is applied in the live index **before** match counting and limit truncation: `path_scope` is folded into the shared `path_allowed` predicate used by every search tier, so **hits, `total_matches`, and overflow counts** all reflect the same prefix. The MCP handler normalizes `path_prefix` via the existing helper and uses the same scope when computing hidden vendor/personal-tooling noise. The STEL planner forwards caller `path` into `search_files` through **`PATH_PREFIX_FORWARD_TOOLS`**.
> 
> New integration tests cover basic prefix filtering and an overflow regression (out-of-prefix paths must not leak in truncated results or inflated totals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0e814b7bf1d4af827b5791683f0957ab79af18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->