### PR TITLE
chore(deps): migrate to rmcp 2.0 (1.7 -> 2.0 API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ schemars = "1"
 # resolves >=1.7 (the `allowed_hosts` DNS-rebinding behavior depends on >=1.7
 # APIs). Future fix: pin an exact/min version (or treat Cargo.lock as the source
 # of truth) and add a minimum-version / deny check so a downgrade can't slip in.
-rmcp = { version = "1.1.0", features = ["transport-io", "transport-streamable-http-server"], optional = true }
+rmcp = { version = "2.0", features = ["transport-io", "transport-streamable-http-server"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Maintained libyaml-lineage YAML backend. The previous `serde_yml 0.0.13` fork

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -190,7 +190,7 @@ fn statused_edit_tool_result(
     let mut meta = rmcp::model::JsonObject::new();
     meta.insert(RESULT_STATUS_META_KEY.to_string(), status_payload);
 
-    let content = vec![rmcp::model::Content::text(text)];
+    let content = vec![rmcp::model::ContentBlock::text(text)];
     let result = if status.outcome_class().is_error() {
         rmcp::model::CallToolResult::error(content)
     } else {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -30,9 +30,8 @@ use rmcp::RoleServer;
 use rmcp::handler::server::router::prompt::PromptRouter;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListResourceTemplatesResult,
-    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
-    ReadResourceResult, ServerCapabilities, ServerInfo, Tool,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResult, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ServerHandler, prompt_handler, tool_handler};
@@ -1001,6 +1000,14 @@ impl SymForgeServer {
     /// unreachable `roots/list`, or a forbidden root must never break the
     /// session — the server simply stays in its existing (empty) state, exactly
     /// as before this hook existed.
+    // ponytail: SEP-2577 deprecates the entire MCP Roots capability (Root,
+    // ListRootsResult, peer.list_roots()) with NO replacement in rmcp 2.0 — it is
+    // slated for removal from the spec, not renamed. `roots/list` is still the only
+    // way a client can declare its workspace, so we keep using it and scope the
+    // allow to this fn. Upgrade path: when the spec settles on a successor
+    // capability (or rmcp removes Roots), migrate this single function.
+    // https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577
+    #[allow(deprecated)]
     async fn bind_workspace_from_client_roots(&self, peer: &rmcp::Peer<RoleServer>) {
         // Precedence: `SYMFORGE_WORKSPACE_ROOT (env) > client roots > CWD walk`.
         //

--- a/src/protocol/prompts.rs
+++ b/src/protocol/prompts.rs
@@ -1,5 +1,5 @@
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{GetPromptResult, PromptMessage, PromptMessageRole};
+use rmcp::model::{GetPromptResult, PromptMessage, Role};
 use rmcp::{prompt, prompt_router};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -64,16 +64,16 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_code_review_instructions(&self.project_name, &params.0),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_map_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_map_resource()),
         ];
 
         if let Some(path) = params.0.path.as_deref() {
             messages.push(PromptMessage::new_resource_link(
-                PromptMessageRole::User,
+                Role::User,
                 file_context_resource(path, Some(200)),
             ));
         }
@@ -92,17 +92,17 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_architecture_map_instructions(&self.project_name, params.0.area.as_deref()),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_map_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_outline_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_map_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_outline_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
         ];
 
         if let Some(area) = params.0.area.as_deref() {
             messages.push(PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 format!("Prioritize the area or subsystem named '{area}' if it exists."),
             ));
         }
@@ -122,17 +122,17 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_failure_triage_instructions(&self.project_name, &params.0),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_changes_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_map_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_changes_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_map_resource()),
         ];
 
         if let Some(path) = params.0.path.as_deref() {
             messages.push(PromptMessage::new_resource_link(
-                PromptMessageRole::User,
+                Role::User,
                 file_context_resource(path, Some(200)),
             ));
         }
@@ -152,18 +152,18 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_onboard_instructions(&self.project_name, params.0.area.as_deref()),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_map_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_outline_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, tools_catalog_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_map_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_outline_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, tools_catalog_resource()),
         ];
 
         if let Some(area) = params.0.area.as_deref() {
             messages.push(PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 format!("Focus onboarding on the '{area}' area first."),
             ));
         }
@@ -182,16 +182,16 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_refactor_instructions(&self.project_name, &params.0),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_map_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_map_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
         ];
 
         if let Some(target) = params.0.target.as_deref() {
             messages.push(PromptMessage::new_resource_link(
-                PromptMessageRole::User,
+                Role::User,
                 file_context_resource(target, Some(200)),
             ));
         }
@@ -210,16 +210,16 @@ impl SymForgeServer {
     ) -> GetPromptResult {
         let mut messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 build_debug_instructions(&self.project_name, &params.0),
             ),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_health_resource()),
-            PromptMessage::new_resource_link(PromptMessageRole::User, repo_changes_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_health_resource()),
+            PromptMessage::new_resource_link(Role::User, repo_changes_resource()),
         ];
 
         if let Some(path) = params.0.path.as_deref() {
             messages.push(PromptMessage::new_resource_link(
-                PromptMessageRole::User,
+                Role::User,
                 file_context_resource(path, Some(200)),
             ));
         }
@@ -255,7 +255,7 @@ impl SymForgeServer {
                 .unwrap_or(None);
 
         let body = build_admin_instructions(&self.project_name, dashboard_url.as_deref());
-        GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, body)])
+        GetPromptResult::new(vec![PromptMessage::new_text(Role::User, body)])
             .with_description(
                 "Open the SymForge operator dashboard (reuse the running server, or start it via `symforge admin`).",
             )
@@ -629,7 +629,7 @@ mod tests {
             .messages
             .iter()
             .find_map(|message| match &message.content {
-                rmcp::model::PromptMessageContent::Text { text } => Some(text.clone()),
+                rmcp::model::ContentBlock::Text(content) => Some(content.text.clone()),
                 _ => None,
             })
             .expect("admin prompt returns a text message");
@@ -674,7 +674,7 @@ mod tests {
         assert!(
             result.messages.iter().any(|message| matches!(
                 &message.content,
-                rmcp::model::PromptMessageContent::ResourceLink { link }
+                rmcp::model::ContentBlock::ResourceLink(link)
                     if link.uri == REPO_HEALTH_URI
             )),
             "symforge-review prompt should link repo health"
@@ -682,7 +682,7 @@ mod tests {
         assert!(
             result.messages.iter().any(|message| matches!(
                 &message.content,
-                rmcp::model::PromptMessageContent::ResourceLink { link }
+                rmcp::model::ContentBlock::ResourceLink(link)
                     if link.uri.contains("symforge://file/context")
             )),
             "symforge-review prompt should link file context"

--- a/src/protocol/resources.rs
+++ b/src/protocol/resources.rs
@@ -1,10 +1,7 @@
 use reqwest::Url;
 use rmcp::ErrorData as McpError;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{
-    AnnotateAble, RawResource, RawResourceTemplate, ReadResourceResult, Resource, ResourceContents,
-    ResourceTemplate,
-};
+use rmcp::model::{ReadResourceResult, Resource, ResourceContents, ResourceTemplate};
 
 use super::SymForgeServer;
 use crate::protocol::tools::{
@@ -374,11 +371,12 @@ fn render_glossary() -> String {
 }
 
 fn make_resource(uri: &str, name: &str, title: &str, description: &str) -> Resource {
-    RawResource::new(uri.to_string(), name.to_string())
+    // rmcp 2.0: `Resource` is a flat struct (no more `Annotated<RawResource>` /
+    // `AnnotateAble::no_annotation()`); build it directly.
+    Resource::new(uri.to_string(), name.to_string())
         .with_title(title.to_string())
         .with_description(description.to_string())
         .with_mime_type("text/markdown")
-        .no_annotation()
 }
 
 fn make_resource_template(
@@ -387,11 +385,11 @@ fn make_resource_template(
     title: &str,
     description: &str,
 ) -> ResourceTemplate {
-    RawResourceTemplate::new(uri_template.to_string(), name.to_string())
+    // rmcp 2.0: `ResourceTemplate` is a flat struct; build it directly.
+    ResourceTemplate::new(uri_template.to_string(), name.to_string())
         .with_title(title.to_string())
         .with_description(description.to_string())
         .with_mime_type("text/markdown")
-        .no_annotation()
 }
 
 fn build_uri(base: &str, params: &[(&str, Option<String>)]) -> String {

--- a/src/protocol/result_status.rs
+++ b/src/protocol/result_status.rs
@@ -1,4 +1,4 @@
-use rmcp::model::{CallToolResult, Content, JsonObject, Meta};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Meta};
 use serde::{Deserialize, Serialize};
 
 pub const RESULT_STATUS_META_KEY: &str = "symforge/result_status";
@@ -62,7 +62,7 @@ impl ResultStatus {
             serde_json::to_value(self).expect("ResultStatus must serialize to JSON"),
         );
 
-        let content = vec![Content::text(human_text.into())];
+        let content = vec![ContentBlock::text(human_text.into())];
         let result = if self.outcome_class.is_error() {
             CallToolResult::error(content)
         } else {


### PR DESCRIPTION
## rmcp 1.7 → 2.0 migration

Dependabot #393 bumped rmcp to 2.0 (version only); rmcp 2.0 has breaking API changes (its CI rust job failed with 8 errors). This PR does the code migration so the bump actually compiles + passes.

### Type consolidation (each new path verified against `rmcp-2.0.0` source)
| 1.7 | 2.0 |
|---|---|
| `PromptMessageRole` | `Role` |
| `Content` | `ContentBlock` |
| `RawResource` + `AnnotateAble::no_annotation()` | `Resource::new(...)` (flat struct) |
| `RawResourceTemplate` + `no_annotation()` | `ResourceTemplate::new(...)` (flat) |
| `PromptMessageContent::{Text,ResourceLink}` struct-variants | `ContentBlock::{Text,ResourceLink}` tuple-variants (prompts tests) |

Plus removal of 3 genuinely-unused model imports now provided by the `prompt_handler` macro.

### Roots deprecation (SEP-2577) — scoped allow, justified
rmcp 2.0 deprecates the **entire** Roots capability (`Root`, `ListRootsResult`, `peer.list_roots()`) with **no replacement** — it's slated for removal from the spec, not renamed. `roots/list` is still the only way a client declares its workspace, and SymForge's client-driven retargeting (`bind_workspace_from_client_roots`) depends on it. Disabling it would silently regress a working feature, so a **function-scoped** `#[allow(deprecated)]` (not crate-wide) is applied with a comment naming SEP-2577 and the single-function upgrade path for when the spec settles a successor.

### Verification
On-wire contract preserved (`ContentBlock`/`Role` serde shapes match the old `PromptMessageContent`/`PromptMessageRole`). Full gate green locally: `fmt --check`, `check`, `clippy --all-targets -- -D warnings`, `build --release`; **3239 tests pass, 0 failed** (incl. resource/prompt serialization assertions). Supersedes dependabot #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all MCP tool/prompt/resource wire shapes via a major dependency bump; behavior is intended to stay compatible but client-driven workspace binding still relies on deprecated Roots APIs until the spec moves on.
> 
> **Overview**
> Bumps optional **`rmcp`** from 1.x to **2.0** in `Cargo.toml` / lockfile and updates the MCP protocol layer so the server compiles against the new crate API.
> 
> **API renames / simplifications:** tool and edit status paths now build results with **`ContentBlock::text`** instead of **`Content`**. Prompts use **`Role::User`** instead of **`PromptMessageRole`**, and tests match **`ContentBlock::Text`** / **`ContentBlock::ResourceLink`** instead of the old **`PromptMessageContent`** variants. Resources are constructed with flat **`Resource::new`** / **`ResourceTemplate::new`** (drops **`RawResource`**, **`AnnotateAble::no_annotation()`**, and related imports). Unused prompt-related model imports are removed from **`mod.rs`**.
> 
> **Deprecated Roots (SEP-2577):** **`bind_workspace_from_client_roots`** keeps calling **`peer.list_roots()`** with a function-scoped **`#[allow(deprecated)]`** and an inline note that there is no rmcp 2.0 replacement yet for client workspace binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873abe59ff00e2f7f8b1359d451439b35a63b0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->