### PR TITLE
fix(daemon,status): stop false cross-project refusal and false 'tuned' calibration

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3557,10 +3557,18 @@ fn format_cross_project_references(
     out
 }
 
+fn strip_cross_project_targeting(mut params: serde_json::Value) -> serde_json::Value {
+    if let serde_json::Value::Object(ref mut object) = params {
+        object.remove("project");
+        object.remove("projects");
+    }
+    params
+}
+
 async fn execute_tool_call(
     runtime: SessionRuntime,
     tool_name: &str,
-    params: serde_json::Value,
+    mut params: serde_json::Value,
 ) -> anyhow::Result<String> {
     runtime.token_stats.record_tool_call(tool_name);
 
@@ -3601,7 +3609,10 @@ async fn execute_tool_call(
             let working_set = runtime.working_set.read();
             return execute_cross_project_read(tool_name, params, targets, &working_set);
         }
-        // else: single active project -> fall through to the unchanged path.
+        // else: single active project -> fall through to the unchanged path. The
+        // worker is intentionally local-only and refuses any `project`/`projects`
+        // field, so erase the already-resolved targeting hint before dispatch.
+        params = strip_cross_project_targeting(params);
     }
 
     // Use the cached server from ProjectInstance (cloned cheaply via Arc internals)
@@ -5770,6 +5781,44 @@ mod tests {
         assert!(
             !active_only.contains("project: "),
             "single-active query must render flat (no project header): {active_only}"
+        );
+
+        // (4b) Explicitly targeting the active project is still the same
+        // single-project route. The daemon resolves the target before dispatch,
+        // then strips the hint so the local worker does not refuse it as a
+        // cross-project request without a daemon.
+        let explicit_active = http
+            .post(format!(
+                "{base_url}/v1/sessions/{}/tools/search_symbols",
+                opened.session_id
+            ))
+            .json(&serde_json::json!({
+                "query": "xproj_marker",
+                "project": project_a_id
+            }))
+            .send()
+            .await
+            .expect("explicit active query request")
+            .error_for_status()
+            .expect("explicit active query status")
+            .text()
+            .await
+            .expect("explicit active query body");
+        assert!(
+            explicit_active.contains("xproj_marker_alpha"),
+            "explicit active project query must surface A's symbol: {explicit_active}"
+        );
+        assert!(
+            !explicit_active.contains("xproj_marker_beta"),
+            "explicit active project query must NOT surface B's symbol: {explicit_active}"
+        );
+        assert!(
+            !explicit_active.contains("Cross-project queries"),
+            "explicit active project must not hit the local cross-project refusal: {explicit_active}"
+        );
+        assert!(
+            !explicit_active.contains("project: "),
+            "explicit active project must render as the flat single-project route: {explicit_active}"
         );
 
         // (5) B1 — cross-project scoping is now HONORED over the wire, not

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -10891,6 +10891,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn missing_durable_store_pins_status_calibration_to_deferred() {
+        use crate::stel::calibration::{CalibrationVerdict, TUNING_MIN_CORPUS};
+
+        let client = crate::daemon::DaemonSessionClient::new_for_test(
+            "http://127.0.0.1:1".to_string(),
+            "p".to_string(),
+            "s".to_string(),
+            "proj".to_string(),
+        );
+        let proxy = SymForgeServer::new_daemon_proxy(client);
+        for i in 0..TUNING_MIN_CORPUS {
+            let mut event = sample_durable_event();
+            event.ts_ms += i as u64;
+            event.plan_id = format!("p-no-store-biased-{i}");
+            event.actual_response_tokens = event.predicted_response_tokens * 2;
+            proxy.stel_ledger().lock().push(event);
+        }
+
+        let session_events = proxy.stel_ledger().lock().events();
+        assert!(
+            matches!(
+                crate::stel::summarize_calibration(&session_events).verdict,
+                CalibrationVerdict::Tuned { .. }
+            ),
+            "fixture must prove the in-memory session alone would claim tuned"
+        );
+        assert_eq!(
+            proxy.durable_calibration_verdict(),
+            None,
+            "precondition: this proxy has no durable store wired"
+        );
+
+        let body = proxy.render_stel_status_body(&crate::stel::StelStatusRequest {
+            detail: Some(crate::stel::StelStatusDetail::Full),
+            reset_calibration: None,
+            connection_surface: None,
+        });
+        assert!(
+            body.contains("durable_ledger: unavailable"),
+            "missing store must be surfaced as unavailable:\n{body}"
+        );
+        assert!(
+            body.contains("calibration: deferred"),
+            "status must not keep the in-memory tuned verdict when no durable store is wired:\n{body}"
+        );
+        assert!(
+            !body.contains("calibration: tuned"),
+            "status must never claim tuned without a durable artifact:\n{body}"
+        );
+    }
+
     /// D2-ROOT: a `new_daemon_proxy` server WITH a populated session ledger AND a
     /// durable store (samples + a validated `tuned` artifact) must overlay ALL of
     /// its proxy-owned `status detail:full` lines — `ledger_events` (non-zero),

--- a/src/stel/status.rs
+++ b/src/stel/status.rs
@@ -146,7 +146,12 @@ impl<'a> StelStatusContext<'a> {
     /// for stdio/embed callers (which default to `Unavailable`); the server-only
     /// `status` read calls this with the opened store's `subsystem_state()`.
     pub fn with_durable_ledger(mut self, state: DurableLedgerState) -> Self {
+        let readable = matches!(state, DurableLedgerState::Durable(_));
         self.durable_ledger = state;
+        if !readable {
+            self = self
+                .with_calibration_verdict(crate::stel::calibration::CalibrationVerdict::Deferred);
+        }
         self
     }
 
@@ -156,12 +161,10 @@ impl<'a> StelStatusContext<'a> {
     /// events. Also re-renders the `tuning_note` from the new verdict so the
     /// section's two calibration lines stay consistent.
     ///
-    /// Honesty invariant (data-model): the durable verdict is fail-closed. `None`
-    /// is reserved for "no durable store wired" — the caller keeps the in-memory
-    /// verdict (`Deferred`/`Accumulating`, never a false `Tuned`). A wired-but-
-    /// broken store whose sample read fails passes `Some(Deferred)` so status
-    /// never keeps an in-memory `Tuned` without a readable durable artifact. Only
-    /// a readable `Durable` store with a real artifact yields `Tuned` here.
+    /// Honesty invariant (data-model): the durable verdict is fail-closed. No
+    /// readable durable store (`Unavailable`/`Disabled`) pins calibration to
+    /// `Deferred`; only a readable `Durable` store with a real artifact yields
+    /// `Tuned` here.
     pub fn with_calibration_verdict(
         mut self,
         verdict: crate::stel::calibration::CalibrationVerdict,


### PR DESCRIPTION
## Two independent fail-closed / honesty bugs

Neither is fixed on main (8.10.5). Recovered from a stranded `cursor/critical-bug-investigation-*` branch that was pushed ~2 weeks ago and never merged; triaged against current main, confirmed both still live, then **rebuilt by hand** against current source (the branch referenced a since-changed struct shape — see note below).

### Bug 1 — false cross-project refusal (`src/daemon.rs`)
A read verb explicitly targeting the **active** project (e.g. `search_symbols` with `project=<active-id>`) was refused with *"Cross-project queries (project/projects) require the daemon."*

`execute_tool_call` resolved the target to the single active project via `resolve_targets` → `targets_is_single_active`, then **fell through to the local worker without stripping** the `project`/`projects` field. The worker is intentionally local-only and calls `local_cross_project_refusal` on any such field — so a legitimate, daemon-served, single-active query got refused.

**Fix:** `strip_cross_project_targeting` erases the already-resolved targeting hint before local dispatch.

### Bug 2 — false `tuned` calibration (`src/stel/status.rs`)
`status detail:full` reported `calibration: tuned` from **in-memory session events alone** when no durable store was wired. No durable artifact = no proof of tuning; it should read `Deferred`.

**Fix at the builder:** `with_durable_ledger` pins `Deferred` whenever the durable state is not `Durable(_)`. This is the robust locus — **both** render paths (`render_stel_status_body` and `proxy_owned_status_lines`) funnel through `with_durable_ledger`, so it closes a second leak site (`proxy_owned_status_lines`) that the original branch's single-call-site approach would have missed.

## Verification
- `cargo fmt --check` ✓, `cargo check` ✓, `cargo clippy --all-targets -- -D warnings` ✓
- Two new regression tests pass: the `explicit_active` route (inside `test_cross_project_query_returns_attributed_hits_from_both_projects`), and `missing_durable_store_pins_status_calibration_to_deferred`.

## Note on the hand-rebuild
`cargo check` (lib only) passed, but `clippy --all-targets` caught that the branch's 2-week-old test literal was missing a newly-added `StelStatusRequest.connection_surface` field — fixed to match current sibling tests. This is why the stranded diff was re-applied by hand rather than cherry-picked.

Sibling to #408 (self-update wrong-process-kill), the other real fix from the same stranded-branch triage. Three siblings were already superseded by dogfood-wave fixes and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon tool routing and STEL status truthfulness; behavior changes are narrow and covered by new regression tests, but both paths affect user-visible tool and status output.
> 
> **Overview**
> Fixes two fail-closed honesty bugs: daemon read tools wrongly refusing valid single-active queries, and **STEL status** reporting **tuned** calibration from in-memory events when no durable ledger is available.
> 
> For cross-project read verbs that resolve to the **active** project only, the daemon now removes **`project` / `projects`** from tool params before handing off to the local worker, so explicit active targeting no longer hits the worker’s cross-project refusal path.
> 
> **STEL status** construction now forces **`calibration: deferred`** whenever durable ledger state is not a readable **`Durable(_)`** store, so **`with_durable_ledger`** cannot leave an in-memory tuned verdict on **`Unavailable`** / **`Disabled`** paths.
> 
> Adds an HTTP regression for **`search_symbols`** with **`project=<active-id>`** and a unit test that a daemon proxy without a wired store never renders **`calibration: tuned`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971bbf79bfd1f1f1ba0891d8afb0fbb8119162f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->