### PR TITLE
fix: detect_impact caps, get_symbol name lookup, status on full surface

### DIFF
--- a/specs/015-cbm-capability-ports/contracts/detect-impact.md
+++ b/specs/015-cbm-capability-ports/contracts/detect-impact.md
@@ -43,13 +43,19 @@ Git path union: `GitRepo::merge_git_changed_paths` (see sprint-1a spec P-S1A-008
 
 ## Output
 
+(pagination shape amended 2026-07-02 — see addendum)
+
 ```json
 {
   "changed_files": ["..."],
   "changed_symbols": [{"name","path","kind"}],
   "blast_radius": [{"symbol","hop","risk"}],
   "risk_summary": {"critical":0,"high":1,"medium":2,"low":5},
-  "pagination": {"total":...,"returned":...,"offset":0,"has_more":false}
+  "pagination": {
+    "changed_files":   {"total": N, "returned": M, "truncated": false},
+    "changed_symbols": {"total": N, "returned": M, "truncated": false},
+    "blast_radius":    {"total": N, "returned": M, "truncated": false}
+  }
 }
 ```
 
@@ -71,3 +77,44 @@ Git path union: `GitRepo::merge_git_changed_paths` (see sprint-1a spec P-S1A-008
 ## Backward compatibility
 
 Daemon routes `detect_changes` → this tool with deprecation warning (D-015-012).
+
+## Addendum — 2026-07-02 (dogfood defect Wave 1)
+
+Defect-fix amendment to the frozen 2026-06-30 contract. The **input** is
+unchanged; these clarify **default resolution** and **output bounds** the frozen
+text did not specify.
+
+### Default base resolution (Fix 6)
+
+When the caller supplies neither `base_branch` nor `since`, the DEFAULT
+substitution now resolves in this order:
+
+1. `origin/main` if it exists (the shared remote truth), else
+2. local `main`, else
+3. the existing "Invalid git ref" error when neither exists.
+
+Rationale: a local `main` that lags `origin/main` (observed 83 commits behind)
+produced a confidently-wrong blast radius against a stale base. An **explicit**
+caller-passed `base_branch: "main"` still means local `main` (unchanged). The
+response header discloses the resolved ref (`base: origin/main`) and appends a
+one-line note when local `main` differs from `origin/main`.
+
+### Bounded output + per-list pagination (Fix 1)
+
+A raw dump on a large repo reached 54 MB / 291K changed symbols (89.6s). Every
+list in the payload is now capped at 200 entries: `changed_files`,
+`changed_symbols`, and `blast_radius` (sorted by risk severity desc, then hop
+asc). `risk_summary` still counts the FULL blast set.
+
+The frozen § Output `pagination` object was a single flat
+`{total, returned, offset, has_more}` that only described the blast list and did
+not anticipate the `changed_files`/`changed_symbols` explosion. It is replaced by
+a **per-list** shape (a documented, honest widening of the looser frozen shape):
+
+```json
+"pagination": {
+  "changed_files":   {"total": N, "returned": M, "truncated": bool},
+  "changed_symbols": {"total": N, "returned": M, "truncated": bool},
+  "blast_radius":    {"total": N, "returned": M, "truncated": bool}
+}
+```

--- a/src/git.rs
+++ b/src/git.rs
@@ -225,6 +225,24 @@ impl GitRepo {
         Ok(paths)
     }
 
+    /// Resolve a ref/revspec to its commit OID, or `None` when it does not
+    /// exist. Used by `detect_impact`'s default base resolution to prefer
+    /// `origin/main` over a possibly-stale local `main` (dogfood Wave 1 Fix 6).
+    pub fn resolve_ref_commit(&self, reference: &str) -> Option<git2::Oid> {
+        let obj = self.repo.revparse_single(reference).ok()?;
+        obj.peel_to_commit().ok().map(|commit| commit.id())
+    }
+
+    /// Ahead/behind commit counts of `local` relative to `upstream`, as
+    /// `(ahead, behind)`: `ahead` = commits reachable from `local` but not
+    /// `upstream` (unpushed work); `behind` = commits reachable from `upstream`
+    /// but not `local` (staleness). Returns `None` when the two share no common
+    /// ancestor, where the direction is not a meaningful scalar.
+    pub fn ahead_behind(&self, local: git2::Oid, upstream: git2::Oid) -> Option<(usize, usize)> {
+        self.repo.merge_base(local, upstream).ok()?;
+        self.repo.graph_ahead_behind(local, upstream).ok()
+    }
+
     /// Read file content at a specific git ref. Returns None if the file doesn't exist at that ref.
     ///
     /// Replaces: `git show <ref>:<path>`

--- a/src/live_index/graph.rs
+++ b/src/live_index/graph.rs
@@ -225,6 +225,18 @@ impl RiskTier {
         }
     }
 
+    /// Severity ordering for ranking blast entries (higher = more severe):
+    /// Critical > High > Medium > Low. Used by `detect_impact` to keep the most
+    /// severe nodes when the returned list is capped.
+    pub fn severity_rank(self) -> u8 {
+        match self {
+            RiskTier::Critical => 3,
+            RiskTier::High => 2,
+            RiskTier::Medium => 1,
+            RiskTier::Low => 0,
+        }
+    }
+
     /// Tier for a blast node at `hop` hops from the nearest changed symbol,
     /// promoted to `Critical` when the node is an entry point at hop 1
     /// (contracts/detect-impact.md § Risk tiers: hop 1 = High, hop 2 = Medium,

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -2348,22 +2348,39 @@ pub fn detect_impact_result(
     payload: &serde_json::Value,
     requested_depth: u8,
     effective_depth: u8,
+    base_ref: Option<&str>,
+    staleness_note: Option<&str>,
 ) -> String {
-    let changed_files = payload["changed_files"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
-    let changed_symbols = payload["changed_symbols"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
+    // Counts come from the per-list `pagination` totals, NOT the (capped) arrays,
+    // so the summary reports the FULL change/blast size even when the lists are
+    // truncated (Wave 1 Fix 1).
+    let pagination = &payload["pagination"];
+    let changed_files = pagination["changed_files"]["total"].as_u64().unwrap_or(0);
+    let changed_symbols = pagination["changed_symbols"]["total"].as_u64().unwrap_or(0);
+    let total_blast = pagination["blast_radius"]["total"].as_u64().unwrap_or(0);
     let risk = &payload["risk_summary"];
-    let total_blast = payload["pagination"]["total"].as_u64().unwrap_or(0);
-    let summary = format!(
+    let mut summary = format!(
         "Impact analysis: {changed_files} changed file(s), {changed_symbols} changed symbol(s), \
          {total_blast} blast-radius node(s) ({} critical / {} high / {} medium / {} low)",
         risk["critical"], risk["high"], risk["medium"], risk["low"],
     );
+    // Self-describing base ref + staleness disclosure (Wave 1 Fix 6).
+    if let Some(base) = base_ref {
+        summary.push_str(&format!("\nbase: {base}"));
+    }
+    if let Some(note) = staleness_note {
+        summary.push_str(&format!("\nnote: {note}"));
+    }
+    // Truncation disclosure in the human summary (machine-readable totals live in
+    // `pagination`), using the house truncation marker (Wave 1 Fix 1).
+    let any_truncated = ["changed_files", "changed_symbols", "blast_radius"]
+        .iter()
+        .any(|list| pagination[*list]["truncated"].as_bool().unwrap_or(false));
+    if any_truncated {
+        summary.push_str(&format!(
+            "\n{CANONICAL_TRUNCATION_MARKER} one or more lists capped; see `pagination` for full totals and returned counts."
+        ));
+    }
     let json = serde_json::to_string_pretty(payload).expect("detect_impact payload serializes");
     let mut out = format!("{summary}\n\n--- impact payload ---\n{json}");
     if requested_depth > effective_depth {
@@ -2374,6 +2391,11 @@ pub fn detect_impact_result(
     out
 }
 
+/// Fix 3 (Wave 1): cap the changed/uncommitted-path listing. On a large repo the
+/// working-tree listing reached ~100 KB of raw paths; bound it and disclose the
+/// omitted count with the house truncation marker.
+const WHAT_CHANGED_MAX_PATHS: usize = 200;
+
 pub fn what_changed_paths_result(paths: &[String], empty_message: &str) -> String {
     let mut normalized_paths: Vec<String> =
         paths.iter().map(|path| path.replace('\\', "/")).collect();
@@ -2382,6 +2404,17 @@ pub fn what_changed_paths_result(paths: &[String], empty_message: &str) -> Strin
 
     if normalized_paths.is_empty() {
         return empty_message.to_string();
+    }
+
+    let total = normalized_paths.len();
+    if total > WHAT_CHANGED_MAX_PATHS {
+        let omitted = total - WHAT_CHANGED_MAX_PATHS;
+        normalized_paths.truncate(WHAT_CHANGED_MAX_PATHS);
+        let mut out = normalized_paths.join("\n");
+        out.push_str(&format!(
+            "\n{CANONICAL_TRUNCATION_MARKER} {WHAT_CHANGED_MAX_PATHS} of {total} paths shown; {omitted} more omitted."
+        ));
+        return out;
     }
 
     normalized_paths.join("\n")

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -2125,6 +2125,30 @@ fn test_what_changed_paths_result_sorts_and_deduplicates() {
 }
 
 #[test]
+fn test_what_changed_paths_result_caps_large_listing() {
+    // Fix 3: a large changed-path listing (100 KB on a real repo) must be bounded
+    // with the house truncation marker + an omitted count, not dumped whole.
+    let paths: Vec<String> = (0..250).map(|i| format!("src/f{i:04}.rs")).collect();
+    let result = what_changed_paths_result(&paths, "No git changes detected.");
+
+    let lines: Vec<&str> = result.lines().collect();
+    // 200 path lines + 1 truncation notice line.
+    assert_eq!(
+        lines.len(),
+        201,
+        "must cap to 200 paths + one notice: {result}"
+    );
+    assert!(
+        lines.last().unwrap().contains("[truncated]"),
+        "must disclose truncation with the house marker: {result}"
+    );
+    assert!(
+        result.contains("200 of 250 paths shown; 50 more omitted"),
+        "must disclose the omitted count: {result}"
+    );
+}
+
+#[test]
 fn test_search_files_resolve_result_view_returns_exact_path() {
     let view = SearchFilesResolveView::Resolved {
         path: "src/protocol/tools.rs".to_string(),

--- a/src/protocol/read_tools.rs
+++ b/src/protocol/read_tools.rs
@@ -258,7 +258,10 @@ where
 /// Input for `get_symbol`.
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub struct GetSymbolInput {
-    /// Relative path to the file (required for single lookup; ignored when `targets` is provided).
+    /// Relative path to the file. OPTIONAL: when omitted, the symbol is resolved
+    /// by an exact `name` search across the index (pass `symbol_line`/`kind` to
+    /// disambiguate a common name). Provide `path` to skip the search and go
+    /// straight to that file. Ignored when `targets` is provided.
     #[serde(default)]
     pub path: String,
     /// Symbol name to look up (required for single lookup; ignored when `targets` is provided).

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -506,9 +506,11 @@ fn default_include_untracked() -> bool {
 /// (contracts/detect-impact.md § Risk tiers / error catalog: "depth capped").
 const DETECT_IMPACT_MAX_DEPTH: u8 = 5;
 
-/// ponytail: fixed safety cap on `blast_radius` entries returned per call.
-/// The frozen contract's `pagination` envelope has no `offset`/`limit` input
-/// field to page past it — add one if a real need for deeper paging shows up.
+/// ponytail: fixed safety cap on EACH list (`changed_files`, `changed_symbols`,
+/// `blast_radius`) returned per call — the bound that stops the 54 MB / 291K-symbol
+/// dump seen on a large repo. The frozen contract's `pagination` envelope has no
+/// `offset`/`limit` input field to page past it — add one if a real need for
+/// deeper paging shows up. `risk_summary` is always counted over the full set.
 const DETECT_IMPACT_MAX_RETURNED: usize = 200;
 
 /// Input for `detect_impact` (contracts/detect-impact.md, frozen 2026-06-30).
@@ -3506,8 +3508,139 @@ fn loading_guard_message_from_published(
     }
 }
 
+/// Outcome of a name-only `get_symbol` lookup (Wave 1 Fix 2).
+enum SymbolNameLookup {
+    /// Exactly one exact-name match — its path is used as if the caller passed it.
+    Unique { path: String },
+    /// More than one exact-name match — a ready-to-return disambiguation listing.
+    Ambiguous(String),
+    /// No exact-name match — a ready-to-return loud not-found (D18 style).
+    NotFound(String),
+}
+
+/// Render the disambiguation listing for a name-only `get_symbol` hit that
+/// matched multiple symbols. Shows path + start line + kind per candidate,
+/// capped at 20 with a count disclosure, and names how to disambiguate.
+fn render_symbol_name_ambiguity(
+    name: &str,
+    hits: &[crate::live_index::search::SymbolSearchHit],
+    overflowed: bool,
+) -> String {
+    const MAX_CANDIDATES: usize = 20;
+    // Under the 500-hit search cap the exact count can under-report; when the
+    // search overflowed, disclose the total as a lower bound (Wave 1 Fix 4).
+    let total = if overflowed {
+        format!("more than {}", hits.len())
+    } else {
+        hits.len().to_string()
+    };
+    let mut output = format!(
+        "Ambiguous symbol selector: {total} symbols named \"{name}\" found across the index.\n\
+         Pass `path` (and `symbol_line` if a file has several) to disambiguate.\n\
+         Candidates:",
+    );
+    for hit in hits.iter().take(MAX_CANDIDATES) {
+        output.push_str(&format!(
+            "\n- {} (line {}, {})",
+            hit.path, hit.line, hit.kind
+        ));
+    }
+    if hits.len() > MAX_CANDIDATES {
+        output.push_str(&format!(
+            "\n... and {} more (use search_symbols to list them all)",
+            hits.len() - MAX_CANDIDATES
+        ));
+    }
+    output
+}
+
 #[tool_router(router = core_tool_router, vis = "pub(crate)")]
 impl SymForgeServer {
+    /// Resolve a bare symbol `name` (no path) to a file path by an EXACT
+    /// name search across the index, honoring the `kind` filter and the
+    /// `symbol_line` disambiguator (Wave 1 Fix 2). Reuses the same search
+    /// machinery `search_symbols` uses so name resolution is consistent with it.
+    fn resolve_symbol_path_by_name(
+        &self,
+        name: &str,
+        kind: Option<&str>,
+        symbol_line: Option<u32>,
+    ) -> SymbolNameLookup {
+        use crate::live_index::search::{
+            ResultLimit, SymbolMatchTier, SymbolSearchOptions, search_symbols_with_options,
+        };
+        let guard = self.index.read();
+        // Permissive noise policy (the default) so a symbol defined only in a
+        // test/vendor/generated file is still resolvable by exact name — an
+        // explicit path already reaches those files. A generous limit keeps the
+        // ambiguity count honest without changing the O(symbols) scan cost.
+        let options = SymbolSearchOptions {
+            result_limit: ResultLimit::new(500),
+            ..Default::default()
+        };
+        let result = search_symbols_with_options(&guard, name, kind, &options);
+        // Under the 500-hit search cap, `overflow_count > 0` means more matches
+        // exist than were returned, so the ambiguity total must be a lower bound,
+        // never an exact under-report (Wave 1 Fix 4).
+        let overflowed = result.overflow_count > 0;
+        // Exact tier + exact (case-sensitive) name only — a name selector must
+        // not silently resolve to a prefix/substring neighbor.
+        let mut exact: Vec<crate::live_index::search::SymbolSearchHit> = result
+            .hits
+            .into_iter()
+            .filter(|hit| hit.tier == SymbolMatchTier::Exact && hit.name == name)
+            .collect();
+        // `symbol_line` narrows to matches at that 1-based start line when it
+        // resolves at least one candidate (e.g. two files, one line each).
+        if let Some(line) = symbol_line {
+            let narrowed: Vec<_> = exact
+                .iter()
+                .filter(|hit| hit.line == line)
+                .cloned()
+                .collect();
+            if !narrowed.is_empty() {
+                exact = narrowed;
+            }
+        }
+        match exact.len() {
+            0 => {
+                // Kind-mismatch guard (Wave 1 Fix 1): before claiming the name is
+                // absent, re-check WITHOUT the kind filter. If it exists under other
+                // kinds, "No symbol named X" is factually false — name the kinds it
+                // DOES have so the caller can drop or correct the filter.
+                if let Some(requested_kind) = kind {
+                    let unfiltered = search_symbols_with_options(&guard, name, None, &options);
+                    let mut kinds: Vec<String> = unfiltered
+                        .hits
+                        .into_iter()
+                        .filter(|hit| hit.tier == SymbolMatchTier::Exact && hit.name == name)
+                        .map(|hit| hit.kind)
+                        .collect();
+                    kinds.sort();
+                    kinds.dedup();
+                    if !kinds.is_empty() {
+                        return SymbolNameLookup::NotFound(format!(
+                            "`{name}` exists in the index, but not as kind={requested_kind} \
+                             (found: {}). Drop the kind filter or pass the correct kind.",
+                            kinds.join(", ")
+                        ));
+                    }
+                }
+                SymbolNameLookup::NotFound(format!(
+                    "No symbol named `{name}` in the index. \
+                     Use search_symbols(query=\"{name}\") for a fuzzy lookup, \
+                     or pass an explicit `path` if the file is not indexed."
+                ))
+            }
+            1 => SymbolNameLookup::Unique {
+                path: exact.remove(0).path,
+            },
+            _ => {
+                SymbolNameLookup::Ambiguous(render_symbol_name_ambiguity(name, &exact, overflowed))
+            }
+        }
+    }
+
     /// Look up symbol(s) by file path and name. Single mode: provide path + name for one symbol.
     /// Batch mode: provide targets[] array for multiple symbols or code slices in one call.
     /// When multiple symbols share the same name (e.g. `handle` in different impl blocks),
@@ -3647,6 +3780,34 @@ impl SymForgeServer {
         }
 
         // Single mode: path + name
+        let mut params = params;
+
+        // Name-only lookup (Wave 1 Fix 2): `path` is OPTIONAL. When the caller
+        // supplies a `name` but no `path`, resolve the path by an EXACT name
+        // search across the index (the same machinery `search_symbols` uses),
+        // honoring `kind` and the `symbol_line` disambiguator. This also powers
+        // the compact `read` intent, which routes here via the STEL planner —
+        // one fix, two surfaces. Both empty (and no `targets`) is a clean
+        // invalid-request, never `File not found: .`.
+        if params.0.path.trim().is_empty() {
+            if params.0.name.trim().is_empty() {
+                return "Invalid request: get_symbol needs a `name` (optionally with `path`), \
+                        or a `targets` array. Add `path`/`symbol_line` to disambiguate a common \
+                        name, or use search_symbols for a fuzzy lookup."
+                    .to_string();
+            }
+            match self.resolve_symbol_path_by_name(
+                params.0.name.trim(),
+                params.0.kind.as_deref(),
+                params.0.symbol_line,
+            ) {
+                SymbolNameLookup::Unique { path } => params.0.path = path,
+                SymbolNameLookup::Ambiguous(message) | SymbolNameLookup::NotFound(message) => {
+                    return message;
+                }
+            }
+        }
+
         let force_refresh = params.0.force_refresh == Some(true);
         let params_hash = crate::protocol::session::hash_symbol_params(
             params.0.kind.as_deref(),
@@ -6917,15 +7078,66 @@ impl SymForgeServer {
         // against. A repo with no `main` branch degrades to the "Invalid git
         // ref" error below (git2 ref resolution fails), never a panic; pass an
         // explicit `base_branch`/`since` for non-`main` default branches.
-        let base_branch: Option<&str> =
+        //
+        // Wave-1 defect fix (2026-07-02, contracts/detect-impact.md § 2026-07-02
+        // addendum): the DEFAULT substitution now prefers `origin/main` over
+        // local `main`. A local `main` that lags the remote (e.g. 83 commits
+        // behind) produces a confidently-wrong blast radius against a stale base;
+        // the shared remote ref is the intended comparison. An EXPLICIT
+        // caller-passed `base_branch:"main"` still means local `main` (unchanged).
+        // The resolved ref (and any staleness) is disclosed in the response
+        // header so the output is self-describing.
+        let mut staleness_note: Option<String> = None;
+        let base_branch: Option<String> =
             if params.0.base_branch.is_none() && params.0.since.is_none() {
-                Some("main")
+                let origin = repo.resolve_ref_commit("origin/main");
+                let local = repo.resolve_ref_commit("main");
+                let resolved = match (origin, local) {
+                    (Some(origin_oid), Some(local_oid)) => {
+                        if origin_oid != local_oid {
+                            // Direction-aware disclosure (Wave 1 Fix 3): behind is the
+                            // motivating stale-local case; ahead means unpushed local
+                            // work landed in the base; both means diverged. `ahead` =
+                            // commits in local not in origin; `behind` = the reverse.
+                            staleness_note = Some(match repo.ahead_behind(local_oid, origin_oid) {
+                                Some((ahead, behind)) if behind > 0 && ahead == 0 => {
+                                    "local main is behind origin/main; using origin/main"
+                                        .to_string()
+                                }
+                                Some((ahead, behind)) if ahead > 0 && behind == 0 => {
+                                    "local main is ahead of origin/main (unpushed commits); using \
+                                 origin/main — the blast radius includes your unpushed work \
+                                 relative to the shared base"
+                                        .to_string()
+                                }
+                                Some((ahead, behind)) if ahead > 0 && behind > 0 => {
+                                    "local main and origin/main have diverged; using origin/main"
+                                        .to_string()
+                                }
+                                // No common ancestor (or the unreachable both-zero given
+                                // origin != local): fall back to the direction-neutral note.
+                                _ => "local main differs from origin/main; using origin/main"
+                                    .to_string(),
+                            });
+                        }
+                        "origin/main"
+                    }
+                    (Some(_), None) => "origin/main",
+                    // No origin/main (or neither ref exists): fall back to local
+                    // `main`. When neither exists, merge_git_changed_paths surfaces
+                    // the existing "Invalid git ref" error below, unchanged.
+                    (None, _) => "main",
+                };
+                Some(resolved.to_string())
             } else {
-                params.0.base_branch.as_deref()
+                params.0.base_branch.clone()
             };
+        // The base ref disclosed in the response header: the resolved default or
+        // the explicit caller value; `None` when only `since` was supplied.
+        let base_disclosure: Option<String> = base_branch.clone();
 
         let changed_files = match repo.merge_git_changed_paths(
-            base_branch,
+            base_branch.as_deref(),
             params.0.since.as_deref(),
             params.0.include_untracked,
         ) {
@@ -6985,30 +7197,66 @@ impl SymForgeServer {
                         .collect()
                 }
             };
-        blast_entries.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+        // Fix 1 (Wave 1, 2026-07-02): keep the most severe blast nodes when the
+        // list is capped — sort by risk severity desc, then hop asc, then name.
+        blast_entries.sort_by(|a, b| {
+            b.2.severity_rank()
+                .cmp(&a.2.severity_rank())
+                .then(a.1.cmp(&b.1))
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
-        let total = blast_entries.len();
-        let returned_entries = &blast_entries[..total.min(DETECT_IMPACT_MAX_RETURNED)];
-        let returned = returned_entries.len();
-
+        // risk_summary counts the FULL blast set (it is counts, not entries), so
+        // it stays complete even though the returned entries are capped.
         let mut risk_counts: HashMap<&'static str, u32> = HashMap::new();
         for (_, _, risk) in &blast_entries {
             *risk_counts.entry(risk.as_str()).or_insert(0) += 1;
         }
 
+        // Fix 1: bound the JSON PAYLOAD — cap each list at DETECT_IMPACT_MAX_RETURNED
+        // and disclose the full totals + truncation in `pagination`. This bounds the
+        // serialized/emitted entries at 200/list; it does NOT make the tool
+        // sub-linear. The changed_symbols collection above, the BFS in
+        // compute_impact, the blast clone+sort, and the risk counting all remain
+        // O(full set) by necessity: risk_summary and the pagination totals must
+        // reflect the COMPLETE set, so everything is still counted. A large explicit
+        // diff still costs linear time; what the cap removes is the multi-MB payload
+        // (the 54 MB / 291K-entry dump).
+        let cap = DETECT_IMPACT_MAX_RETURNED;
+
+        let changed_files_total = changed_files.len();
+        let changed_files_json: Vec<&String> = changed_files.iter().take(cap).collect();
+
+        let changed_symbols_total = changed_symbols.len();
         let changed_symbols_json: Vec<serde_json::Value> = changed_symbols
             .iter()
+            .take(cap)
             .map(
                 |s| serde_json::json!({"name": s.name, "path": s.path, "kind": s.kind.to_string()}),
             )
             .collect();
-        let blast_radius_json: Vec<serde_json::Value> = returned_entries
+
+        let blast_total = blast_entries.len();
+        let blast_radius_json: Vec<serde_json::Value> = blast_entries
             .iter()
+            .take(cap)
             .map(|(symbol, hop, risk)| serde_json::json!({"symbol": symbol, "hop": hop, "risk": risk.as_str()}))
             .collect();
 
+        let changed_files_returned = changed_files_json.len();
+        let changed_symbols_returned = changed_symbols_json.len();
+        let blast_returned = blast_radius_json.len();
+
+        let list_page = |total: usize, returned: usize| {
+            serde_json::json!({
+                "total": total,
+                "returned": returned,
+                "truncated": total > returned,
+            })
+        };
+
         let payload = serde_json::json!({
-            "changed_files": changed_files,
+            "changed_files": changed_files_json,
             "changed_symbols": changed_symbols_json,
             "blast_radius": blast_radius_json,
             "risk_summary": {
@@ -7017,15 +7265,24 @@ impl SymForgeServer {
                 "medium": risk_counts.get("medium").copied().unwrap_or(0),
                 "low": risk_counts.get("low").copied().unwrap_or(0),
             },
+            // Per-list pagination (total / returned / truncated). The frozen
+            // contract's flat single-list `pagination` shape did not anticipate
+            // the changed_files/changed_symbols explosion; this per-list shape is
+            // the honest disclosure (contracts/detect-impact.md § 2026-07-02).
             "pagination": {
-                "total": total,
-                "returned": returned,
-                "offset": 0,
-                "has_more": total > returned,
+                "changed_files": list_page(changed_files_total, changed_files_returned),
+                "changed_symbols": list_page(changed_symbols_total, changed_symbols_returned),
+                "blast_radius": list_page(blast_total, blast_returned),
             },
         });
 
-        let result = format::detect_impact_result(&payload, requested_depth, effective_depth);
+        let result = format::detect_impact_result(
+            &payload,
+            requested_depth,
+            effective_depth,
+            base_disclosure.as_deref(),
+            staleness_note.as_deref(),
+        );
         self.session_context.record_summary_output(
             "detect_impact",
             (result.len() / 4).min(u32::MAX as usize) as u32,
@@ -8945,6 +9202,13 @@ impl SymForgeServer {
                 .into_call_tool_result("query is required: pass a natural-language phrase"));
         }
 
+        // Gate KEPT (unlike `status`, Wave 1 Fix 4): the `symforge` facade is a
+        // genuine compact-surface invariant, not a self-inflicted refusal. It is
+        // deliberately NOT advertised on the full surface (surface_probe.rs filters
+        // it out of `tools/list`), and the A-019 golden-replay harness special-
+        // cases THIS exact string as the "compact surface was not selected" signal
+        // (stel/golden_replay.rs). On full, the caller has the 32 legacy tools the
+        // facade fuses — the message names that path.
         if super::surface_probe::surface_profile_from_env()
             != super::surface_probe::SurfaceProfile::Compact
         {
@@ -9083,11 +9347,17 @@ impl SymForgeServer {
         }
 
         if should_skip_legacy_dispatch(&decision) {
-            let body = if decision.decision == crate::stel::AdmissionDecision::CacheHit {
+            let mut body = if decision.decision == crate::stel::AdmissionDecision::CacheHit {
                 format_cache_hit_body(&decision)
             } else {
                 format_bypass_body(&decision)
             };
+            // Wave 1 Fix 5: disclose unconsumed caller params on the bypass path
+            // too, so an economics-bypassed impact request is equally honest.
+            for note in crate::stel::planner::served_param_disclosures(request, &plan) {
+                body.push_str("\n\n");
+                body.push_str(&note);
+            }
             let output = self.finalize_symforge_with_ledger(
                 "symforge",
                 request,
@@ -9208,6 +9478,14 @@ impl SymForgeServer {
             self.append_impact_intent_cochanges(&mut body, &exec_plan.steps[0].args);
         }
 
+        // Wave 1 Fix 5: disclose any caller param the route did NOT consume
+        // (e.g. a `path` on the git-derived impact route) — lossless-or-loud,
+        // via the existing ParamDisposition accounting, never a silent drop.
+        for note in crate::stel::planner::served_param_disclosures(request, &plan) {
+            body.push_str("\n\n");
+            body.push_str(&note);
+        }
+
         let tools = tools_executed(&step_results);
         let route_label = route_tool_label(&tools);
         let tools_called = if tools.len() > 1 { Some(tools) } else { None };
@@ -9294,6 +9572,11 @@ impl SymForgeServer {
         &self,
         params: Parameters<crate::stel::StelEditRequest>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+        // Gate KEPT (unlike `status`, Wave 1 Fix 4): `symforge_edit` routes through
+        // the STEL economics/ledger apply path, the compact-surface invariant the
+        // A-019 golden replay pins. On full the caller has the legacy edit tools
+        // (replace_symbol_body / edit_within_symbol / …) this facade fuses — the
+        // message names that path. Pinned by tests/stel_symforge_edit.rs.
         if super::surface_probe::surface_profile_from_env()
             != super::surface_probe::SurfaceProfile::Compact
         {
@@ -9477,13 +9760,14 @@ impl SymForgeServer {
         &self,
         params: Parameters<crate::stel::StelStatusRequest>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-        if super::surface_probe::surface_profile_from_env()
-            != super::surface_probe::SurfaceProfile::Compact
-        {
-            return Ok(ResultStatus::new(OutcomeClass::InvalidRequest).into_call_tool_result(
-                "status STEL handler requires SYMFORGE_SURFACE=compact; use health or health_compact on the full surface",
-            ));
-        }
+        // Wave-1 defect fix (2026-07-02): NO surface gate here. `status` is a
+        // read-only health/trust readout that the docs tell every client to call
+        // at session start, so refusing it on `SYMFORGE_SURFACE=full` was a
+        // self-inflicted failure with no invariant behind it (unlike `symforge`/
+        // `symforge_edit`, whose gates guard the STEL economics/golden-replay
+        // path — kept, see those handlers). The body self-describes the active
+        // surface via `render_stel_status_body`, so a full-surface `status` is
+        // honest about where it ran.
 
         // TR-01 (FR-006/007): in the default daemon-proxy topology this front-end
         // server's `self.index` is EMPTY — the populated index lives in the warm
@@ -9553,6 +9837,15 @@ impl SymForgeServer {
             None
         };
 
+        // Report the ACTIVE surface, not a hardcoded label (Wave 1 Fix 4): now
+        // that `status` runs on `SYMFORGE_SURFACE=full` too, claiming `compact`
+        // would be a lie. Reads the same env the dispatch gate reads.
+        let surface_label = match super::surface_probe::surface_profile_from_env() {
+            super::surface_probe::SurfaceProfile::Full => "full",
+            super::surface_probe::SurfaceProfile::Meta => "meta",
+            super::surface_probe::SurfaceProfile::Compact => "compact",
+        };
+
         let guard = self.index.read();
         let ledger = self.stel_ledger.lock();
         // 012 D6-a bound-root visibility: surface WHICH workspace answered. This
@@ -9565,7 +9858,7 @@ impl SymForgeServer {
         // 013: `mut` — line below reassigns `ctx` with the durable calibration
         // verdict override (T033/FR-009).
         let mut ctx = crate::stel::StelStatusContext::from_server(
-            "compact",
+            surface_label,
             &self.project_name,
             project_root,
             guard.is_ready(),
@@ -10778,6 +11071,36 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn status_serves_on_full_surface_without_corpus() {
+        // Wave 1 Fix 4 (corpus-free proof): with SYMFORGE_SURFACE=full active,
+        // `status` must NOT refuse (its old surface gate is gone) and must
+        // self-describe the active surface. Runs over a temp in-memory index —
+        // no phase0 corpus, so it executes in a fresh clone (unlike the
+        // corpus-gated tests/stel_status.rs coverage that skips when absent).
+        // The lib suite runs --test-threads=1; EnvVarGuard restores on drop.
+        let _surface = EnvVarGuard::set("SYMFORGE_SURFACE", "full");
+
+        let (key, file) = make_file("src/lib.rs", b"fn core() {}", vec![]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .status_stel_tool(Parameters(crate::stel::StelStatusRequest::default()))
+            .await
+            .expect("status dispatch");
+        let serialized = serde_json::to_value(&result).expect("serialize CallToolResult");
+        let output = tool_result_text(&serialized);
+
+        assert!(
+            !output.contains("requires SYMFORGE_SURFACE=compact"),
+            "status must not refuse on the full surface:\n{output}"
+        );
+        assert!(
+            output.contains("surface: full"),
+            "status must self-describe the active (full) surface:\n{output}"
+        );
+    }
+
     fn make_symbol_with_bytes(
         name: &str,
         kind: SymbolKind,
@@ -11618,6 +11941,135 @@ mod tests {
         assert!(
             result.contains("fn foo"),
             "valid symbol must return its body; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_name_only_unique_resolves_path() {
+        // Fix 2: a `name` with no `path` resolves via an exact index search and
+        // returns the body — never `File not found: .`.
+        let sym = make_symbol("core", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn core() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("", "core")))
+            .await;
+
+        assert!(
+            result.contains("fn core"),
+            "name-only lookup must resolve and return the body; got: {result}"
+        );
+        assert!(
+            !result.contains("File not found"),
+            "name-only lookup must not report file-not-found; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_name_only_ambiguous_lists_candidates() {
+        // Fix 2: a name matching symbols in multiple files returns a
+        // disambiguation listing naming path + line + kind, not one arbitrary hit.
+        let sym_a = make_symbol("handle", SymbolKind::Function, 1, 3);
+        let sym_b = make_symbol("handle", SymbolKind::Function, 5, 7);
+        let content = medium_test_source("fn handle() {}");
+        let (key_a, file_a) = make_file("src/a.rs", &content, vec![sym_a]);
+        let (key_b, file_b) = make_file("src/b.rs", &content, vec![sym_b]);
+        let server = make_server(make_live_index_ready(vec![
+            (key_a, file_a),
+            (key_b, file_b),
+        ]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("", "handle")))
+            .await;
+
+        assert!(
+            result.contains("Ambiguous symbol selector"),
+            "multiple matches must return a disambiguation listing; got: {result}"
+        );
+        assert!(
+            result.contains("src/a.rs") && result.contains("src/b.rs"),
+            "disambiguation must list every candidate path; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_name_only_missing_is_loud_not_found() {
+        // Fix 2: a name absent from the index yields a loud not-found that names
+        // the symbol and points at search_symbols — not `File not found: .`.
+        let sym = make_symbol("core", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn core() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("", "Nonexistent")))
+            .await;
+
+        assert!(
+            result.contains("No symbol named `Nonexistent`"),
+            "missing name must be a loud not-found; got: {result}"
+        );
+        assert!(
+            result.contains("search_symbols"),
+            "missing name must suggest search_symbols for fuzzy lookup; got: {result}"
+        );
+        assert!(
+            !result.contains("File not found"),
+            "missing name must not read as file-not-found; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_name_only_kind_mismatch_names_actual_kinds() {
+        // Fix 1: a `name` that exists only under OTHER kinds must not read as a
+        // hard "No symbol named X" (factually false); it must name the kinds the
+        // symbol DOES have so the caller can drop or correct the `kind` filter.
+        let sym = make_symbol("core", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn core() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let mut input = get_symbol_input("", "core");
+        input.kind = Some("struct".to_string());
+        let result = server.get_symbol(Parameters(input)).await;
+
+        assert!(
+            result.contains("`core` exists in the index, but not as kind=struct"),
+            "kind mismatch must not claim the name is absent; got: {result}"
+        );
+        assert!(
+            result.contains("found: fn"),
+            "kind mismatch must name the kinds the symbol does have; got: {result}"
+        );
+        assert!(
+            !result.contains("No symbol named"),
+            "kind mismatch must not degrade to a hard not-found; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_all_empty_is_clean_invalid_request() {
+        // Fix 2: neither path nor name (nor targets) must yield a clean
+        // invalid-request naming what is required — never `File not found: .`.
+        let sym = make_symbol("core", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn core() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+
+        let result = server
+            .get_symbol(Parameters(get_symbol_input("", "")))
+            .await;
+
+        assert!(
+            result.contains("Invalid request") && result.contains("name"),
+            "all-empty input must name what is required; got: {result}"
+        );
+        assert!(
+            !result.contains("File not found"),
+            "all-empty input must not degrade to `File not found: .`; got: {result}"
         );
     }
 

--- a/src/stel/planner.rs
+++ b/src/stel/planner.rs
@@ -41,8 +41,11 @@ pub enum ParamDisposition {
     /// The field is consumed downstream of the planner (the handler layer),
     /// not by the plan steps — named by where it lands today.
     Forwarded { into_arg: String },
-    /// The field is loudly refused (the facade returns an error rather than a
-    /// silently-partial answer) — named by why.
+    /// The field is loudly refused — named by why. Surfaced one of two ways:
+    /// as a hard error INSTEAD of a silently-partial answer (project/projects,
+    /// D9), or DISCLOSED alongside a still-served result when the answer is
+    /// useful without the field (impact-route `path`, Wave 1 Fix 5 — see
+    /// `served_param_disclosures`). Either way the drop is loud, never silent.
     Refused { reason: String },
     /// The field carries no actionable caller value on this route today
     /// (absent/blank, or a route the planner does not consume it on yet). An
@@ -123,6 +126,15 @@ pub fn classify_param_dispositions(
 
     let path = if path_set && plan_carries_path(plan, request) {
         ParamDisposition::Routed
+    } else if path_set && plan_targets_git_impact(plan) {
+        // Impact route (`detect_impact`) derives its changed-file set from git and
+        // has no `path` input, so a caller-supplied path IS meaningfully dropped.
+        // Record it as a loud Refusal (disclosed alongside the served impact
+        // result by `served_param_disclosures`, not a hard abort) rather than a
+        // silent NotApplicable — root D-A0 lossless-or-loud. Wave 1 Fix 5.
+        ParamDisposition::Refused {
+            reason: "detect_impact derives its changed-file set from git; the `path` filter is not applied".to_string(),
+        }
     } else {
         // `path` absent, or a route whose tool carries no path scope and no path
         // selector (so neither A1b's forwarding nor a target arg applies — e.g.
@@ -184,6 +196,44 @@ pub fn classify_param_dispositions(
         ("project", project),
         ("projects", projects),
     ]
+}
+
+/// True when the finalized `plan`'s primary step is the git-aware `detect_impact`
+/// tool, which derives its changed-file set from git and consumes no `path`
+/// (Wave 1 Fix 5).
+fn plan_targets_git_impact(plan: &StelPlan) -> bool {
+    plan.steps
+        .first()
+        .is_some_and(|step| step.tool == "detect_impact")
+}
+
+/// Caller-facing disclosure lines for any `Refused` param that is surfaced
+/// ALONGSIDE a served result (not a hard abort). Today this is only the
+/// impact-route `path` drop: `detect_impact` ignores `path`, so a caller-supplied
+/// path is refused-with-reason and DISCLOSED rather than silently dropped (Wave 1
+/// Fix 5). project/projects Refusals never reach here — the handler aborts on them
+/// before the plan is built (D9), so at serve time they are blank/NotApplicable.
+/// Routes through the existing `classify_param_dispositions` accounting; it does
+/// not invent a parallel mechanism.
+pub fn served_param_disclosures(request: &StelRequest, plan: &StelPlan) -> Vec<String> {
+    classify_param_dispositions(request, plan)
+        .into_iter()
+        .filter_map(|(field, disposition)| match disposition {
+            ParamDisposition::Refused { reason } => {
+                let value = match field {
+                    "path" => request.path.as_deref(),
+                    _ => None,
+                }
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+                Some(match value {
+                    Some(value) => format!("note: `{field}` \"{value}\" not consumed — {reason}"),
+                    None => format!("note: `{field}` not consumed — {reason}"),
+                })
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 /// True when the finalized `plan` carries the caller's `symbol` value in any

--- a/tests/detect_impact.rs
+++ b/tests/detect_impact.rs
@@ -142,9 +142,12 @@ async fn detect_impact_fixture_blast_matches_expected() {
     assert_eq!(payload["risk_summary"]["medium"], json!(0));
     assert_eq!(payload["risk_summary"]["low"], json!(0));
 
-    assert_eq!(payload["pagination"]["total"], json!(1));
-    assert_eq!(payload["pagination"]["returned"], json!(1));
-    assert_eq!(payload["pagination"]["has_more"], json!(false));
+    assert_eq!(payload["pagination"]["blast_radius"]["total"], json!(1));
+    assert_eq!(payload["pagination"]["blast_radius"]["returned"], json!(1));
+    assert_eq!(
+        payload["pagination"]["blast_radius"]["truncated"],
+        json!(false)
+    );
 }
 
 /// Contract default (contracts/detect-impact.md § Input): omitting both
@@ -200,6 +203,16 @@ async fn detect_impact_defaults_base_branch_to_main_when_unset() {
         "omitting base_branch/since must diff against the default `main` branch \
          (a real blast radius), not return an empty uncommitted-only result:\n{body}"
     );
+    // Fix 6: with only a local `main` (no origin/main), the default resolves to
+    // local `main` and discloses it; no staleness note is emitted.
+    assert!(
+        body.contains("base: main"),
+        "default resolution must disclose the resolved base ref:\n{body}"
+    );
+    assert!(
+        !body.contains("differs from origin/main"),
+        "no origin/main → no staleness note:\n{body}"
+    );
 }
 
 #[tokio::test]
@@ -215,6 +228,180 @@ async fn detect_impact_non_git_repo_clear_error() {
     assert!(
         body.contains("Git unavailable"),
         "expected a clear git-unavailable error, got:\n{body}"
+    );
+}
+
+/// Fix 6: when local `main` lags `origin/main`, the DEFAULT resolution (no
+/// base_branch/since) must diff against `origin/main` — the true delta — not the
+/// stale local ref, and disclose the resolved ref + staleness.
+#[tokio::test]
+async fn detect_impact_default_prefers_origin_main_over_stale_local() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let fixture_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cbm_impact");
+    for rel in FIXTURE_FILES {
+        let to = root.join(rel);
+        if let Some(parent) = to.parent() {
+            fs::create_dir_all(parent).unwrap_or_else(|e| panic!("mkdir for {rel}: {e}"));
+        }
+        fs::copy(fixture_src.join(rel), &to).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+    }
+
+    git(&["init"], root);
+    git(&["config", "user.email", "test@test.com"], root);
+    git(&["config", "user.name", "Test"], root);
+    git(&["add", "."], root);
+    git(&["commit", "-m", "C0 initial"], root);
+    git(&["branch", "-M", "main"], root);
+
+    // C1 changes src/b.rs — this is the "origin/main" state.
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn call_b() -> u32 {\n    2\n}\n// C1: on origin/main only.\n",
+    )
+    .expect("rewrite src/b.rs");
+    git(&["commit", "-am", "C1 change b"], root);
+    // Record C1 as origin/main, THEN rewind local main to C0 (stale by 1 commit).
+    git(&["update-ref", "refs/remotes/origin/main", "main"], root);
+    git(&["checkout", "-b", "feature"], root);
+    git(&["branch", "-f", "main", "HEAD~1"], root);
+
+    // C2 changes src/a.rs on feature — the true delta vs origin/main (C1).
+    fs::write(
+        root.join("src/a.rs"),
+        "use cbm_impact_fixture::core;\n\n\
+         // C2: on feature only.\n\
+         pub fn call_a() -> u32 {\n    core()\n}\n",
+    )
+    .expect("rewrite src/a.rs");
+    git(&["commit", "-am", "C2 change a on feature"], root);
+
+    let server = server_over(root);
+    let body = server
+        .dispatch_tool_for_tests("detect_impact", json!({}))
+        .await;
+    let payload = impact_payload(&body);
+
+    // origin/main(C1)...HEAD(C2) = src/a.rs only. If it had used the stale local
+    // main(C0) the diff would also include src/b.rs (C1) — the confidently-wrong
+    // result this fix prevents.
+    assert_eq!(
+        payload["changed_files"],
+        json!(["src/a.rs"]),
+        "default must diff against origin/main (true delta), not stale local main:\n{body}"
+    );
+    assert!(
+        body.contains("base: origin/main"),
+        "must disclose the resolved base ref:\n{body}"
+    );
+    assert!(
+        body.contains("local main is behind origin/main"),
+        "must disclose direction-aware staleness (local behind) vs origin/main:\n{body}"
+    );
+}
+
+/// Fix 1: a changed-set exceeding the per-list caps must bound every list at 200,
+/// disclose the full totals + truncation in `pagination`, and keep `risk_summary`
+/// counting the FULL blast set (not the truncated 200).
+#[tokio::test]
+async fn detect_impact_caps_large_changed_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::create_dir_all(root.join("src")).expect("mkdir src");
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"caps_fixture\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+
+    // changed.rs: core() + 210 standalone pads => 211 changed symbols (> cap).
+    let mut changed = String::from("pub fn core() -> u32 {\n    0\n}\n");
+    for i in 0..210 {
+        changed.push_str(&format!("pub fn pad_{i}() -> u32 {{\n    {i}\n}}\n"));
+    }
+    fs::write(root.join("src/changed.rs"), &changed).expect("write changed.rs");
+
+    // callers.rs: 210 functions each calling core() => 210 blast nodes (> cap),
+    // all hop 1 / risk High. Lives in an UNCHANGED file so the callers are not
+    // themselves hop-0 changed symbols (which compute_impact excludes).
+    let mut callers = String::new();
+    for i in 0..210 {
+        callers.push_str(&format!("pub fn caller_{i}() -> u32 {{\n    core()\n}}\n"));
+    }
+    fs::write(root.join("src/callers.rs"), &callers).expect("write callers.rs");
+
+    git(&["init"], root);
+    git(&["config", "user.email", "test@test.com"], root);
+    git(&["config", "user.name", "Test"], root);
+    git(&["add", "."], root);
+    git(&["commit", "-m", "initial"], root);
+
+    // Second commit touches ONLY changed.rs, so the changed-file set is one file
+    // but its 211 symbols all enter changed_symbols.
+    changed.push_str("// widened comment, same symbols.\n");
+    fs::write(root.join("src/changed.rs"), &changed).expect("rewrite changed.rs");
+    git(&["commit", "-am", "touch changed"], root);
+
+    let server = server_over(root);
+    let body = server
+        .dispatch_tool_for_tests("detect_impact", json!({ "since": "HEAD~1" }))
+        .await;
+    let payload = impact_payload(&body);
+
+    // changed_files: exactly one, not truncated.
+    assert_eq!(payload["changed_files"], json!(["src/changed.rs"]));
+    assert_eq!(payload["pagination"]["changed_files"]["total"], json!(1));
+    assert_eq!(
+        payload["pagination"]["changed_files"]["truncated"],
+        json!(false)
+    );
+
+    // changed_symbols: capped at 200, full total disclosed.
+    assert_eq!(
+        payload["changed_symbols"].as_array().expect("array").len(),
+        200,
+        "changed_symbols array must be capped at 200:\n{body}"
+    );
+    assert_eq!(
+        payload["pagination"]["changed_symbols"]["total"],
+        json!(211)
+    );
+    assert_eq!(
+        payload["pagination"]["changed_symbols"]["returned"],
+        json!(200)
+    );
+    assert_eq!(
+        payload["pagination"]["changed_symbols"]["truncated"],
+        json!(true)
+    );
+
+    // blast_radius: capped at 200, full total disclosed.
+    assert_eq!(
+        payload["blast_radius"].as_array().expect("array").len(),
+        200,
+        "blast_radius array must be capped at 200:\n{body}"
+    );
+    assert_eq!(payload["pagination"]["blast_radius"]["total"], json!(210));
+    assert_eq!(
+        payload["pagination"]["blast_radius"]["returned"],
+        json!(200)
+    );
+    assert_eq!(
+        payload["pagination"]["blast_radius"]["truncated"],
+        json!(true)
+    );
+
+    // risk_summary counts the FULL blast set (210 high), NOT the truncated 200.
+    assert_eq!(
+        payload["risk_summary"]["high"],
+        json!(210),
+        "risk_summary must reflect the full blast set, not the capped list:\n{body}"
+    );
+
+    // Human summary discloses truncation with the house marker.
+    assert!(
+        body.contains("[truncated]"),
+        "summary must disclose truncation:\n{body}"
     );
 }
 

--- a/tests/impact_intent.rs
+++ b/tests/impact_intent.rs
@@ -210,6 +210,33 @@ async fn impact_intent_routes_to_detect_impact_blast_radius() {
     );
 }
 
+/// Fix 5 (Wave 1): the impact route drops the caller's `path` (detect_impact
+/// derives its changed-file set from git), but the drop must be LOUD — disclosed
+/// in the response envelope via the ParamDisposition accounting, not silently
+/// discarded as it was before.
+#[tokio::test]
+async fn impact_intent_discloses_unconsumed_path() {
+    let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
+    let _surface = stel_surface_env::set_symforge_surface("compact");
+
+    let (_dir, server) = server_over_repo_with_uncommitted_widget_change(false);
+
+    let body = run_impact_intent(&server, "src/widget.rs").await;
+
+    assert!(
+        body.contains("Chosen tool: detect_impact"),
+        "impact intent (path only) must route to detect_impact:\n{body}"
+    );
+    assert!(
+        body.contains("`path` \"src/widget.rs\" not consumed"),
+        "impact intent must disclose the caller's path was not consumed:\n{body}"
+    );
+    assert!(
+        body.contains("derives its changed-file set from git"),
+        "disclosure must name WHY the path was dropped:\n{body}"
+    );
+}
+
 /// The old `find_dependents` + git co-change chain
 /// (`append_impact_intent_cochanges`) only fires when the executed step's
 /// args carry a `path` key — `detect_impact`'s args never do (scope=files

--- a/tests/stel_status.rs
+++ b/tests/stel_status.rs
@@ -86,15 +86,33 @@ fn row_by_id<'a>(rows: &'a [GoldenRouteRow], id: &str) -> &'a GoldenRouteRow {
 }
 
 #[tokio::test]
-async fn status_rejects_non_compact_surface() {
+async fn status_runs_on_full_surface_and_reports_it() {
+    // Wave 1 Fix 4: `status` is a read-only health/trust readout the docs tell
+    // every client to call at session start, so it must NOT refuse on the full
+    // surface (the pre-fix behavior). It self-describes the ACTIVE surface
+    // instead of erroring or lying about being compact.
+    if !corpora_available() {
+        eprintln!("skip status_runs_on_full_surface_and_reports_it: missing corpora");
+        return;
+    }
+
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("full");
 
-    let server = server_for_corpus(stel::S4_REPLAY_CORPUS, "status-non-compact");
+    let server = server_for_corpus(stel::S4_REPLAY_CORPUS, "status-full-surface");
     let output = dispatch_status(&server, None).await;
+
     assert!(
-        output.contains("requires SYMFORGE_SURFACE=compact"),
-        "unexpected status output:\n{output}"
+        !output.contains("requires SYMFORGE_SURFACE=compact"),
+        "status must not refuse on the full surface:\n{output}"
+    );
+    assert!(
+        output.contains("── stel status ──"),
+        "status must render its report on the full surface:\n{output}"
+    );
+    assert!(
+        output.contains("surface: full"),
+        "status must self-describe the active (full) surface:\n{output}"
     );
 }
 


### PR DESCRIPTION
## What

Wave 1 fixes for the defects found by live MCP stdio dogfood testing on this repo and a 328K-symbol workspace (`E:\project\Agent_Army_Professionals`) — the failures behind the "8.10.0 is unworkable / crashes / LLM can't use the tools" report.

### Defects fixed

| Defect (live evidence) | Fix |
|---|---|
| `detect_impact` returned **54 MB / 291K entries in 89.6s** — reads as a client crash | Cap each list (`changed_files`, `changed_symbols`, `blast_radius`) at 200 entries, severity-first so the cap never drops a higher-risk entry for a lower one; per-list `{total, returned, truncated}` pagination keeps counts truthful (54 MB → 67 KB, 805x, verified live) |
| `detect_impact` silently diffed against a **stale local `main`** | Default base ref prefers `origin/main`; when local and origin differ, a behind/ahead/diverged note is disclosed (git2 `graph_ahead_behind`) |
| `route_impact` **silently dropped** caller `path`/`query` params | Loud `ParamDisposition::Refused` disclosure |
| `get_symbol` with name-only args failed with **"File not found: ."** (schema said `path` optional, handler required it) | Name-only lookup resolves the file; ambiguous names get a bounded disambiguation with truthful ("more than N") totals; kind mismatches report the kinds that DO exist instead of a false not-found |
| `status` **refused to serve** unless the compact surface was configured — advertised-but-refuses | Serves on every surface and reports which surface is active |
| `what_changed` unbounded path listings | Capped at 200 with a truncation marker |

Contract: `contracts/detect-impact.md` amended (per-list pagination shape + default-ref resolution order).

## Process

Implemented → reviewed by **2 independent adversarial reviewers** (contract/regression lens + behavioral lens; both HOLDS_WITH_CAVEATS, zero blocking) → all 6 review findings fixed → verified independently.

## Verification (run independently of the implementing agent)

- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` exit 0
- lib suite **2593/2593** single-threaded; `detect_impact` 6/6, `impact_intent` 3/3, `stel_status` 3/3
- New corpus-free regression test `status_serves_on_full_surface_without_corpus` proven to **execute** (not skip) in a fresh clone
- Live stdio battery rerun on both dogfood repos against the fixed binary: all previously-failing calls now serve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `detect_impact` git comparison and pagination shape (contract-amended), plus core symbol lookup and STEL param disclosure—behavioral shifts callers may rely on, but bounded with tests and loud disclosures rather than silent drift.
> 
> **Overview**
> Wave 1 defect fixes from live MCP dogfood: tools that returned huge payloads, wrong git bases, or misleading errors are tightened and made self-describing.
> 
> **`detect_impact`** caps `changed_files`, `changed_symbols`, and `blast_radius` at 200 entries each (blast sorted by severity then hop); `risk_summary` and pagination totals still reflect the full set. Default base when neither `base_branch` nor `since` is set prefers `origin/main` over local `main`, with `base:` and staleness notes in the text summary. Contract `detect-impact.md` documents per-list pagination and default ref resolution.
> 
> **`get_symbol`** treats optional `path`: name-only exact index lookup with disambiguation, kind-mismatch messaging, and clean invalid input instead of `File not found: .`.
> 
> **STEL / formatting:** impact routes disclose ignored `path` via `served_param_disclosures`; `what_changed` path lists cap at 200. **`status`** runs on all surfaces and reports the active surface (compact gate removed); `symforge` / `symforge_edit` compact gates unchanged.
> 
> **Git helpers:** `resolve_ref_commit` and `ahead_behind` support default-base and staleness disclosure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a1c8c45c86843b4b7de38ad9dabec49df2b43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->