### PR TITLE
fix(update): kill every same-path holder natively before the npm swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2429,6 +2429,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "ts-parser-perl",
+ "windows",
  "zstd",
 ]
 
@@ -3198,16 +3199,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3215,6 +3250,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3240,11 +3286,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,18 @@ socket2 = { version = "0.6", optional = true }
 # `index.bin.zst` export/import (contracts/team-artifact.md, C-S1A-005).
 zstd = "0.13"
 
+[target.'cfg(windows)'.dependencies]
+# Native process control for the self-update binary swap (cli/update.rs):
+# ToolHelp enumeration + image-path identity + TerminateProcess instead of
+# spawned powershell/taskkill/tasklist (taskkill's graceful mode is refused
+# by console daemons, and corporate EDR flags spawned kill tools). Pattern
+# ported from Terminal Commander's supervisor.
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 once_cell = "1"

--- a/SELF_UPDATE_PROCEDURE.md
+++ b/SELF_UPDATE_PROCEDURE.md
@@ -85,6 +85,11 @@ If SymForge exposes a clean-shutdown verb (e.g. a `symforge shutdown` /
 checkpoint command, or an IPC `shutdown`), call THAT first instead of `taskkill`
 so the index is flushed deterministically; fall back to the kill ladder above.
 
+Note: `symforge update` automates this whole step natively (IPC daemon stop,
+then an identity-gated `TerminateProcess` of every remaining same-path holder —
+no taskkill; a bare `taskkill /PID` is refused by console processes anyway).
+The manual ladder above remains the fallback when the updater itself is broken.
+
 Easiest of all (what happened here): **disconnect the MCP client first** (its
 `/mcp` teardown stops the daemon it spawned). With no holder left, the file is
 unlocked with zero force-kills — the cleanest path when the client is yours.

--- a/docs/dogfood/2026-07-07-symforge-8.10.7-beta-findings.md
+++ b/docs/dogfood/2026-07-07-symforge-8.10.7-beta-findings.md
@@ -68,6 +68,29 @@ should take/honor an absolute target path and refuse to silently retarget onto t
 error loudly — never remap. (Related: `worktree=explicit-call enabled` exists in capabilities —
 maybe the facade should require it in worktree contexts.)
 
+### F7 — 8.13.1 recheck: F1 FIXED, F5 persists (mixed)
+Post-update spin (same session lineage, version now 8.13.1):
+- **F1 (degraded daemon) FIXED**: `mode=daemon_reused_session`, `Sidecar: alive pid=28116`,
+  `Watcher: active/idle`, `Stale-mutation rejections: 0`. Reconnect after the update came back
+  healthy with no manual intervention. New `Worktree misuse/hour: 0` counter suggests F6 got
+  instrumentation too (no live worktree-edit repro attempted this pass).
+- **Freshness proof**: a helper added ~1h earlier via plain (non-symforge) edits
+  (`override_model_from_credential`, gateway.rs) already appears as a callee in
+  `get_symbol_context` — watcher picks up foreign edits live. The same call surfaced callers in
+  `model_qualification.rs` the manual grep pass had missed. This is the tool earning its keep.
+- **F5 (graphify-out/cache admission) PERSISTS in 8.13.1**: `graphify-out/cache: 963 files,
+  280,253 symbols` still fully indexed — 86% of all 327,511 symbols is one untracked JSON cache
+  dump. Also `frontend/dist: 3 files, 6,029 symbols` (tracked build artifacts) get full-index
+  admission. The admission-tier line (`2508/195/0`) shows nothing demoted to metadata-only for
+  these. Re-raising: untracked+gitignored dirs and `dist/`-class build outputs deserve
+  metadata-tier default, opt-in for full indexing.
+
+### F8 — get_symbol_context "Evidence" header lists a subset of caller files (LOW, cosmetic)
+For `resolve_effective_provider_config` the Evidence line names 2 files (gateway.rs,
+agent_configs.rs) while the callers body correctly lists 4 (adds model_qualification.rs,
+orchestration.rs). Harmless — the body is right — but a reader trusting the header would
+undercount usage sites.
+
 ## Environment
 - SymForge 8.10.7, MCP client Claude Code, Windows 11, project root `E:/project/Agent_Army_Professionals`.
 - Prior baseline: 8.10.3 same session lineage (healthy daemon mode) — see F1.

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -577,38 +577,10 @@ fn select_inscope_holder_pids(
         .collect()
 }
 
-#[cfg(any(windows, test))]
-fn process_path_matches(processes: &[(u32, String)], pid: u32, expected_exe: &str) -> bool {
-    let expected = normalize_exe_path(expected_exe);
-    processes
-        .iter()
-        .any(|(candidate_pid, path)| *candidate_pid == pid && normalize_exe_path(path) == expected)
-}
-
-/// Parse the `"<pid>|<executable_path>"` lines emitted by the CIM process query
-/// into `(pid, path)` pairs. Malformed lines and rows with an empty path (access
-/// denied / system rows) are skipped. Pure, so parsing is unit-tested without
-/// spawning PowerShell.
-#[cfg(any(windows, test))]
-fn parse_symforge_process_lines(text: &str) -> Vec<(u32, String)> {
-    text.lines()
-        .filter_map(|line| {
-            let (pid, path) = line.trim().split_once('|')?;
-            let pid: u32 = pid.trim().parse().ok()?;
-            let path = path.trim();
-            if path.is_empty() {
-                None
-            } else {
-                Some((pid, path.to_string()))
-            }
-        })
-        .collect()
-}
-
 /// Stop every OTHER symforge process running from this process's own executable
-/// path (the binary npm will overwrite), graceful-then-forced, so the Windows
-/// image lock is released before the npm swap. Excludes this process. Returns a
-/// summary line when any holder was stopped.
+/// path (the binary npm will overwrite), identity-gated native terminate, so
+/// the Windows image lock is released before the npm swap. Excludes this
+/// process. Returns a summary line when any holder was stopped.
 #[cfg(windows)]
 fn stop_other_inscope_holders() -> Vec<String> {
     let Ok(self_exe) = std::env::current_exe() else {
@@ -623,7 +595,7 @@ fn stop_other_inscope_holders() -> Vec<String> {
         return Vec::new();
     }
     for pid in &pids {
-        graceful_then_forced_stop(*pid, &self_exe);
+        terminate_inscope_holder(*pid, &self_exe);
     }
     vec![format!(
         "{} other in-scope symforge holder(s) (pid {})",
@@ -643,130 +615,182 @@ fn stop_other_inscope_holders() -> Vec<String> {
     Vec::new()
 }
 
-/// Enumerate every running `symforge.exe` as `(pid, executable_path)` via CIM
-/// (`ExecutablePath` is required to scope by path per Invariant 1; `tasklist`
-/// does not expose it). Tries Windows PowerShell (`powershell`, the 5.1 default)
-/// and falls back to PowerShell 7 (`pwsh`) when the former is not installed.
-/// Returns an empty list when neither shell can be spawned — a safe no-op that
-/// degrades to the staged-guidance bail rather than killing nothing silently.
+/// Enumerate every running `symforge.exe` as `(pid, full_image_path)` natively
+/// via a ToolHelp snapshot + `QueryFullProcessImageNameW` — spawning NO external
+/// process (pattern ported from Terminal Commander's supervisor). The full image
+/// path is required to scope by install path per Invariant 1. Returns an empty
+/// list when the snapshot cannot be taken — a safe no-op that degrades to the
+/// staged-guidance bail rather than killing anything on uncertainty.
 #[cfg(windows)]
 fn enumerate_symforge_processes() -> Vec<(u32, String)> {
-    let script = "Get-CimInstance Win32_Process -Filter \"name='symforge.exe'\" | \
-                  ForEach-Object { \"$($_.ProcessId)|$($_.ExecutablePath)\" }";
-    for shell in ["powershell", "pwsh"] {
-        match crate::process_util::hidden_command(shell)
-            .args(["-NoProfile", "-NonInteractive", "-Command", script])
-            .stdin(Stdio::null())
-            .stderr(Stdio::null())
-            .output()
-        {
-            // The shell ran: trust its output (an empty list is a valid answer —
-            // genuinely no other holders — so do NOT retry the next shell).
-            Ok(out) => return parse_symforge_process_lines(&String::from_utf8_lossy(&out.stdout)),
-            // This shell is not installed: try the next one.
-            Err(_) => continue,
-        }
-    }
-    Vec::new()
+    windows_native::enumerate_by_image_name("symforge.exe")
 }
 
-/// Graceful stop (`taskkill /PID`, a WM_CLOSE that lets a daemon flush its index
-/// checkpoint), a short grace window, then a forced stop (`/F`) only if the
-/// process ignored the graceful close (Invariant 2: graceful before forced).
+/// Identity-gated forced terminate of one in-scope holder. Re-verifies via the
+/// OS — immediately before the kill — that `pid`'s image path is THIS install's
+/// binary, then terminates natively.
+///
+/// There is deliberately NO graceful leg on Windows: `taskkill` without `/F`
+/// is REFUSED by console processes ("can only be terminated forcefully"),
+/// which is what the daemon/sidecar/MCP server are — the old graceful-then-
+/// forced dance either mistook that refusal for "nothing to stop" (leaving
+/// holders alive and the npm swap blocked) or added a wait that protected
+/// nothing. The graceful path is the IPC daemon stop in `stop_processes`;
+/// whatever still holds the binary after it is terminated here.
+///
+/// A pid that cannot be queried or whose image path no longer matches is left
+/// alone (recycled-pid defense: never kill on uncertainty).
 #[cfg(windows)]
-fn graceful_then_forced_stop(pid: u32, expected_exe: &str) {
-    use std::time::{Duration, Instant};
-
-    if !taskkill_if_process_matches_path(pid, expected_exe, false) {
-        return;
-    }
-
-    // 5s grace window (matches SELF_UPDATE_PROCEDURE.md Step 3) so a daemon can
-    // flush its index checkpoint before a forced kill.
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline && process_is_alive(pid) {
-        std::thread::sleep(Duration::from_millis(150));
-    }
-
-    // Forced only if it ignored the graceful close, and only after re-checking
-    // that the PID still belongs to this install path. A stale snapshot must not
-    // let us kill an unrelated same-named install.
-    if process_is_alive(pid) {
-        let _ = taskkill_if_process_matches_path(pid, expected_exe, true);
+fn terminate_inscope_holder(pid: u32, expected_exe: &str) {
+    let expected = normalize_exe_path(expected_exe);
+    let still_ours = windows_native::pid_image_full_path(pid)
+        .is_some_and(|path| normalize_exe_path(&path) == expected);
+    if still_ours {
+        let _ = windows_native::terminate_process(pid);
     }
 }
 
+/// Native Win32 process control for the update swap, ported from Terminal
+/// Commander's supervisor: ToolHelp enumeration, image-path identity, and
+/// `TerminateProcess`. Spawns NO external process — no powershell/CIM, no
+/// taskkill, no tasklist (corporate EDR flags spawned kill tools, and the
+/// tools themselves were the source of the refused-graceful bug).
+///
+/// `unsafe` here is FFI-only, each call justified by a SAFETY comment; the
+/// crate-level `unsafe_code = "deny"` is opted out per-item, matching the
+/// repo's test-env precedent.
 #[cfg(windows)]
-fn taskkill_if_process_matches_path(pid: u32, expected_exe: &str, force: bool) -> bool {
-    if !process_matches_exe_path(pid, expected_exe) {
-        return false;
-    }
-    let pid_arg = pid.to_string();
-    let mut args = Vec::with_capacity(3);
-    if force {
-        args.push("/F");
-    }
-    args.extend(["/PID", pid_arg.as_str()]);
-    matches!(
-        crate::process_util::hidden_command("taskkill")
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status(),
-        Ok(status) if status.success()
-    )
-}
+mod windows_native {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows::Win32::System::Threading::{
+        OpenProcess, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+        QueryFullProcessImageNameW, TerminateProcess,
+    };
 
-#[cfg(windows)]
-fn process_matches_exe_path(pid: u32, expected_exe: &str) -> bool {
-    let script = format!(
-        "Get-CimInstance Win32_Process -Filter \"ProcessId={pid} AND name='symforge.exe'\" | \
-         ForEach-Object {{ \"$($_.ProcessId)|$($_.ExecutablePath)\" }}"
-    );
-    for shell in ["powershell", "pwsh"] {
-        match crate::process_util::hidden_command(shell)
-            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-            .stdin(Stdio::null())
-            .stderr(Stdio::null())
-            .output()
-        {
-            Ok(out) => {
-                return process_path_matches(
-                    &parse_symforge_process_lines(&String::from_utf8_lossy(&out.stdout)),
-                    pid,
-                    expected_exe,
-                );
+    /// RAII guard so a process/snapshot handle is closed on every return path.
+    /// `CloseHandle` failure on drop is ignored: the handle is being discarded
+    /// regardless.
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is a handle we opened (OpenProcess /
+            // CreateToolhelp32Snapshot) and have not closed yet. Closing it
+            // exactly once here is the paired release for that open.
+            #[allow(unsafe_code)]
+            unsafe {
+                let _ = CloseHandle(self.0);
             }
-            Err(_) => continue,
         }
     }
-    false
-}
 
-/// Whether `pid` is still running AND still a `symforge.exe`. The `tasklist`
-/// query filters server-side to that exact pid + image name and emits one CSV row
-/// (which echoes the pid as a quoted token) when alive, or "No tasks" otherwise.
-/// Path safety is enforced separately immediately before each `taskkill`.
-#[cfg(windows)]
-fn process_is_alive(pid: u32) -> bool {
-    let needle = pid.to_string();
-    let output = crate::process_util::hidden_command("tasklist")
-        .args([
-            "/FI",
-            &format!("PID eq {pid}"),
-            "/FI",
-            "IMAGENAME eq symforge.exe",
-            "/NH",
-            "/FO",
-            "CSV",
-        ])
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output();
-    match output {
-        Ok(out) => String::from_utf8_lossy(&out.stdout).contains(needle.as_str()),
-        Err(_) => false,
+    /// Read `pid`'s FULL image path via the OS, or `None` if the process
+    /// cannot be opened/queried (it exited, the pid is invalid, or access was
+    /// denied). Callers treat `None` as "not ours" — never kill on uncertainty.
+    #[allow(unsafe_code)]
+    pub(super) fn pid_image_full_path(pid: u32) -> Option<String> {
+        // SAFETY: OpenProcess takes a desired-access mask, an inherit BOOL,
+        // and a pid; it returns a valid handle on success or an Err we map to
+        // None. PROCESS_QUERY_LIMITED_INFORMATION is the least privilege that
+        // permits QueryFullProcessImageNameW.
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()? };
+        let proc = OwnedHandle(handle);
+
+        let mut buf = [0u16; 1024];
+        let mut len = u32::try_from(buf.len()).expect("image-path buffer length fits in u32");
+        // SAFETY: `proc.0` is a live handle (just opened) valid for this call.
+        // PROCESS_NAME_FORMAT(0) requests the win32 path form. `buf`/`len`
+        // describe a properly sized, owned u16 buffer; the call writes at most
+        // `len` code units and updates `len` to the count written. We check
+        // the BOOL result and a non-zero length before reading the buffer.
+        let ok = unsafe {
+            QueryFullProcessImageNameW(
+                proc.0,
+                PROCESS_NAME_FORMAT(0),
+                windows::core::PWSTR(buf.as_mut_ptr()),
+                &raw mut len,
+            )
+            .is_ok()
+        };
+        if !ok || len == 0 {
+            return None;
+        }
+        Some(String::from_utf16_lossy(&buf[..len as usize]))
+    }
+
+    /// Force-terminate `pid` natively. Caller has already identity-gated the
+    /// pid. Returns an IO error if the process cannot be opened for
+    /// termination or the terminate call fails.
+    #[allow(unsafe_code)]
+    pub(super) fn terminate_process(pid: u32) -> std::io::Result<()> {
+        let access = PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION;
+        // SAFETY: OpenProcess as above; PROCESS_TERMINATE is the access right
+        // TerminateProcess requires. The Err arm maps the Win32 error into an
+        // io::Error without dereferencing anything.
+        let handle = unsafe { OpenProcess(access, false, pid) }
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        let proc = OwnedHandle(handle);
+        // SAFETY: `proc.0` is a live handle opened with PROCESS_TERMINATE.
+        // TerminateProcess posts the exit and returns a BOOL we propagate as
+        // an io::Error on failure. Exit code 1 mirrors the prior `taskkill /F`.
+        unsafe { TerminateProcess(proc.0, 1) }.map_err(|e| std::io::Error::other(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Enumerate all processes whose image FILE NAME matches `image_name`
+    /// (case-insensitive) as `(pid, full_image_path)`. The full path comes
+    /// from the authoritative per-pid query, not the snapshot's base name, so
+    /// callers can scope by install path. Self-exclusion is the caller's job
+    /// (`select_inscope_holder_pids` excludes `self_pid`).
+    #[allow(unsafe_code)]
+    pub(super) fn enumerate_by_image_name(image_name: &str) -> Vec<(u32, String)> {
+        // SAFETY: CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) returns a
+        // valid snapshot handle or an Err we map to an empty list. The handle
+        // is owned by `OwnedHandle` and released on every return path.
+        let Ok(snapshot_handle) = (unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) })
+        else {
+            return Vec::new();
+        };
+        let snapshot = OwnedHandle(snapshot_handle);
+
+        let mut entry = PROCESSENTRY32W {
+            dwSize: u32::try_from(std::mem::size_of::<PROCESSENTRY32W>())
+                .expect("PROCESSENTRY32W size fits in u32"),
+            ..Default::default()
+        };
+
+        let mut found = Vec::new();
+        // SAFETY: `snapshot.0` is a valid snapshot handle and `entry` is a
+        // properly initialized PROCESSENTRY32W with `dwSize` set, as the API
+        // requires. Process32FirstW fills `entry` and returns Ok/Err.
+        let mut has_entry = unsafe { Process32FirstW(snapshot.0, &raw mut entry).is_ok() };
+        while has_entry {
+            let pid = entry.th32ProcessID;
+            if exe_name_from_entry(&entry).eq_ignore_ascii_case(image_name)
+                && let Some(path) = pid_image_full_path(pid)
+            {
+                found.push((pid, path));
+            }
+            // SAFETY: same invariants as Process32FirstW; advances `entry` to
+            // the next process or returns Err at the end of the snapshot.
+            has_entry = unsafe { Process32NextW(snapshot.0, &raw mut entry).is_ok() };
+        }
+        found
+    }
+
+    /// Decode the NUL-terminated UTF-16 `szExeFile` base name from a snapshot
+    /// entry into a Rust string.
+    fn exe_name_from_entry(entry: &PROCESSENTRY32W) -> String {
+        let end = entry
+            .szExeFile
+            .iter()
+            .position(|c| *c == 0)
+            .unwrap_or(entry.szExeFile.len());
+        String::from_utf16_lossy(&entry.szExeFile[..end])
     }
 }
 
@@ -1121,49 +1145,101 @@ mod tests {
         );
     }
 
+    /// Copy a benign long-lived system exe to `<tmp>/symforge.exe` and spawn
+    /// it so the process's image FILE NAME is the symforge binary name (the
+    /// pattern Terminal Commander's supervisor tests use). The returned
+    /// `TempDir` keeps the copied exe alive for the test's duration.
+    #[cfg(windows)]
+    fn spawn_fake_symforge() -> (tempfile::TempDir, std::process::Child) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake = dir.path().join("symforge.exe");
+        let ping = std::path::Path::new(r"C:\Windows\System32\PING.EXE");
+        std::fs::copy(ping, &fake).expect("copy ping.exe to symforge.exe");
+        // `ping -n 30 127.0.0.1` stays alive ~30s; far longer than the test.
+        let child = std::process::Command::new(&fake)
+            .args(["-n", "30", "127.0.0.1"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn fake symforge");
+        (dir, child)
+    }
+
     #[test]
-    fn process_path_matches_requires_same_pid_and_same_executable_path() {
+    #[cfg(windows)]
+    fn enumerate_symforge_processes_finds_spawned_symforge_image_with_full_path() {
+        let (dir, mut child) = spawn_fake_symforge();
+        let pid = child.id();
+        let procs = enumerate_symforge_processes();
+        let _ = child.kill();
+        let _ = child.wait();
+        let found = procs.iter().find(|(p, _)| *p == pid);
+        let (_, path) = found.expect("native enumeration must list the spawned symforge.exe");
+        assert_eq!(
+            normalize_exe_path(path),
+            normalize_exe_path(&dir.path().join("symforge.exe").to_string_lossy()),
+            "the enumerated entry must carry the FULL image path for install scoping"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn terminate_inscope_holder_kills_matching_path_and_spares_mismatch() {
+        // Mismatched expected path -> the holder must be left alive
+        // (Invariant 1: never touch another install; recycled-pid defense).
+        let (dir, mut child) = spawn_fake_symforge();
+        let pid = child.id();
+        terminate_inscope_holder(pid, r"C:\some\other\install\symforge.exe");
+        assert!(
+            child.try_wait().expect("try_wait").is_none(),
+            "a path-mismatched pid must NOT be terminated"
+        );
+
+        // Matching expected path -> terminated (this is the bug the taskkill
+        // graceful leg used to mask: console processes refused the graceful
+        // close and never reached the forced kill).
+        let expected = dir
+            .path()
+            .join("symforge.exe")
+            .to_string_lossy()
+            .to_string();
+        terminate_inscope_holder(pid, &expected);
+        let status = child.wait().expect("wait on terminated child");
+        assert!(
+            !status.success(),
+            "TerminateProcess(exit=1) must make the holder exit non-zero"
+        );
+
+        // A second terminate of the now-dead pid must be a no-op (identity
+        // gate: the pid no longer resolves to this image path).
+        terminate_inscope_holder(pid, &expected);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn terminate_inscope_holder_never_kills_the_test_runner() {
+        // The test runner is alive but its image is the test binary, not the
+        // expected symforge path -> must be refused (this failing would kill
+        // the test host, exactly TC's guard).
+        terminate_inscope_holder(std::process::id(), r"C:\npm\symforge.exe");
+    }
+
+    #[test]
+    fn select_inscope_rejects_other_install_and_absent_rows() {
         let procs = vec![
             (100u32, r"C:\npm\symforge.exe".to_string()),
             (200u32, r"D:\other\symforge.exe".to_string()),
             (300u32, r"\\?\C:\NPM\symforge.exe".to_string()),
         ];
-
-        assert!(
-            process_path_matches(&procs, 100, r"C:\NPM\symforge.exe"),
-            "same PID and path identity should match"
-        );
-        assert!(
-            process_path_matches(&procs, 300, r"C:\npm\symforge.exe"),
-            "path form normalization should match the same executable"
-        );
-        assert!(
-            !process_path_matches(&procs, 200, r"C:\npm\symforge.exe"),
-            "a recycled PID at a different install path must not be killable"
-        );
-        assert!(
-            !process_path_matches(&procs, 999, r"C:\npm\symforge.exe"),
-            "a missing PID must not match"
-        );
-    }
-
-    #[test]
-    fn parse_symforge_process_lines_parses_pid_path_and_skips_malformed() {
-        let text = "100|C:\\npm\\symforge.exe\r\n\
-                    200|C:\\other\\symforge.exe\n\
-                    notapid|C:\\x\\symforge.exe\n\
-                    300|\n\
-                    \n\
-                    400|C:\\a b\\symforge.exe";
-        let parsed = parse_symforge_process_lines(text);
         assert_eq!(
-            parsed,
-            vec![
-                (100, "C:\\npm\\symforge.exe".to_string()),
-                (200, "C:\\other\\symforge.exe".to_string()),
-                (400, "C:\\a b\\symforge.exe".to_string()),
-            ],
-            "malformed pid, empty path, and blank lines are skipped"
+            select_inscope_holder_pids(&procs, r"C:\NPM\symforge.exe", 999),
+            vec![100, 300],
+            "same-path rows (any form) are in scope; the other install is not"
+        );
+        assert_eq!(
+            select_inscope_holder_pids(&procs, r"C:\npm\symforge.exe", 100),
+            vec![300],
+            "the self pid must never be selected, even at the same path"
         );
     }
 


### PR DESCRIPTION
symforge update left the daemon/sidecar/MCP server running on Windows: a non-forced taskkill is refused by console processes ("can only be terminated forcefully"), the refusal was treated as "nothing to stop", the forced kill never ran, the old exe stayed locked, and the npm swap silently installed nothing (hit live going 8.13.0 → 8.13.1).

Ports Terminal Commander's supervisor pattern:
- Native ToolHelp snapshot enumeration of symforge.exe holders (full image path via QueryFullProcessImageNameW) — no spawned powershell/CIM, taskkill, or tasklist
- Identity re-verified by full install path immediately before each kill; recycled/unqueryable PIDs are never touched
- Native TerminateProcess; the graceful path remains the IPC daemon stop that runs first
- Target-gated `windows` crate dep; FFI unsafe with per-item allow + SAFETY comments per repo convention
- Real-process tests: a fake symforge.exe (copied ping) is enumerated with full path, terminated on path match, spared on mismatch and for the test runner

Also updates SELF_UPDATE_PROCEDURE.md (Step 3 automated natively) and carries the 2026-07-07 dogfood findings log update (F6–F8).

Gates: fmt --check, check, clippy --all-targets -D warnings, full test suite (--test-threads=1), release build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the updater terminates processes on Windows (native `TerminateProcess` after path gating); scope is limited to same-install holders and is covered by integration tests, but forced termination during self-update can still disrupt live MCP/daemon sessions if path matching regresses.
> 
> **Overview**
> Fixes a Windows self-update failure where **non-forced `taskkill` was refused** by console daemon/sidecar/MCP processes, the refusal was treated as success, **forced kills never ran**, the `.exe` stayed locked, and **`npm install` could report success without actually swapping the binary**.
> 
> **Windows holder cleanup in `cli/update.rs`** is rewritten to match Terminal Commander’s supervisor pattern:
> - **Enumerate** `symforge.exe` via **ToolHelp** + **`QueryFullProcessImageNameW`** (full image path for install scoping)—no spawned PowerShell/CIM, **`taskkill`**, or **`tasklist`**
> - **Stop holders** with **identity re-check** on full install path, then **`TerminateProcess`**; **no Windows “graceful taskkill” leg** (IPC daemon stop in `stop_processes` remains the graceful path)
> - New **`windows_native`** module with RAII handle cleanup and scoped **`unsafe`** FFI; **`windows` 0.58** added as a **`cfg(windows)`** dependency (`Cargo.toml` / lockfile)
> 
> **Tests** on Windows spawn a fake `symforge.exe` (copied ping) to verify enumeration, path-match termination, path-mismatch sparing, and that the test runner is never killed; pure **`select_inscope_holder_pids`** tests replace CIM line-parser tests.
> 
> **Docs:** `SELF_UPDATE_PROCEDURE.md` notes that **`symforge update` automates Step 3** natively; dogfood log adds **F7–F8** (8.13.1 recheck).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978818d958ce40e6c1f27da11189841e40f6905e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->