### PR TITLE
fix(hooks,edit): cut hook prompt-context noise + edit_within_symbol occurrence/near_line disambiguators

### DIFF
--- a/docs/reviews/2026-07-06-dogfood-findings.md
+++ b/docs/reviews/2026-07-06-dogfood-findings.md
@@ -131,3 +131,36 @@ Wave 1 (trust honesty, branch `fix/trust-envelope-tier2`, 2026-07-06):
   crossed 1MB and was repeatedly demoted to Tier-2 mid-session (#1's cutoff
   hitting the repo's own load-bearing file), and every external (non-symforge)
   edit to it triggered the #7 eviction until `analyze_file_impact`.
+
+Wave 2 (daemon correctness, PR #418, merged 2026-07-06):
+
+- **#7 FIXED (root-caused)** — not a UNC path bug: the impact path
+  (`analyze_file_impact` → `process_file` + `update_file`) force-admitted any
+  file, bypassing the admission gate the bulk walk and watcher both apply, so
+  files flapped admit/demote until evicted. `impact_admission_refusal`
+  (sidecar/handlers.rs) now runs `classify_admission` before impact and
+  records demotions in the skip registry. Companion fix: code languages get a
+  4MB `METADATA_ONLY_CODE_BYTES` threshold (data formats keep 1MB), so
+  first-party code just over 1MB — the AAP field failure and symforge's own
+  tools.rs — stays Tier-1. Tests: `tests/impact_admission.rs`.
+- **#6 MITIGATED (cheap half)** — edit-impact NotFound messages now name the
+  daemon root ("not found under <root> — … this daemon is rooted at a
+  different project than your session"), so a hijacked daemon is diagnosable.
+  The full fix (per-session active project) needs a written spec first —
+  wave 4.
+
+Wave 3 (ergonomics/noise, branch `fix/hook-noise-edit-disambiguators`,
+2026-07-06):
+
+- **#8 FIXED** (and #5b) — three noise sources cut: (1) the Grep PostToolUse
+  hook only forwards bare-identifier patterns to `/symbol-context`; regexes
+  and multi-token phrases (`Tip:`, `compact|SYMFORGE_SURFACE`) fail open
+  instead of buying a guaranteed zero-hit report; (2) the bare-token heuristic
+  prompt hint is now a one-line pointer (was a full ~1000-token symbol
+  context); (3) the no-evidence prompt report and the sidecar zero-reference
+  report are each one line.
+- **#4 FIXED** — `edit_within_symbol` gains `occurrence: N` (1-based) and
+  `near_line: L` disambiguators for old_text that appears several times
+  within one symbol (the match-arm case); targeting modes are mutually
+  exclusive; an untargeted multi-match edit now discloses "occurred N times;
+  edited the FIRST" instead of silently rewriting the first match.

--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -730,6 +730,16 @@ fn is_non_source_path(path: &str) -> bool {
     false
 }
 
+/// True when a Grep pattern is a bare code identifier worth a symbol lookup.
+/// Regexes, globs, and multi-token phrases can never match a symbol name, so
+/// forwarding them only produces zero-hit noise in prompt context (dogfood #8).
+fn is_plausible_symbol_name(pattern: &str) -> bool {
+    let mut chars = pattern.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
 /// Maps a resolved subcommand + stdin input to `(path, query_string)`.
 ///
 /// The `input` carries the file path and search pattern extracted from the
@@ -776,12 +786,14 @@ pub(crate) fn endpoint_for(
                 .as_ref()
                 .and_then(|ti| ti.pattern.as_deref().or(ti.path.as_deref()))
                 .unwrap_or("");
-            let query = if q.is_empty() {
-                String::new()
-            } else {
-                format!("name={}", url_encode(q))
-            };
-            ("/symbol-context", query)
+            // Dogfood #8 (2026-07-06): grep patterns are often regexes or
+            // multi-token phrases (`Tip:`, `compact|SYMFORGE_SURFACE`) — not
+            // symbol names. Forwarding them buys a guaranteed zero-hit report
+            // in prompt context. Only a bare identifier is worth the lookup.
+            if q.is_empty() || !is_plausible_symbol_name(q) {
+                return ("/health", String::new());
+            }
+            ("/symbol-context", format!("name={}", url_encode(q)))
         }
         Some(HookSubcommand::SessionStart) => ("/repo-map", String::new()),
         Some(HookSubcommand::PromptSubmit) => {
@@ -1567,6 +1579,43 @@ mod tests {
     }
 
     #[test]
+    fn test_endpoint_for_grep_regex_pattern_fails_open() {
+        // Dogfood #8: regex / multi-token grep patterns are not symbol names —
+        // forwarding them guarantees a zero-hit report in prompt context.
+        for pattern in [
+            "compact|SYMFORGE_SURFACE",
+            "Tip:",
+            "fn .*_handler",
+            "two words",
+            "foo.bar",
+            "^anchor",
+        ] {
+            let json = format!(
+                r#"{{"tool_name":"Grep","tool_input":{{"pattern":"{pattern}"}},"cwd":"/abs"}}"#
+            );
+            let input: HookInput = serde_json::from_str(&json).unwrap_or_default();
+            let (path, query) = endpoint_for(Some(&HookSubcommand::Grep), &input);
+            assert_eq!(path, "/health", "pattern {pattern:?} must fail open");
+            assert!(
+                query.is_empty(),
+                "pattern {pattern:?} must not forward a query"
+            );
+        }
+        // Bare identifiers still get the lookup.
+        for pattern in ["classify_admission", "TODO", "_private", "Vec2d"] {
+            let json = format!(
+                r#"{{"tool_name":"Grep","tool_input":{{"pattern":"{pattern}"}},"cwd":"/abs"}}"#
+            );
+            let input: HookInput = serde_json::from_str(&json).unwrap_or_default();
+            let (path, _) = endpoint_for(Some(&HookSubcommand::Grep), &input);
+            assert_eq!(
+                path, "/symbol-context",
+                "pattern {pattern:?} is a plausible symbol"
+            );
+        }
+    }
+
+    #[test]
     fn test_endpoint_for_session_start_routes_to_repo_map() {
         let input = HookInput::default();
         let (path, query) = endpoint_for(Some(&HookSubcommand::SessionStart), &input);
@@ -1664,9 +1713,12 @@ mod tests {
 
     #[test]
     fn test_hook_subcommand_to_endpoint_grep_backward_compat() {
+        // Empty pattern fail-opens to /health (dogfood #8): with nothing to
+        // look up, /symbol-context could only produce a zero-hit report.
         let input = HookInput::default();
-        let (path, _query) = endpoint_for(Some(&HookSubcommand::Grep), &input);
-        assert_eq!(path, "/symbol-context");
+        let (path, query) = endpoint_for(Some(&HookSubcommand::Grep), &input);
+        assert_eq!(path, "/health");
+        assert!(query.is_empty());
     }
 
     #[test]

--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -1495,6 +1495,16 @@ pub struct EditWithinSymbolInput {
     /// If true, replace all occurrences within the symbol. Default: false (first match only).
     #[serde(default)]
     pub replace_all: bool,
+    /// Target the Nth exact occurrence of `old_text` within the symbol (1-based).
+    /// Use when `old_text` appears more than once (e.g. identical lines in
+    /// several match arms). Mutually exclusive with `replace_all` and `near_line`.
+    #[serde(default, deserialize_with = "super::tools::lenient_u32")]
+    pub occurrence: Option<u32>,
+    /// Target the exact occurrence of `old_text` closest to this 1-based FILE
+    /// line. Alternative to `occurrence` when you know where the target is but
+    /// not its rank. Mutually exclusive with `replace_all` and `occurrence`.
+    #[serde(default, deserialize_with = "super::tools::lenient_u32")]
+    pub near_line: Option<u32>,
     /// When true, validate and preview but skip the actual write.
     #[serde(default, deserialize_with = "super::tools::lenient_bool")]
     pub dry_run: Option<bool>,

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -1414,12 +1414,25 @@ impl SymForgeServer {
             edit::normalize_line_endings(params.0.new_text.as_bytes(), line_ending);
         let normalized_new_str =
             String::from_utf8(normalized_new).unwrap_or_else(|_| params.0.new_text.clone());
-        let (new_body, count) = if params.0.replace_all {
+        // Dogfood #4 (2026-07-06): `occurrence`/`near_line` target one exact
+        // match when `old_text` appears several times within the symbol
+        // (e.g. identical lines across match arms of a long fn).
+        let targeting_modes = usize::from(params.0.replace_all)
+            + usize::from(params.0.occurrence.is_some())
+            + usize::from(params.0.near_line.is_some());
+        if targeting_modes > 1 {
+            return fail_and_return_mutation_replay(
+                &idempotency,
+                "Error: `replace_all`, `occurrence`, and `near_line` are mutually exclusive — pass at most one targeting mode.".to_string(),
+            );
+        }
+        let (new_body, count, untargeted_extra) = if params.0.replace_all {
             let count = body_str.matches(&normalized_old_str).count();
             if count > 0 {
                 (
                     body_str.replace(&normalized_old_str, &normalized_new_str),
                     count,
+                    0,
                 )
             } else {
                 // Fallback: try whitespace-flexible matching.
@@ -1429,15 +1442,62 @@ impl SymForgeServer {
                     &normalized_new_str,
                     true,
                 ) {
-                    Some(result) => result,
-                    None => (body_str.to_string(), 0), // hits count==0 error below
+                    Some((body, count)) => (body, count, 0),
+                    None => (body_str.to_string(), 0, 0), // hits count==0 error below
                 }
+            }
+        } else if params.0.occurrence.is_some() || params.0.near_line.is_some() {
+            // Targeted single replacement: exact matches only (a targeted edit
+            // must never silently rebind to a whitespace-flexible guess).
+            let positions: Vec<usize> = body_str
+                .match_indices(normalized_old_str.as_str())
+                .map(|(pos, _)| pos)
+                .collect();
+            if positions.is_empty() {
+                (body_str.to_string(), 0, 0) // hits count==0 error below
+            } else {
+                let index = if let Some(n) = params.0.occurrence {
+                    let n = n as usize;
+                    if n == 0 || n > positions.len() {
+                        return fail_and_return_mutation_replay(
+                            &idempotency,
+                            format!(
+                                "Error: occurrence {n} is out of range — `old_text` has {} exact occurrence(s) within `{}`.",
+                                positions.len(),
+                                params.0.name
+                            ),
+                        );
+                    }
+                    n - 1
+                } else {
+                    // near_line: pick the match whose file line is closest.
+                    let target = i64::from(params.0.near_line.unwrap_or(1));
+                    let line_of = |pos: usize| {
+                        1 + file.content[..sym_start + pos]
+                            .iter()
+                            .filter(|&&byte| byte == b'\n')
+                            .count() as i64
+                    };
+                    (0..positions.len())
+                        .min_by_key(|&i| (line_of(positions[i]) - target).abs())
+                        .unwrap_or(0)
+                };
+                let pos = positions[index];
+                let mut body = String::with_capacity(body_str.len() + normalized_new_str.len());
+                body.push_str(&body_str[..pos]);
+                body.push_str(&normalized_new_str);
+                body.push_str(&body_str[pos + normalized_old_str.len()..]);
+                (body, 1, 0)
             }
         } else {
             match body_str.find(&normalized_old_str) {
                 Some(_) => (
                     body_str.replacen(&normalized_old_str, &normalized_new_str, 1),
                     1,
+                    body_str
+                        .matches(&normalized_old_str)
+                        .count()
+                        .saturating_sub(1),
                 ),
                 None => {
                     // Fallback: try whitespace-flexible matching.
@@ -1447,7 +1507,7 @@ impl SymForgeServer {
                         &normalized_new_str,
                         false,
                     ) {
-                        Some(result) => result,
+                        Some((body, count)) => (body, count, 0),
                         None => {
                             // Show a preview of the symbol body so the LLM can see what's actually there
                             let preview_len = 800.min(body_str.len());
@@ -1504,6 +1564,13 @@ impl SymForgeServer {
                 params.0.path,
                 count
             );
+            if untargeted_extra > 0 {
+                result.push_str(&format!(
+                    "\nNote: `old_text` occurs {} times within `{}`; this targets the FIRST. Pass `occurrence: N` or `near_line: L` to pick another.",
+                    untargeted_extra + 1,
+                    params.0.name
+                ));
+            }
             append_project_config_trust_suffix(&mut result, project_config_trust_suffix.as_deref());
             return result;
         }
@@ -1569,6 +1636,15 @@ impl SymForgeServer {
                 new_body.len(),
             )
         );
+        if untargeted_extra > 0 {
+            // Dogfood #4: replacing the first of several matches silently is a
+            // mini trust lie — disclose the ambiguity and the targeting knobs.
+            out.push_str(&format!(
+                "\nNote: `old_text` occurred {} times within `{}`; edited the FIRST. Pass `occurrence: N` or `near_line: L` to target another.",
+                untargeted_extra + 1,
+                params.0.name
+            ));
+        }
         out.push_str(&edit_format::format_reroute_suffix(
             working_directory,
             &resolved_target,

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -13262,6 +13262,8 @@ mod tests {
                 old_text: "let x = 1;".to_string(),
                 new_text: "let x = 7;".to_string(),
                 replace_all: false,
+                occurrence: None,
+                near_line: None,
                 dry_run: None,
                 idempotency_key: None,
                 working_directory: None,
@@ -24241,6 +24243,8 @@ mod tests {
             old_text: "\"hello\"".to_string(),
             new_text: "\"HELLO\"".to_string(),
             replace_all: false,
+            occurrence: None,
+            near_line: None,
             dry_run: None,
             idempotency_key: None,
             working_directory: None,
@@ -24255,6 +24259,106 @@ mod tests {
         let on_disk = std::fs::read_to_string(&file_path).unwrap();
         assert!(on_disk.contains("HELLO"), "edited: {on_disk}");
         assert!(!on_disk.contains("\"hello\""), "old text gone: {on_disk}");
+    }
+
+    fn multi_match_edit_input(
+        old_text: &str,
+        new_text: &str,
+    ) -> crate::protocol::edit::EditWithinSymbolInput {
+        crate::protocol::edit::EditWithinSymbolInput {
+            path: "src/lib.rs".to_string(),
+            name: "hello".to_string(),
+            kind: None,
+            symbol_line: None,
+            old_text: old_text.to_string(),
+            new_text: new_text.to_string(),
+            replace_all: false,
+            occurrence: None,
+            near_line: None,
+            dry_run: None,
+            idempotency_key: None,
+            working_directory: None,
+        }
+    }
+
+    // Dogfood #4 (2026-07-06): identical lines across arms of one fn were
+    // unaddressable — edit_within_symbol silently rewrote the first match.
+    const MULTI_MATCH_BODY: &[u8] =
+        b"fn hello() {\n    let a = 1;\n    let a = 1;\n    let a = 1;\n}\n";
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_occurrence_targets_nth_match() {
+        let (_dir, server, file_path) = setup_edit_test(MULTI_MATCH_BODY);
+        let mut input = multi_match_edit_input("let a = 1;", "let a = 2;");
+        input.occurrence = Some(2);
+        let result = server.edit_within_symbol(Parameters(input)).await;
+        assert!(result.contains("edited within"), "result: {result}");
+        let on_disk = std::fs::read_to_string(&file_path).unwrap();
+        assert!(
+            on_disk.contains("let a = 1;\n    let a = 2;\n    let a = 1;"),
+            "only the second occurrence changes: {on_disk}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_near_line_picks_closest_match() {
+        let (_dir, server, file_path) = setup_edit_test(MULTI_MATCH_BODY);
+        let mut input = multi_match_edit_input("let a = 1;", "let a = 2;");
+        // Occurrences sit on file lines 2, 3, 4 — line 4 selects the third.
+        input.near_line = Some(4);
+        let result = server.edit_within_symbol(Parameters(input)).await;
+        assert!(result.contains("edited within"), "result: {result}");
+        let on_disk = std::fs::read_to_string(&file_path).unwrap();
+        assert!(
+            on_disk.contains("let a = 1;\n    let a = 1;\n    let a = 2;"),
+            "only the occurrence nearest line 4 changes: {on_disk}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_occurrence_out_of_range_errors() {
+        let (_dir, server, file_path) = setup_edit_test(MULTI_MATCH_BODY);
+        let mut input = multi_match_edit_input("let a = 1;", "let a = 2;");
+        input.occurrence = Some(5);
+        let result = server.edit_within_symbol(Parameters(input)).await;
+        assert!(
+            result.contains("out of range") && result.contains("3 exact occurrence(s)"),
+            "out-of-range occurrence must error with the real count: {result}"
+        );
+        let on_disk = std::fs::read_to_string(&file_path).unwrap();
+        assert!(
+            !on_disk.contains("let a = 2;"),
+            "no write on error: {on_disk}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_untargeted_multi_match_discloses() {
+        let (_dir, server, file_path) = setup_edit_test(MULTI_MATCH_BODY);
+        let input = multi_match_edit_input("let a = 1;", "let a = 2;");
+        let result = server.edit_within_symbol(Parameters(input)).await;
+        assert!(
+            result.contains("occurred 3 times") && result.contains("edited the FIRST"),
+            "an untargeted multi-match edit must disclose the ambiguity: {result}"
+        );
+        let on_disk = std::fs::read_to_string(&file_path).unwrap();
+        assert!(
+            on_disk.contains("let a = 2;\n    let a = 1;\n    let a = 1;"),
+            "untargeted edit still rewrites the first occurrence: {on_disk}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_within_symbol_targeting_modes_are_mutually_exclusive() {
+        let (_dir, server, _file_path) = setup_edit_test(MULTI_MATCH_BODY);
+        let mut input = multi_match_edit_input("let a = 1;", "let a = 2;");
+        input.replace_all = true;
+        input.occurrence = Some(1);
+        let result = server.edit_within_symbol(Parameters(input)).await;
+        assert!(
+            result.contains("mutually exclusive"),
+            "conflicting targeting modes must error: {result}"
+        );
     }
 
     #[tokio::test]
@@ -24310,6 +24414,8 @@ mod tests {
             old_text: "nonexistent".to_string(),
             new_text: "replacement".to_string(),
             replace_all: false,
+            occurrence: None,
+            near_line: None,
             dry_run: None,
             idempotency_key: None,
             working_directory: None,
@@ -24426,6 +24532,8 @@ mod tests {
                 old_text: "old_text".to_string(),
                 new_text: "new_text".to_string(),
                 replace_all: false,
+                occurrence: None,
+                near_line: None,
                 dry_run: Some(true),
                 idempotency_key: None,
                 working_directory: None,

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -128,10 +128,9 @@ fn format_prompt_context_signal(level: &str, evidence: impl Into<String>, body: 
 }
 
 fn no_high_confidence_prompt_context_message() -> String {
-    "Prompt-context signal: no high-confidence hint\n\
-Evidence: no exact file, symbol, or repo-map cue matched the prompt\n\n\
-Suggested next step: use `search_symbols(...)` for likely names or `search_text(...)` for code/content search."
-        .to_string()
+    // Dogfood #8 (2026-07-06): a no-evidence report must cost one line, not a
+    // multi-line report — this lands in the agent's prompt on EVERY submit.
+    "Prompt-context signal: none (no file/symbol/repo-map cue in prompt)".to_string()
 }
 
 fn context_source_authority_label(authority: ContextSourceAuthority) -> &'static str {
@@ -1450,9 +1449,11 @@ fn symbol_context_text(
     }
 
     if body_lines.is_empty() {
-        body_lines.push("No references found in the index.".to_string());
+        // Dogfood #8 (2026-07-06): hooks feed this into prompt context on
+        // every Grep, so a zero-hit report must cost one line.
         body_lines.push(
-            "Tip: this symbol may only be used via dynamic dispatch, reflection, or external entry points.".to_string(),
+            "No references found in the index (not a symbol, or only dynamic/external usage)."
+                .to_string(),
         );
     }
 
@@ -1866,21 +1867,12 @@ async fn prompt_context_text(
             return Ok(format_prompt_context_signal(level, evidence, body));
         }
         (None, Some(name)) => {
-            let body = symbol_context_text(
-                state,
-                &SymbolContextParams {
-                    name: name.clone(),
-                    file: None,
-                    path: None,
-                    symbol_kind: None,
-                    symbol_line: None,
-                },
-                options,
-            )?;
-            return Ok(format_prompt_context_signal(
-                "heuristic",
-                format!("symbol token `{name}` matched somewhere in the index"),
-                body,
+            // Dogfood #8 (2026-07-06): a bare prompt token matching a symbol
+            // name is the weakest evidence tier — a conversational word can
+            // collide with an indexed symbol. Emit a one-line pointer, never
+            // a full symbol context (~1000 tokens on every prompt submit).
+            return Ok(format!(
+                "Prompt-context signal: heuristic\nEvidence: symbol token `{name}` matched somewhere in the index — get_symbol_context(name=\"{name}\") if intended"
             ));
         }
         (None, None) => {}
@@ -3512,14 +3504,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(
-            result.contains("src/service.rs"),
-            "symbol-only prompt should use symbol context: {result}"
-        );
-        assert!(
-            result.contains("src/other.rs"),
-            "name-only symbol context should keep global same-name hits: {result}"
-        );
+        // Dogfood #8: a bare-token match is the weakest evidence tier — it
+        // must cost a one-line pointer, never a full symbol context.
         assert!(
             result.contains("Prompt-context signal: heuristic"),
             "symbol-only hints should be labeled heuristic: {result}"
@@ -3527,6 +3513,14 @@ mod tests {
         assert!(
             result.contains("symbol token `connect` matched somewhere in the index"),
             "symbol-only hints should expose their evidence source: {result}"
+        );
+        assert!(
+            result.contains("get_symbol_context(name=\"connect\")"),
+            "the pointer should name the follow-up tool call: {result}"
+        );
+        assert!(
+            !result.contains("src/service.rs"),
+            "heuristic hints must not inline reference bodies: {result}"
         );
     }
 
@@ -3550,12 +3544,13 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("Prompt-context signal: no high-confidence hint"),
-            "unmatched prompts should explicitly report low confidence: {result}"
+            result.contains("Prompt-context signal: none"),
+            "unmatched prompts should explicitly report no signal: {result}"
         );
+        // Dogfood #8: a no-evidence report costs one line on every prompt submit.
         assert!(
-            result.contains("search_symbols(...)"),
-            "unmatched prompts should suggest the next narrowing step: {result}"
+            !result.trim().contains('\n'),
+            "the no-signal report must be a single line: {result}"
         );
     }
 
@@ -3601,7 +3596,7 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("Prompt-context signal: no high-confidence hint"),
+            result.contains("Prompt-context signal: none"),
             "common-word collisions must not fire a heuristic symbol signal: {result}"
         );
         assert!(
@@ -4552,11 +4547,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            partial.contains("src/app.ts"),
+            partial.contains("symbol token `connect`"),
             "partial slash module aliases should stay on the fallback path: {partial}"
         );
         assert!(
-            partial.contains("src/other.ts"),
+            partial.contains("Prompt-context signal: heuristic"),
             "partial slash module aliases should not collapse to one exact file: {partial}"
         );
 
@@ -4570,11 +4565,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            continued.contains("src/app.ts"),
+            continued.contains("symbol token `connect`"),
             "continued slash module aliases should stay on the fallback path: {continued}"
         );
         assert!(
-            continued.contains("src/other.ts"),
+            continued.contains("Prompt-context signal: heuristic"),
             "continued slash module aliases should not collapse to one exact file: {continued}"
         );
     }
@@ -4832,11 +4827,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "partial module aliases should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("src/other.rs"),
+            result.contains("Prompt-context signal: heuristic"),
             "partial module aliases should not collapse to one exact file: {result}"
         );
     }
@@ -4877,11 +4872,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "continued qualified symbol aliases should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("src/other.rs"),
+            result.contains("Prompt-context signal: heuristic"),
             "continued qualified symbol aliases should not collapse to one exact file: {result}"
         );
     }
@@ -5230,11 +5225,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("pkg/service.py"),
+            result.contains("symbol token `connect`"),
             "continued dotted aliases should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("pkg/other.py"),
+            result.contains("Prompt-context signal: heuristic"),
             "continued dotted aliases should not collapse to one exact file: {result}"
         );
     }
@@ -5317,11 +5312,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/app.ts"),
+            result.contains("symbol token `connect`"),
             "continued slash aliases should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("src/other.ts"),
+            result.contains("Prompt-context signal: heuristic"),
             "continued slash aliases should not collapse to one exact file: {result}"
         );
     }
@@ -5602,11 +5597,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "partial module aliases should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("src/other.rs"),
+            result.contains("Prompt-context signal: heuristic"),
             "partial module aliases should not collapse to one exact file: {result}"
         );
     }
@@ -5654,11 +5649,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "partial extensionless paths should stay on the fallback path: {result}"
         );
         assert!(
-            result.contains("src/other.rs"),
+            result.contains("Prompt-context signal: heuristic"),
             "partial extensionless paths should not collapse to one exact file: {result}"
         );
     }
@@ -5784,11 +5779,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "ambiguous basename should fall back to name-only symbol context: {result}"
         );
         assert!(
-            result.contains("tests/helper.rs"),
+            result.contains("Prompt-context signal: heuristic"),
             "ambiguous basename should not collapse to one file hint: {result}"
         );
     }
@@ -5886,11 +5881,11 @@ mod tests {
         .unwrap();
 
         assert!(
-            result.contains("src/service.rs"),
+            result.contains("symbol token `connect`"),
             "ambiguous extensionless alias should fall back to name-only symbol context: {result}"
         );
         assert!(
-            result.contains("tests/helper.py"),
+            result.contains("Prompt-context signal: heuristic"),
             "ambiguous extensionless alias should not collapse to one file hint: {result}"
         );
     }


### PR DESCRIPTION
## Wave 3 of the dogfood fix campaign (findings #8/#5b + #4)

Findings doc: `docs/reviews/2026-07-06-dogfood-findings.md` (Fix log updated in this PR with Wave 2 + Wave 3 entries).

### #8 (and #5b) — hook prompt-context noise
Three noise sources, each burned ~800–1000 tokens of prompt context on conversational prompts or non-symbol grep patterns:

1. **Grep PostToolUse hook** (`src/cli/hook.rs`): only bare-identifier patterns (`^[A-Za-z_][A-Za-z0-9_]*$`) are forwarded to `/symbol-context`. Regexes and multi-token phrases (`Tip:`, `compact|SYMFORGE_SURFACE`) fail open to `/health` — they can never match a symbol name, so forwarding them only bought a guaranteed zero-hit report.
2. **Bare-token heuristic prompt hint** (`src/sidecar/handlers.rs`): a prompt token that happens to match an indexed symbol is the weakest evidence tier — it now emits a one-line pointer (`get_symbol_context(name="…") if intended`) instead of inlining a full symbol context.
3. **No-evidence reports**: the no-hint prompt report and the sidecar zero-reference report are one line each.

### #4 — sub-symbol edit granularity
`edit_within_symbol` (the match-arm case: identical `old_text` on several lines of one fn):

- `occurrence: N` — target the Nth exact match (1-based); out-of-range errors with the real count.
- `near_line: L` — target the exact match closest to file line L.
- Targeting modes (`replace_all`/`occurrence`/`near_line`) are mutually exclusive.
- Trust fix: an **untargeted** multi-match edit used to silently rewrite the first occurrence; it now discloses "occurred N times; edited the FIRST — pass occurrence/near_line".

### Tests
5 new edit_within tests (nth-match, near-line, out-of-range, disclosure, mutual exclusion); Grep-gate test matrix (6 non-identifiers fail open, 4 identifiers forward); 12 prompt-context tests updated to pin the one-line contracts.

### Gate
fmt ✅ · clippy `-D warnings` ✅ · full suite single-threaded ✅ (104 suites) · release build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edit mutation semantics and hook routing for Grep/prompt injection; behavior is well-tested but affects every prompt submit and symbol-scoped edit path.
> 
> **Overview**
> Wave 3 dogfood fixes (#8/#5b and #4): less token burn in agent prompts and safer symbol-scoped edits when `old_text` repeats.
> 
> **Hook / prompt-context noise (#8):** The Grep PostToolUse path now forwards to `/symbol-context` only when the pattern looks like a bare identifier (`is_plausible_symbol_name`); regexes, multi-word phrases, and empty patterns fail open to `/health`. Prompt-context and symbol-context responses shrink: no-hint prompts and zero-reference cases are one line; bare-token symbol hints are a single pointer to `get_symbol_context(...)` instead of inlining full symbol context.
> 
> **edit_within_symbol (#4):** New optional **`occurrence`** (1-based nth exact match) and **`near_line`** (match closest to a file line), mutually exclusive with **`replace_all`**. Targeted edits use exact matches only (no whitespace-flexible fallback). Untargeted edits that still hit multiple matches now note that the **first** occurrence was changed and suggest `occurrence` / `near_line`.
> 
> Docs fix log updated for Wave 2–3; tests cover Grep gating, prompt one-liners, and edit targeting/disclosure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0cd14cf369709ceec27dd3fd2ae38d1cdaf2acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
