### PR TITLE
fix(admission): impact-path admission coherence and 4MB code-language threshold

### DIFF
--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1036,7 +1036,19 @@ pub fn classify_admission(
             SkipReason::DenylistedExtension,
         );
     }
-    if file_size > METADATA_ONLY_BYTES {
+    // Language-aware threshold (dogfood #1/#7, 2026-07-06): code languages get
+    // METADATA_ONLY_CODE_BYTES (4MB) before demotion — >1MB first-party source
+    // is load-bearing in real repos and tree-sitter parses it in milliseconds.
+    // Data/markup formats keep the 1MB threshold (symbol-pollution guard).
+    let size_threshold = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .and_then(crate::domain::LanguageId::from_extension)
+        .filter(crate::domain::LanguageId::is_code_language)
+        .map_or(METADATA_ONLY_BYTES, |_| {
+            crate::domain::index::METADATA_ONLY_CODE_BYTES
+        });
+    if file_size > size_threshold {
         return AdmissionDecision::skip(AdmissionTier::MetadataOnly, SkipReason::SizeThreshold);
     }
     if let Some(content) = content_sample
@@ -1741,6 +1753,45 @@ mod tests {
     fn test_medium_rust_source_is_normal() {
         let decision = classify_admission(std::path::Path::new("big_module.rs"), 500 * 1024, None);
         assert_eq!(decision, AdmissionDecision::normal());
+    }
+
+    #[test]
+    fn test_oversized_code_file_under_4mb_is_normal() {
+        // Dogfood #1/#7 (2026-07-06): >1MB first-party code is load-bearing
+        // (a 1.2MB Rust module held the only construction site of a queried
+        // type; symforge's own tools.rs crossed 1MB). Code languages get the
+        // 4MB METADATA_ONLY_CODE_BYTES threshold.
+        for name in ["orchestrator.rs", "big.py", "huge.ts", "large.pm"] {
+            let decision = classify_admission(std::path::Path::new(name), 1_200_000, None);
+            assert_eq!(
+                decision,
+                AdmissionDecision::normal(),
+                "1.2MB code file {name} must stay Tier-1"
+            );
+        }
+    }
+
+    #[test]
+    fn test_code_file_above_4mb_is_metadata_only() {
+        let decision =
+            classify_admission(std::path::Path::new("generated.rs"), 5 * 1024 * 1024, None);
+        assert_eq!(decision.tier, AdmissionTier::MetadataOnly);
+        assert_eq!(decision.reason, Some(SkipReason::SizeThreshold));
+    }
+
+    #[test]
+    fn test_data_formats_keep_1mb_threshold() {
+        // The symbol-pollution guard: machine-generated data files demote at
+        // 1MB even though their language is "supported".
+        for name in ["big.yaml", "big.toml", "big.md", "big.html"] {
+            let decision = classify_admission(std::path::Path::new(name), 1_200_000, None);
+            assert_eq!(
+                decision.tier,
+                AdmissionTier::MetadataOnly,
+                "1.2MB data file {name} must stay Tier-2"
+            );
+            assert_eq!(decision.reason, Some(SkipReason::SizeThreshold));
+        }
     }
 
     #[test]

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -62,6 +62,24 @@ impl LanguageId {
         }
     }
 
+    /// True for programming languages (symbol-bearing code) as opposed to
+    /// data/markup formats. Drives the higher metadata-only size threshold
+    /// ([`METADATA_ONLY_CODE_BYTES`]): oversized machine-generated data files
+    /// must stay Tier-2, but oversized first-party code is load-bearing.
+    pub fn is_code_language(&self) -> bool {
+        !matches!(
+            self,
+            Self::Json
+                | Self::Toml
+                | Self::Yaml
+                | Self::Markdown
+                | Self::Env
+                | Self::Html
+                | Self::Css
+                | Self::Scss
+        )
+    }
+
     /// Returns `true` when `relative_path` is a TSX source file (`.tsx`).
     ///
     /// `.tsx` and `.ts` both map to [`LanguageId::TypeScript`], but they require
@@ -635,6 +653,13 @@ impl SkippedFile {
 
 pub const HARD_SKIP_BYTES: u64 = 100 * 1024 * 1024;
 pub const METADATA_ONLY_BYTES: u64 = 1024 * 1024;
+/// Higher metadata-only threshold for CODE languages (dogfood #1/#7,
+/// 2026-07-06): >1MB machine-generated JSON/YAML must stay Tier-2 (symbol
+/// pollution), but >1MB first-party code is load-bearing in real repos — a
+/// 1.2MB Rust module held the only construction site of a queried type, and
+/// symforge's own `src/protocol/tools.rs` crossed 1MB. Tree-sitter parses
+/// multi-MB source in milliseconds, so code gets 4MB before demotion.
+pub const METADATA_ONLY_CODE_BYTES: u64 = 4 * 1024 * 1024;
 pub const BINARY_SNIFF_BYTES: usize = 8192;
 
 const DENYLISTED_EXTENSIONS: &[&str] = &[

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1156,6 +1156,7 @@ impl SymForgeServer {
             "get_symbol_context" => call!(get_symbol_context, tools::GetSymbolContextInput),
             "find_references" => call!(find_references, tools::FindReferencesInput),
             "find_dependents" => call!(find_dependents, tools::FindDependentsInput),
+            "analyze_file_impact" => call!(analyze_file_impact, tools::AnalyzeFileImpactInput),
             "detect_impact" => call!(detect_impact, tools::DetectImpactInput),
             "explore" => call!(explore, tools::ExploreInput),
             "get_repo_map" => call!(get_repo_map, tools::GetRepoMapInput),

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -14098,8 +14098,9 @@ mod tests {
             .await;
 
         assert!(
-            result.contains("not found on disk"),
-            "deleted file should report 'not found on disk'; got: {result}"
+            result.contains("not found under"),
+            "deleted file should report 'not found under <root>' (dogfood #6: \
+             the lookup root is always named); got: {result}"
         );
     }
 

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -761,6 +761,17 @@ async fn impact_text(
     params: &ImpactParams,
     options: RenderOptions,
 ) -> Result<String, StatusCode> {
+    // Admission coherence (dogfood #7, 2026-07-06): this path used to
+    // force-index ANY file via process_file + update_file, bypassing the
+    // admission gate that the bulk walk and the watcher both apply. The result
+    // was flapping: analyze_file_impact admitted an oversized file, the next
+    // watcher event demoted it again. Apply the SAME gate here — a Tier-2/3
+    // file gets an honest refusal plus a skip-registry update, never a silent
+    // admit that the watcher will undo.
+    if let Some(refusal) = impact_admission_refusal(&state, &params.path) {
+        return Ok(refusal);
+    }
+
     let is_new_file = params.new_file.unwrap_or(false);
 
     if is_new_file {
@@ -791,6 +802,65 @@ async fn impact_text(
 
     // HOOK-05: Re-index existing file and compute symbol diff.
     handle_edit_impact(state, &params.path, options).await
+}
+
+/// Run the admission gate for the impact path. Returns `Some(refusal_text)`
+/// when the on-disk file classifies Tier-2/3 — the caller must not parse or
+/// insert it. Also records the demotion in the skip registry so `health` and
+/// the watcher agree with what this refusal says. Returns `None` for Tier-1
+/// files, unreadable paths (downstream NOT_FOUND handling owns those), and
+/// files outside a resolvable repo root.
+fn impact_admission_refusal(state: &SidecarState, path: &str) -> Option<String> {
+    use crate::domain::index::{AdmissionTier, BINARY_SNIFF_BYTES, SkippedFile};
+
+    let root = resolve_repo_root(state).ok()?;
+    let abs_path = root.join(path);
+    let metadata = std::fs::metadata(&abs_path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let file_size = metadata.len();
+    // Content sample for the binary sniff — bounded read, never the whole file.
+    let sample = std::fs::File::open(&abs_path).ok().and_then(|mut f| {
+        use std::io::Read;
+        let mut buf = vec![0u8; BINARY_SNIFF_BYTES];
+        let n = f.read(&mut buf).ok()?;
+        buf.truncate(n);
+        Some(buf)
+    });
+    let decision = crate::discovery::classify_admission(&abs_path, file_size, sample.as_deref());
+    if decision.tier == AdmissionTier::Normal {
+        return None;
+    }
+    let tier_label = match decision.tier {
+        AdmissionTier::MetadataOnly => "Tier 2 (metadata only)",
+        AdmissionTier::HardSkip => "Tier 3 (hard skip)",
+        AdmissionTier::Normal => unreachable!("Normal returned above"),
+    };
+    let reason = decision
+        .reason
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "policy".to_string());
+    let extension = abs_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_string());
+    let sf = SkippedFile {
+        path: path.to_string(),
+        size: file_size,
+        extension,
+        decision,
+    };
+    let expected_gen = state.index.current_project_generation();
+    state
+        .index
+        .demote_to_skipped_at_generation(path, sf, expected_gen);
+    Some(format!(
+        "Not indexed: {path} is {tier_label} — reason: {reason}, size {:.1} MB. \
+         The admission gate applies to analyze_file_impact the same as bulk load \
+         and the watcher (no force-admit). Use get_file_content for raw reads.",
+        file_size as f64 / (1024.0 * 1024.0)
+    ))
 }
 
 async fn handle_new_file_impact(
@@ -1003,10 +1073,19 @@ async fn handle_edit_impact(
                 let mut cache = state.symbol_cache.write();
                 cache.remove(path);
             }
+            // Dogfood #6 (2026-07-06): ALWAYS name the root the lookup ran
+            // against. When another session retargets the shared daemon
+            // (index_folder on a different project), every path from THIS
+            // session resolves against the wrong root and this branch fires
+            // for files that exist — a bare "not found" reads as a false
+            // alarm; naming the root exposes the mismatch immediately.
+            let root_display = resolve_repo_root(&state)
+                .map(|r| r.display().to_string())
+                .unwrap_or_else(|_| "<unresolved root>".to_string());
             let text = if prev_symbol_count > 0 {
                 format!(
-                    "── Impact: {} ──\nStatus: not found on disk — removed from index\nPreviously had {} symbols.",
-                    path, prev_symbol_count
+                    "── Impact: {} ──\nStatus: not found under {} — removed from index\nPreviously had {} symbols.",
+                    path, root_display, prev_symbol_count
                 )
             } else {
                 // The file-watcher may have already purged the index entry
@@ -1014,8 +1093,10 @@ async fn handle_edit_impact(
                 // have no pre-count to report, so say so plainly instead of
                 // printing a misleading `Previously had 0 symbols.`.
                 format!(
-                    "── Impact: {} ──\nStatus: not found on disk — no index record remains (may have been removed by watcher).",
-                    path
+                    "── Impact: {} ──\nStatus: not found under {} — no index record remains (removed by watcher, \
+                     or this daemon is rooted at a different project than your session; \
+                     re-run index_folder on your repo if the root looks wrong).",
+                    path, root_display
                 )
             };
             return Ok(text);

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1757,10 +1757,11 @@ mod tests {
             assert_eq!(idx.tier_counts(), (1, 0, 0));
         }
 
-        // Grow the file past the 1MB metadata-only threshold (still valid Rust),
+        // Grow the file past the 4MB CODE metadata-only threshold (still valid
+        // Rust; code languages get METADATA_ONLY_CODE_BYTES, dogfood #1/#7),
         // then bump mtime so the freshen path detects staleness.
         let mut grown = b"fn big() {}\n".to_vec();
-        grown.resize(1_200_000, b' ');
+        grown.resize(4_400_000, b' ');
         std::fs::write(&abs, &grown).unwrap();
         // Ensure the on-disk mtime differs from the indexed one so the freshen
         // mtime comparison fires (writes within the same second can otherwise
@@ -1805,9 +1806,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let rel = "shrink.rs";
         let abs = tmp.path().join(rel);
-        // Start oversized -> Tier 2 (SizeThreshold).
+        // Start oversized -> Tier 2 (SizeThreshold). Code files demote above
+        // METADATA_ONLY_CODE_BYTES (4MB), not the 1MB data threshold.
         let mut big = b"fn shrink() {}\n".to_vec();
-        big.resize(1_200_000, b' ');
+        big.resize(4_400_000, b' ');
         std::fs::write(&abs, &big).unwrap();
 
         let shared = crate::live_index::LiveIndex::load(tmp.path()).unwrap();

--- a/tests/impact_admission.rs
+++ b/tests/impact_admission.rs
@@ -1,0 +1,125 @@
+// Server-only integration test: depends on a `#[cfg(feature = "server")]`
+// module (protocol/daemon/cli/sidecar/watcher/analytics). Gating the whole
+// file keeps `--no-default-features --features embed --all-targets` compiling.
+#![cfg(feature = "server")]
+
+//! Admission coherence for `analyze_file_impact` (dogfood #7, 2026-07-06).
+//!
+//! The impact path used to force-index ANY file via `process_file` +
+//! `update_file`, bypassing the admission gate that the bulk walk and the
+//! watcher both apply. The result was flapping: `analyze_file_impact`
+//! admitted an oversized file, the next watcher event demoted it again.
+//! These tests pin: (1) a Tier-2 file gets an honest refusal that names the
+//! tier and reason, never a silent admit; (2) the refusal updates the skip
+//! registry so `health`/watcher agree; (3) code files between 1MB and 4MB
+//! are Tier-1 end-to-end under METADATA_ONLY_CODE_BYTES (dogfood #1/#7).
+
+use std::fs;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::json;
+use symforge::live_index::LiveIndex;
+use symforge::protocol::SymForgeServer;
+use symforge::watcher::WatcherInfo;
+use tempfile::TempDir;
+
+fn make_server(files: &[(&str, &str)]) -> (TempDir, SymForgeServer) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    for (rel, content) in files {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(&path, content).expect("write fixture file");
+    }
+    let shared = LiveIndex::load(&root).expect("LiveIndex::load");
+    let watcher_info = Arc::new(Mutex::new(WatcherInfo::default()));
+    let server = SymForgeServer::new(
+        shared,
+        "impact_admission_test".to_string(),
+        watcher_info,
+        Some(root),
+        None,
+    );
+    (dir, server)
+}
+
+#[tokio::test]
+async fn impact_refuses_oversized_code_file() {
+    // 5MB .rs is above METADATA_ONLY_CODE_BYTES (4MB) — Tier-2 at load, and
+    // analyze_file_impact must refuse honestly instead of force-admitting.
+    let big = format!("fn generated() {{}}\n// {}\n", "x".repeat(5 * 1024 * 1024));
+    let (_dir, server) = make_server(&[("src/lib.rs", "pub fn keep() {}\n"), ("src/big.rs", &big)]);
+
+    let result = server
+        .dispatch_tool_for_tests("analyze_file_impact", json!({ "path": "src/big.rs" }))
+        .await;
+    assert!(
+        result.contains("Not indexed") && result.contains("Tier 2"),
+        "oversized code file must get an honest Tier-2 refusal; got: {result}"
+    );
+    assert!(
+        result.contains(">1MB"),
+        "the refusal must name the size reason; got: {result}"
+    );
+    // No silent admit: the file must NOT be in the Tier-1 index afterwards.
+    assert!(
+        server.index().read().get_file("src/big.rs").is_none(),
+        "impact must not force-admit a Tier-2 file"
+    );
+    // The skip registry knows it, so health/watcher agree with the refusal.
+    assert!(
+        server
+            .index()
+            .read()
+            .skipped_files()
+            .iter()
+            .any(|f| f.path == "src/big.rs"),
+        "the refusal must record the demotion in the skip registry"
+    );
+}
+
+#[tokio::test]
+async fn impact_admits_code_file_between_1mb_and_4mb() {
+    // Dogfood #1/#7: 1.2MB first-party code is load-bearing and must be
+    // Tier-1 end-to-end — indexed at load AND re-indexable via impact.
+    let medium = format!("pub fn loaded() {{}}\n// {}\n", "x".repeat(1_200_000));
+    let (_dir, server) = make_server(&[("src/medium.rs", &medium)]);
+
+    assert!(
+        server.index().read().get_file("src/medium.rs").is_some(),
+        "1.2MB code file must be Tier-1 at load under METADATA_ONLY_CODE_BYTES"
+    );
+    let result = server
+        .dispatch_tool_for_tests("analyze_file_impact", json!({ "path": "src/medium.rs" }))
+        .await;
+    assert!(
+        !result.contains("Not indexed"),
+        "1.2MB code file must not be refused; got: {result}"
+    );
+    assert!(
+        result.contains("Impact:") || result.contains("Symbols:"),
+        "impact must actually run on a Tier-1 file (positive signal, not just \
+         absence of refusal); got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn impact_refuses_oversized_data_file_at_1mb_threshold() {
+    // Data formats keep the 1MB symbol-pollution threshold.
+    let big_json = format!("{{\"pad\": \"{}\"}}", "x".repeat(1_500_000));
+    let (_dir, server) = make_server(&[
+        ("src/lib.rs", "pub fn keep() {}\n"),
+        ("data/big.json", &big_json),
+    ]);
+
+    let result = server
+        .dispatch_tool_for_tests("analyze_file_impact", json!({ "path": "data/big.json" }))
+        .await;
+    assert!(
+        result.contains("Not indexed") && result.contains("Tier 2"),
+        "1.5MB data file must get an honest Tier-2 refusal; got: {result}"
+    );
+}


### PR DESCRIPTION
## Wave 2 of the dogfood fix campaign (findings #6 cheap / #7)

Findings doc: `docs/reviews/2026-07-06-dogfood-findings.md` (on the PR #416 branch).

### #7 — external-edit index eviction (root cause: admission incoherence)
`analyze_file_impact` bypassed the admission gate via `process_file` + `update_file` (force-admit), while the watcher re-ran admission per event and demoted the same file — flapping, and eventually eviction of load-bearing files. Live self-repro during this session: symforge's own `src/protocol/tools.rs` (~1.07MB) crossed the 1MB cutoff and was repeatedly demoted, breaking symforge's edit tools on its own repo.

Fixes:
- **Impact path now gated**: new `impact_admission_refusal` in `src/sidecar/handlers.rs` runs `classify_admission` before impact; a non-Normal file gets an honest refusal (tier, reason, size) and `demote_to_skipped_at_generation` keeps the skip registry in agreement with `health`/watcher. No more force-admit.
- **4MB code-language threshold**: `METADATA_ONLY_CODE_BYTES = 4MB` for code languages (`LanguageId::is_code_language`); data formats (json/toml/yaml/md/env/html/css/scss) keep the 1MB symbol-pollution guard. The bulk-load `InflightByteBudget` governor was designed for this raise (pre-classifies by size before reads).

### #6 — shared-daemon retarget hijack (cheap mitigation)
`handle_edit_impact` NotFound messages now name the daemon root: "not found under {root} — … this daemon is rooted at a different project than your session; re-run index_folder …". The full per-session active-project isolation gets a written spec first (Wave 4).

### Tests
- New `tests/impact_admission.rs`: Tier-2 refusal + skip-registry agreement (5MB .rs), 1.2MB code file Tier-1 end-to-end with positive impact signal, 1.5MB data file still refused.
- 3 new `classify_admission` unit tests; 2 watcher tests re-sized for the 4MB threshold.
- `dispatch_tool_for_tests` gained `analyze_file_impact`.

### Gate
`cargo fmt --check` ✅ · clippy `-D warnings` ✅ · full test suite single-threaded ✅ (104 suites) · `cargo build --release --features server` ✅

Note: PR #416's Tier-2 disclosure text still says ">1MB"; minor wording follow-up once both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes index admission thresholds and the analyze_file_impact indexing path, which affects what files get symbols and can refuse previously force-admitted files; behavior is heavily tested but touches core indexing consistency.
> 
> **Overview**
> Aligns **file admission** across bulk load, the watcher, and **`analyze_file_impact`**, and raises the metadata-only size limit for **code** files so large first-party sources stay Tier-1.
> 
> **4MB threshold for code languages:** `classify_admission` now uses **`METADATA_ONLY_CODE_BYTES` (4MB)** when the extension maps to a programming language (`LanguageId::is_code_language`); JSON/TOML/YAML/markup and similar formats still demote at **1MB** to limit symbol pollution.
> 
> **Impact path gated:** Before force-indexing, **`impact_admission_refusal`** runs the same `classify_admission` check. Tier-2/3 files get an explicit refusal (tier, reason, size) and **`demote_to_skipped_at_generation`** so health and the watcher match—fixing admit-then-demote flapping on oversized files.
> 
> **Clearer missing-file errors:** When impact cannot find a file on disk, messages say **not found under {root}** and hint at a shared-daemon root mismatch.
> 
> **Tests:** New `tests/impact_admission.rs`, extra `classify_admission` unit tests, watcher tests resized for 4MB, and **`analyze_file_impact`** wired into test dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774f73600933ccbbf29cf71c137c2cd0f6866360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->