### PR TITLE
fix(012f): orphan GC for the bases intern table (SC-002-safe)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -806,8 +806,9 @@ impl DaemonState {
         // clone of the SAME map Arc, so the map value's `strong_count == 1` iff no
         // live consumer references it. Retain everything still referenced; drop the
         // orphans. No `Weak<IndexBase>` exists and no other Arc<IndexBase> holder
-        // exists, so the count is exact. This is the ONLY path that orphans a base
-        // (the no-commit watcher path force-replaces the SAME key — no orphan).
+        // exists, so the count is exact. Commit-advance is ONE orphan source; the
+        // other is the last session on a BaseKey closing (swept in close_session).
+        // The no-commit watcher path force-replaces the SAME key — no orphan.
         // ponytail: full-map retain is O(bases); fine — table is tiny per daemon.
         // Add a threshold only if base count ever grows large.
         self.gc_orphaned_bases();
@@ -1043,6 +1044,19 @@ impl DaemonState {
         }
 
         let session = self.sessions.write().remove(session_id)?;
+        // Take only what the response needs, then DROP the rest of the session —
+        // critically its `working_set`, which holds the `Arc<IndexBase>` clones.
+        // The GC below relies on those being released first; keeping `session`
+        // live across the sweep would keep its bases at strong_count >= 2 and
+        // defeat the reclaim (the base would never look orphaned).
+        let closed_session_id = session.session_id.clone();
+        drop(session);
+
+        // If this was the last session on a BaseKey, that map value is now a
+        // map-only orphan (strong_count == 1) — the same unbounded-growth defect
+        // class as commit-advance, via a parallel path. Sweep it. LOCK ORDER safe:
+        // `gc_orphaned_bases` takes ONLY `bases.write()`, no other map lock held.
+        self.gc_orphaned_bases();
 
         // If the session referenced no project, or its active project was already
         // gone (e.g. concurrent reassignment), report an orphan close — the
@@ -1053,7 +1067,7 @@ impl DaemonState {
         };
 
         Some(CloseSessionResponse {
-            session_id: session.session_id,
+            session_id: closed_session_id,
             project_id,
             remaining_sessions: active_remaining,
             project_removed: active_removed,
@@ -4346,6 +4360,44 @@ mod tests {
         assert!(
             Arc::ptr_eq(table_live, &entry.base),
             "SC-002: survivor is the same shared Arc the working set holds"
+        );
+    }
+
+    // ── Feature 012f — close_session sweeps last-holder orphans (the parallel
+    //    orphan path the commit-advance trigger misses) ─────────────────────────
+    //
+    // Opening the only session on a root interns its base (map + working-set =
+    // strong_count 2). Closing that last session drops the working_set, leaving
+    // the base map-only — an orphan the GC must reclaim from close_session.
+    #[test]
+    fn test_close_last_session_gcs_orphaned_base() {
+        let project = project_dir("symforge-daemon-close-gc");
+        let state = DaemonState::new();
+        let opened = state
+            .open_project_session(OpenProjectRequest {
+                project_root: project.path().display().to_string(),
+                client_name: "claude".to_string(),
+                pid: None,
+            })
+            .expect("session");
+
+        // Precondition: the open interned exactly one base, held by map + session.
+        assert_eq!(
+            state.bases.read().len(),
+            1,
+            "open interns one base for the root"
+        );
+
+        state
+            .close_session(&opened.session_id)
+            .expect("close the only session");
+
+        // The last (only) session closed -> its working_set dropped -> the base is
+        // a map-only orphan -> close_session's GC sweep reclaims it.
+        assert_eq!(
+            state.bases.read().len(),
+            0,
+            "close_session must GC the base no session references anymore"
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -796,6 +796,42 @@ impl DaemonState {
             // uncommitted deltas on every freshness refresh.
             ws.add(project_id, base);
         }
+        drop(ws); // release working_set before sweeping the bases table
+
+        // (5) GC orphaned bases. A genuine commit-advance changes BaseKey.commit,
+        // so step (3)/(4) interned the snapshot under a NEW key and replaced the
+        // working-set entry — the OLD key's value is now referenced only by the
+        // map (no session/working-set entry holds it). SC-002-safe eviction: under
+        // `bases.write()` (the sole mutator/cloner of the map), `entry.base` is a
+        // clone of the SAME map Arc, so the map value's `strong_count == 1` iff no
+        // live consumer references it. Retain everything still referenced; drop the
+        // orphans. No `Weak<IndexBase>` exists and no other Arc<IndexBase> holder
+        // exists, so the count is exact. This is the ONLY path that orphans a base
+        // (the no-commit watcher path force-replaces the SAME key — no orphan).
+        // ponytail: full-map retain is O(bases); fine — table is tiny per daemon.
+        // Add a threshold only if base count ever grows large.
+        self.gc_orphaned_bases();
+    }
+
+    /// Evict orphaned interned bases — values no live consumer references anymore
+    /// (the unbounded-growth defect on a long-lived multi-commit daemon).
+    ///
+    /// SC-002-safe eviction condition: under `bases.write()` (the SOLE mutator and
+    /// cloner of the map), every `WorkingSetEntry.base` is a clone of the SAME map
+    /// `Arc<IndexBase>`, so a map value's `Arc::strong_count == 1` means the map is
+    /// the only owner — no session/working-set holds it. We retain everything still
+    /// referenced and drop only `== 1`. No `Weak<IndexBase>` exists and no other
+    /// `Arc<IndexBase>` holder exists anywhere, so the count is exact and the sweep
+    /// can never evict a base a later `intern_base` would re-share (which would mint
+    /// a SECOND Arc per BaseKey — the SC-002 violation this guards against).
+    ///
+    /// LOCK ORDER: acquires ONLY `bases` (top of `bases -> projects -> sessions`).
+    /// Never call while holding `projects`/`sessions`, nor while holding a transient
+    /// clone of a map value in the same scope (that would self-inflate the count).
+    fn gc_orphaned_bases(&self) {
+        self.bases
+            .write()
+            .retain(|_key, base| Arc::strong_count(base) > 1);
     }
 
     fn register_session_for_existing_project(
@@ -4216,6 +4252,100 @@ mod tests {
             state.bases.read().len(),
             2,
             "two roots -> two interned bases"
+        );
+    }
+
+    // ── Feature 012f — bases-table orphan GC (SC-002-safe) ──────────────────────
+    //
+    // A genuine commit-advance interns the snapshot under a NEW BaseKey and swaps
+    // the working-set entry, leaving the OLD key referenced only by the map: an
+    // orphan that grows the table unbounded on a long-lived multi-commit daemon.
+    // The GC evicts orphans (strong_count == 1) and MUST NOT evict a base a live
+    // working set still holds (strong_count > 1) — evicting it would let a later
+    // intern mint a SECOND Arc per key (the SC-002 violation).
+    #[test]
+    fn test_gc_orphaned_bases_evicts_orphan_keeps_live() {
+        use crate::live_index::store::LiveIndex;
+        use crate::live_index::view::{CommitId, WorkingSet};
+
+        let state = DaemonState::new();
+        let root = "/synthetic/gc-root";
+
+        // OLD-commit base: interned, then no longer referenced by any working set
+        // (simulating the entry-swap a commit-advance performs). Map-only Arc.
+        let orphan_key = BaseKey::new(root, CommitId::Sha("old-commit".to_string()));
+        state.bases.write().insert(
+            orphan_key.clone(),
+            Arc::new(IndexBase::new(
+                orphan_key.clone(),
+                Arc::new(LiveIndex::empty_live_index()),
+                1,
+            )),
+        );
+
+        // NEW-commit base: interned AND held by a live working set (the post-advance
+        // state). The working-set entry stores a CLONE of the SAME map Arc, so the
+        // map value's strong_count is > 1 — the liveness signal the GC relies on.
+        let live_key = BaseKey::new(root, CommitId::Sha("new-commit".to_string()));
+        let live_base = Arc::new(IndexBase::new(
+            live_key.clone(),
+            Arc::new(LiveIndex::empty_live_index()),
+            2,
+        ));
+        state
+            .bases
+            .write()
+            .insert(live_key.clone(), Arc::clone(&live_base));
+        let working_set = Arc::new(RwLock::new(WorkingSet::new()));
+        working_set.write().add("proj", Arc::clone(&live_base));
+        // Drop our local strong ref so ONLY the map + the working-set entry hold the
+        // live base (strong_count == 2). Without this, our local clone would mask a
+        // buggy GC that relies on an accidental extra ref.
+        drop(live_base);
+
+        // Non-vacuity: BEFORE the sweep the orphan IS in the table (the leak the GC
+        // closes) and both keys are present.
+        {
+            let bases = state.bases.read();
+            assert!(
+                bases.contains_key(&orphan_key),
+                "precondition: orphan must be present before GC (proves the leak)"
+            );
+            assert_eq!(bases.len(), 2, "precondition: both bases interned");
+            assert_eq!(
+                Arc::strong_count(bases.get(&orphan_key).unwrap()),
+                1,
+                "orphan must be map-only (the eviction signal)"
+            );
+            assert_eq!(
+                Arc::strong_count(bases.get(&live_key).unwrap()),
+                2,
+                "live base is held by map + working-set entry"
+            );
+        }
+
+        state.gc_orphaned_bases();
+
+        let bases = state.bases.read();
+        // Orphan evicted.
+        assert!(
+            !bases.contains_key(&orphan_key),
+            "GC must evict the orphaned (map-only) base"
+        );
+        // SC-002 guard: the still-referenced base survives — evicting it would let a
+        // later intern mint a second Arc for this key.
+        assert!(
+            bases.contains_key(&live_key),
+            "GC must NOT evict a base a live working set still references"
+        );
+        assert_eq!(bases.len(), 1, "only the orphan is removed");
+        // The surviving map value is STILL the SAME Arc the working-set entry holds.
+        let table_live = bases.get(&live_key).unwrap();
+        let ws = working_set.read();
+        let entry = ws.get("proj").expect("live entry present");
+        assert!(
+            Arc::ptr_eq(table_live, &entry.base),
+            "SC-002: survivor is the same shared Arc the working set holds"
         );
     }
 


### PR DESCRIPTION
## bases-table orphan GC (tracked-minor, surfaced by the B2/012e review)

The daemon's `bases` intern table (keyed by `BaseKey = (canonical_root, commit)`) had no orphan GC. Two paths orphan a base; both are now swept:
1. **Commit-advance** — `refresh_working_set_bases` re-interns under a new `BaseKey`, orphaning the old.
2. **Last-session-close** — `close_session` drops the session's `working_set` (its `Arc<IndexBase>` clones); if it held the last reference, the map value becomes a map-only orphan.

Left unbounded, these grow over a long-lived multi-commit / many-client daemon session.

### Mechanism (SC-002-safe by construction)
- `gc_orphaned_bases()`: under `bases.write()`, `retain(|_, b| Arc::strong_count(b) > 1)`.
- Verified reference model: `WorkingSetEntry.base` is a **clone of the same map `Arc<IndexBase>`** (no derived/Weak/other holders), and the write lock serializes all mutators/cloners → `strong_count == 1` means *map-only orphan* exactly. Any base a live session/working-set holds has `count ≥ 2` and **survives** — so a later intern never mints a 2nd `Arc` for a live key (SC-002 preserved).
- Triggers: end of `refresh_working_set_bases` (commit-advance) **and** `close_session`. In `close_session` the removed `SessionRecord` is **dropped before** the sweep (else its `Arc` clones keep `strong_count ≥ 2` and defeat reclaim). Lock-order safe: `sessions.write()` guard released first, then `bases.write()` alone (no upward `sessions→bases` acquisition).

### Why a second commit
The skeptic correctly caught that the first commit's trigger (commit-advance only) missed the **session-close** orphan path — the same defect class. Fixed by adding the `close_session` sweep + an integration test that drives the real open→close path (which caught a live-session-across-sweep bug in the first attempt — proving non-vacuity).

### Verification
- `test_gc_orphaned_bases_evicts_orphan_keeps_live` (unit: orphan evicted, live base kept via `ptr_eq`) + `test_close_last_session_gcs_orphaned_base` (integration: real open→close).
- Gate (`CARGO_INCREMENTAL=0`): `fmt`/`clippy --all-targets -D warnings`/`test --lib` (2578 pass) — all PASS. `test --all-targets` + `build --release` deferred to CI (disk-tight cold-link, LNK1180 risk) — CI is authoritative.
- Reviews: code-reviewer APPROVE; skeptic BLOCK on the session-close gap → fixed + re-verified.

### Known coupling-fragility (flagged in the doc comment)
`strong_count == 1 == orphan` holds only while the map + `WorkingSetEntry.base` are the sole `Arc<IndexBase>` owners. A future base cache or the deferred Phase-4 rebase would need to re-check this. Documented at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon memory lifecycle and `Arc` reference counting; incorrect eviction could violate SC-002 or drop bases still in use, though the design is narrowly scoped to map-only orphans.
> 
> **Overview**
> Adds **`gc_orphaned_bases`**, which under `bases.write()` retains only map entries whose `Arc<IndexBase>` still has `strong_count > 1`, so map-only orphans from commit advances and last-session closes are reclaimed without breaking SC-002 (one shared `Arc` per `BaseKey` for live consumers).
> 
> **Commit-advance path:** After `refresh_working_set_bases` updates working sets, the working-set lock is dropped first, then GC runs so old `BaseKey` entries left with only the map reference are evicted.
> 
> **Session-close path:** `close_session` drops the removed session (including its `working_set` clones) before sweeping, then calls the same GC so bases with no remaining session holders are removed.
> 
> Two tests cover unit eviction (orphan vs live `ptr_eq`) and integration open→close clearing the bases table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1404057b6cfb962d47ff735d72b904140db3b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->