### PR TITLE
fix(trust): size-threshold wording no longer claims >1MB for code files

### DIFF
--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1004,7 +1004,7 @@ use crate::domain::index::{
 /// 1. Hard-skip size ceiling (>100MB) → Tier 3
 /// 2. Dependency lockfile (exact basename) → Tier 2
 /// 3. Extension denylist → Tier 2
-/// 4. Metadata-only size threshold (>1MB) → Tier 2
+/// 4. Metadata-only size threshold (1MB data / 4MB code) → Tier 2
 /// 5. Binary sniff (null bytes in first 8KB) → Tier 2
 /// 6. All else → Tier 1
 pub fn classify_admission(

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -607,7 +607,7 @@ impl std::fmt::Display for SkipReason {
         match self {
             SkipReason::SizeCeiling => write!(f, ">100MB"),
             SkipReason::DenylistedExtension => write!(f, "artifact"),
-            SkipReason::SizeThreshold => write!(f, ">1MB"),
+            SkipReason::SizeThreshold => write!(f, "over size threshold (1MB data / 4MB code)"),
             SkipReason::BinaryContent => write!(f, "binary"),
             SkipReason::DependencyLockfile => write!(f, "lockfile"),
             SkipReason::Untracked => write!(f, "untracked"),

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -867,7 +867,7 @@ pub struct SearchFilesHit {
     pub coupling_score: Option<f32>,
     pub shared_commits: Option<u32>,
     /// Short human-readable reason a Tier-2 metadata-only path was demoted
-    /// (e.g. "lockfile", "artifact", ">1MB"). `None` for every Tier-1 hit.
+    /// (e.g. "lockfile", "artifact", size threshold). `None` for every Tier-1 hit.
     /// Carried on the hit so the formatter can render
     /// `[metadata-only: <reason>]` without re-deriving from the index.
     pub metadata_reason: Option<String>,
@@ -1125,7 +1125,7 @@ impl LiveIndex {
     /// Tier-3 hard-skipped files (and any future tiers) are excluded — only
     /// metadata-only files are surfaced as findable `search_files` hits. The
     /// reason label is the `SkipReason` display string (e.g. "lockfile",
-    /// "artifact", ">1MB") used by the formatter's `[metadata-only: …]` suffix.
+    /// "artifact", size threshold) used by the formatter's `[metadata-only: …]` suffix.
     pub fn metadata_only_skipped_paths(&self) -> impl Iterator<Item = (&str, String)> {
         self.skipped_files().iter().filter_map(|sf| {
             if sf.tier() == crate::domain::index::AdmissionTier::MetadataOnly {

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2578,7 +2578,7 @@ fn find_references_completeness_label(
 
 /// Tier-2 honesty sweep (dogfood finding #1, 2026-07-06): the reference scan
 /// covers Tier-1 files only, but first-party source demoted to Tier-2 for size
-/// (>1MB, `SkipReason::SizeThreshold`) can still contain the queried name —
+/// (`SkipReason::SizeThreshold`: 1MB data / 4MB code) can still contain the queried name —
 /// the field failure was a compile-breaking construction site inside a 1.2 MB
 /// file while the envelope claimed "full for current scope". Sweep those files
 /// textually (bounded) and return a disclosure so the envelope never claims a
@@ -2617,7 +2617,7 @@ fn tier2_reference_disclosure(
         // No resolvable root: cannot sweep, but silence would be the lie.
         let paths: Vec<&str> = candidates.iter().map(|f| f.path.as_str()).collect();
         return Some(format!(
-            "Tier-2 exclusion: {} first-party file(s) >1MB were NOT reference-scanned \
+            "Tier-2 exclusion: {} first-party file(s) over the size threshold (1MB data / 4MB code) were NOT reference-scanned \
              (metadata-only) and could not be swept for \"{name}\" (no repo root): {}",
             candidates.len(),
             preview(&paths),
@@ -2647,7 +2647,7 @@ fn tier2_reference_disclosure(
     let mut parts: Vec<String> = Vec::new();
     if !matched.is_empty() {
         parts.push(format!(
-            "\"{name}\" appears textually in {} file(s) >1MB that were NOT \
+            "\"{name}\" appears textually in {} size-demoted Tier-2 file(s) that were NOT \
              reference-scanned (metadata-only): {} — grep or get_file_content to inspect",
             matched.len(),
             preview(&matched),
@@ -2655,7 +2655,7 @@ fn tier2_reference_disclosure(
     }
     if !unswept.is_empty() {
         parts.push(format!(
-            "{} file(s) >1MB not reference-scanned and not swept (budget): {}",
+            "{} size-demoted Tier-2 file(s) not reference-scanned and not swept (budget): {}",
             unswept.len(),
             preview(&unswept),
         ));

--- a/tests/impact_admission.rs
+++ b/tests/impact_admission.rs
@@ -61,7 +61,7 @@ async fn impact_refuses_oversized_code_file() {
         "oversized code file must get an honest Tier-2 refusal; got: {result}"
     );
     assert!(
-        result.contains(">1MB"),
+        result.contains("over size threshold"),
         "the refusal must name the size reason; got: {result}"
     );
     // No silent admit: the file must NOT be in the Tier-1 index afterwards.


### PR DESCRIPTION
Backlog item 3 (docs/backlog.md): since PR #418 raised the code-language demotion threshold to 4MB, the Tier-2 disclosure and `SkipReason::SizeThreshold` display still claimed ">1MB". Display is now "over size threshold (1MB data / 4MB code)"; the three find_references disclosure messages, the pinned test assertion, and stale doc comments updated.

Gate: fmt ✅ · clippy -D warnings ✅ · full suite --test-threads=1 ✅ (106 suites) · release build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and comment-only changes to user-facing labels and tests; no admission or indexing logic modified.
> 
> **Overview**
> User-visible **Tier-2 size demotion** copy still said **>1MB** after code files were allowed up to **4MB** for full indexing. This PR only updates **wording and comments**; admission logic is unchanged.
> 
> **`SkipReason::SizeThreshold`** now displays **"over size threshold (1MB data / 4MB code)"** instead of **>1MB**, so impact refusals, search metadata suffixes, and health-style labels match the language-aware thresholds.
> 
> **`find_references`** Tier-2 exclusion / sweep disclosure strings in **`tools.rs`** use the same phrasing (and **size-demoted Tier-2** instead of **>1MB**). Doc comments in **`classify_admission`**, **`SearchFilesHit`**, and **`metadata_only_skipped_paths`** were refreshed.
> 
> **`tests/impact_admission.rs`** now asserts **over size threshold** instead of **>1MB**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244abf71637f5de09110d4ad8ed13c17dfeec0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->