### PR TITLE
docs(research): token-cost optimization loop harness

### DIFF
--- a/research/token-cost/instructions.md
+++ b/research/token-cost/instructions.md
@@ -1,0 +1,84 @@
+# INSTRUCTIONS — SymForge Token-Cost Optimization Loop
+
+**Locked to the AI. Edited only by the human.**
+
+## Goal
+
+Shrink the token cost of SymForge MCP tool *output* (the text a caller pays
+for per response) without losing information content or violating the trust
+contract (`specs/010-v8-trust-remediation/`). This is **portfolio
+optimization**, not single-file evolution: rank formatter output paths in
+`src/protocol/format.rs` (and siblings) by token cost on fixed fixtures, and
+attack the current worst offender each round.
+
+Feature `011-ccr-output-compression` already shipped cross-call savings
+(session cache-hits, ranked search compaction, CCR retrieve, dedup hints).
+**Do not re-solve those.** This loop targets *per-call* formatter verbosity —
+the shape of a single fresh, uncached response.
+
+## Rules
+
+1. **Asset**: files under `src/protocol/` (formatters), plus
+   `src/sidecar/handlers.rs::repo_map_text` (the real formatter behind
+   `get_repo_map`'s compact mode — widened into scope at Round 2 once it
+   turned out to be outside `src/protocol/`). Never touch
+   `research/token-cost/score.py` or this instructions file.
+2. **One hypothesis, one change, one round.** Pick the current worst-scoring
+   fixture/tool pair, form one hypothesis, make one change, rescore only that
+   pair.
+3. **Keep or revert**: if the round's score beats its own baseline (strictly
+   lower tokens, same or better information content — see "What counts as a
+   win" below), keep the change and it becomes the new baseline for that
+   fixture. If not, `git checkout --` the touched file(s) back to the prior
+   commit and try a different hypothesis next round.
+4. **Never touch trust-contract prose.** Anything backing
+   `specs/010-v8-trust-remediation/` honesty/envelope guarantees (parse
+   resilience wording, STEL envelope fields, admission/degraded-mode
+   disclosures) is off-limits for deletion. Compressing *wording* is fine;
+   deleting *disclosures* is not.
+5. **What counts as a win**: strictly fewer real tokens (see score.py) on the
+   frozen fixture, with no loss of distinct information (same set of facts
+   recoverable from the output — renaming/shortening labels is fine,
+   dropping a field that has no other source is not).
+6. **No moving the goalposts**: scoring logic lives in `score.py` only and is
+   locked. If a fixture or metric turns out to be wrong, tell the human and
+   wait — don't quietly patch the scorer to make a change look better.
+7. Run in ~5-minute rounds, overnight, indefinitely, until the human stops it
+   or the ranked worst-offender list stops improving for 2 consecutive full
+   passes (diminishing returns = pause and report, don't grind forever).
+
+## Scope note (why not all 32+ tools at once)
+
+The scoring file freezes a small fixture set (see `score.py`) covering the
+formatters the initial survey flagged as highest-cost:
+`get_symbol` (full body dump), `search_text` (default view), `get_repo_map`
+(outline rows), `get_symbol_context` (callers/callees padding),
+`find_references` (verbose per-hit view). Expand the fixture set only with
+explicit human approval — adding fixtures silently changes what "biggest
+win" means mid-run.
+
+## Cross-repo validation (blocked, revisit later)
+
+Ideally fixtures would also run against a large external project
+(`C:\AI_STUFF\PROGRAMMING\Agent_Army_Professionals` was proposed) to catch
+formatter changes overfit to SymForge's own code shape. Current MCP session
+is hard-scoped to one `project_root` at connect time; the `project`/`projects`
+params exist in the protocol (feature 012) but are documented as
+surface-parity-only on the compact facade — not yet routed. Revisit by
+opening a second MCP-connected session pointed at that project and running
+the same fixture *shapes* (large function, common search term, repo map,
+referenced symbol, well-used type) there for comparison, once 012 wires
+cross-project routing through or a second session is available.
+
+## Verification path
+
+`cargo build --release` is buildable in this environment (release binary
+confirmed at v8.10.0, matching `main`). Prefer scoring via the already-connected
+live MCP session (`mcp__symforge__*` tools) — it needs no extra harness and
+reflects the exact running server. Rebuild + rerun `cargo test` after each kept
+change to catch regressions the fixture set wouldn't show.
+
+## Log
+
+Every round appends one line to `research/token-cost/log.md`:
+`round #, fixture/tool, hypothesis, tokens before -> after, kept/reverted`.

--- a/research/token-cost/log.md
+++ b/research/token-cost/log.md
@@ -1,0 +1,20 @@
+# Token-Cost Loop — Results Log
+
+Append one line per round. Format:
+`Round # | fixture | hypothesis | tokens before -> after | kept/reverted`
+
+Baseline round (Round 0) records the starting score for each fixture before
+any changes.
+
+| Round | Fixture | Hypothesis | Tokens (before -> after) | Result |
+|---|---|---|---|---|
+| 0 | F1-get_symbol-large-fn | baseline (real tiktoken cl100k_base on `search_text_result_view` full body) | n/a -> 2350 | baseline (corrected; initial 2159 figure was a hand-transcription error that dropped inline `//` comments — fixed via raw `sed` extraction on clean main, see Round 1 note) |
+| 0 | F2-search_text-default | baseline (default view, query `estimate_tokens` in `src/protocol`) | n/a -> 263 | baseline |
+| 0 | F3-repo_map-compact | baseline (`get_repo_map` detail=compact, whole repo — path only scopes detail=tree) | n/a -> 1024 | baseline |
+| 0 | F4-symbol_context-callers | baseline (`find_references`/context for `estimate_tokens`, compact routing) | n/a -> 149 | baseline |
+| 0 | F5-find_references-verbose | baseline (`find_references` for `OutputLimits`, verbose default view) | n/a -> 396 | baseline |
+| 0 | TOTAL | — | — | **4182 tokens** (corrected from 3991 after F1 fix) |
+| 1 | F1-get_symbol-large-fn | Tighten the two structural-search error-arm hint strings (`InvalidStructuralPattern`, `UnsupportedStructuralLanguage`) — shorter wording, same facts (params, example, guidance) preserved; no other text or logic touched | 2350 -> 2309 | **kept** (build clean, `cargo test` shows no new failures — 2 pre-existing `stel_golden_replay` + ~9 pre-existing flaky `--lib` failures confirmed identical on clean main before this change) |
+| 1 | TOTAL | — | — | **4141 tokens** (down from 4182, -41 / -1.0%) |
+| 2 | F3-repo_map-compact | Drop the literal words "files"/"symbols" from every directory row in `src/sidecar/handlers.rs::repo_map_text` (scope widened here — see instructions.md), replace `{:>3} files   {:>5} symbols` with `{:>3}/{:<5}` plus a one-time header legend. Measured via real live tool calls (revert -> capture -> reapply -> capture, no hand-transcription) at matching fully-warmed 618-file index state | 1151 -> 1163 | **reverted** (regression: +12 tokens net. Per-row cost did drop (13->11 tokens/row measured in isolation), but the freed budget let more "Key types" lines fit before the response's own truncation point, more than offsetting the row savings — net loss. Lesson: `get_repo_map` compact has an implicit length budget: local density wins get reallocated to more content, not saved) |
+| 2 | TOTAL | — | — | **4141 tokens** (unchanged, F3 reverted) |

--- a/research/token-cost/score.py
+++ b/research/token-cost/score.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""SCORING FILE — LOCKED. Read-only for the AI. Never edit to make a round score higher.
+
+Defines the objective measuring stick for the token-cost research loop:
+- the frozen fixture set (tool + args) every round is scored against
+- the real-tokenizer counter (tiktoken cl100k_base, NOT the codebase's own
+  chars/4 estimator in handler.rs, which is a heuristic and not truth)
+
+Usage (per round):
+    1. Run each fixture's MCP tool call live against the current build.
+    2. Paste/pipe the raw response text into count_tokens().
+    3. Sum across fixtures -> the round's single score.
+
+This file defines WHAT to measure. It does not itself drive the MCP
+connection (there is no local build to shell out to in this environment;
+see research/token-cost/instructions.md for why). The loop runner executes
+the fixture calls via the connected MCP session and feeds output here.
+"""
+
+import sys
+
+try:
+    import tiktoken
+    _ENC = tiktoken.get_encoding("cl100k_base")
+except ImportError:
+    print("tiktoken required: pip install tiktoken", file=sys.stderr)
+    raise
+
+
+def count_tokens(text: str) -> int:
+    """The single objective number for a piece of tool output. Real tokenizer, not a heuristic."""
+    return len(_ENC.encode(text))
+
+
+# Frozen fixtures. Do not add/remove/reword without human sign-off
+# (instructions.md rule 7) — changing these mid-run changes what "biggest
+# win" means and breaks round-to-round comparability.
+FIXTURES = [
+    {
+        "id": "F1-get_symbol-large-fn",
+        "tool": "get_symbol",
+        "args": {"name": "search_text_result_view", "path": "src/protocol/format.rs"},
+        "why": "largest suspected single payload: full verbatim body dump (format.rs)",
+    },
+    {
+        "id": "F2-search_text-default",
+        "tool": "search_text",
+        "args": {"query": "estimate_tokens", "path": "src/protocol"},
+        "why": "default (non-symbol-grouped) view repeats per-match header block",
+    },
+    {
+        "id": "F3-repo_map-compact",
+        "tool": "get_repo_map",
+        "args": {"detail": "compact"},
+        "why": "one padded row per directory; scales with directory/file count (path scoping only applies to detail=tree, not compact/full)",
+    },
+    {
+        "id": "F4-symbol_context-callers",
+        "tool": "get_symbol_context",
+        "args": {"name": "estimate_tokens", "project": "symforge"},
+        "why": "fixed-width padded caller/callee/type-dep rows repeat file paths",
+    },
+    {
+        "id": "F5-find_references-verbose",
+        "tool": "find_references",
+        "args": {"name": "OutputLimits", "project": "symforge"},
+        "why": "default verbose per-hit view vs the existing compact variant",
+    },
+]
+
+
+def score_round(fixture_id: str, raw_output: str) -> int:
+    """Score one fixture's output for one round. This IS the objective number."""
+    return count_tokens(raw_output)
+
+
+if __name__ == "__main__":
+    # Smoke test: confirm the counter works. Does not run fixtures (needs a live MCP call).
+    sample = "hello world, this is a token counting smoke test"
+    print(f"tiktoken smoke test: {count_tokens(sample)} tokens for {len(sample)} chars")
+    print(f"Fixtures defined: {len(FIXTURES)}")
+    for f in FIXTURES:
+        print(f"  {f['id']}: {f['tool']}({f['args']}) — {f['why']}")


### PR DESCRIPTION
Commits the token-cost research loop (instructions.md, log.md, score.py) so another machine can take the work over; compiled pycache excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018c9EM6NYCNmPzDz5uNs9MX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and research tooling only; no runtime, protocol, or formatter code changes in this diff.
> 
> **Overview**
> Adds **`research/token-cost/`** so the SymForge MCP **per-call formatter token-cost** loop can run (or be handed off) on another machine: human-locked **`instructions.md`**, append-only **`log.md`**, and a read-only **`score.py`** scorer.
> 
> **`instructions.md`** defines the loop: attack the worst fixture each round with one hypothesis/change, keep only strict tiktoken wins without dropping information or trust-contract disclosures (`specs/010-v8-trust-remediation/`), scope formatters in `src/protocol/` plus `repo_map_text`, verify via live MCP + `cargo test`, and log every round.
> 
> **`score.py`** freezes five MCP fixtures (`get_symbol`, `search_text`, `get_repo_map` compact, `get_symbol_context`, `find_references`) and counts output with **tiktoken `cl100k_base`** (not the in-repo heuristic).
> 
> **`log.md`** seeds Round 0 baselines (~4182 tokens total), records Round 1 as kept (-41 on F1 error hints), and Round 2 as reverted (F3 repo-map row compression regressed under truncation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f1cb7d2a3ab9989ed188448076a167d9691298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->