### PR TITLE
fix(trust): Tier-2 exclusion disclosure in the trust envelope (dogfood wave 1)

### DIFF
--- a/docs/reviews/2026-07-06-dogfood-findings.md
+++ b/docs/reviews/2026-07-06-dogfood-findings.md
@@ -1,0 +1,133 @@
+# Dogfood findings — 2026-07-06 (two concurrent sessions)
+
+Two independent Claude sessions used SymForge 8.11.1 for real work on the same
+day: one on the AAP repo (external, large Rust workspace), one on the symforge
+repo itself (this session: surface flip, Perl fixtures, tips overhaul). Both
+hit real defects. Findings are ordered by severity; each is reproducible.
+
+## From the AAP session (external repo, real refactor task)
+
+### 1. SILENT Tier-2 exclusion breaks reference completeness — trust-critical
+
+- Repro: `find_references(name="PortRegistry")` returned 3 references in
+  2 files with trust line `parsed | full for current scope`. Raw grep found
+  the only **construction site** in a 1.2 MB first-party file — excluded
+  because >1 MB puts it at Tier-2 (metadata only), so it was never
+  reference-scanned.
+- Impact: a would-be compile-breaking miss (adding a struct field). The trust
+  envelope claimed completeness while a first-party source file was excluded.
+  **This is the only finding that actively lies.**
+- Fix directions: (a) trust envelope must enumerate Tier-2/excluded
+  first-party files whenever they contain the queried token — even one line:
+  `1 Tier-2 file matches textually and was not reference-scanned: <path>`;
+  (b) on-demand symbol-indexing of a Tier-2 file when directly named by a
+  query, or a higher tier cutoff — 1 MB load-bearing Rust files exist.
+
+### 2. get_symbol cross-language ambiguity resolves silently
+
+- Repro: `get_symbol(name="ProjectId")` (no path) returned the frontend
+  TypeScript alias with no notice that a Rust candidate existed.
+- Fix: return the ambiguity list, or footnote `also matched: <lang> <path>`.
+
+### 3. Macro-generated symbols invisible to search_symbols
+
+- Repro: `search_symbols(query="ProjectId", language="Rust")` → no symbols,
+  although `define_id_type!(ProjectId)` generates a `pub struct` used
+  workspace-wide. Text fallback listed usage files (saving grace).
+- Fix (cheap heuristic): index `macro_invocation(ident)` argument tokens as
+  declaration-ish symbols, kind `macro-generated`, trust-flagged.
+
+### 4. Symbol-scoped editing lacks sub-symbol granularity
+
+- Scenario: change an identical line in 2 of 3 match arms of a 334-line fn.
+  `edit_within_symbol` scopes to the whole fn → `old_text` ambiguous at
+  exactly the granularity the tool offers. On the Tier-2 file, symbol
+  editing was unavailable entirely.
+- Fix ideas: `occurrence: N` / `near_line:` disambiguators; match arms and
+  impl items as addressable sub-ranges; on-demand parse for Tier-2 edits.
+
+### 5. Minor
+
+- `search_text(query="pub type ProjectId")` → zero hits, no hint that the
+  declaration doesn't exist textually (macro-generated). Combined with #3,
+  name-lookup AND text-lookup both dead-end; only `regex=true` on the bare
+  name found the trail.
+- Hook-injected prompt-context on plain-English prompts burns ~800–1000
+  tokens on heuristic no-reference reports (see #8 below — reproduced).
+
+## From the symforge session (this repo, surface/Perl/tips work)
+
+### 6. Shared-daemon project retarget hijacks every other session
+
+- Repro: a benchmark subagent ran `index_folder` on a scratchpad clone
+  (mojo). The daemon's ACTIVE project switched for all sessions sharing it:
+  the main session's PostToolUse hooks began reporting
+  `not found on disk — no index record remains` for every repo file it
+  edited, `status` showed `project_root: .../scratchpad/mojo`, and
+  `search_text(projects=["*"])` found nothing that existed in the repo.
+- Impact: silent, confusing, and long-lived — every hook readout was a false
+  alarm until a manual re-`index_folder`. Feature 012's additive
+  `add:true` exists, but nothing warns when a plain retarget happens under
+  a session that didn't request it.
+- Fix directions: per-session active project; or hook/facade queries pinned
+  to the session's workspace root; at minimum a loud line in every hook
+  readout when the daemon root ≠ the session's cwd repo.
+
+### 7. External edits EVICT files from the index instead of re-indexing
+
+- Repro: after Edit-tool (non-symforge) writes to `src/protocol/tools.rs`,
+  the file vanished from the index: `search_text` no longer matched content
+  that was on disk, and `edit_within_symbol` failed with
+  `File not found: src/protocol/tools.rs` while `get_file_content` (disk
+  fallback) still worked. `analyze_file_impact` restored it; symbol edits
+  then succeeded.
+- Suspect: daemon root is UNC-prefixed (`//?/C:/...`); watcher events for
+  externally-written files may arrive non-UNC and fail the repo-bound path
+  match → treated as outside-repo → evicted. Same signature as the false
+  hook messages in #6 (observed both before AND after re-rooting).
+- Fix directions: canonicalize both sides before comparing; on watcher event
+  for a known indexed path, always re-read rather than evict.
+
+### 8. Hook prompt-context noise on conversational prompts (confirms 5b)
+
+- Repro (this session): prompt "pull latest from git" → heuristic
+  `surface`-token report (~1000 tokens); PostToolUse Grep hooks emitted
+  ~1000-token "No references found in the index" reports for regex patterns
+  (`Tip:`, `compact|SYMFORGE_SURFACE`) that are not symbols.
+- Fix: suppress injection when the matched "symbol token" is a conversational
+  word or a regex/multi-token pattern; a no-evidence report should be 1 line.
+
+## Status
+
+- #1 is the priority: it violates the trust-envelope contract (envelope says
+  full; scan wasn't). Candidate spec: extend the completeness label with a
+  Tier-2 textual-match sweep.
+- #6/#7 degrade the daemon-shared workflow that agent teams actually use.
+- #2/#3/#4/#5/#8 are ergonomics/recall gaps, real but honest failures.
+
+## Fix log
+
+Wave 1 (trust honesty, branch `fix/trust-envelope-tier2`, 2026-07-06):
+
+- **#1 FIXED** — `find_references` now runs a bounded Tier-2 textual sweep
+  (`tier2_reference_disclosure`, tools.rs): size-demoted (>1MB) files
+  containing the queried name are named in the output, the completeness label
+  gains "Tier-2 exclusions apply", and sweep-budget overruns are reported as
+  unswept rather than silently skipped. Tests:
+  `test_find_references_discloses_tier2_textual_match` (real 1.1MB fixture,
+  zero indexed refs — the exact field-failure shape) and the
+  no-match-stays-silent guard.
+- **#2 ROOT-CAUSED + MITIGATED** — the "silent wrong-language pick" was not a
+  resolution bug: `resolve_symbol_path_by_name` already returns the ambiguity
+  list for >1 exact hits. The AAP pick was Unique *because the Rust candidate
+  was macro-generated and absent from the index* — #2 is a symptom of #3.
+  Mitigation shipped: bare-name `get_symbol` output now opens with
+  `Resolved bare name to <path>` so the picked file/language is always
+  visible. Full fix rides #3.
+- **#5a FIXED** — zero-hit `search_text` with a multi-word literal now
+  suggests retrying the bare identifier (declarations may be macro-generated
+  or formatted differently).
+- Live corroboration during the fix work: `src/protocol/tools.rs` itself
+  crossed 1MB and was repeatedly demoted to Tier-2 mid-session (#1's cutoff
+  hitting the repo's own load-bearing file), and every external (non-symforge)
+  edit to it triggered the #7 eviction until `analyze_file_impact`.

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -1036,6 +1036,8 @@ pub fn search_text_result_with_options(
         SearchSuggestionContext {
             regex,
             include_tests: false,
+            multi_word_literal: !regex
+                && query.is_some_and(|q| q.trim().contains(char::is_whitespace)),
         },
     )
 }
@@ -1078,6 +1080,11 @@ pub fn is_noise_line(line: &str) -> bool {
 pub struct SearchSuggestionContext {
     pub regex: bool,
     pub include_tests: bool,
+    /// True when the zero-hit query was a multi-word literal. Declarations are
+    /// often macro-generated or wrapped/formatted differently than the query
+    /// (dogfood #5a: `pub type ProjectId` finds nothing when the type is minted
+    /// by a macro), so the suggestions steer toward the bare identifier.
+    pub multi_word_literal: bool,
 }
 
 /// Build the suggestion list for a zero-hit (non-structural) literal/regex
@@ -1094,6 +1101,12 @@ fn no_match_suggestions(ctx: SearchSuggestionContext) -> String {
         suggestions.push("broaden with include_tests=true / include_generated=true");
     } else {
         suggestions.push("broaden with include_generated=true or a wider path_prefix");
+    }
+    if ctx.multi_word_literal {
+        suggestions.push(
+            "a multi-word literal misses declarations that are macro-generated or \
+             formatted differently — retry with the bare identifier alone",
+        );
     }
     suggestions.join(", ")
 }
@@ -5248,19 +5261,6 @@ pub(crate) fn format_hook_adoption(snap: &HookAdoptionSnapshot) -> String {
     }
 
     lines.join("\n")
-}
-
-/// Format a compact "what next" hint line for tool outputs.
-pub fn compact_next_step_hint(items: &[&str]) -> String {
-    let items: Vec<&str> = items
-        .iter()
-        .copied()
-        .filter(|item| !item.trim().is_empty())
-        .collect();
-    if items.is_empty() {
-        return String::new();
-    }
-    format!("\nTip: {}", items.join(" | "))
 }
 
 /// Format a one-line git temporal summary for the health report.

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -606,6 +606,7 @@ fn test_search_text_zero_hit_drops_regex_suggestion_when_regex_already_set() {
         SearchSuggestionContext {
             regex: true,
             include_tests: false,
+            multi_word_literal: false,
         },
     );
     assert!(
@@ -633,11 +634,34 @@ fn test_search_text_zero_hit_keeps_regex_suggestion_when_not_regex() {
         SearchSuggestionContext {
             regex: false,
             include_tests: false,
+            multi_word_literal: false,
         },
     );
     assert!(
         rendered.contains("use regex=true"),
         "should suggest regex=true for a literal search; got: {rendered}"
+    );
+}
+
+#[test]
+fn test_search_text_zero_hit_multi_word_literal_suggests_bare_identifier() {
+    // Dogfood #5a (2026-07-06): `pub type ProjectId` finds nothing when the
+    // declaration is macro-generated; the zero-hit suggestions must steer
+    // toward the bare identifier instead of dead-ending.
+    let rendered = search_text_result_view(
+        empty_text_search_result("'pub type ProjectId'"),
+        None,
+        None,
+        None,
+        SearchSuggestionContext {
+            regex: false,
+            include_tests: false,
+            multi_word_literal: true,
+        },
+    );
+    assert!(
+        rendered.contains("bare identifier"),
+        "multi-word zero-hit must suggest the bare identifier; got: {rendered}"
     );
 }
 
@@ -651,6 +675,7 @@ fn test_search_text_zero_hit_drops_include_tests_when_already_included() {
         SearchSuggestionContext {
             regex: false,
             include_tests: true,
+            multi_word_literal: false,
         },
     );
     assert!(
@@ -3895,18 +3920,6 @@ fn test_compact_savings_footer_empty_when_no_savings() {
 fn test_compact_savings_footer_empty_for_small_files() {
     let footer = compact_savings_footer(50, 100);
     assert!(footer.is_empty());
-}
-
-#[test]
-fn test_compact_next_step_hint_formats_joined_items() {
-    let hint = compact_next_step_hint(&["get_symbol (body)", "find_references (usages)"]);
-    assert_eq!(hint, "\nTip: get_symbol (body) | find_references (usages)");
-}
-
-#[test]
-fn test_compact_next_step_hint_ignores_empty_items() {
-    let hint = compact_next_step_hint(&["", "search_text"]);
-    assert_eq!(hint, "\nTip: search_text");
 }
 
 // ── search_symbols tier ordering tests ───────────────────────────────────

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2576,6 +2576,93 @@ fn find_references_completeness_label(
     format!("{}{recall_caveat}", parts.join("; "))
 }
 
+/// Tier-2 honesty sweep (dogfood finding #1, 2026-07-06): the reference scan
+/// covers Tier-1 files only, but first-party source demoted to Tier-2 for size
+/// (>1MB, `SkipReason::SizeThreshold`) can still contain the queried name —
+/// the field failure was a compile-breaking construction site inside a 1.2 MB
+/// file while the envelope claimed "full for current scope". Sweep those files
+/// textually (bounded) and return a disclosure so the envelope never claims a
+/// completeness it does not have. Returns `None` when there is nothing to
+/// disclose (no size-demoted files, or none contain the name).
+fn tier2_reference_disclosure(
+    skipped: &[crate::domain::index::SkippedFile],
+    repo_root: Option<&std::path::Path>,
+    name: &str,
+) -> Option<String> {
+    use crate::domain::index::SkipReason;
+    // Only size-demoted files are reference-relevant: binary, lockfile, and
+    // artifact demotions cannot hold code references to the queried symbol.
+    let candidates: Vec<&crate::domain::index::SkippedFile> = skipped
+        .iter()
+        .filter(|f| f.reason() == Some(SkipReason::SizeThreshold))
+        .collect();
+    if candidates.is_empty() || name.trim().is_empty() {
+        return None;
+    }
+    // ponytail: bounded whole-file reads + str::contains; the OS page cache
+    // makes repeated sweeps cheap. Budgets keep the pathological repo honest
+    // (reported as unswept) instead of slow.
+    const MAX_SWEEP_FILES: usize = 8;
+    const MAX_SWEEP_BYTES: u64 = 32 * 1024 * 1024;
+    let preview = |paths: &[&str]| -> String {
+        let shown: Vec<&str> = paths.iter().take(3).copied().collect();
+        let suffix = if paths.len() > shown.len() {
+            format!(", … (+{} more)", paths.len() - shown.len())
+        } else {
+            String::new()
+        };
+        format!("{}{}", shown.join(", "), suffix)
+    };
+    let Some(root) = repo_root else {
+        // No resolvable root: cannot sweep, but silence would be the lie.
+        let paths: Vec<&str> = candidates.iter().map(|f| f.path.as_str()).collect();
+        return Some(format!(
+            "Tier-2 exclusion: {} first-party file(s) >1MB were NOT reference-scanned \
+             (metadata-only) and could not be swept for \"{name}\" (no repo root): {}",
+            candidates.len(),
+            preview(&paths),
+        ));
+    };
+    let mut matched: Vec<&str> = Vec::new();
+    let mut unswept: Vec<&str> = Vec::new();
+    let mut bytes_budget = MAX_SWEEP_BYTES;
+    for (i, file) in candidates.iter().enumerate() {
+        if i >= MAX_SWEEP_FILES || bytes_budget < file.size {
+            unswept.push(file.path.as_str());
+            continue;
+        }
+        match std::fs::read(root.join(&file.path)) {
+            Ok(bytes) => {
+                bytes_budget = bytes_budget.saturating_sub(bytes.len() as u64);
+                if String::from_utf8_lossy(&bytes).contains(name) {
+                    matched.push(file.path.as_str());
+                }
+            }
+            Err(_) => unswept.push(file.path.as_str()),
+        }
+    }
+    if matched.is_empty() && unswept.is_empty() {
+        return None;
+    }
+    let mut parts: Vec<String> = Vec::new();
+    if !matched.is_empty() {
+        parts.push(format!(
+            "\"{name}\" appears textually in {} file(s) >1MB that were NOT \
+             reference-scanned (metadata-only): {} — grep or get_file_content to inspect",
+            matched.len(),
+            preview(&matched),
+        ));
+    }
+    if !unswept.is_empty() {
+        parts.push(format!(
+            "{} file(s) >1MB not reference-scanned and not swept (budget): {}",
+            unswept.len(),
+            preview(&unswept),
+        ));
+    }
+    Some(format!("Tier-2 exclusion: {}", parts.join("; ")))
+}
+
 fn find_references_evidence(view: &crate::live_index::FindReferencesView) -> String {
     let anchors = view
         .files
@@ -3120,6 +3207,8 @@ fn render_search_text_output(
         format::SearchSuggestionContext {
             regex: is_regex,
             include_tests: options.noise_policy.include_tests,
+            multi_word_literal: !is_regex
+                && query.is_some_and(|q| q.trim().contains(char::is_whitespace)),
         },
     );
     let mut rendered = match envelope {
@@ -3745,9 +3834,6 @@ impl SymForgeServer {
                 .collect::<std::collections::HashSet<_>>()
                 .into_iter()
                 .collect();
-            let has_symbol_lookup = captured
-                .iter()
-                .any(|entry| matches!(entry, CapturedGetSymbolsEntry::SymbolLookup { .. }));
             let batch_baseline_chars: usize = captured
                 .iter()
                 .filter_map(|entry| match entry {
@@ -3758,7 +3844,7 @@ impl SymForgeServer {
                     CapturedGetSymbolsEntry::FileNotFound { .. } => None,
                 })
                 .sum();
-            let mut output = captured
+            let output = captured
                 .into_iter()
                 .map(|entry| match entry {
                     CapturedGetSymbolsEntry::SymbolLookup {
@@ -3781,16 +3867,8 @@ impl SymForgeServer {
                 })
                 .collect::<Vec<_>>()
                 .join("\n---\n");
-            // Append the next-step hint ONCE for the whole batch — an agent
-            // learns it after the first occurrence, so repeating it per entry is
-            // pure token overhead.
-            if has_symbol_lookup {
-                output.push_str(&format::compact_next_step_hint(&[
-                    "get_symbol_context (callers/callees/types)",
-                    "find_references (usages)",
-                    "edit_within_symbol / replace_symbol_body (edits)",
-                ]));
-            }
+            // No next-step tip: always-on tips measured as saturation, not
+            // steering (2026-07-03 spike gate, B5) — tips stay rare + contextual.
             self.record_tool_savings_named(
                 "get_symbol",
                 format::estimate_tokens_from_chars(batch_baseline_chars),
@@ -3810,6 +3888,7 @@ impl SymForgeServer {
         // the compact `read` intent, which routes here via the STEL planner —
         // one fix, two surfaces. Both empty (and no `targets`) is a clean
         // invalid-request, never `File not found: .`.
+        let mut resolved_from_bare_name: Option<String> = None;
         if params.0.path.trim().is_empty() {
             if params.0.name.trim().is_empty() {
                 return "Invalid request: get_symbol needs a `name` (optionally with `path`), \
@@ -3823,6 +3902,10 @@ impl SymForgeServer {
                 params.0.symbol_line,
             ) {
                 SymbolNameLookup::Unique { path, symbol_name } => {
+                    // Dogfood #2 (2026-07-06): a bare-name pick must SAY which
+                    // file it resolved to — the caller cannot tell a TypeScript
+                    // alias from a Rust struct by the body alone.
+                    resolved_from_bare_name = Some(path.clone());
                     params.0.path = path;
                     params.0.name = symbol_name;
                 }
@@ -3902,25 +3985,19 @@ impl SymForgeServer {
         match file {
             Some(file) => {
                 let raw_chars = file.content.len();
-                let line_count = format::indexed_file_line_count(&file.content);
-                let is_small_file = format::is_small_indexed_file(raw_chars, line_count);
                 let body = format::symbol_detail_from_indexed_file(
                     file.as_ref(),
                     &params.0.name,
                     params.0.kind.as_deref(),
                     params.0.symbol_line,
                 );
-                let hint = if is_small_file {
-                    String::new()
-                } else {
-                    format::compact_next_step_hint(&[
-                        "get_symbol_context (callers/callees/types)",
-                        "find_references (usages)",
-                        "edit_within_symbol / replace_symbol_body (edits)",
-                    ])
-                    .to_string()
+                let output = match &resolved_from_bare_name {
+                    Some(path) => format!(
+                        "Resolved bare name to {path} — pass `path` (and `symbol_line`) \
+                         to pin a different same-named symbol.\n{body}"
+                    ),
+                    None => body,
                 };
-                let output = format!("{body}{hint}");
                 let max_tokens = format::resolve_read_max_tokens(params.0.max_tokens, raw_chars);
                 self.record_tool_savings_named(
                     "get_symbol",
@@ -4121,17 +4198,11 @@ impl SymForgeServer {
                 let state = sidecar_state_for_server(self);
                 match repo_map_text(&state) {
                     Ok(result) => {
-                        let hint = format::compact_next_step_hint(&[
-                            "get_file_context (open one file)",
-                            "search_symbols (find by name)",
-                            "search_text (find text/patterns)",
-                            "diff_symbols (review changes)",
-                        ]);
                         let doctrine = "\nDoctrine: the map orients; the tools prove. \
                              Completeness: ranked and truncated by result cap - absence \
                              from the map is not absence from the repo; confirm with \
                              search_symbols / search_text before concluding something is missing.";
-                        format!("{result}{hint}{doctrine}")
+                        format!("{result}{doctrine}")
                     }
                     Err(StatusCode::NOT_FOUND) => "Repository map unavailable.".to_string(),
                     Err(StatusCode::INTERNAL_SERVER_ERROR) => {
@@ -4277,17 +4348,7 @@ impl SymForgeServer {
                         format!("{note}\n\n{result}")
                     };
                 }
-                let hint = if is_small_file {
-                    String::new()
-                } else {
-                    format::compact_next_step_hint(&[
-                        "get_symbol (body)",
-                        "find_references (callers/imports)",
-                        "search_text (string/pattern usage)",
-                        "get_file_content (exact raw text)",
-                    ])
-                };
-                let body = format!("{result}{hint}");
+                let body = result;
                 let footer = format::compact_savings_footer(body.len(), raw_chars);
                 let mut output =
                     format::enforce_token_budget(format!("{body}{footer}"), context_max_tokens);
@@ -4604,11 +4665,6 @@ impl SymForgeServer {
                 if !impl_block_tip.is_empty() {
                     output.push_str(impl_block_tip.trim_start_matches('\n'));
                 }
-                output.push_str(&format::compact_next_step_hint(&[
-                    "get_symbol_context (callers/callees/types)",
-                    "find_references (usages)",
-                    "edit_within_symbol / replace_symbol_body (edits)",
-                ]));
                 let footer = format::compact_savings_footer(output.len(), raw_chars);
                 // Frecency bump — commitment tool, default-mode happy path.
                 // Resolve the bump path the same way the output did:
@@ -4637,10 +4693,6 @@ impl SymForgeServer {
                         body.push('\n');
                         body.push_str(impl_block_tip.trim_start_matches('\n'));
                     }
-                    body.push_str(&format::compact_next_step_hint(&[
-                        "get_symbol_context (callers/callees/types)",
-                        "find_references (usages)",
-                    ]));
                     let footer = format::compact_savings_footer(body.len(), raw_chars);
                     self.record_read_savings(format::saved_tokens_vs_competent_manual(
                         body.len(),
@@ -4892,14 +4944,9 @@ impl SymForgeServer {
             ))
         };
         let output = format::search_symbols_result_view(&result, query_str);
-        let hint = format::compact_next_step_hint(&[
-            "get_symbol (body)",
-            "get_symbol_context (callers/callees)",
-            "get_file_context (file overview)",
-        ]);
         let output = match envelope {
-            Some(envelope) => format!("{envelope}\n\n{output}{hint}"),
-            None => format!("{output}{hint}"),
+            Some(envelope) => format!("{envelope}\n\n{output}"),
+            None => output,
         };
         let output = if !is_browse
             && query_str.len() >= 2
@@ -5051,17 +5098,11 @@ impl SymForgeServer {
                 false,
                 false,
             );
-            let hint = format::compact_next_step_hint(&[
-                "inspect_match (deep-dive one hit)",
-                "get_file_context (file overview)",
-                "search_symbols (name-based lookup)",
-            ]);
-            let result = format!("{output}{hint}");
             self.session_context.record_summary_output(
                 "search_text",
-                (result.len() / 4).min(u32::MAX as usize) as u32,
+                (output.len() / 4).min(u32::MAX as usize) as u32,
             );
-            return self.apply_ccr_budget("search_text", result, params.0.max_tokens);
+            return self.apply_ccr_budget("search_text", output, params.0.max_tokens);
         }
 
         let mut options = match search_text_options_from_input(&params.0) {
@@ -5198,11 +5239,6 @@ impl SymForgeServer {
                         "\n(auto-corrected double-escaped regex: `{}` → `{}`)",
                         query, fixed
                     ));
-                    output.push_str(&format::compact_next_step_hint(&[
-                        "inspect_match (deep-dive one hit)",
-                        "get_file_context (file overview)",
-                        "search_symbols (name-based lookup)",
-                    ]));
                     self.session_context.record_summary_output(
                         "search_text",
                         (output.len() / 4).min(u32::MAX as usize) as u32,
@@ -5227,12 +5263,7 @@ impl SymForgeServer {
             auto_detected_regex,
             false,
         );
-        let hint = format::compact_next_step_hint(&[
-            "inspect_match (deep-dive one hit)",
-            "get_file_context (file overview)",
-            "search_symbols (name-based lookup)",
-        ]);
-        let result = format!("{output}{hint}");
+        let result = output;
         self.session_context.record_summary_output(
             "search_text",
             (result.len() / 4).min(u32::MAX as usize) as u32,
@@ -7776,8 +7807,25 @@ impl SymForgeServer {
                 if collect_qualified_usages {
                     merge_qualified_usages_into_view(&mut view, qualified_usages, indexed_ranges);
                 }
+                // Tier-2 honesty sweep (dogfood #1): compute BEFORE the envelope
+                // so the completeness label can confess the exclusion instead of
+                // claiming "full for current scope" over an unscanned file.
+                let tier2_disclosure = {
+                    let repo_root = self.capture_repo_root();
+                    let guard = self.index.read();
+                    tier2_reference_disclosure(
+                        guard.skipped_files(),
+                        repo_root.as_deref(),
+                        &input.name,
+                    )
+                };
                 let envelope = if !view.files.is_empty() {
                     let guard = self.index.read();
+                    let mut completeness =
+                        find_references_completeness_label(&view, &limits, input.kind.as_deref());
+                    if tier2_disclosure.is_some() {
+                        completeness.push_str("; Tier-2 exclusions apply (see below)");
+                    }
                     Some(search_format::format_search_envelope(
                         find_references_match_type_label(input, mode),
                         "current index",
@@ -7785,7 +7833,7 @@ impl SymForgeServer {
                             &guard,
                             view.files.iter().map(|file| file.file_path.as_str()),
                         ),
-                        &find_references_completeness_label(&view, &limits, input.kind.as_deref()),
+                        &completeness,
                         &find_references_scope_summary(input, mode),
                         &find_references_evidence(&view),
                     ))
@@ -7862,6 +7910,14 @@ impl SymForgeServer {
                             tr.files.len(), input.name, input.name, input.name
                         ));
                     }
+                }
+
+                // Tier-2 honesty sweep (dogfood #1): the disclosure rides the
+                // OUTPUT (both the hits and zero-hits paths), not only the
+                // envelope, so a truncated or compact read still sees it.
+                if let Some(disclosure) = &tier2_disclosure {
+                    output.push_str("\n\n");
+                    output.push_str(disclosure);
                 }
 
                 self.record_tool_savings_named(
@@ -12155,7 +12211,11 @@ mod tests {
             .await;
         assert!(result.contains("src/main.rs"), "should contain path");
         assert!(result.contains("main"), "should contain symbol name");
-        assert!(result.contains("Tip:"), "should include next-step hint");
+        // B5 (2026-07-03 spike gate): success paths carry no always-on tip.
+        assert!(
+            !result.contains("Tip:"),
+            "success path must not carry a tip"
+        );
     }
 
     #[tokio::test]
@@ -12181,9 +12241,37 @@ mod tests {
             !result.starts_with("Index"),
             "should not return guard message, got: {result}"
         );
+        // B5 (2026-07-03 spike gate): success paths carry no always-on tip.
         assert!(
-            result.contains("Tip:"),
-            "should include next-step hint: {result}"
+            !result.contains("Tip:"),
+            "success path must not carry a tip: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_symbol_bare_name_echoes_resolved_path() {
+        // Dogfood #2 (2026-07-06): a bare-name lookup must SAY which file it
+        // resolved to — the caller cannot tell a same-named TypeScript alias from
+        // a Rust struct by the body alone.
+        let sym = make_symbol("foo", SymbolKind::Function, 1, 3);
+        let content = medium_test_source("fn foo() {}");
+        let (key, file) = make_file("src/lib.rs", &content, vec![sym]);
+        let server = make_server(make_live_index_ready(vec![(key, file)]));
+        let result = server
+            .get_symbol(Parameters(super::GetSymbolInput {
+                path: String::new(),
+                name: "foo".to_string(),
+                kind: None,
+                symbol_line: None,
+                targets: None,
+                estimate: None,
+                max_tokens: None,
+                force_refresh: None,
+            }))
+            .await;
+        assert!(
+            result.contains("Resolved bare name to src/lib.rs"),
+            "bare-name resolution must echo the picked path; got: {result}"
         );
     }
 
@@ -12553,9 +12641,10 @@ mod tests {
             result.contains("src"),
             "repo map should include directory breakdown; got: {result}"
         );
+        // B5 (2026-07-03 spike gate): success paths carry no always-on tip.
         assert!(
-            result.contains("Tip:"),
-            "repo map should include next-step hint"
+            !result.contains("Tip:"),
+            "repo map success path must not carry a tip"
         );
     }
 
@@ -14490,9 +14579,10 @@ mod tests {
             result.contains("Trust: constrained (prefix tier) | current index | parsed"),
             "search_symbols should expose the compact trust line, got: {result}"
         );
+        // B5 (2026-07-03 spike gate): success paths carry no always-on tip.
         assert!(
-            result.contains("Tip:"),
-            "search_symbols should include next-step hint"
+            !result.contains("Tip:"),
+            "search_symbols success path must not carry a tip"
         );
     }
 
@@ -15142,9 +15232,10 @@ mod tests {
             ),
             "search_text should expose applied scope, got: {result}"
         );
+        // B5 (2026-07-03 spike gate): success paths carry no always-on tip.
         assert!(
-            result.contains("Tip:"),
-            "search_text should include next-step hint"
+            !result.contains("Tip:"),
+            "search_text success path must not carry a tip"
         );
     }
 
@@ -22119,6 +22210,91 @@ mod tests {
         assert!(
             !result.contains("definitions named"),
             "single definition must not trigger the disclosure; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_references_discloses_tier2_textual_match() {
+        // Dogfood #1 (2026-07-06): a first-party file demoted to Tier-2 for size
+        // held the only construction site while the envelope claimed
+        // "full for current scope". The sweep must confess the textual match on
+        // BOTH the zero-hits path and the envelope.
+        let dir = tempfile::tempdir().unwrap();
+        let mut big = "x".repeat(1_100_000);
+        big.push_str("\nlet r = PortRegistry::new();\n");
+        std::fs::write(dir.path().join("big.rs"), &big).unwrap();
+
+        // Index knows the definition but has ZERO references to it (the only
+        // reference lives in the Tier-2 file) — the exact field failure shape.
+        let def = make_symbol("PortRegistry", SymbolKind::Struct, 1, 1);
+        let (key, file) = make_file("src/lib.rs", b"struct PortRegistry;\n", vec![def]);
+        let mut index = make_live_index_ready(vec![(key, file)]);
+        index.skipped_files = vec![crate::domain::index::SkippedFile {
+            path: "big.rs".to_string(),
+            size: big.len() as u64,
+            extension: Some("rs".to_string()),
+            decision: crate::domain::index::AdmissionDecision::skip(
+                crate::domain::index::AdmissionTier::MetadataOnly,
+                crate::domain::index::SkipReason::SizeThreshold,
+            ),
+        }];
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+        let result = server
+            .find_references(Parameters(find_references_input("PortRegistry")))
+            .await;
+        assert!(
+            result.contains("Tier-2 exclusion"),
+            "envelope must confess the unscanned Tier-2 textual match; got: {result}"
+        );
+        assert!(
+            result.contains("big.rs"),
+            "the unscanned file must be named; got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_references_tier2_sweep_stays_silent_without_match() {
+        // No lie to confess: the Tier-2 file does not contain the queried name,
+        // so the disclosure must not fire (noise is its own honesty failure).
+        let dir = tempfile::tempdir().unwrap();
+        let big = "y".repeat(1_100_000);
+        std::fs::write(dir.path().join("big.rs"), &big).unwrap();
+
+        let def = make_symbol("solitary_fn", SymbolKind::Function, 1, 1);
+        let caller = make_symbol("caller", SymbolKind::Function, 2, 2);
+        let file = make_file_with_refs(
+            "src/only.rs",
+            b"fn solitary_fn() {}\nfn caller() { solitary_fn(); }\n",
+            vec![def, caller],
+            vec![make_ref(
+                "solitary_fn",
+                None,
+                ReferenceKind::Call,
+                1,
+                Some(1),
+            )],
+        );
+        let mut index = make_live_index_ready(vec![file]);
+        index.skipped_files = vec![crate::domain::index::SkippedFile {
+            path: "big.rs".to_string(),
+            size: big.len() as u64,
+            extension: Some("rs".to_string()),
+            decision: crate::domain::index::AdmissionDecision::skip(
+                crate::domain::index::AdmissionTier::MetadataOnly,
+                crate::domain::index::SkipReason::SizeThreshold,
+            ),
+        }];
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+        let result = server
+            .find_references(Parameters(find_references_input("solitary_fn")))
+            .await;
+        assert!(
+            !result.contains("Tier-2 exclusion"),
+            "no textual match means no disclosure; got: {result}"
+        );
+        assert!(
+            result.contains("full for current scope"),
+            "completeness stays unqualified when nothing was excluded; got: {result}"
         );
     }
 

--- a/tests/fixtures/verify-tools-real/snapshots/file_context.types.snap
+++ b/tests/fixtures/verify-tools-real/snapshots/file_context.types.snap
@@ -49,6 +49,5 @@ Imports from (5 sources):
   serde::Serialize (1 symbols)
   serde_json::Value (1 symbols)
   serde_json::json (1 symbols)
-Tip: get_symbol (body) | find_references (callers/imports) | search_text (string/pattern usage) | get_file_content (exact raw text)
 
-~4747 tokens vs whole-file read; ~490 tokens vs ~50-line windowed read (competent-manual baseline)
+~4780 tokens vs whole-file read; ~523 tokens vs ~50-line windowed read (competent-manual baseline)

--- a/tests/fixtures/verify-tools-real/snapshots/get_symbol.as_str_intent.snap
+++ b/tests/fixtures/verify-tools-real/snapshots/get_symbol.as_str_intent.snap
@@ -11,4 +11,3 @@ pub const fn as_str(self) -> &'static str {
         }
     }
 [fn, lines 25-36, 362 bytes]
-Tip: get_symbol_context (callers/callees/types) | find_references (usages) | edit_within_symbol / replace_symbol_body (edits)

--- a/tests/fixtures/verify-tools-real/snapshots/get_symbol_context.tally.snap
+++ b/tests/fixtures/verify-tools-real/snapshots/get_symbol_context.tally.snap
@@ -15,4 +15,3 @@ Evidence: path-constrained symbol `tally` in `src/code_target.rs`
 Callees (2):
   iter                           src/code_target.rs:7  in fn tally
   sum                            src/code_target.rs:7  in fn tally
-Tip: get_symbol_context (callers/callees/types) | find_references (usages) | edit_within_symbol / replace_symbol_body (edits)


### PR DESCRIPTION
Wave 1 of the 2026-07-06 dogfood findings (report: docs/reviews/2026-07-06-dogfood-findings.md, included in this PR). Also carries the tips overhaul from the 2026-07-03 spike gate (same files, was uncommitted in the working tree).

## Trust fixes

- **Finding #1 (trust-envelope lie)**: `find_references` now sweeps size-demoted (>1MB) Tier-2 files textually (bounded: 8 files / 32MB, overruns reported as unswept) and names any that contain the queried symbol. The completeness label gains `Tier-2 exclusions apply (see below)` instead of claiming `full for current scope` over an unscanned first-party file. Field failure this fixes: a compile-breaking construction site inside a 1.2MB file was invisible while the envelope claimed completeness.
- **Finding #2 (mitigation)**: bare-name `get_symbol` output opens with `Resolved bare name to <path>` so a cross-language pick is always visible. Root cause (macro-generated symbols absent from the index) is finding #3, next wave.
- **Finding #5a**: zero-hit `search_text` with a multi-word literal suggests retrying the bare identifier.

## Tips overhaul (B5, 2026-07-03 spike gate)

All 10 always-on `compact_next_step_hint` success-path appends removed (get_symbol ×2, get_repo_map, get_file_context, get_symbol_context ×2, search_symbols, search_text ×3) — mined data showed 63% of results carried tips with follow lift ≤ 1 (saturation, not steering). Contextual tips kept (0-callers impl tip, zero-result recovery, `what_changed`-on-unchanged: the 21× lift case). Dead helper + its 2 tests deleted; 5 tests flipped to pin tip *absence* on success paths.

## Tests

- `test_find_references_discloses_tier2_textual_match` — real 1.1MB fixture, zero indexed refs (the exact field-failure shape)
- `test_find_references_tier2_sweep_stays_silent_without_match` — no noise when there is nothing to confess
- `test_get_symbol_bare_name_echoes_resolved_path`
- `test_search_text_zero_hit_multi_word_literal_suggests_bare_identifier`

Full gate green locally: fmt, clippy -D warnings, `cargo test --features server --all-targets` (exit 0), release build.

Live corroboration: during this very fix, `src/protocol/tools.rs` crossed 1MB and was repeatedly demoted to Tier-2 by our own cutoff — finding #1 hitting the repo's own load-bearing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust/completeness messaging and reference-scan disclosure on a core tool path; behavior is bounded and heavily tested but affects agent decisions on reference completeness.
> 
> **Overview**
> **Trust and ergonomics from 2026-07-06 dogfood** — adds `docs/reviews/2026-07-06-dogfood-findings.md` and implements wave 1 fixes in protocol tooling.
> 
> **`find_references`** no longer implies full reference coverage when >1MB Tier-2 files were skipped. A bounded textual sweep (`tier2_reference_disclosure`) names size-demoted files that still contain the symbol, updates the completeness line with **Tier-2 exclusions apply**, and reports budget overruns as unswept.
> 
> **`get_symbol`** with name-only lookup now prefixes **`Resolved bare name to <path>`** so cross-language picks are visible. **`search_text`** zero-hit suggestions gain a **multi-word literal → bare identifier** hint when the query contains whitespace.
> 
> **Tips (B5)** — removes all success-path **`Tip:`** appends via deleted **`compact_next_step_hint`** across read/search tools; tests and verify-tool snapshots updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abcd0dd98a02433bdde6b4c36d08490c19483430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->