### PR TITLE
fix(init): G-036 init/update coherence — stop wiping user MCP config, write explicit surface

### DIFF
--- a/docs/reviews/2026-07-03-surface-spike-gate.md
+++ b/docs/reviews/2026-07-03-surface-spike-gate.md
@@ -1,0 +1,124 @@
+# Surface spike gate — measurements and verdict (2026-07-03)
+
+Executes phase 2 of the phased decision in
+`docs/superpowers/specs/2026-07-03-staged-surface-design.md` §8a. Three
+measurements were run by independent agents; raw artifacts are referenced at
+the end. This document records the numbers and the gate verdict they force.
+
+## Measurement (a) — full `tools/list` acceptance per harness
+
+Payload, measured over a real MCP stdio handshake against the shipped
+`symforge.exe` 8.10.3 (protocol 2025-06-18), not estimated:
+
+| Surface | Tools | Result bytes | Tokens (o200k_base) |
+|---|---|---|---|
+| `full` | 36 | 71,437 | 16,153 |
+| `compact` | 3 | 4,603 | 1,135 |
+| names-only (what a deferred harness pays) | 36 | — | 119 |
+
+The spec's "~62 KB" estimate was 15% low; actual is 71.4 KB. Heaviest schema:
+`search_text` (5,362 B); per-tool median 1,846 B.
+
+Per-harness acceptance (live-tested without touching any persistent config):
+
+| Harness | Schema handling | Full-surface cost | Accepts full 36? |
+|---|---|---|---|
+| Claude Code 2.1.199 | deferred (native) — observed | ~119 tokens names-only | **MEASURED: YES** |
+| Codex CLI 0.142.2 | deferred via undocumented `tool_search` — observed (docs still claim full-injection) | names/deferred until searched | **MEASURED: YES** (live `status` call succeeded) |
+| Gemini CLI 0.37.1 | full-injection — official docs, no cap/deferral | ~16k tokens per request | **MEASURED: YES** (all 36 enumerated, exit 0) |
+| Kilo CLI 7.1.19 | full-injection — observed | ~16k tokens per request | **MEASURED: YES** (all 36 enumerated) |
+| Kilo VS Code ext 7.2.52 | full-injection into system prompt — official docs | ≥16k tokens per request | INFERRED: YES (no documented cap; not live-tested, GUI-only) |
+| Claude Desktop 1.18286 | hybrid — default loads all, official opt-in "On demand" mode | ~16k default / ~0 on-demand | INFERRED: YES (community ~100/server cap ≫ 36; live test forbidden: persistent config + running app) |
+| Cursor 3.10.2 | in transition — historical hard 40-tool cap removed from docs; community reports cap lifted | UNKNOWN | UNKNOWN (36 fits even the old cap alone; cumulative cap with other servers unknown) |
+
+**No harness rejected or errored on the full 36-tool list.** Degradation is a
+per-turn token cost (~16k) on full-injection harnesses, not a refusal.
+
+## Measurement (b) — tips-follow-rate (behavior-model claim B5)
+
+Mined from 4,154 real symforge MCP calls across 138 sessions
+(2026-03-23 → 2026-07-03):
+
+- 63% of all full-surface results carry a `Tip:` line — tips are boilerplate,
+  not signal.
+- Raw loose follow rate 39.1%, strict 27.7% — but with a base-rate (lift)
+  control the effect disappears: for most tipped tools, agents were equally or
+  MORE likely to call the tool when it was **not** tipped (lift ≤ 1 for
+  `edit_within_symbol` 0.46, `get_file_content` 0.57, `search_symbols` 0.83,
+  `search_text` 0.84, `replace_symbol_body` 0.73; `diff_symbols` 0/11).
+- The only positive steering came from rare, contextual tips
+  (`what_changed`: ~21× lift, n=3).
+
+**Verdict on B5: killed in its strong form.** Always-on tips do not measurably
+steer tool choice; saturation destroyed the channel. This independently
+undermines the staged design's reveal-discovery mechanism (B9 leaned on tips)
+and flags the existing always-on tip machinery as unpaid context spend
+(follow-up: make tips rare and contextual).
+
+## Measurement (c) — misroute / turns-to-first-evidence, full vs compact
+
+**Unanswerable from this corpus**: compact-facade routing is 0.3% of calls
+(~5 organic data points; the production compact failures happened in project
+directories outside the mined corpus). Reported for the record: full-surface
+misroute ≤ 6.7% (upper bound; dominated by honest zero-match answers to
+speculative searches), median 1 symforge call to first substantive evidence
+(2 when diagnostics readouts are excluded), 59% of failures self-recover on
+the immediate retry. The full surface's own record is strong; no causal
+full-vs-compact claim is made.
+
+## Gate verdict (per §8a phase 3 rule)
+
+The §8a rule: *"if no harness rejects `full` and selection quality holds →
+`full` becomes the default, `compact` stays as the escape hatch, and §3 is
+SHELVED as design-on-file. Staged is built only if the spike finds a genuinely
+constrained consumer."*
+
+- No harness rejects full — condition met (measured on 4 harnesses, inferred
+  on 2, unknown only for Cursor's undocumented cumulative cap).
+- Selection quality holds — condition met (≤6.7% misroute, first evidence at
+  call 1–2).
+- Genuinely constrained consumer — **not found**. Gemini CLI, Kilo, and
+  default-mode Claude Desktop PAY (~16k tokens/turn) but none REFUSE, and the
+  proven-unusable alternative was compact-3 (the 8.10.0 field failure).
+  `compact` remains the documented escape hatch for token-sensitive setups.
+- Additional strike against staged: its discovery mechanism (tips, B5) is
+  now evidenced not to steer.
+
+**VERDICT: `full` becomes the default surface; `compact` stays as the escape
+hatch; the staged 7-verb surface stays SHELVED as design-on-file** (§3 of the
+design spec), to be revisited only if a harness with a hard cap or genuine
+refusal shows up.
+
+Implementation consequences (follow-up wave, separate from the G-036 fix):
+
+1. Flip the env-absent server default from `Compact` to `Full`
+   (`surface_profile_from_env` default arm in `src/protocol/surface_probe.rs`)
+   plus the test suite that pins the compact default
+   (`tests/surface_default_compact.rs`), prompts/docs that state the default,
+   and the D22/D23 surface-honesty strings. Note: this retroactively makes the
+   G-036-era field configs (37-name allowlist, no env) coherent.
+2. Decide per-harness init values for full-injection harnesses
+   (Gemini/Kilo/Desktop/Cursor currently written as explicit `compact` by the
+   G-036 fix): keep compact-by-init for the ~16k/turn harnesses, or flip to
+   full. Operator decision; the G-036 preserve semantics make either safe to
+   change later.
+3. Tips overhaul (rare + contextual) tracked as a separate backlog item.
+
+## Incidental findings worth tracking
+
+- Codex CLI 0.142.2 has an undocumented `tool_search` deferred layer — docs
+  lag the binary; both Anthropic and OpenAI CLIs now defer schema loading.
+- Gemini CLI 0.37.1 oauth-personal auth is dead (`IneligibleTierError`,
+  "migrate to Antigravity") — `symforge init` guidance for Gemini should
+  assume API-key auth.
+- The `status` tool's readout opens with the internal codename banner
+  (`── stel status ──`) — visible verbatim in third-party harnesses; consider
+  a product-name banner.
+
+## Raw artifacts
+
+Session scratchpad (`C:\Users\rakovnik\AppData\Local\Temp\claude\E--project-symforge\6a067a28-d117-45c5-a205-9bf6ac08eb7d\scratchpad\`):
+`tools_list_full.json`, `tools_list_compact.json`, `measure_tools_list.py`
+(payload measurement); `mine_surface.py`, `mine_pass2.py`, `results.json`,
+`results2.json` (transcript mining). Harness live-test configs were scratch-dir
+only; no persistent config was modified during measurement.

--- a/docs/superpowers/specs/2026-07-03-staged-surface-design.md
+++ b/docs/superpowers/specs/2026-07-03-staged-surface-design.md
@@ -116,6 +116,14 @@ Both reviews returned **SOUND_WITH_REVISIONS**. The architecture survives; the p
 2. **Spike gate (§9):** (a) full `tools/list` acceptance test at each real target harness; (b) tips-follow-rate mined from the waves-1–3 dogfood transcripts (evidences or kills B5); (c) misroute / turns-to-first-evidence, full vs compact, on the existing corpus.
 3. **Gate verdict:** if no harness rejects `full` and selection quality holds → **`full` becomes the default**, `compact` stays as the escape hatch, and §3 is SHELVED as design-on-file. Staged is built only if the spike finds a genuinely constrained consumer — and then with every §8a reconciliation applied.
 
+**Gate RUN 2026-07-03** (`docs/reviews/2026-07-03-surface-spike-gate.md`): no
+harness rejected the full 36-tool list (measured: Claude Code, Codex CLI,
+Gemini CLI, Kilo CLI; inferred: Kilo ext, Claude Desktop; unknown: Cursor);
+full payload measured at 71.4 KB / ~16.1k tokens (~119 tokens on deferred
+harnesses); B5 (tips steer discovery) KILLED by base-rate-controlled mining of
+4,154 real calls. **Verdict: `full` default, `compact` escape hatch, staged
+stays shelved.**
+
 ## 8. Open questions (to resolve in planning)
 
 1. Does Claude Code re-read `tools/list` promptly on `listChanged` in current builds? (Determines whether `staged` is also viable there, or `full` remains its init default. Verify empirically.)

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -476,46 +476,6 @@ const SYMFORGE_TOOL_NAMES: &[&str] = &[
     "mcp__symforge__symforge_edit",
 ];
 
-const KILO_ALWAYS_ALLOW: &[&str] = &[
-    "health",
-    "health_compact",
-    "checkpoint_now",
-    "index_folder",
-    "validate_file_syntax",
-    "get_repo_map",
-    "get_file_content",
-    "search_symbols",
-    "search_text",
-    "search_files",
-    "get_file_context",
-    "get_symbol",
-    "get_symbol_context",
-    "find_references",
-    "find_dependents",
-    "inspect_match",
-    "what_changed",
-    "analyze_file_impact",
-    "diff_symbols",
-    "detect_impact",
-    "explore",
-    "replace_symbol_body",
-    "edit_within_symbol",
-    "insert_symbol",
-    "delete_symbol",
-    "batch_edit",
-    "batch_insert",
-    "batch_rename",
-    "ask",
-    "conventions",
-    "edit_plan",
-    "context_inventory",
-    "investigation_suggest",
-    "symforge_retrieve",
-    "status",
-    "symforge",
-    "symforge_edit",
-];
-
 const CLAUDE_ALWAYS_ALLOW: &[&str] = &[
     "health",
     "health_compact",
@@ -682,6 +642,70 @@ fn merge_event_entries(
     hooks.insert(event_key.to_string(), Value::Array(retained));
 }
 
+// ---------------------------------------------------------------------------
+// Shared JSON MCP-entry merge helpers (G-036 init/update coherence)
+// ---------------------------------------------------------------------------
+//
+// Every JSON harness (Claude Code, Claude Desktop, Cursor, Gemini, Kilo) writes
+// its `mcpServers.symforge` entry through these. Invariant: re-registration
+// (e.g. `symforge update` -> `symforge init --client all`) REFRESHES the managed
+// launcher path but never clobbers a user-set env value, allowlist entry, or
+// unknown field. The 8.10.1 update wiped `SYMFORGE_SURFACE=full`; merging into
+// the existing object in place instead of replacing it kills that defect class.
+
+/// Get (or create) the `mcpServers.symforge` entry as a mutable object so
+/// callers merge INTO the existing entry rather than replacing it wholesale.
+fn symforge_json_entry_mut(config: &mut Value) -> &mut serde_json::Map<String, Value> {
+    if !config["mcpServers"].is_object() {
+        config["mcpServers"] = json!({});
+    }
+    let servers = config["mcpServers"]
+        .as_object_mut()
+        .expect("mcpServers is an object");
+    let slot = servers.entry("symforge").or_insert_with(|| json!({}));
+    if !slot.is_object() {
+        *slot = json!({});
+    }
+    slot.as_object_mut().expect("symforge entry is an object")
+}
+
+/// Insert each `(key, value)` env default into the entry's `env` object ONLY
+/// when the key is absent — a present env key's value is preserved verbatim.
+fn insert_env_defaults(entry: &mut serde_json::Map<String, Value>, defaults: &[(&str, &str)]) {
+    if defaults.is_empty() {
+        return;
+    }
+    if !entry.get("env").map(Value::is_object).unwrap_or(false) {
+        entry.insert("env".to_string(), json!({}));
+    }
+    let env = entry
+        .get_mut("env")
+        .and_then(Value::as_object_mut)
+        .expect("env is an object");
+    for (key, val) in defaults {
+        env.entry((*key).to_string())
+            .or_insert_with(|| Value::String((*val).to_string()));
+    }
+}
+
+/// Union `names` into the entry's `key` array (e.g. `alwaysAllow`), preserving
+/// order and every user-added entry — names already present are not duplicated.
+fn union_allow_names(entry: &mut serde_json::Map<String, Value>, key: &str, names: &[&str]) {
+    if !entry.get(key).map(Value::is_array).unwrap_or(false) {
+        entry.insert(key.to_string(), json!([]));
+    }
+    let arr = entry
+        .get_mut(key)
+        .and_then(Value::as_array_mut)
+        .expect("allow list is an array");
+    for name in names {
+        let val = Value::String((*name).to_string());
+        if !arr.contains(&val) {
+            arr.push(val);
+        }
+    }
+}
+
 /// Register symforge as an MCP server in `~/.claude.json` using the absolute binary path.
 ///
 /// This ensures Claude Code launches the native binary directly — no shell, no .cmd wrapper,
@@ -701,21 +725,18 @@ pub fn register_mcp_server(
     // Use backslashes on Windows for the command path (Claude Code spawns natively, not via shell).
     let command_path = native_command_path(binary_path);
 
-    if !config["mcpServers"].is_object() {
-        config["mcpServers"] = json!({});
-    }
-
-    let always_allow: Vec<Value> = CLAUDE_ALWAYS_ALLOW
-        .iter()
-        .map(|s| Value::String(s.to_string()))
-        .collect();
-
-    config["mcpServers"]["symforge"] = json!({
-        "command": command_path,
-        "args": [],
-        "disabled": false,
-        "alwaysAllow": always_allow
-    });
+    let entry = symforge_json_entry_mut(&mut config);
+    // Refresh the managed launcher path; preserve every other user-set field.
+    entry.insert("command".to_string(), Value::String(command_path));
+    entry.entry("args".to_string()).or_insert_with(|| json!([]));
+    entry
+        .entry("disabled".to_string())
+        .or_insert_with(|| Value::Bool(false));
+    // Claude Code has native deferred tool loading, so pin the full surface —
+    // this makes the 37-name allowlist coherent (spec §4). Never clobber a
+    // user-set value (the 8.10.1 SYMFORGE_SURFACE=full wipe).
+    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "full")]);
+    union_allow_names(entry, "alwaysAllow", CLAUDE_ALWAYS_ALLOW);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(claude_json_path, pretty)
@@ -758,10 +779,6 @@ fn register_claude_desktop_mcp_server_with_home(
         json!({})
     };
 
-    if !config["mcpServers"].is_object() {
-        config["mcpServers"] = json!({});
-    }
-
     let desktop_binary_path =
         desktop_binary_for_registration(std::path::Path::new(binary_path), home_dir)?;
     let desktop_binary_path_str = desktop_binary_path.display().to_string();
@@ -794,23 +811,17 @@ fn register_claude_desktop_mcp_server_with_home(
     //    populates the index even when the launcher CWD is unusable. Only set
     //    when a real root was discovered (the server validates it again at
     //    startup via the same trust-boundary guard).
-    let mut env = serde_json::Map::new();
-    env.insert(
-        "SYMFORGE_SURFACE".to_string(),
-        Value::String("compact".to_string()),
-    );
+    let mut env_defaults: Vec<(&str, &str)> = vec![("SYMFORGE_SURFACE", "compact")];
     if let Some(root) = workspace_root_str.as_deref() {
-        env.insert(
-            crate::discovery::WORKSPACE_ROOT_ENV.to_string(),
-            Value::String(root.to_string()),
-        );
+        env_defaults.push((crate::discovery::WORKSPACE_ROOT_ENV, root));
     }
 
-    config["mcpServers"]["symforge"] = json!({
-        "command": command_path,
-        "args": [],
-        "env": Value::Object(env)
-    });
+    let entry = symforge_json_entry_mut(&mut config);
+    // Refresh the managed launcher path; preserve every other user-set field,
+    // including a user-set env value or an existing SYMFORGE_WORKSPACE_ROOT.
+    entry.insert("command".to_string(), Value::String(command_path));
+    entry.entry("args".to_string()).or_insert_with(|| json!([]));
+    insert_env_defaults(entry, &env_defaults);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(desktop_config_path, pretty)
@@ -981,29 +992,52 @@ fn merge_symforge_codex_server_for_target_os(
         .expect("symforge server entry must be a table");
 
     symforge["command"] = value(native_command_path(binary_path));
-    symforge["startup_timeout_sec"] = value(CODEX_STARTUP_TIMEOUT_SEC);
-    symforge["tool_timeout_sec"] = value(CODEX_TOOL_TIMEOUT_SEC);
+    // Preserve user-tuned timeouts on re-registration (same wipe class as the
+    // G-036 env wipe); only seed defaults when absent.
+    symforge
+        .entry("startup_timeout_sec")
+        .or_insert(value(CODEX_STARTUP_TIMEOUT_SEC));
+    symforge
+        .entry("tool_timeout_sec")
+        .or_insert(value(CODEX_TOOL_TIMEOUT_SEC));
     merge_codex_mcp_env_overrides(symforge, target_os);
 
-    let mut allow_array = Array::new();
-    for tool_name in SYMFORGE_TOOL_NAMES {
-        // Codex uses plain tool names without mcp__ prefix
-        let short_name = tool_name
-            .strip_prefix("mcp__symforge__")
-            .unwrap_or(tool_name);
-        allow_array.push(short_name);
-    }
-    symforge["allowed_tools"] = value(allow_array);
+    merge_codex_allowed_tools(symforge);
 
     merge_codex_project_doc_fallbacks(config);
 }
 
-fn merge_codex_mcp_env_overrides(symforge: &mut Table, target_os: &str) {
-    let overrides = codex_mcp_env_overrides_for_target_os(target_os);
-    if overrides.is_empty() {
-        return;
+/// Union the compact-surface tool names into Codex's `allowed_tools`,
+/// preserving any user-added entries. Codex strips the `mcp__symforge__` prefix,
+/// so the compact short names (`symforge`, `symforge_edit`, `status`) are what
+/// the served surface actually exposes — the allowlist matches the surface.
+fn merge_codex_allowed_tools(symforge: &mut Table) {
+    let mut names: Vec<String> = symforge
+        .get("allowed_tools")
+        .and_then(|item| item.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for name in crate::stel::COMPACT_TOOL_NAMES {
+        if !names.iter().any(|existing| existing == name) {
+            names.push(name.to_string());
+        }
     }
 
+    let mut allow_array = Array::new();
+    for name in &names {
+        allow_array.push(name.as_str());
+    }
+    symforge["allowed_tools"] = value(allow_array);
+}
+
+fn merge_codex_mcp_env_overrides(symforge: &mut Table, target_os: &str) {
+    // Ensure an env table exists — SYMFORGE_SURFACE is written on every OS, not
+    // only where an OS override applies.
     if !symforge.contains_key("env") || !symforge["env"].is_table_like() {
         symforge["env"] = Item::Table(Table::new());
     }
@@ -1012,7 +1046,13 @@ fn merge_codex_mcp_env_overrides(symforge: &mut Table, target_os: &str) {
         .as_table_like_mut()
         .expect("symforge env must be a table or inline table");
 
-    for (name, env_value) in overrides {
+    // Make the served compact surface explicit, but never clobber a user-set
+    // value (G-036: the 8.10.1 update wiped SYMFORGE_SURFACE=full).
+    if env.get("SYMFORGE_SURFACE").is_none() {
+        env.insert("SYMFORGE_SURFACE", value("compact"));
+    }
+
+    for (name, env_value) in codex_mcp_env_overrides_for_target_os(target_os) {
         env.insert(name, value(*env_value));
     }
 }
@@ -1072,15 +1112,18 @@ pub fn register_gemini_mcp_server(
 
     let command_path = native_command_path(binary_path);
 
-    if !config["mcpServers"].is_object() {
-        config["mcpServers"] = json!({});
-    }
-    config["mcpServers"]["symforge"] = json!({
-        "command": command_path,
-        "args": [],
-        "timeout": 120000,
-        "trust": true
-    });
+    let entry = symforge_json_entry_mut(&mut config);
+    // Refresh the managed launcher path; preserve every other user-set field.
+    entry.insert("command".to_string(), Value::String(command_path));
+    entry.entry("args".to_string()).or_insert_with(|| json!([]));
+    entry
+        .entry("timeout".to_string())
+        .or_insert_with(|| json!(120000));
+    entry
+        .entry("trust".to_string())
+        .or_insert_with(|| Value::Bool(true));
+    // Gemini CLI has no deferred loading — make the compact surface explicit.
+    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "compact")]);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(gemini_settings_path, pretty)
@@ -1112,21 +1155,17 @@ pub fn register_kilo_mcp_server(
 
     let command_path = native_command_path(binary_path);
 
-    if !config["mcpServers"].is_object() {
-        config["mcpServers"] = json!({});
-    }
-
-    let always_allow: Vec<Value> = KILO_ALWAYS_ALLOW
-        .iter()
-        .map(|s| Value::String(s.to_string()))
-        .collect();
-
-    config["mcpServers"]["symforge"] = json!({
-        "command": command_path,
-        "args": [],
-        "disabled": false,
-        "alwaysAllow": always_allow
-    });
+    let entry = symforge_json_entry_mut(&mut config);
+    // Refresh the managed launcher path; preserve every other user-set field.
+    entry.insert("command".to_string(), Value::String(command_path));
+    entry.entry("args".to_string()).or_insert_with(|| json!([]));
+    entry
+        .entry("disabled".to_string())
+        .or_insert_with(|| Value::Bool(false));
+    // Kilo has no deferred loading — serve the compact 3-tool facade and grant
+    // exactly those names so the allowlist matches the served surface (spec §4).
+    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "compact")]);
+    union_allow_names(entry, "alwaysAllow", &crate::stel::COMPACT_TOOL_NAMES);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(kilo_config_path, pretty)
@@ -1161,10 +1200,6 @@ pub fn register_cursor_mcp_server(
         json!({})
     };
 
-    if !config["mcpServers"].is_object() {
-        config["mcpServers"] = json!({});
-    }
-
     let command_path = native_command_path(binary_path);
 
     // Discover the operator's workspace at install time (same rationale as
@@ -1172,29 +1207,25 @@ pub fn register_cursor_mcp_server(
     let workspace_root = crate::discovery::find_project_root();
     let workspace_root_str = workspace_root.as_ref().map(|r| r.display().to_string());
 
-    let mut env = serde_json::Map::new();
-    env.insert(
-        "SYMFORGE_SURFACE".to_string(),
-        Value::String("compact".to_string()),
-    );
+    let mut env_defaults: Vec<(&str, &str)> = vec![("SYMFORGE_SURFACE", "compact")];
     if let Some(root) = workspace_root_str.as_deref() {
-        env.insert(
-            crate::discovery::WORKSPACE_ROOT_ENV.to_string(),
-            Value::String(root.to_string()),
-        );
+        env_defaults.push((crate::discovery::WORKSPACE_ROOT_ENV, root));
     }
 
-    let mut server = json!({
-        "command": command_path,
-        "args": [],
-        "env": Value::Object(env),
-    });
+    let entry = symforge_json_entry_mut(&mut config);
+    // Refresh the managed launcher path; preserve every other user-set field,
+    // including a user-set env value, workspace root, or `cwd`.
+    entry.insert("command".to_string(), Value::String(command_path));
+    entry.entry("args".to_string()).or_insert_with(|| json!([]));
+    insert_env_defaults(entry, &env_defaults);
     // Cursor honors a per-server `cwd`; point it at the discovered workspace so
-    // the launch CWD is the project, not the home directory.
+    // the launch CWD is the project, not the home directory. Preserve an
+    // existing user-set `cwd`.
     if let Some(root) = workspace_root_str.as_deref() {
-        server["cwd"] = Value::String(root.to_string());
+        entry
+            .entry("cwd".to_string())
+            .or_insert_with(|| Value::String(root.to_string()));
     }
-    config["mcpServers"]["symforge"] = server;
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(cursor_config_path, pretty)
@@ -1975,10 +2006,6 @@ mod tests {
             "Codex/client allow list should not grant retired trace_symbol alias"
         );
         assert!(
-            !KILO_ALWAYS_ALLOW.contains(&"trace_symbol"),
-            "Kilo allow list should not grant retired trace_symbol alias"
-        );
-        assert!(
             !CLAUDE_ALWAYS_ALLOW.contains(&"trace_symbol"),
             "Claude allow list should not grant retired trace_symbol alias"
         );
@@ -1989,10 +2016,6 @@ mod tests {
         assert!(
             SYMFORGE_TOOL_NAMES.contains(&"mcp__symforge__health_compact"),
             "Codex/client allow list should grant health_compact when conformance exposes it"
-        );
-        assert!(
-            KILO_ALWAYS_ALLOW.contains(&"health_compact"),
-            "Kilo allow list should grant health_compact when conformance exposes it"
         );
         assert!(
             CLAUDE_ALWAYS_ALLOW.contains(&"health_compact"),
@@ -2011,22 +2034,20 @@ mod tests {
             .collect();
 
         // SYMFORGE_TOOL_NAMES carries the `mcp__symforge__` prefix; strip it to compare.
-        let codex: BTreeSet<String> = SYMFORGE_TOOL_NAMES
+        // It backs the Claude Code settings.json `allowedTools` union (the full
+        // surface). Kilo/Codex intentionally grant only the compact names now
+        // (see the coherence tests), so they are not compared against the full
+        // surface here.
+        let full: BTreeSet<String> = SYMFORGE_TOOL_NAMES
             .iter()
             .map(|n| n.trim_start_matches("mcp__symforge__").to_string())
             .collect();
         assert_eq!(
-            codex, registered,
-            "SYMFORGE_TOOL_NAMES (Codex/Claude client allow list) must match the registered MCP tool \
-             surface exactly — a registered tool missing here means clients prompt for permission on \
-             every call; a stale entry grants a retired tool. Update the allow list when the tool \
-             surface changes."
-        );
-
-        let kilo: BTreeSet<String> = KILO_ALWAYS_ALLOW.iter().map(|n| n.to_string()).collect();
-        assert_eq!(
-            kilo, registered,
-            "KILO_ALWAYS_ALLOW must match the registered MCP tool surface exactly"
+            full, registered,
+            "SYMFORGE_TOOL_NAMES (Claude settings.json allowedTools union) must match the registered \
+             MCP tool surface exactly — a registered tool missing here means clients prompt for \
+             permission on every call; a stale entry grants a retired tool. Update the allow list \
+             when the tool surface changes."
         );
 
         let claude: BTreeSet<String> = CLAUDE_ALWAYS_ALLOW.iter().map(|n| n.to_string()).collect();
@@ -2068,25 +2089,312 @@ mod tests {
         let config_path = dir.path().join("config.toml");
         register_codex_mcp_server(&config_path, "/usr/bin/symforge").unwrap();
         let content = std::fs::read_to_string(&config_path).unwrap();
+        // G-036 coherence: Codex serves the compact surface, so its allowlist
+        // grants exactly the compact facade names — nothing more.
         assert!(
-            content.contains("search_symbols"),
-            "should contain tool names: {content}"
+            content.contains("allowed_tools = [\"symforge\", \"symforge_edit\", \"status\"]"),
+            "Codex allow list must be exactly the compact facade names: {content}"
         );
         assert!(
-            content.contains("get_file_content"),
-            "should contain canonical raw-read tool: {content}"
-        );
-        assert!(
-            content.contains("get_file_context"),
-            "should contain canonical context tool: {content}"
+            !content.contains("\"search_symbols\""),
+            "Codex allow list must not grant full-surface tools when serving compact: {content}"
         );
         assert!(
             !content.contains("trace_symbol"),
             "Codex allow list must not include retired trace_symbol alias: {content}"
         );
         assert!(
+            content.contains("SYMFORGE_SURFACE = \"compact\""),
+            "Codex env must make the compact surface explicit: {content}"
+        );
+        assert!(
             content.contains("project_doc_fallback_filenames = [\"AGENTS.md\", \"CLAUDE.md\"]"),
             "should register both AGENTS.md and CLAUDE.md as project doc fallbacks: {content}"
+        );
+    }
+
+    // -- G-036 init/update coherence regression tests -----------------------
+
+    #[test]
+    fn test_claude_code_fresh_registration_is_coherent_full_surface() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+        register_mcp_server(&path, "/usr/bin/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entry = &config["mcpServers"]["symforge"];
+        assert_eq!(
+            entry["env"]["SYMFORGE_SURFACE"].as_str(),
+            Some("full"),
+            "fresh Claude Code registration must pin the full surface: {entry}"
+        );
+        let allow = entry["alwaysAllow"].as_array().unwrap();
+        assert_eq!(
+            allow.len(),
+            CLAUDE_ALWAYS_ALLOW.len(),
+            "the allowlist must match the full surface it serves: {entry}"
+        );
+    }
+
+    #[test]
+    fn test_reregistration_preserves_user_set_surface_both_directions() {
+        // Direction 1: user pinned compact on Claude Code (fresh default full).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": {
+                    "symforge": {
+                        "command": "/old/symforge",
+                        "env": {"SYMFORGE_SURFACE": "compact"}
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        register_mcp_server(&path, "/new/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            config["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
+            Some("compact"),
+            "re-registration must NOT downgrade a user-set surface (the 8.10.1 wipe)"
+        );
+
+        // Direction 2: user pinned full on a compact-default harness (Kilo).
+        let dir2 = tempfile::tempdir().unwrap();
+        let path2 = dir2.path().join("mcp.json");
+        std::fs::write(
+            &path2,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": {
+                    "symforge": {
+                        "command": "/old/symforge",
+                        "env": {"SYMFORGE_SURFACE": "full"}
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        register_kilo_mcp_server(&path2, "/new/symforge").unwrap();
+        let config2: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path2).unwrap()).unwrap();
+        assert_eq!(
+            config2["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
+            Some("full"),
+            "re-registration must preserve a user-set full surface on a compact harness"
+        );
+    }
+
+    #[test]
+    fn test_reregistration_preserves_unknown_fields_and_updates_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": {
+                    "symforge": {
+                        "command": "/old/symforge",
+                        "userField": "keep-me",
+                        "env": {"MY_CUSTOM_ENV": "keep-me-too"},
+                        "alwaysAllow": ["my_custom_tool"]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        register_mcp_server(&path, "/new/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entry = &config["mcpServers"]["symforge"];
+        assert_eq!(
+            entry["userField"].as_str(),
+            Some("keep-me"),
+            "unknown user field must survive re-registration: {entry}"
+        );
+        assert_eq!(
+            entry["env"]["MY_CUSTOM_ENV"].as_str(),
+            Some("keep-me-too"),
+            "unknown user env key must survive re-registration: {entry}"
+        );
+        let allow: Vec<&str> = entry["alwaysAllow"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(
+            allow.contains(&"my_custom_tool"),
+            "user-added allowlist entries must never be dropped (union): {entry}"
+        );
+        let expected_command = if cfg!(windows) {
+            "\\new\\symforge"
+        } else {
+            "/new/symforge"
+        };
+        assert_eq!(
+            entry["command"].as_str(),
+            Some(expected_command),
+            "re-registration must refresh the launcher command path: {entry}"
+        );
+    }
+
+    #[test]
+    fn test_cursor_reregistration_preserves_existing_workspace_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": {
+                    "symforge": {
+                        "command": "/old/symforge",
+                        "env": {
+                            "SYMFORGE_SURFACE": "compact",
+                            "SYMFORGE_WORKSPACE_ROOT": "/user/pinned/workspace"
+                        },
+                        "cwd": "/user/pinned/workspace"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        register_cursor_mcp_server(&path, "/new/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entry = &config["mcpServers"]["symforge"];
+        assert_eq!(
+            entry["env"][crate::discovery::WORKSPACE_ROOT_ENV].as_str(),
+            Some("/user/pinned/workspace"),
+            "existing workspace root must NOT be overwritten by rediscovery: {entry}"
+        );
+        assert_eq!(
+            entry["cwd"].as_str(),
+            Some("/user/pinned/workspace"),
+            "existing cwd must be preserved: {entry}"
+        );
+    }
+
+    #[test]
+    fn test_gemini_fresh_registration_pins_compact_surface() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        register_gemini_mcp_server(&path, "/usr/bin/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            config["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
+            Some("compact"),
+            "fresh Gemini registration must make the compact surface explicit"
+        );
+    }
+
+    #[test]
+    fn test_kilo_fresh_registration_allowlist_is_exactly_compact() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        register_kilo_mcp_server(&path, "/usr/bin/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let allow: Vec<&str> = config["mcpServers"]["symforge"]["alwaysAllow"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(allow, vec!["symforge", "symforge_edit", "status"]);
+    }
+
+    #[test]
+    fn test_kilo_reregistration_unions_existing_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": {
+                    "symforge": {
+                        "command": "/old/symforge",
+                        "alwaysAllow": ["my_custom_tool"]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        register_kilo_mcp_server(&path, "/new/symforge").unwrap();
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let allow: Vec<&str> = config["mcpServers"]["symforge"]["alwaysAllow"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(
+            allow.contains(&"my_custom_tool"),
+            "user entry dropped: {allow:?}"
+        );
+        for name in ["symforge", "symforge_edit", "status"] {
+            assert!(
+                allow.contains(&name),
+                "missing compact name {name}: {allow:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codex_fresh_registration_allowlist_is_exactly_compact() {
+        let mut config = DocumentMut::new();
+        merge_symforge_codex_server_for_target_os(&mut config, "/usr/bin/symforge", "macos");
+        let content = config.to_string();
+        assert!(
+            content.contains("allowed_tools = [\"symforge\", \"symforge_edit\", \"status\"]"),
+            "fresh Codex allowlist must be exactly the compact names: {content}"
+        );
+        assert!(
+            content.contains("SYMFORGE_SURFACE = \"compact\""),
+            "fresh Codex env must pin the compact surface on every OS: {content}"
+        );
+    }
+
+    #[test]
+    fn test_codex_reregistration_unions_allowlist_and_preserves_surface() {
+        let mut config = r#"
+    [mcp_servers.symforge]
+    command = "/old/symforge"
+    startup_timeout_sec = 90
+    tool_timeout_sec = 900
+    allowed_tools = ["my_custom_tool"]
+
+    [mcp_servers.symforge.env]
+    SYMFORGE_SURFACE = "full"
+    "#
+        .parse::<DocumentMut>()
+        .unwrap();
+        merge_symforge_codex_server_for_target_os(&mut config, "/new/symforge", "macos");
+        let content = config.to_string();
+        assert!(
+            content.contains("my_custom_tool"),
+            "user-added Codex allow entry must never be dropped: {content}"
+        );
+        for name in ["\"symforge\"", "\"symforge_edit\"", "\"status\""] {
+            assert!(
+                content.contains(name),
+                "compact name {name} must be unioned in: {content}"
+            );
+        }
+        assert!(
+            content.contains("SYMFORGE_SURFACE = \"full\""),
+            "re-registration must preserve a user-set Codex surface: {content}"
+        );
+        assert!(
+            content.contains("startup_timeout_sec = 90")
+                && content.contains("tool_timeout_sec = 900"),
+            "re-registration must preserve user-tuned Codex timeouts: {content}"
+        );
+        assert!(
+            !content.contains("/old/symforge") && content.contains("symforge"),
+            "re-registration must still refresh the binary path: {content}"
         );
     }
 

--- a/tests/init_integration.rs
+++ b/tests/init_integration.rs
@@ -397,18 +397,21 @@ fn test_init_registers_kilo_mcp_server() {
         "args must be empty"
     );
 
+    // G-036 coherence: Kilo serves the compact surface, so its allowlist grants
+    // exactly the compact facade names and the env pins that surface.
+    assert_eq!(
+        symforge["env"]["SYMFORGE_SURFACE"].as_str(),
+        Some("compact"),
+        "Kilo env must make the compact surface explicit"
+    );
     let always_allow = symforge["alwaysAllow"]
         .as_array()
         .expect("alwaysAllow must be an array");
-    assert!(
-        always_allow.iter().any(|v| v.as_str() == Some("health")),
-        "alwaysAllow must include health"
-    );
-    assert!(
-        always_allow
-            .iter()
-            .any(|v| v.as_str() == Some("batch_rename")),
-        "alwaysAllow must include batch_rename"
+    let names: Vec<&str> = always_allow.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["symforge", "symforge_edit", "status"],
+        "alwaysAllow must be exactly the compact facade names"
     );
 }
 


### PR DESCRIPTION
## What

Closes the G-036 class at its root. `symforge update` spawns `init --client all`, and all six client registration paths replaced the `mcpServers.symforge` entry wholesale — the 8.10.1 update wiped a user's `SYMFORGE_SURFACE=full` from `~/.claude.json` in production (2026-07-02).

**Rule A — preserve on re-registration** (all six paths): merge in place; preserve every existing env key, allowlist entry, unknown field, workspace root, cwd, and Codex timeouts; refresh only the launcher `command` path.

**Rule B — coherent explicit surface on fresh write**: init always writes an explicit `SYMFORGE_SURFACE` with a matching allowlist. Claude Code: `full` + 37 names (native deferred loading — spec §4). Kilo/Codex/Gemini/Desktop/Cursor: explicit `compact` with compact allowlists where the client has one. An incoherent generated config is now impossible.

Also included: the surface spike gate report (`docs/reviews/2026-07-03-surface-spike-gate.md`) + spec §8a verdict stamp — no harness rejected the full 36-tool list (71.4 KB / ~16.1k tokens measured; ~119 tokens on deferred harnesses); B5 tips-steering killed by base-rate-controlled mining. Verdict: `full` default (follow-up wave), `compact` escape hatch, staged shelved.

## Verification

- Adversarial review: APPROVE_WITH_NITS; the one actionable finding (Codex timeouts still clobbered) fixed + pinned by test. 9 new regression tests each fail against the old wiping code (verified by mental revert in review).
- `cargo fmt --check` / `cargo check` / `cargo clippy --all-targets -- -D warnings` — clean
- lib suite 2618 passed; init_integration 24; conformance 19; surface_default_compact 4; npm 31 — all green
- Known residuals documented in the fix commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all six MCP client registration paths and user home config files; incorrect merge logic could still corrupt settings, though extensive new tests target the 8.10.1 wipe class.
> 
> **Overview**
> Fixes **G-036**: re-registration (`symforge update` → `init --client all`) no longer replaces `mcpServers.symforge` wholesale. Shared helpers merge in place—refresh launcher `command`, **preserve** user env (e.g. `SYMFORGE_SURFACE=full`), allowlists, workspace `cwd`/roots, Codex timeouts, and unknown fields; env defaults and allow names are **unioned** only when absent.
> 
> **Per-harness fresh defaults** make surface and allowlist coherent: Claude Code gets `SYMFORGE_SURFACE=full` + full `alwaysAllow`; Kilo/Codex get compact env + exactly `symforge` / `symforge_edit` / `status` (drops the old 36-name Kilo list). Gemini, Desktop, and Cursor keep explicit `compact` env via the same merge path.
> 
> Adds **`docs/reviews/2026-07-03-surface-spike-gate.md`** and stamps the staged-surface spec §8a: no harness rejected full 36 tools; tips-steering (B5) killed—**full default / compact escape / staged shelved** (server default flip is follow-up, not in this diff). Regression tests in `init.rs` and `init_integration.rs` pin preserve/union behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d169d61067042812dc63de186432d322afd1d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->