### PR TITLE
fix(tools): address 2026-07-07 tool-smoke and beta dogfood findings

### DIFF
--- a/docs/dogfood/2026-07-07-symforge-8.10.7-beta-findings.md
+++ b/docs/dogfood/2026-07-07-symforge-8.10.7-beta-findings.md
@@ -1,0 +1,77 @@
+# SymForge 8.10.7 — beta-test findings (AAP workstation, 2026-07-07)
+
+Live-use log from real work in `E:/project/Agent_Army_Professionals` (Claude Code MCP client,
+Windows host). Append-only during the beta; each finding carries impact + repro where known.
+Convention borrowed from terminal-commander's dogfood docs.
+
+## Findings
+
+### F1 — daemon degraded to local fallback right after the update (HIGH)
+First `health_compact` after the 8.10.7 update reports:
+`mode=daemon_degraded_local_fallback | Sidecar: dead pid=14780 port=55420 | Watcher: local-fallback (no watcher attached) | session_id=local-process-14780`.
+Impact: no file watcher means edits made outside this process (other agents, git pulls) will NOT
+be picked up live — stale-index risk in exactly the multi-agent scenario AAP runs; frecency has
+no history; co-change reports `stale/head-mismatch`. The engine still answers (index fresh-loaded,
+2504 files, 3.3 s), so it's a silent degradation: nothing failed loudly, the mode string is the
+only tell. Two asks: (a) sidecar/daemon should self-heal or the MCP reconnect should restart it;
+(b) a degraded mode this consequential deserves a louder signal than a substring in the runtime
+line (e.g. a `degraded: true` top-level field + one-line WHY).
+Context: previous session (8.10.3) the same client showed `mode=daemon_reused_session` with an
+active watcher, so this is a regression or an update-transition artifact (old sidecar pid killed
+by the update, never respawned).
+
+### F2 — UserPromptSubmit hook: heuristic single-token matches are noise (MEDIUM)
+The prompt-submit hook fires "Prompt-context signal: heuristic" on generic English words in
+conversational prompts — observed matching the tokens `output`, `pull`, `idle`, `limit`,
+`progress`, `close`, `program`, `intel`, `updated` — each injecting a context block (sometimes
+with anchors to unrelated files, e.g. `pull` → nothing, `close` → plasmate/transport.rs) and
+claiming savings like "~51508 tokens vs whole-file read" for a prompt that never asked about
+code. The claimed-savings baseline is fiction when the prompt is conversational ("pull latest
+from git" is a git request, not a symbol lookup). Suggest: require ≥2 corroborating signals
+(path-like token, camel/snake case, backticks) before injecting on heuristic matches, and cap
+the claimed-savings line to exact/high-confidence matches.
+
+### F3 — PostToolUse hook re-anchors on files mid-merge-conflict (LOW, arguably correct)
+While a file contained git conflict markers (`<<<<<<<`), the Read/Edit hook reported
+`Parse status: partial — tree-sitter: syntax error near '}'` with a byte span. This is honest
+(the file WAS broken), and after the conflict was resolved the next hook fire showed the symbols
+back. Logging as a positive-with-a-nit: the diagnostic names the tree-sitter error but not the
+obvious probable cause; a one-word hint ("conflict markers present?") when `<<<<<<<` is in the
+file would turn a scary-looking diagnostic into an obviously benign one.
+
+### F4 — index survived the frontend→studio cutover cleanly (POSITIVE)
+After a 45-commit fast-forward that deleted an entire tracked frontend tree and added `studio/`,
+the fresh load re-indexed without failures (2504 files, 0 failed, 4 quarantined partials — all
+pre-existing/expected classes). Project generation bumped (p2-g2) as expected. No stale-path
+ghosts observed in searches so far.
+
+### F5 — graphify-out/cache dominates the index (MEDIUM)
+`get_repo_map` shows `graphify-out/cache: 963 files, 280,253 symbols` — that's ~86% of ALL indexed
+symbols (326,941 total) coming from a knowledge-graph tool's JSON cache dump that happens to sit
+untracked in the repo root. Admission tiers let 1000 JSON files in as full-index. Impact: load
+time, memory, and ranking noise (any symbol search now competes with a quarter-million cache
+entries). The vendor/generated heuristics catch `expected_generated_partial` for parse purposes
+but not for ADMISSION. Suggest: default-exclude untracked+gitignored directories (or at least
+`*-out/cache/` patterns / directories >N files of pure JSON) from full indexing, with an explicit
+opt-in.
+
+### F6 — edit facade writes to the INDEX ROOT, not the caller's worktree (HIGH)
+A subagent working in an isolated git worktree (`.claude/worktrees/agent-…`) used the SymForge
+edit facade to apply a change; the edit landed in the SHARED main checkout (the daemon's indexed
+`project_root`) instead of the agent's worktree copy. The agent caught it, reverted the shared
+tree, and re-applied by hand — but in a parallel multi-agent campaign this is silent
+cross-contamination: worktree isolation is defeated by any symforge edit, and a sibling agent's
+`git add -A` could sweep in a foreign change. Root cause is presumably that edit ops resolve
+paths against the daemon's project root rather than the MCP client's CWD. Asks: (a) edit ops
+should take/honor an absolute target path and refuse to silently retarget onto the index root;
+(b) when the requested file's realpath is outside the index root, either edit it in place or
+error loudly — never remap. (Related: `worktree=explicit-call enabled` exists in capabilities —
+maybe the facade should require it in worktree contexts.)
+
+## Environment
+- SymForge 8.10.7, MCP client Claude Code, Windows 11, project root `E:/project/Agent_Army_Professionals`.
+- Prior baseline: 8.10.3 same session lineage (healthy daemon mode) — see F1.
+
+## Protocol
+Ongoing: every SymForge friction/regression/win observed during normal AAP work gets appended
+here with a Fx number. Nothing in this file is speculative — observed behavior only.

--- a/docs/reviews/2026-07-07-symforge-tool-smoke.md
+++ b/docs/reviews/2026-07-07-symforge-tool-smoke.md
@@ -1,0 +1,141 @@
+# SymForge tool smoke test — 2026-07-07 (8.13.0)
+
+Ad-hoc MCP exercise on the symforge repo after pulling `main` @ `acb1953`
+(version **8.13.0**). Full-repo `index_folder(E:/project/symforge)` → 691
+files, 21178 symbols. Issues below are ordered by severity; tools not
+exercised are listed at the end.
+
+## Setup / indexing
+
+### 1. Cold start is empty until `index_folder`
+
+- Repro: first `health` / `status` showed `project_root` unbound and **0**
+  indexed files; most read tools fail or return empty until indexing runs.
+- Impact: agents that assume SymForge is warm on connect get silent empties.
+- Note: expected for local-process mode, but worth a one-line nudge in
+  `health_compact` when `index_files=0` (“run `index_folder` on your repo
+  root”).
+
+### 2. Partial index breaks repo-relative paths
+
+- Repro: `index_folder(.../src)` indexed 160 files; `get_file_context("src/cli/hook.rs")` → **File not found**; same file worked as `cli/hook.rs`.
+- Impact: path conventions in tool descriptions assume repo root; subfolder
+  indexing silently shifts the path namespace.
+- Fix direction: reject or warn when `index_folder` target ≠ detected git
+  root; or always normalize paths against git root even when index scope is
+  narrower.
+
+## Discovery / search
+
+### 3. `search_text` hides tests by default
+
+- Repro: `search_text(query="hook_root_guard")` → no matches; `search_text(..., include_tests=true)` or searching `src/` finds hits. Same for Perl fixtures under `tests/fixtures/perl/`.
+- Impact: dogfood tests and fixture corpora are invisible unless the caller
+  knows the flag.
+- Fix direction: when zero hits in production paths but matches exist in
+  tests, always emit the existing hint (already done for some queries) and
+  mention `include_tests=true` in the tool description’s first paragraph.
+
+### 4. `ask` misroutes conceptual questions to the wrong symbol
+
+- Repro: `ask(query="How does caller_root_guard interact with index_folder retarget?")` routed to **`get_symbol_context(name="index_folder")`**, not `caller_root_guard` or an explore/diff answer.
+- Impact: NL entry point sends agents down a misleading rabbit hole.
+- Fix direction: prefer `explore` for “how does X interact with Y” when
+  multiple tokens match; or require two-symbol routing.
+
+### 5. Middleware / qualified registrations invisible to reference tools
+
+- Repro: `find_references(name="caller_root_guard")` → **0**; `edit_plan` reports **0 call sites**; `search_text` finds 2 files (`handlers.rs` definition, `router.rs` `handlers::caller_root_guard` registration).
+- Impact: edit planning under-counts impact for Axum middleware and similar
+  value-passing registrations.
+- Mitigation today: footer already suggests `search_text` fallback — good.
+- Fix direction: index `handlers::symbol` middleware layer registrations as
+  references (same class as qualified calls).
+
+### 6. `macro-generated` browse is noisy, not declaration-useful
+
+- Repro: `search_symbols(kind="macro-generated", path_prefix="src/parsing/languages/")` returns four names at the **same line** (`AST_WALK_DEPTH`, `Cell`, `cell`, `std`) — macro-expansion debris, not `define_id_type!`-style declared names.
+- Impact: dogfood #3 (macro-generated ProjectId) may be partially addressed
+  but browse mode still unusable for “list generated types”.
+- Fix direction: filter expansion tokens; keep macro-invocation argument
+  names only.
+
+### 7. Perl fixtures: syntax ok, symbols empty, symbol search empty
+
+- Repro: `validate_file_syntax(tests/fixtures/perl/use_parent.pl)` → ok,
+  **0 symbols**; `search_symbols(query="parent", path_prefix="tests/fixtures/perl/")` → no symbols; content only visible via `search_text(..., include_tests=true)`.
+- Impact: Perl hardening fixtures are second-class for symbol-first workflows.
+- Note: may be acceptable for bare `use` lines; worth confirming whether
+  subs/packages in richer fixtures index.
+
+### 8. `search_files` weak on fixture paths
+
+- Repro: `search_files(query="perl corpus")` ranked docs/tests driver files
+  but not `tests/fixtures/perl/*.pl` paths.
+- Impact: file discovery for fixture work still needs `search_text` or known
+  paths.
+
+## Session / runtime
+
+### 9. Sidecar dead while hooks report heavy fail-open
+
+- Repro: `health` → `Sidecar: ... state=dead`; same health block shows
+  **702 fail-open (no sidecar)** hook outcomes in the session.
+- Impact: expected in local-process + Cursor hook mode, but the dead sidecar
+  line reads like an error when fail-open is intentional.
+- Fix direction: clarify in `health` that local-process mode may not keep a
+  sidecar alive; downgrade to informational when hooks are fail-open by design.
+
+### 10. `context_inventory` duplicate paths after retarget
+
+- Repro: after earlier partial `src/` index, inventory listed both
+  `src/cli/hook.rs` and `cli/hook.rs` as separate file entries.
+- Impact: token accounting double-counts the same file under two roots.
+- Fix direction: normalize inventory keys to repo-relative paths after
+  rebind.
+
+## Minor / informational
+
+- **`get_file_content` on system paths** — `C:\Windows\System32\kernel32.dll` → clear “outside repository root” message (good). `/etc/passwd` via `get_file_context` → generic “File not found” (acceptable; not indexed).
+- **`diff_symbols` on `main`** — default `main...HEAD` with no local commits → “No file changes”; use explicit `base`/`target` refs for history (works: `acb1953~15...HEAD` showed sidecar symbol adds).
+- **`get_repo_map(detail=medium)`** — truncates with doctrine footer; use `symforge_retrieve` for full map (documented behavior).
+- **`detect_impact`** — returned empty vs `origin/main` (clean tree); JSON payload is verbose but correct.
+
+## Tools exercised successfully
+
+| Tool | Notes |
+|------|-------|
+| `health`, `health_compact`, `status` | 8.13.0, full surface, admission tiers visible |
+| `index_folder` | Full repo bind |
+| `get_repo_map` | Language/symbol counts incl. Perl: 26 |
+| `get_file_context`, `get_file_content` | Line ranges, trust lines |
+| `get_symbol`, `get_symbol_context` | Bodies + callees |
+| `search_text`, `search_symbols` | Literal + browse (`kind=fn`) |
+| `search_files` | Path ranking |
+| `find_references`, `find_dependents` | With helpful zero-ref fallback text |
+| `explore` | Concept search (dogfood symbols) |
+| `what_changed` | Git temporal |
+| `conventions` | Rust project summary |
+| `investigation_suggest` | Session gap hints |
+| `edit_plan` | Tool sequence (refs under-count, see #5) |
+| `diff_symbols` | Git ref diff |
+| `analyze_file_impact` | Unchanged file |
+| `validate_file_syntax` | Perl fixture |
+| `inspect_match` | Enclosing symbol + siblings |
+| `detect_impact` | Empty blast radius on clean tree |
+| `ask` | Routed (misroute, see #4) |
+
+## Not exercised (no issues filed)
+
+Mutating / write path: `replace_symbol_body`, `edit_within_symbol`,
+`insert_symbol`, `delete_symbol`, `batch_*`, `symforge_edit`, `checkpoint_now`.
+Compact-only aliases (`symforge`, `symforge_edit` routing) not re-tested.
+MCP **resources** and **prompts** not exercised in this pass.
+
+## Environment
+
+- Client: Cursor MCP (`user-symforge`)
+- Repo: `E:/project/symforge`
+- Index: 691 files, 21178 symbols, watcher active
+- Parse quarantine: 5 failed (intentional malformed fixtures), 4 expected
+  vendor partial

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -536,6 +536,25 @@ pub fn find_project_root() -> Option<PathBuf> {
     }
 }
 
+/// Walk up from `start` looking for a `.git`-bearing ancestor STRICTLY ABOVE
+/// `start` (the directory itself is not considered). Returns the first such
+/// non-forbidden ancestor, or `None` when there is no wider git root.
+///
+/// Used by `index_folder` to warn (without retargeting) when a caller indexes a
+/// subfolder of a git repo, which shifts the path namespace off the repo root.
+pub(crate) fn git_root_above(start: &Path) -> Option<PathBuf> {
+    let mut current = start.parent()?.to_path_buf();
+    loop {
+        if current.join(".git").exists() && !is_forbidden_root(&current) {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) => current = parent.to_path_buf(),
+            None => return None,
+        }
+    }
+}
+
 /// Resolve and validate the `SYMFORGE_WORKSPACE_ROOT` cold-start override.
 ///
 /// Returns `Some(root)` only when the env var is set to a non-empty path that

--- a/src/live_index/view.rs
+++ b/src/live_index/view.rs
@@ -408,8 +408,10 @@ impl<'a> IndexView<'a> {
     /// from the base result, the base's `overflow_count` and
     /// `suppressed_by_noise` would be STALE; rather than carry misleading base
     /// numbers, the overlay branch sets `overflow_count = 0` (no precise
-    /// merged-overflow claim) and `suppressed_by_noise` to ONLY the overlay
-    /// `#[cfg(test)]` suppressions actually counted while scanning the dirty set.
+    /// merged-overflow claim) and `suppressed_by_noise` to the BASE suppression
+    /// total PLUS the overlay `#[cfg(test)]` suppressions counted while scanning
+    /// the dirty set (the base count still holds for the non-dropped files, so
+    /// the zero-hit test-match hint survives a dirty working tree).
     /// Per-consumer derived indices that would make these globally exact are the
     /// deferred work.
     pub fn search_text(
@@ -493,12 +495,19 @@ impl<'a> IndexView<'a> {
         // honest-but-coarse value instead of stale base numbers:
         //   * overflow_count -> 0 (we do not claim a precise hidden-overflow
         //     count across the merged set);
-        //   * suppressed_by_noise -> only the overlay `#[cfg(test)]` suppressions
-        //     we actually counted while scanning the dirty set (the base's own
-        //     suppression total is not re-derived across the post-filter).
+        //   * suppressed_by_noise -> the BASE suppression total (source-level
+        //     `#[cfg(test)]` ranges + whole test files the base counted) PLUS
+        //     the overlay `#[cfg(test)]` suppressions we counted while scanning
+        //     the dirty set. The base count still describes suppressions in the
+        //     files we did NOT drop above (drops are keyed on delta paths, the
+        //     only files re-scanned), so adding is coherent — and it keeps the
+        //     zero-hit "N match(es) found in test modules" hint from silently
+        //     vanishing whenever the working tree is dirty.
         // This keeps every reported field consistent with the result we return.
         result.overflow_count = 0;
-        result.suppressed_by_noise = overlay_suppressed;
+        result.suppressed_by_noise = result
+            .suppressed_by_noise
+            .saturating_add(overlay_suppressed);
 
         Ok(result)
     }
@@ -1504,6 +1513,75 @@ mod tests {
             1,
             "result_limit=1 bounds the per-project hits (D14): got {}",
             bounded_hits.len()
+        );
+    }
+
+    // ── Regression — dirty-tree overlay must PRESERVE the base's test-match
+    //    suppression count, else the zero-hit "N match(es) found in test modules"
+    //    hint silently vanishes whenever the working tree is dirty (finding #3).
+    #[test]
+    fn overlay_preserves_base_test_suppression_count() {
+        // Base: one Rust source file whose ONLY `needle` match lives inside a
+        // `#[cfg(test)] mod tests` block. The base scans it (file is not
+        // test-classified), suppresses the in-`cfg(test)` line, and reports
+        // suppressed_by_noise = 1 with zero visible source hits.
+        let content = "fn real() {}\n#[cfg(test)]\nmod tests {\n    let needle = 1;\n}\n";
+        let mut lib = make_file("src/lib.rs", content);
+        lib.symbols = vec![SymbolRecord {
+            name: "tests".to_string(),
+            kind: SymbolKind::Module,
+            depth: 0,
+            sort_order: 0,
+            byte_range: (0, content.len() as u32),
+            line_range: (1, 4),
+            doc_byte_range: None,
+            item_byte_range: None,
+        }];
+        let mut map: HashMap<String, Arc<IndexedFile>> = HashMap::new();
+        map.insert("src/lib.rs".to_string(), Arc::new(lib));
+        let mut idx = LiveIndex::empty_live_index();
+        idx.is_empty = false;
+        idx.loaded_at = Instant::now();
+        idx.trigram_index = crate::live_index::trigram::TrigramIndex::build_from_files(&map);
+        idx.files = map;
+        let base = Arc::new(IndexBase::new(base_key("c0"), Arc::new(idx), 1));
+        let opts = TextSearchOptions::for_current_code_search();
+
+        // Sanity: the base-only path already records the suppression.
+        let base_view = IndexView::new(&base, None).expect("base view");
+        let base_result = base_view
+            .search_text(Some("needle"), None, false, &opts)
+            .expect("base search");
+        assert!(
+            base_result.files.is_empty(),
+            "no visible source hits in base"
+        );
+        assert_eq!(
+            base_result.suppressed_by_noise, 1,
+            "base must count the #[cfg(test)] match as suppressed"
+        );
+
+        // Overlay: an unrelated dirty upsert with NO `needle` makes `deltas`
+        // non-empty, forcing the overlay merge path — which previously OVERWROTE
+        // `suppressed_by_noise` with the (zero) overlay-only count.
+        let mut overlay = Overlay::fresh(&base);
+        overlay.deltas.insert(
+            "src/other.rs".to_string(),
+            FileDelta::Upsert(Arc::new(make_file("src/other.rs", "fn other() {}\n"))),
+        );
+        let view = IndexView::new(&base, Some(&overlay)).expect("overlay view");
+        let result = view
+            .search_text(Some("needle"), None, false, &opts)
+            .expect("overlay search");
+
+        assert!(
+            result.files.is_empty(),
+            "still no visible source hits after the overlay merge"
+        );
+        assert!(
+            result.suppressed_by_noise >= 1,
+            "dirty-tree overlay must preserve the base test-match suppression count, got {}",
+            result.suppressed_by_noise
         );
     }
 }

--- a/src/parsing/languages/rust.rs
+++ b/src/parsing/languages/rust.rs
@@ -98,8 +98,15 @@ fn is_module_level(node: &Node) -> bool {
 /// Index identifier argument tokens of a module-level macro invocation as
 /// `macro-generated` symbols (dogfood #3). Cheap heuristic by design: the
 /// kind label is the trust flag — the index has the declared NAME, not the
-/// synthesized body. Capped and deduplicated to bound pollution from
-/// block-style macros (`lazy_static!`, `cfg_if!`).
+/// synthesized body. A token_tree is a FLAT token list, so a path argument
+/// like `std::cell::Cell` would otherwise yield `std`, `cell`, `Cell` as
+/// separate "symbols". Precision filter: accept an identifier only when its
+/// immediate preceding token starts the tree or a top-level arg
+/// (`(` `[` `{` `,`) AND its immediate following token ends the arg
+/// (`,` `)` `]` `}`). This keeps `ProjectId` in `define_id_type!(ProjectId)`
+/// and `Alpha`/`Beta` in `declare_pair!(Alpha, Beta, ...)` while rejecting
+/// `::`-adjacent path segments and identifiers nested in larger expressions.
+/// Under-capture is the safe direction. Capped and deduplicated.
 fn push_macro_generated_names(node: &Node, source: &str, depth: u32, sink: &mut SymbolSink<'_, '_>) {
     const MAX_NAMES_PER_INVOCATION: usize = 8;
     let mut cursor = node.walk();
@@ -109,13 +116,22 @@ fn push_macro_generated_names(node: &Node, source: &str, depth: u32, sink: &mut 
     else {
         return;
     };
-    let mut seen: Vec<String> = Vec::new();
+    // Flat token list — index neighbors directly to check arg boundaries.
     let mut tree_cursor = token_tree.walk();
-    for token in token_tree.children(&mut tree_cursor) {
+    let tokens: Vec<Node> = token_tree.children(&mut tree_cursor).collect();
+    let mut seen: Vec<String> = Vec::new();
+    for (i, token) in tokens.iter().enumerate() {
         if seen.len() >= MAX_NAMES_PER_INVOCATION {
             break;
         }
         if !matches!(token.kind(), "identifier" | "type_identifier") {
+            continue;
+        }
+        // Preceding token must start the tree or a top-level arg.
+        let prev_ok = i == 0 || tokens.get(i - 1).is_some_and(|prev| matches!(prev.kind(), "(" | "[" | "{" | ","));
+        // Following token must end the arg (or terminate the tree).
+        let next_ok = tokens.get(i + 1).is_none_or(|next| matches!(next.kind(), "," | ")" | "]" | "}"));
+        if !prev_ok || !next_ok {
             continue;
         }
         let Ok(name) = token.utf8_text(source.as_bytes()) else {
@@ -248,6 +264,32 @@ fn caller() {
 }
 "#,
         [(SymbolKind::Function, "caller")]
+    );
+
+    // Qualified path argument: a flat token_tree splits `std::cell::Cell`
+    // into sibling tokens `std`, `::`, `cell`, `::`, `Cell`. The precision
+    // filter rejects every `::`-adjacent segment — no debris captured.
+    inline_test!(
+        rust_inline_test_macro_generated_rejects_qualified_path,
+        LanguageId::Rust,
+        r#"
+foo!(std::cell::Cell);
+"#,
+        []
+    );
+
+    // Multi-arg invocation: each top-level identifier is bounded by
+    // `(`/`,` before and `,`/`)` after, so both are captured.
+    inline_test!(
+        rust_inline_test_macro_generated_multi_arg,
+        LanguageId::Rust,
+        r#"
+m!(Alpha, Beta);
+"#,
+        [
+            (SymbolKind::MacroGenerated, "Alpha"),
+            (SymbolKind::MacroGenerated, "Beta"),
+        ]
     );
 
     // Module-level invocations inside a `mod` body still declare.

--- a/src/parsing/xref.rs
+++ b/src/parsing/xref.rs
@@ -59,6 +59,16 @@ const RUST_VALUE_IDENT_QUERY: &str = r#"
 (identifier) @ref.value
 "#;
 
+// Captures every `scoped_identifier` (a `::`-qualified path).  On its own this
+// is very noisy (it matches call targets, path prefixes of longer paths, `use`
+// segments, and match-pattern paths), so `extract_rust_qualified_value_refs`
+// gates each hit by parent node kind: it keeps ONLY value-position paths whose
+// function was not already captured as a qualified call, are not the prefix of
+// a longer path, and are not inside a `use` declaration or a match pattern.
+const RUST_QUALIFIED_VALUE_QUERY: &str = r#"
+(scoped_identifier) @ref.qualified_value
+"#;
+
 const PYTHON_XREF_QUERY: &str = r#"
 ; Function calls: foo(x)
 (call function: (identifier) @ref.call)
@@ -445,6 +455,7 @@ const PERL_XREF_QUERY: &str = r#"
 static RUST_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static RUST_CONST_DEF_QUERY_C: OnceLock<Option<Query>> = OnceLock::new();
 static RUST_VALUE_IDENT_QUERY_C: OnceLock<Option<Query>> = OnceLock::new();
+static RUST_QUALIFIED_VALUE_QUERY_C: OnceLock<Option<Query>> = OnceLock::new();
 static PYTHON_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static PYTHON_VALUE_TYPE_IDENT_QUERY_C: OnceLock<Option<Query>> = OnceLock::new();
 static PYTHON_STRING_TYPE_QUERY_C: OnceLock<Option<Query>> = OnceLock::new();
@@ -532,6 +543,15 @@ fn rust_value_ident_query(lang: &Language) -> Option<&'static Query> {
         lang,
         RUST_VALUE_IDENT_QUERY,
         "rust value-ident",
+    )
+}
+
+fn rust_qualified_value_query(lang: &Language) -> Option<&'static Query> {
+    compile_xref_query(
+        &RUST_QUALIFIED_VALUE_QUERY_C,
+        lang,
+        RUST_QUALIFIED_VALUE_QUERY,
+        "rust qualified-value",
     )
 }
 
@@ -1099,6 +1119,130 @@ fn extract_rust_value_refs(
     out
 }
 
+/// Resolve path-qualified references used in *value* position, e.g. a function
+/// passed as an argument rather than called: `from_fn(handlers::caller_guard)`.
+///
+/// The main Rust query captures a `scoped_identifier` only when it is the
+/// function of a `call_expression` (`Vec::new()`), and the macro-body text
+/// fallback only recovers `a::b::name(` *call* shapes. A qualified path in a
+/// value position (argument, `let` binding, struct field init, `Self::CONST`,
+/// `Enum::Variant` as an expression) is therefore invisible to
+/// `find_references`. This pass closes that gap.
+///
+/// Precision — a bare `(scoped_identifier)` match is enormous, so each hit is
+/// gated by the parent node kind (cheaper and clearer than encoding these
+/// exclusions in the tree-sitter query):
+///  * parent `call_expression` / `generic_function` → the path IS the callee of
+///    a (possibly turbofish) qualified call, already captured as `Call`; skip.
+///  * parent `scoped_identifier` → this is the `path:` prefix of a longer path
+///    (`axum::middleware` inside `axum::middleware::from_fn`); only the
+///    outermost path is emitted, so skip the prefix.
+///  * any ancestor `use_declaration` → import segment, handled by import capture.
+///  * parent is a pattern node (`match_pattern`, `tuple_struct_pattern`,
+///    `struct_pattern`, `or_pattern`) → a match/`let` pattern, not a value use.
+///
+/// `Type::CONST` / `Enum::Variant` in genuine value position are kept — they
+/// are real value usages. `name` is the leaf identifier (for name-based
+/// `find_references`); `qualified_name` retains the full `::` path.
+fn extract_rust_qualified_value_refs(
+    root: &Node,
+    source: &str,
+    ts_language: &Language,
+    existing: &[ReferenceRecord],
+) -> Vec<ReferenceRecord> {
+    let source_bytes = source.as_bytes();
+    let Some(query) = rust_qualified_value_query(ts_language) else {
+        return Vec::new();
+    };
+    let capture_names = query.capture_names();
+    // Dedup against ranges already captured by the main query (belt-and-braces;
+    // the parent-kind gate below is the real call-site guard) and within pass.
+    let existing_ranges: HashSet<(u32, u32)> = existing.iter().map(|r| r.byte_range).collect();
+    let mut emitted_ranges: HashSet<(u32, u32)> = HashSet::new();
+    let mut out: Vec<ReferenceRecord> = Vec::new();
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, *root, source_bytes);
+    while let Some(m) = {
+        matches.advance();
+        matches.get()
+    } {
+        for capture in m.captures {
+            if capture_names[capture.index as usize] != "ref.qualified_value" {
+                continue;
+            }
+            let node = capture.node;
+
+            // Parent-kind gate.
+            let parent_kind = node.parent().map(|p| p.kind());
+            // Callee of a qualified call (already a `Call` ref), the prefix
+            // of a longer path, or a pattern position — all excluded.
+            if let Some(
+                "call_expression"
+                | "generic_function"
+                | "scoped_identifier"
+                | "match_pattern"
+                | "tuple_struct_pattern"
+                | "struct_pattern"
+                | "or_pattern",
+            ) = parent_kind
+            {
+                continue;
+            }
+
+            // Skip anything inside a `use` declaration (imports are captured by
+            // the main query's import rules).
+            let mut ancestor = node.parent();
+            let mut in_use = false;
+            while let Some(a) = ancestor {
+                if a.kind() == "use_declaration" {
+                    in_use = true;
+                    break;
+                }
+                ancestor = a.parent();
+            }
+            if in_use {
+                continue;
+            }
+
+            let range = (node.start_byte() as u32, node.end_byte() as u32);
+            if existing_ranges.contains(&range) || emitted_ranges.contains(&range) {
+                continue;
+            }
+
+            // Leaf identifier for name-based lookup; full path for qualified_name.
+            let Some(leaf) = node.child_by_field_name("name") else {
+                continue;
+            };
+            let Ok(leaf_text) = leaf.utf8_text(source_bytes) else {
+                continue;
+            };
+            let name = leaf_text.trim();
+            if name.is_empty() {
+                continue;
+            }
+            let qualified_name = node
+                .utf8_text(source_bytes)
+                .ok()
+                .map(|t| t.trim().to_string());
+
+            let start = node.start_position();
+            let end = node.end_position();
+            out.push(ReferenceRecord {
+                name: name.to_string(),
+                qualified_name,
+                kind: ReferenceKind::ValueUse,
+                byte_range: range,
+                line_range: (start.row as u32, end.row as u32),
+                enclosing_symbol_index: None,
+            });
+            emitted_ranges.insert(range);
+        }
+    }
+
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Main extraction function
 // ---------------------------------------------------------------------------
@@ -1639,6 +1783,12 @@ pub fn extract_references(
     if *language == LanguageId::Rust {
         let value_refs = extract_rust_value_refs(root, source, &ts_language, &references);
         references.extend(value_refs);
+        // Path-qualified value-position uses (`from_fn(handlers::foo)`), which
+        // the main query and macro fallback never see. Runs after the const
+        // pass so it dedups against every reference captured so far.
+        let qualified_value_refs =
+            extract_rust_qualified_value_refs(root, source, &ts_language, &references);
+        references.extend(qualified_value_refs);
     }
 
     if *language == LanguageId::Python {
@@ -2177,6 +2327,75 @@ fn helper(n: usize) {
             has_ref(&refs, "SIZE", ReferenceKind::ValueUse),
             "const SIZE used as a bare arg should surface as ValueUse, refs: {:?}",
             refs
+        );
+    }
+
+    #[test]
+    fn test_rust_qualified_value_arg_surfaces_as_value_use() {
+        // A path-qualified function passed as an argument (not called) must
+        // surface as a ValueUse named by its leaf, with the full path retained.
+        let source = r#"
+fn wire() {
+    let _ = from_fn(handlers::foo);
+}
+"#;
+        let (refs, _) = parse_and_extract(source, LanguageId::Rust);
+        let value_ref = refs
+            .iter()
+            .find(|r| r.name == "foo" && r.kind == ReferenceKind::ValueUse)
+            .unwrap_or_else(|| panic!("expected ValueUse for `foo`, refs: {refs:?}"));
+        assert_eq!(
+            value_ref.qualified_name.as_deref(),
+            Some("handlers::foo"),
+            "qualified_name should retain the full path, refs: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn test_rust_qualified_call_not_duplicated_by_value_pass() {
+        // A qualified CALL must remain exactly one reference: the value pass
+        // must not add a second ValueUse for the same path.
+        let source = r#"
+fn run() {
+    handlers::foo();
+}
+"#;
+        let (refs, _) = parse_and_extract(source, LanguageId::Rust);
+        let foo_refs: Vec<_> = refs.iter().filter(|r| r.name == "foo").collect();
+        assert_eq!(
+            foo_refs.len(),
+            1,
+            "qualified call `handlers::foo()` should yield exactly one ref, refs: {refs:?}"
+        );
+        assert_eq!(
+            foo_refs[0].kind,
+            ReferenceKind::Call,
+            "the single ref should be a Call, not a ValueUse, refs: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn test_rust_use_declaration_produces_no_qualified_value_use() {
+        // `use handlers::foo;` must not emit a ValueUse from the new rule;
+        // import handling is unchanged (it stays an Import ref).
+        let source = r#"
+use handlers::foo;
+
+fn run() {
+    let _ = foo;
+}
+"#;
+        let (refs, _) = parse_and_extract(source, LanguageId::Rust);
+        assert!(
+            !refs
+                .iter()
+                .any(|r| r.qualified_name.as_deref() == Some("handlers::foo")
+                    && r.kind == ReferenceKind::ValueUse),
+            "a `use` path must not surface as a qualified ValueUse, refs: {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|r| r.kind == ReferenceKind::Import),
+            "the use declaration should still produce an Import ref, refs: {refs:?}"
         );
     }
 

--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -1381,6 +1381,11 @@ pub struct ReplaceSymbolBodyInput {
     /// Relative file path.
     pub path: String,
     /// Symbol name to replace.
+    // `symbol` is accepted as an alias on every symbol-addressed edit input:
+    // the `symforge_edit` facade and its docs use `symbol`, so models moving
+    // between the facade and the direct tools should not trip on the field
+    // name. Canonical field stays `name`; both keys at once is a hard error.
+    #[serde(alias = "symbol")]
     pub name: String,
     /// Optional kind filter (e.g., "fn", "struct", "impl").
     pub kind: Option<String>,
@@ -1429,6 +1434,7 @@ pub struct InsertSymbolInput {
     /// Relative file path.
     pub path: String,
     /// Name of the reference symbol to insert adjacent to.
+    #[serde(alias = "symbol")]
     pub name: String,
     /// Optional kind filter.
     pub kind: Option<String>,
@@ -1458,6 +1464,7 @@ pub struct DeleteSymbolInput {
     /// Relative file path.
     pub path: String,
     /// Symbol name to delete.
+    #[serde(alias = "symbol")]
     pub name: String,
     /// Optional kind filter.
     pub kind: Option<String>,
@@ -1482,6 +1489,7 @@ pub struct EditWithinSymbolInput {
     /// Relative file path.
     pub path: String,
     /// Symbol name that scopes the edit.
+    #[serde(alias = "symbol")]
     pub name: String,
     /// Optional kind filter.
     pub kind: Option<String>,
@@ -1643,6 +1651,7 @@ impl<'de> serde::Deserialize<'de> for SingleEdit {
         enum EditOrStr {
             Struct {
                 path: String,
+                #[serde(alias = "symbol")]
                 name: String,
                 #[serde(default)]
                 kind: Option<String>,
@@ -2136,6 +2145,7 @@ pub struct BatchRenameInput {
     /// Relative file path containing the symbol definition.
     pub path: String,
     /// Current symbol name.
+    #[serde(alias = "symbol")]
     pub name: String,
     /// Optional kind filter.
     pub kind: Option<String>,
@@ -2632,6 +2642,7 @@ impl<'de> serde::Deserialize<'de> for InsertTarget {
         enum TargetOrStr {
             Struct {
                 path: String,
+                #[serde(alias = "symbol")]
                 name: String,
                 kind: Option<String>,
                 #[serde(default, deserialize_with = "super::tools::lenient_u32")]
@@ -5806,6 +5817,24 @@ fn uses_it() { Widget::default(); }
             err.contains("duplicate field"),
             "expected duplicate-field error, got: {err}"
         );
+    }
+
+    // -- symbol-addressed inputs: name / symbol alias --
+
+    #[test]
+    fn test_edit_within_symbol_input_accepts_symbol_alias() {
+        let raw =
+            r#"{"path":"src/lib.rs","symbol":"foo","old_text":"a","new_text":"b","kind":null}"#;
+        let input: EditWithinSymbolInput = serde_json::from_str(raw).unwrap();
+        assert_eq!(input.name, "foo");
+    }
+
+    #[test]
+    fn test_edit_within_symbol_input_rejects_both_name_and_symbol() {
+        let raw =
+            r#"{"path":"src/lib.rs","name":"foo","symbol":"bar","old_text":"a","new_text":"b"}"#;
+        let result: Result<EditWithinSymbolInput, _> = serde_json::from_str(raw);
+        assert!(result.is_err(), "expected duplicate-field error");
     }
 
     // ─── working_directory plumbing — round-trip tests ───────────────────

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -1947,6 +1947,12 @@ pub fn health_report_compact_from_published_state(
         output.push_str(&line);
     }
 
+    if published.file_count == 0 {
+        output.push_str(
+            "\n⚠ Empty index — run index_folder(path=\"<your-repo-root>\") to bind an index",
+        );
+    }
+
     output
 }
 

--- a/src/protocol/search_tools.rs
+++ b/src/protocol/search_tools.rs
@@ -88,7 +88,10 @@ pub struct SearchTextInput {
     /// When true, include generated files in the result set.
     #[serde(default, deserialize_with = "lenient_bool")]
     pub include_generated: Option<bool>,
-    /// When true, include test files in the result set.
+    /// When true, include test files AND `#[cfg(test)]` modules in the result
+    /// set. Both are EXCLUDED by default, so a query that only matches test
+    /// code returns zero source hits (a hint reports how many test matches were
+    /// suppressed); set this true to see them.
     #[serde(default, deserialize_with = "lenient_bool")]
     pub include_tests: Option<bool>,
     /// When true, include vendored/third-party paths (vendor/, node_modules/, third_party/).

--- a/src/protocol/session.rs
+++ b/src/protocol/session.rs
@@ -101,6 +101,24 @@ impl SessionContext {
         }
     }
 
+    /// Reset all session accounting to a fresh state. Called when the index is
+    /// retargeted to a new repo root: paths recorded under the old root no longer
+    /// belong to this session and would otherwise double-count in context_inventory.
+    pub fn reset(&self) {
+        let mut inner = self.inner.lock();
+        *inner = SessionInner {
+            fetched_symbols: HashMap::new(),
+            listed_symbols: HashMap::new(),
+            fetched_files: HashMap::new(),
+            listed_files: HashMap::new(),
+            summary_outputs: HashMap::new(),
+            detailed_fetches: HashMap::new(),
+            cache_hit_count: 0,
+            total_tokens: 0,
+            started_at: Instant::now(),
+        };
+    }
+
     /// Record that a symbol body/detail was served to the LLM.
     pub fn record_symbol(&self, path: &str, name: &str, tokens: u32) {
         let mut inner = self.inner.lock();
@@ -596,6 +614,24 @@ mod tests {
         assert_eq!(snap.listed_files.len(), 1);
         assert_eq!(snap.summary_outputs.len(), 1);
         assert_eq!(snap.total_tokens, 700);
+    }
+
+    #[test]
+    fn test_reset_clears_accounting() {
+        let ctx = SessionContext::new();
+        ctx.record_symbol("old_root/a.rs", "foo", 100);
+        ctx.record_file("old_root/b.rs", 200);
+        assert!(ctx.has_symbol("old_root/a.rs", "foo"));
+        ctx.reset();
+        assert!(
+            !ctx.has_symbol("old_root/a.rs", "foo"),
+            "reset must drop symbols recorded under the previous root"
+        );
+        assert!(!ctx.has_file("old_root/b.rs"));
+        let snap = ctx.snapshot();
+        assert_eq!(snap.fetched_symbols.len(), 0);
+        assert_eq!(snap.fetched_files.len(), 0);
+        assert_eq!(snap.total_tokens, 0);
     }
 
     #[test]

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -5029,7 +5029,7 @@ impl SymForgeServer {
     /// NOT for symbol name search (use search_symbols). NOT for file path search (use search_files).
     #[tool(
         name = "search_text",
-        description = "Prefer this over grep/ripgrep for code search — it returns matches with enclosing symbol context instead of raw lines alone. Full-text search across file contents: literal, OR-terms, regex, or structural AST patterns. Use group_by='symbol' to deduplicate and follow_refs=true to inline callers. Set structural=true with query as an ast-grep pattern to match code by AST structure (e.g., 'fn $NAME($$$) { $$$ }'). Matches are ranked and capped per file; large output may CCR-compress with symforge_retrieve hash. NOT for symbol name search (use search_symbols). NOT for file path search (use search_files).",
+        description = "Prefer this over grep/ripgrep for code search — it returns matches with enclosing symbol context instead of raw lines alone. Test files and #[cfg(test)] modules are EXCLUDED by default (a zero-hit query reports how many test matches were suppressed); set include_tests=true to include them. Full-text search across file contents: literal, OR-terms, regex, or structural AST patterns. Use group_by='symbol' to deduplicate and follow_refs=true to inline callers. Set structural=true with query as an ast-grep pattern to match code by AST structure (e.g., 'fn $NAME($$$) { $$$ }'). Matches are ranked and capped per file; large output may CCR-compress with symforge_retrieve hash. NOT for symbol name search (use search_symbols). NOT for file path search (use search_files).",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     pub(crate) async fn search_text_tool(
@@ -6259,6 +6259,17 @@ impl SymForgeServer {
         let sidecar_status = sidecar_status_for_server(self);
         result.push('\n');
         result.push_str(&format::format_sidecar_status(&sidecar_status));
+        if mode == format::RuntimeMode::LocalProcess
+            && matches!(
+                sidecar_status.liveness,
+                crate::sidecar::port_file::SidecarLiveness::Dead
+                    | crate::sidecar::port_file::SidecarLiveness::NoSidecar
+            )
+        {
+            result.push_str(
+                " (informational: local-process mode keeps no sidecar; hooks fail open by design)",
+            );
+        }
 
         // Append token savings section if the sidecar's TokenStats are available.
         if let Some(ref stats) = self.token_stats {
@@ -6384,6 +6395,17 @@ impl SymForgeServer {
         let sidecar_status = sidecar_status_for_server(self);
         result.push('\n');
         result.push_str(&format::format_sidecar_status_compact(&sidecar_status));
+        if mode == format::RuntimeMode::LocalProcess
+            && matches!(
+                sidecar_status.liveness,
+                crate::sidecar::port_file::SidecarLiveness::Dead
+                    | crate::sidecar::port_file::SidecarLiveness::NoSidecar
+            )
+        {
+            result.push_str(
+                " (informational: local-process mode keeps no sidecar; hooks fail open by design)",
+            );
+        }
 
         if let Some(ref stats) = self.token_stats {
             let snap = stats.summary();
@@ -6640,6 +6662,20 @@ impl SymForgeServer {
             // if the daemon connection degrades later.
             if result.starts_with("Indexed ") {
                 let new_root = PathBuf::from(&params.0.path);
+                // Root actually changed → session accounting recorded under the
+                // previous root (context_inventory) would double-count; start
+                // fresh. A same-root retarget keeps accounting intact. Compare
+                // canonicalized forms so a raw vs canonical path spelling of the
+                // same directory does not spuriously wipe the session.
+                let previous_root = self.capture_repo_root();
+                let root_changed = new_root
+                    .canonicalize()
+                    .ok()
+                    .map(|canonical| previous_root.as_deref() != Some(canonical.as_path()))
+                    .unwrap_or(true);
+                if root_changed {
+                    self.session_context.reset();
+                }
                 self.set_repo_root(Some(new_root));
                 // Trust-critical: invalidate any stale in-process index left
                 // over from a previous local-fallback load. Without this, a
@@ -6760,6 +6796,12 @@ impl SymForgeServer {
                 let file_count = published.file_count;
                 let symbol_count = published.symbol_count;
 
+                // Root actually changed → session accounting recorded under the
+                // previous root (context_inventory) would double-count; start
+                // fresh. A same-root reindex keeps accounting intact.
+                if current_root.as_deref() != Some(root.as_path()) {
+                    self.session_context.reset();
+                }
                 self.set_repo_root(Some(root.clone()));
 
                 // Restart the file watcher at the new root so freshness continues.
@@ -6781,6 +6823,20 @@ impl SymForgeServer {
                 );
 
                 let mut output = format!("Indexed {} files, {} symbols.", file_count, symbol_count);
+                // Warn-only: indexing a subfolder of a git repo binds paths to
+                // that subfolder, not the repo root. Narrow-scope indexing is
+                // supported, so we do NOT auto-retarget — just surface the
+                // namespace shift so repo-root-relative path expectations are
+                // not silently violated.
+                if let Some(git_root) = crate::discovery::git_root_above(&root)
+                    && git_root != root
+                {
+                    output.push_str(&format!(
+                        "\nNote: indexed a subfolder of a git repo — paths will be relative to {}, not the git root {}. Index the git root for repo-root-relative paths.",
+                        root.display(),
+                        git_root.display()
+                    ));
+                }
                 if let Some(reset_report) = reset_report {
                     output.push_str(&format!(
                         "\nReset: scope={} | removed={} | missing={}",
@@ -8339,6 +8395,13 @@ impl SymForgeServer {
             // the highest score for a given name — exactly the entry we want to keep.
             later.0.eq_ignore_ascii_case(&first.0)
         });
+
+        // Two or more DISTINCT symbols resolved (e.g. "how does X interact with Y").
+        // The question is about a relationship, not a single definition — fall through
+        // to Understand → explore rather than picking the highest-scoring subject.
+        if candidates.len() >= 2 {
+            return None;
+        }
 
         // Pick the single candidate with the highest prominence score.
         candidates
@@ -14340,6 +14403,32 @@ mod tests {
         assert!(
             result.contains("src/lib.rs"),
             "what_changed should keep using the indexed repo root after index_folder, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_folder_warns_when_indexing_subfolder_of_git_repo() {
+        let repo = init_git_repo();
+        let sub = repo.path().join("subproject");
+        fs::create_dir_all(&sub).expect("create subfolder");
+        fs::write(sub.join("lib.rs"), "fn foo() {}\n").expect("write source in subfolder");
+
+        let server = make_server(make_live_index_empty());
+        let result = server
+            .index_folder(Parameters(super::IndexFolderInput {
+                path: sub.display().to_string(),
+                idempotency_key: None,
+                add: None,
+            }))
+            .await;
+
+        assert!(
+            result.contains("Indexed"),
+            "subfolder index should still succeed (warn-only, no retarget), got: {result}"
+        );
+        assert!(
+            result.contains("subfolder of a git repo") && result.contains("not the git root"),
+            "indexing a subfolder of a git repo should warn about the path namespace shift, got: {result}"
         );
     }
 
@@ -25662,6 +25751,39 @@ mod tests {
         assert!(
             result.contains("Invocation: get_symbol_context(name=\"MyHandler\")"),
             "result: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ask_routes_two_distinct_symbols_to_explore() {
+        // "how does X interact with Y" names two DISTINCT indexed symbols; the
+        // relationship question must fall through to explore, not get hijacked
+        // into get_symbol_context on whichever symbol scores highest.
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let content = b"struct BusActor;\nimpl BusActor { fn handle(&self) {} }\nstruct WorkerActor;\nimpl WorkerActor { fn run(&self) {} }\n";
+        std::fs::write(src_dir.join("actors.rs"), content).unwrap();
+
+        let result = crate::parsing::process_file("src/actors.rs", content, LanguageId::Rust);
+        let indexed =
+            crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+        let server = make_server_with_root(
+            make_live_index_ready(vec![("src/actors.rs".to_string(), indexed)]),
+            Some(dir.path().to_path_buf()),
+        );
+
+        let input = super::SmartQueryInput {
+            query: "how does BusActor interact with WorkerActor?".to_string(),
+            max_tokens: None,
+        };
+        let result = server.ask(Parameters(input)).await;
+
+        assert!(result.contains("Chosen tool: explore"), "result: {result}");
+        assert!(
+            !result.contains("Chosen tool: get_symbol_context"),
+            "a two-symbol relationship query must not upgrade to get_symbol_context: {result}"
         );
     }
 


### PR DESCRIPTION
Fixes the actionable findings from docs/reviews/2026-07-07-symforge-tool-smoke.md and the 8.10.7 beta log (docs/dogfood/).

- **search_text (#3)**: dirty-tree overlay preserved the base test-suppression count (saturating_add in view.rs), so the include_tests hint no longer vanishes; default test exclusion documented in the tool description + field doc, with an overlay regression test
- **ask (#4)**: relationship questions resolving 2+ distinct symbols route to explore instead of upgrading to the most prominent single symbol
- **find_references (#5)**: Rust path-qualified value usages (e.g. `from_fn(handlers::foo)`) indexed as ValueUse refs, gated against call sites/turbofish, use declarations, path prefixes, and match patterns
- **search_symbols (#6)**: macro-generated browse keeps only top-level comma-separated macro arguments; `::`-path expansion debris dropped
- **index_folder (#2/#10)**: warn-only note when indexing a subfolder of a git repo; session context reset on root retarget so context_inventory stops double-counting
- **health (#1/#9)**: empty-index nudge added to health_compact; dead-sidecar line marked informational under local-process fail-open
- **edit tools (beta)**: `symbol` accepted as alias for `name` on all symbol-addressed edit inputs, duplicate-key hard error, contract tests

Not fixed on purpose: #7 (Perl use-only files correctly yield imports, 0 symbols) and #8 (search_files is a literal path ranker).

Gates: fmt --check, check, clippy --all-targets -D warnings, full test suite (--test-threads=1), release build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index overlay merge, xref extraction, ask routing, and session reset on retarget—behavior changes for search hints, reference counts, and NL routing, but each path has targeted regression tests.
> 
> **Overview**
> Addresses **2026-07-07** tool-smoke and beta dogfood notes with runtime fixes plus two new docs under `docs/dogfood/` and `docs/reviews/`.
> 
> **Search & routing:** Dirty-tree `search_text` overlay now **adds** base `suppressed_by_noise` to overlay counts so the zero-hit **`include_tests`** hint survives a dirty working tree; docs/tool copy call out default test exclusion. **`ask`** stops upgrading to `get_symbol_context` when **two or more** distinct symbols match (relationship questions go to **`explore`**).
> 
> **Indexing & references:** **`git_root_above`** drives a **warn-only** message when `index_folder` targets a git subfolder (no auto-retarget). **`SessionContext::reset()`** runs on real root changes so **`context_inventory`** does not double-count paths. Rust xref indexing gains **`extract_rust_qualified_value_refs`** for path-qualified value uses (e.g. middleware `handlers::foo` passed to `from_fn`). **`macro-generated`** symbol extraction filters `::`-path debris and keeps top-level macro argument identifiers only.
> 
> **Health & edits:** **`health_compact`** nudges when the index is empty; **`health`/`health_compact`** annotate dead sidecar as informational in local-process fail-open mode. Symbol-addressed edit inputs accept **`symbol`** as an alias for **`name`** (duplicate keys still error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ab4083e2a7c9b1da99839a7254b4670ae2bc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->