### PR TITLE
ci(tools): mirror tool-correctness harness onto the release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,19 @@ jobs:
         working-directory: npm
         run: npm test
 
+      # Mirror ci.yml's tool-correctness gate onto the release path. ci.yml gates
+      # PRs; without this a harness regression that lands via a non-PR push (or a
+      # release-please merge) could reach a cut release unverified. Reuses the
+      # Node set up above and the release binary built at "Build release binary
+      # on main pushes". ripgrep backs the harness grep oracle (not on ubuntu).
+      - name: Install ripgrep (harness grep oracle)
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Verify tool correctness (both fixtures)
+        run: |
+          node scripts/verify-tools.cjs --bin target/release/symforge
+          node scripts/verify-tools.cjs --fixture verify-tools-real --bin target/release/symforge
+
   prepare-release:
     needs: verify-main-push
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds the tool-correctness harness to `release.yml`'s `verify-main-push` job — the two steps that already gate PRs in `ci.yml`:

1. `Install ripgrep (harness grep oracle)` — ubuntu-latest doesn't ship `rg`; without it the oracle silently degrades to REVIEW.
2. `Verify tool correctness (both fixtures)` — runs `verify-tools` and `verify-tools-real` against the release binary.

## Why

`ci.yml` gates **PRs**. `release.yml`'s `verify-main-push` did **not** run the harness, so a harness regression landing via a non-PR push — or via a release-please merge commit — could reach a cut release unverified. This mirrors the harness onto the release path exactly the way `embed-build` is already mirrored from PR CI onto main pushes.

Reuses the Node set up for the npm test and the release binary built at *"Build release binary on main pushes"* — no extra toolchain setup.

## Context

Deferred follow-up to #405, which shipped the harness PR-gated only (ci.yml) after cold-start hardening, with release-path mirroring called out as a separate PR. #405 also fixed the two real Linux-runner portability bugs (CRLF snapshot drift, missing `rg`) that this same gate will now enforce on the release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or product code; slightly longer main/release verification runs.
> 
> **Overview**
> **Release workflow now runs the same tool-correctness gate as PR CI** on `verify-main-push`, so harness regressions cannot slip through via direct main pushes or release-please merges.
> 
> After npm tests, the job **installs ripgrep** (required for the harness grep oracle on `ubuntu-latest`) and runs **`scripts/verify-tools.cjs`** against `target/release/symforge` for both the default and `verify-tools-real` fixtures—reusing the existing Node setup and release binary from the same job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab362dc10a4780d3b337954e5c31e771c32e4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->