### PR TITLE
feat(init): Codex/Gemini/Kilo full-surface init + Perl SUPER/coderef fixtures + CPAN benchmark

### DIFF
--- a/docs/research/perl/cpan-benchmark-2026-07-06.json
+++ b/docs/research/perl/cpan-benchmark-2026-07-06.json
@@ -1,0 +1,149 @@
+{
+  "measured_at": "2026-07-06T16:54:58Z",
+  "symforge_version": "8.11.1",
+  "grammar_version": "ts-parser-perl 1.1.3",
+  "method": {
+    "tool": "shipped symforge.exe (npm symforge-windows-x64) via MCP index_folder + health",
+    "parse_outcome_proxy": "health quarantine registry: clean = Perl Tier-1 indexed - partial - failed; partials/failures enumerated per-file with tree-sitter diagnostic",
+    "denominator": "Tier-1 Perl files reported by get_repo_map (SymForge holds .t test files at Tier-2 metadata-only, so they are NOT symbol-parsed and are excluded)",
+    "notes": [
+      "The shipped CLI has no standalone scan/index command; indexing is driven through the MCP index_folder tool, and per-file parse outcomes come from the health quarantine registry.",
+      "health reports index-wide symbol counts but NO aggregate reference/xref count. Per-file 'Used by N refs' exists via get_file_context but there is no total-refs command; total references were therefore NOT measured.",
+      "Wall-clock is the daemon's own 'Loaded in' figure from health (parse+index of Tier-1 files), not end-to-end clone/IO."
+    ]
+  },
+  "repos": [
+    {
+      "name": "Mojolicious",
+      "url": "https://github.com/mojolicious/mojo",
+      "commit": "6007271e9152aa0998129991030c3ed16eb407d0",
+      "perl_files_on_disk": {
+        "total": 274,
+        "pm": 151,
+        "pl": 13,
+        "t": 110
+      },
+      "tier1_indexed_total": 198,
+      "tier1_language_breakdown": {
+        "Perl": 164,
+        "JavaScript": 9,
+        "Yaml": 9,
+        "Json": 6,
+        "Css": 5,
+        "Markdown": 4,
+        "Html": 1
+      },
+      "tier2_metadata_only": 205,
+      "symbols_extracted": 6650,
+      "references_extracted": null,
+      "load_ms": 78,
+      "perl_parse_outcomes": {
+        "perl_files_indexed": 164,
+        "clean": 158,
+        "partial": 6,
+        "failed": 0,
+        "clean_pct_raw": 96.34,
+        "clean_pct_excluding_intentional_fixtures": 98.17,
+        "partials_intentionally_malformed_fixtures": 3,
+        "partials_genuine_grammar_gap": 3
+      },
+      "non_perl_quarantine": {
+        "failed": [
+          "t/mojolicious/json_config_lite_app.json (serde_json data file, not Perl)",
+          "t/mojolicious/yaml_config_lite_app.yml (serde_yml data file, not Perl)"
+        ],
+        "partial": [
+          "lib/Mojolicious/resources/public/mojo/bootstrap/bootstrap.css (CSS, not Perl)",
+          "lib/Mojolicious/resources/public/mojo/mojo.css (CSS, not Perl)"
+        ]
+      },
+      "perl_partials": [
+        {
+          "file": "lib/Mojo/JSON.pm",
+          "symbols_recovered": 18,
+          "diagnostic": "tree-sitter: syntax error near `true` (line 224, column 10)",
+          "construct": "user-defined bareword sub call `true()` in `return true() if /\\Gtrue/gc;` (bareword call as statement-modifier expression)",
+          "intentional": false
+        },
+        {
+          "file": "lib/Mojo/Path.pm",
+          "symbols_recovered": 15,
+          "diagnostic": "tree-sitter: syntax missing ; near `$i, 2 }` (line 16, column 102)",
+          "construct": "chained if/elsif/else with block-form `{ ... }` statement bodies lacking trailing semicolons (grammar expects `;`)",
+          "intentional": false
+        },
+        {
+          "file": "lib/Mojo/Exception.pm",
+          "symbols_recovered": 10,
+          "diagnostic": "tree-sitter: syntax error near `CHECK:` (line 25, column 1)",
+          "construct": "statement label on a C-style for loop: `CHECK: for (my $i = 0; ...)`",
+          "intentional": false
+        },
+        {
+          "file": "t/mojolicious/lib/MojoliciousTest/SyntaxError.pm",
+          "diagnostic": "unexpected_partial",
+          "construct": "intentionally malformed test fixture (unclosed `sub foo {`)",
+          "intentional": true
+        },
+        {
+          "file": "t/mojo/lib/Mojo/LoaderException.pm",
+          "diagnostic": "unexpected_partial",
+          "construct": "intentionally malformed test fixture (bare unclosed `foo {` block)",
+          "intentional": true
+        },
+        {
+          "file": "t/mojo/lib/Mojo/LoaderTestException/A.pm",
+          "diagnostic": "unexpected_partial",
+          "construct": "intentionally malformed test fixture (bare unclosed `foo {` block)",
+          "intentional": true
+        }
+      ]
+    },
+    {
+      "name": "Perl-Critic",
+      "url": "https://github.com/Perl-Critic/Perl-Critic",
+      "commit": "c437d557ec903c99c5114bac738a484dfedb1f9f",
+      "perl_files_on_disk": {
+        "total": 255,
+        "pm": 205,
+        "pl": 0,
+        "t": 50
+      },
+      "tier1_indexed_total": 209,
+      "tier1_language_breakdown": {
+        "Perl": 205,
+        "Markdown": 3,
+        "Html": 1
+      },
+      "tier2_metadata_only": 228,
+      "symbols_extracted": 1761,
+      "references_extracted": null,
+      "load_ms": 45,
+      "perl_parse_outcomes": {
+        "perl_files_indexed": 205,
+        "clean": 205,
+        "partial": 0,
+        "failed": 0,
+        "clean_pct_raw": 100.0,
+        "clean_pct_excluding_intentional_fixtures": 100.0,
+        "partials_intentionally_malformed_fixtures": 0,
+        "partials_genuine_grammar_gap": 0
+      },
+      "non_perl_quarantine": {
+        "failed": [],
+        "partial": []
+      },
+      "perl_partials": []
+    }
+  ],
+  "totals": {
+    "perl_files_indexed": 369,
+    "clean": 363,
+    "partial": 6,
+    "failed": 0,
+    "clean_pct_raw": 98.37,
+    "clean_pct_excluding_intentional_fixtures": 99.19,
+    "genuine_grammar_gap_files": 3,
+    "symbols_extracted": 8411
+  }
+}

--- a/docs/research/perl/cpan-benchmark-2026-07-06.md
+++ b/docs/research/perl/cpan-benchmark-2026-07-06.md
@@ -1,0 +1,91 @@
+# CPAN-scale Perl parsing benchmark — SymForge
+
+**Measured**: 2026-07-06 · **Binary**: shipped `symforge.exe` 8.11.1 (npm `symforge-windows-x64`) · **Grammar**: `ts-parser-perl 1.1.3`
+
+Extends the 22-fixture synthetic corpus (100% clean, `corpus-metrics.json`) to
+real, large, mostly-pure-Perl CPAN distributions. This is a **local research
+benchmark**, not CI.
+
+## Setup
+
+| Repo | URL | Commit |
+|------|-----|--------|
+| Mojolicious | github.com/mojolicious/mojo | `6007271e9152aa0998129991030c3ed16eb407d0` |
+| Perl-Critic | github.com/Perl-Critic/Perl-Critic | `c437d557ec903c99c5114bac738a484dfedb1f9f` |
+
+Both shallow-cloned (`--depth 1`).
+
+## Method — and what the tooling can/can't measure
+
+The shipped CLI has **no standalone `scan`/`index` command**; indexing runs
+through the MCP `index_folder` tool. Per-file parse outcomes come from the
+`health` **quarantine registry**, which enumerates every partial/failed file
+with its tree-sitter diagnostic and byte span.
+
+Two honesty caveats about the proxy:
+
+1. **Denominator = Tier-1 Perl files.** SymForge admits `.t` test files only at
+   **Tier-2 (metadata-only)** — they are *not* symbol-parsed — so they are
+   excluded from the parse-rate denominator. The Perl file count used here is
+   the `Perl:` figure from `get_repo_map`, which counts the `.pm`/`.pl` files
+   that were actually parsed. (Mojo: 274 Perl files on disk, but 110 are `.t`
+   held at Tier-2; 164 Perl files reach the parser. Perl-Critic: 255 on disk,
+   50 `.t` at Tier-2; 205 reach the parser.)
+2. **No reference/xref total.** `health` reports index-wide **symbol** counts but
+   **no aggregate reference count**. Per-file "Used by N refs" is available via
+   `get_file_context`, but there is no total-refs command, so **total references
+   were not measured** (reported as `null`).
+
+Wall-clock is the daemon's own `Loaded in` figure (parse + index of Tier-1
+files), not end-to-end clone/IO time.
+
+## Results
+
+| Repo | Perl files parsed | Clean | Partial | Failed | Clean % (raw) | Symbols | Load |
+|------|------------------:|------:|--------:|-------:|--------------:|--------:|-----:|
+| Mojolicious | 164 | 158 | 6 | 0 | 96.3% | 6650 | 78 ms |
+| Perl-Critic | 205 | 205 | 0 | 0 | 100.0% | 1761 | 45 ms |
+| **Total** | **369** | **363** | **6** | **0** | **98.4%** | **8411** | — |
+
+Of Mojo's 6 partials, **3 are intentionally-malformed test fixtures** that
+SymForge correctly flags (true positives). Excluding those, the real-code clean
+rate is **161/164 = 98.2%** for Mojo and **99.2% across both repos**. There were
+**zero Perl parse failures** — the only two "failed" files are non-Perl data
+fixtures (`.json`/`.yml`) that happened to live in the tree.
+
+## Notable failures (one-line diagnosis each)
+
+Genuine `ts-parser-perl 1.1.3` grammar gaps (all three still recovered most
+symbols via best-effort partial parse):
+
+- **`lib/Mojo/JSON.pm`** L224 — `return true() if /\Gtrue/gc;` — user-defined
+  bareword sub call (`true()`) as a statement-modifier expression trips the
+  grammar. 18/18 symbols still recovered.
+- **`lib/Mojo/Path.pm`** L16 — chained `if/elsif/else` whose bodies are block-form
+  `{ splice ... }` with no trailing `;`; grammar reports "syntax missing ;".
+  15 symbols recovered.
+- **`lib/Mojo/Exception.pm`** L25 — `CHECK: for (my $i = 0; ...)` — a **statement
+  label on a C-style for loop**; grammar errors on the label. 10 symbols
+  recovered.
+
+Correctly-flagged intentional fixtures (not parser weaknesses):
+
+- `t/mojolicious/lib/MojoliciousTest/SyntaxError.pm` — unclosed `sub foo {`.
+- `t/mojo/lib/Mojo/LoaderException.pm` — bare unclosed `foo {` block.
+- `t/mojo/lib/Mojo/LoaderTestException/A.pm` — bare unclosed `foo {` block.
+
+Non-Perl noise caught in the sweep (excluded from Perl rates): 2 CSS partials
+(`bootstrap.css`, `mojo.css`) and the 2 `.json`/`.yml` "failed" data files above.
+
+## Caveats
+
+- Parse-rate is **file-level**, not construct-level: a "clean" file means no
+  tree-sitter ERROR/MISSING node, not that every xref was attached.
+- `.t` files are unmeasured here (Tier-2). A separate run forcing `.t` into
+  Tier-1 would be needed to characterize test-file parsing at CPAN scale.
+- Reference/xref recall was not quantified (no aggregate-count tool); see the
+  fixture-corpus `recall-metrics.json` for construct-level xref recall on the
+  synthetic corpus.
+- Two repos only; not a statistically representative CPAN sample. The three
+  grammar gaps found are candidate S2 backlog items if reproduced on the
+  synthetic corpus.

--- a/docs/reviews/2026-07-03-surface-spike-gate.md
+++ b/docs/reviews/2026-07-03-surface-spike-gate.md
@@ -126,6 +126,11 @@ Post-merge checks on `main` after init fix + 8.11.0:
 | Claude Code init | `SYMFORGE_SURFACE=full` + full allowlist | `tests/init_integration.rs` |
 | Cursor init | `SYMFORGE_SURFACE=full` (operator flip per item 2) | `src/cli/init.rs` unit test |
 | Codex / Gemini / Kilo init | `SYMFORGE_SURFACE=compact` (16k/turn harnesses) | init unit tests |
+
+Update 2026-07-06 (post-8.11.1): operator exercised item 2 — Codex/Gemini/Kilo
+init flipped to `full` (Codex was measured deferred anyway; Gemini/Kilo accept
+full at ~16k/turn). `SYMFORGE_SURFACE=compact` remains the documented escape
+hatch and is preserved on re-init. Claude Desktop stays compact-by-init.
 | CI Release gate | green on Linux | GitHub Actions |
 
 Re-run init locally after upgrade: `symforge init --client cursor` (or `all`) to refresh

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1008,10 +1008,11 @@ fn merge_symforge_codex_server_for_target_os(
     merge_codex_project_doc_fallbacks(config);
 }
 
-/// Union the compact-surface tool names into Codex's `allowed_tools`,
+/// Union the full-surface tool names into Codex's `allowed_tools`,
 /// preserving any user-added entries. Codex strips the `mcp__symforge__` prefix,
-/// so the compact short names (`symforge`, `symforge_edit`, `status`) are what
-/// the served surface actually exposes — the allowlist matches the surface.
+/// so the unprefixed short names are what the served surface actually exposes —
+/// the allowlist matches the surface (spec §4; full-by-init per the 2026-07-03
+/// spike gate + 2026-07-06 operator flip).
 fn merge_codex_allowed_tools(symforge: &mut Table) {
     let mut names: Vec<String> = symforge
         .get("allowed_tools")
@@ -1023,7 +1024,7 @@ fn merge_codex_allowed_tools(symforge: &mut Table) {
         })
         .unwrap_or_default();
 
-    for name in crate::stel::COMPACT_TOOL_NAMES {
+    for name in CLAUDE_ALWAYS_ALLOW {
         if !names.iter().any(|existing| existing == name) {
             names.push(name.to_string());
         }
@@ -1047,10 +1048,11 @@ fn merge_codex_mcp_env_overrides(symforge: &mut Table, target_os: &str) {
         .as_table_like_mut()
         .expect("symforge env must be a table or inline table");
 
-    // Make the served compact surface explicit, but never clobber a user-set
-    // value (G-036: the 8.10.1 update wiped SYMFORGE_SURFACE=full).
+    // Codex defers schema loading (undocumented `tool_search` layer, measured
+    // 2026-07-03), so serve the full surface. Never clobber a user-set value
+    // (G-036: the 8.10.1 update wiped SYMFORGE_SURFACE=full).
     if env.get("SYMFORGE_SURFACE").is_none() {
-        env.insert("SYMFORGE_SURFACE", value("compact"));
+        env.insert("SYMFORGE_SURFACE", value("full"));
     }
 
     for (name, env_value) in codex_mcp_env_overrides_for_target_os(target_os) {
@@ -1123,8 +1125,10 @@ pub fn register_gemini_mcp_server(
     entry
         .entry("trust".to_string())
         .or_insert_with(|| Value::Bool(true));
-    // Gemini CLI has no deferred loading — make the compact surface explicit.
-    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "compact")]);
+    // Gemini CLI full-injects (~16k tokens/turn) but accepts all 36 tools
+    // (measured 2026-07-03); operator flipped init to full 2026-07-06.
+    // `SYMFORGE_SURFACE=compact` stays the documented escape hatch.
+    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "full")]);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(gemini_settings_path, pretty)
@@ -1163,10 +1167,12 @@ pub fn register_kilo_mcp_server(
     entry
         .entry("disabled".to_string())
         .or_insert_with(|| Value::Bool(false));
-    // Kilo has no deferred loading — serve the compact 3-tool facade and grant
-    // exactly those names so the allowlist matches the served surface (spec §4).
-    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "compact")]);
-    union_allow_names(entry, "alwaysAllow", &crate::stel::COMPACT_TOOL_NAMES);
+    // Kilo full-injects (~16k tokens/turn) but accepts all 36 tools (measured
+    // 2026-07-03); operator flipped init to full 2026-07-06. Grant the full
+    // names so the allowlist matches the served surface (spec §4);
+    // `SYMFORGE_SURFACE=compact` stays the documented escape hatch.
+    insert_env_defaults(entry, &[("SYMFORGE_SURFACE", "full")]);
+    union_allow_names(entry, "alwaysAllow", CLAUDE_ALWAYS_ALLOW);
 
     let pretty = serde_json::to_string_pretty(&config)?;
     std::fs::write(kilo_config_path, pretty)
@@ -2036,9 +2042,8 @@ mod tests {
 
         // SYMFORGE_TOOL_NAMES carries the `mcp__symforge__` prefix; strip it to compare.
         // It backs the Claude Code settings.json `allowedTools` union (the full
-        // surface). Kilo/Codex intentionally grant only the compact names now
-        // (see the coherence tests), so they are not compared against the full
-        // surface here.
+        // surface). Kilo/Codex allowlists union CLAUDE_ALWAYS_ALLOW (pinned to
+        // the registered surface below), so they are covered transitively.
         let full: BTreeSet<String> = SYMFORGE_TOOL_NAMES
             .iter()
             .map(|n| n.trim_start_matches("mcp__symforge__").to_string())
@@ -2090,23 +2095,26 @@ mod tests {
         let config_path = dir.path().join("config.toml");
         register_codex_mcp_server(&config_path, "/usr/bin/symforge").unwrap();
         let content = std::fs::read_to_string(&config_path).unwrap();
-        // G-036 coherence: Codex serves the compact surface, so its allowlist
-        // grants exactly the compact facade names — nothing more.
-        assert!(
-            content.contains("allowed_tools = [\"symforge\", \"symforge_edit\", \"status\"]"),
-            "Codex allow list must be exactly the compact facade names: {content}"
-        );
-        assert!(
-            !content.contains("\"search_symbols\""),
-            "Codex allow list must not grant full-surface tools when serving compact: {content}"
-        );
+        // G-036 coherence: Codex serves the full surface, so its allowlist
+        // grants every full-surface short name.
+        for name in [
+            "\"symforge\"",
+            "\"symforge_edit\"",
+            "\"status\"",
+            "\"search_symbols\"",
+        ] {
+            assert!(
+                content.contains(name),
+                "Codex allow list must grant full-surface name {name}: {content}"
+            );
+        }
         assert!(
             !content.contains("trace_symbol"),
             "Codex allow list must not include retired trace_symbol alias: {content}"
         );
         assert!(
-            content.contains("SYMFORGE_SURFACE = \"compact\""),
-            "Codex env must make the compact surface explicit: {content}"
+            content.contains("SYMFORGE_SURFACE = \"full\""),
+            "Codex env must make the full surface explicit: {content}"
         );
         assert!(
             content.contains("project_doc_fallback_filenames = [\"AGENTS.md\", \"CLAUDE.md\"]"),
@@ -2162,7 +2170,7 @@ mod tests {
             "re-registration must NOT downgrade a user-set surface (the 8.10.1 wipe)"
         );
 
-        // Direction 2: user pinned full on a compact-default harness (Kilo).
+        // Direction 2: user pinned compact (escape hatch) on Kilo (fresh default full).
         let dir2 = tempfile::tempdir().unwrap();
         let path2 = dir2.path().join("mcp.json");
         std::fs::write(
@@ -2171,7 +2179,7 @@ mod tests {
                 "mcpServers": {
                     "symforge": {
                         "command": "/old/symforge",
-                        "env": {"SYMFORGE_SURFACE": "full"}
+                        "env": {"SYMFORGE_SURFACE": "compact"}
                     }
                 }
             }))
@@ -2183,8 +2191,8 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&path2).unwrap()).unwrap();
         assert_eq!(
             config2["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
-            Some("full"),
-            "re-registration must preserve a user-set full surface on a compact harness"
+            Some("compact"),
+            "re-registration must preserve a user-set compact escape hatch on Kilo"
         );
     }
 
@@ -2279,20 +2287,20 @@ mod tests {
     }
 
     #[test]
-    fn test_gemini_fresh_registration_pins_compact_surface() {
+    fn test_gemini_fresh_registration_pins_full_surface() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("settings.json");
         register_gemini_mcp_server(&path, "/usr/bin/symforge").unwrap();
         let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(
             config["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
-            Some("compact"),
-            "fresh Gemini registration must make the compact surface explicit"
+            Some("full"),
+            "fresh Gemini registration must make the full surface explicit"
         );
     }
 
     #[test]
-    fn test_kilo_fresh_registration_allowlist_is_exactly_compact() {
+    fn test_kilo_fresh_registration_allowlist_is_exactly_full() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mcp.json");
         register_kilo_mcp_server(&path, "/usr/bin/symforge").unwrap();
@@ -2303,7 +2311,12 @@ mod tests {
             .iter()
             .filter_map(Value::as_str)
             .collect();
-        assert_eq!(allow, vec!["symforge", "symforge_edit", "status"]);
+        assert_eq!(allow, CLAUDE_ALWAYS_ALLOW.to_vec());
+        assert_eq!(
+            config["mcpServers"]["symforge"]["env"]["SYMFORGE_SURFACE"].as_str(),
+            Some("full"),
+            "fresh Kilo registration must make the full surface explicit"
+        );
     }
 
     #[test]
@@ -2344,17 +2357,19 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_fresh_registration_allowlist_is_exactly_compact() {
+    fn test_codex_fresh_registration_allowlist_is_exactly_full() {
         let mut config = DocumentMut::new();
         merge_symforge_codex_server_for_target_os(&mut config, "/usr/bin/symforge", "macos");
         let content = config.to_string();
+        for name in CLAUDE_ALWAYS_ALLOW {
+            assert!(
+                content.contains(&format!("\"{name}\"")),
+                "fresh Codex allowlist must grant full-surface name {name}: {content}"
+            );
+        }
         assert!(
-            content.contains("allowed_tools = [\"symforge\", \"symforge_edit\", \"status\"]"),
-            "fresh Codex allowlist must be exactly the compact names: {content}"
-        );
-        assert!(
-            content.contains("SYMFORGE_SURFACE = \"compact\""),
-            "fresh Codex env must pin the compact surface on every OS: {content}"
+            content.contains("SYMFORGE_SURFACE = \"full\""),
+            "fresh Codex env must pin the full surface on every OS: {content}"
         );
     }
 
@@ -2368,7 +2383,7 @@ mod tests {
     allowed_tools = ["my_custom_tool"]
 
     [mcp_servers.symforge.env]
-    SYMFORGE_SURFACE = "full"
+    SYMFORGE_SURFACE = "compact"
     "#
         .parse::<DocumentMut>()
         .unwrap();
@@ -2381,12 +2396,12 @@ mod tests {
         for name in ["\"symforge\"", "\"symforge_edit\"", "\"status\""] {
             assert!(
                 content.contains(name),
-                "compact name {name} must be unioned in: {content}"
+                "surface name {name} must be unioned in: {content}"
             );
         }
         assert!(
-            content.contains("SYMFORGE_SURFACE = \"full\""),
-            "re-registration must preserve a user-set Codex surface: {content}"
+            content.contains("SYMFORGE_SURFACE = \"compact\""),
+            "re-registration must preserve a user-set Codex compact escape hatch: {content}"
         );
         assert!(
             content.contains("startup_timeout_sec = 90")

--- a/tests/fixtures/perl/README.md
+++ b/tests/fixtures/perl/README.md
@@ -12,7 +12,8 @@ Synthetic snippets for parse-quality and recall measurement. Each file is tagged
 ## Construct classes
 
 `sub`, `package`, `class`, `method`, `method_call`, `plain_call`, `ambiguous_call`,
-`use_import`, `require_import`, `qualified_call`
+`use_import`, `require_import`, `qualified_call`, `super_call`, `coderef_call`,
+`parent_import`
 
 ## Running
 

--- a/tests/fixtures/perl/coderef_call.pl
+++ b/tests/fixtures/perl/coderef_call.pl
@@ -1,0 +1,2 @@
+my $coderef = sub { return 1 };
+$coderef->();

--- a/tests/fixtures/perl/manifest.json
+++ b/tests/fixtures/perl/manifest.json
@@ -162,6 +162,38 @@
         { "kind": "Import", "name": "Bar", "qualified_name": "Foo::Bar" },
         { "kind": "Import", "name": "Qux", "qualified_name": "Baz::Qux" }
       ]
+    },
+    {
+      "file": "super_method_call.pl",
+      "construct_classes": ["super_call", "method_call"],
+      "parse_expect": "clean",
+      "refs": [
+        { "kind": "Call", "name": "method", "qualified_name": "SUPER::method" }
+      ]
+    },
+    {
+      "file": "coderef_call.pl",
+      "construct_classes": ["coderef_call"],
+      "parse_expect": "clean",
+      "refs": [{ "kind": "Call", "name": "coderef" }]
+    },
+    {
+      "file": "use_parent.pl",
+      "construct_classes": ["parent_import"],
+      "parse_expect": "clean",
+      "refs": [{ "kind": "Import", "name": "Foo" }]
+    },
+    {
+      "file": "super_shift_chain.pl",
+      "construct_classes": ["package", "sub", "super_call"],
+      "parse_expect": "clean",
+      "symbols": [
+        { "kind": "Module", "name": "Shape::Circle" },
+        { "kind": "Function", "name": "area" }
+      ],
+      "refs": [
+        { "kind": "Call", "name": "compute", "qualified_name": "SUPER::compute" }
+      ]
     }
   ]
 }

--- a/tests/fixtures/perl/super_method_call.pl
+++ b/tests/fixtures/perl/super_method_call.pl
@@ -1,0 +1,2 @@
+my $self = shift;
+$self->SUPER::method();

--- a/tests/fixtures/perl/super_shift_chain.pl
+++ b/tests/fixtures/perl/super_shift_chain.pl
@@ -1,0 +1,3 @@
+package Shape::Circle;
+sub area { shift->SUPER::compute(@_); }
+1;

--- a/tests/fixtures/perl/use_parent.pl
+++ b/tests/fixtures/perl/use_parent.pl
@@ -1,0 +1,1 @@
+use parent qw(Foo);

--- a/tests/init_integration.rs
+++ b/tests/init_integration.rs
@@ -402,22 +402,29 @@ fn test_init_registers_kilo_mcp_server() {
         "args must be empty"
     );
 
-    // G-036 coherence: Kilo serves the compact surface, so its allowlist grants
-    // exactly the compact facade names and the env pins that surface.
+    // G-036 coherence: Kilo serves the full surface (2026-07-06 operator flip),
+    // so its allowlist grants the full-surface names and the env pins full.
     assert_eq!(
         symforge["env"]["SYMFORGE_SURFACE"].as_str(),
-        Some("compact"),
-        "Kilo env must make the compact surface explicit"
+        Some("full"),
+        "Kilo env must make the full surface explicit"
     );
     let always_allow = symforge["alwaysAllow"]
         .as_array()
         .expect("alwaysAllow must be an array");
     let names: Vec<&str> = always_allow.iter().filter_map(|v| v.as_str()).collect();
-    assert_eq!(
-        names,
-        vec!["symforge", "symforge_edit", "status"],
-        "alwaysAllow must be exactly the compact facade names"
-    );
+    for name in [
+        "symforge",
+        "symforge_edit",
+        "status",
+        "search_symbols",
+        "replace_symbol_body",
+    ] {
+        assert!(
+            names.contains(&name),
+            "alwaysAllow must grant full-surface name {name}: {names:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
The remaining 2026-07-06 session deliverables (the tips overhaul rides PR #416 since it shares files with the trust fixes).

## Commits

1. **feat(init)**: Codex/Gemini/Kilo registration flipped to `SYMFORGE_SURFACE=full` per the 2026-07-03 spike-gate item 2 (operator decision). Allowlists union the full short names (spec §4 coherence); `compact` stays the escape hatch, user-set values preserved on re-init both directions (tests updated to guard the compact escape hatch instead). Claude Desktop stays compact-by-init.
2. **test(perl)**: 016 corpus 22→26 (SUPER::, coderef, use parent, shift->SUPER chain) + CPAN-scale benchmark record: Mojolicious + Perl-Critic, 369 files on shipped 8.11.1, **98.4% raw clean parse, zero true failures**, 3 genuine ts-parser-perl grammar gaps documented as S2 candidates (docs/research/perl/cpan-benchmark-2026-07-06.md).

Full gate green locally (fmt, clippy -D warnings, full test suite ×2, release build) — run on the combined working tree that included these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Init changes alter default MCP tool exposure for three client harnesses (~16k tokens/turn); behavior is intentional and user `compact` pins are preserved, but fresh installs get a wider default surface.
> 
> **Overview**
> **MCP init defaults** for Codex, Gemini, and Kilo now register **`SYMFORGE_SURFACE=full`** and union the **full tool allowlist** (`CLAUDE_ALWAYS_ALLOW`) instead of the compact three-tool facade. User-set **`compact`** values still win on re-init; unit and integration tests were flipped to assert full-by-default and compact-as-escape-hatch. The 2026-07-03 surface spike gate doc records the 2026-07-06 operator decision (Claude Desktop remains compact-by-init).
> 
> **Perl coverage** grows the synthetic corpus from 22 to **26 fixtures** (`SUPER::`, coderef `->()`, `use parent`, `shift->SUPER::` chain) with manifest expectations; fixture README lists new construct classes.
> 
> **Research docs** add a CPAN-scale benchmark (Mojolicious + Perl-Critic on shipped 8.11.1): **369** Tier-1 Perl files, **~98.4%** file-level clean parse, **zero** Perl failures, three genuine grammar gaps called out as S2 candidates (JSON + markdown + JSON artifact).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d603b3593d7fb89b98dbf5246fe689b0de4a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->