### PR TITLE
fix(test): make desktop-wrapper registration assertion platform-aware

### DIFF
--- a/tests/init_integration.rs
+++ b/tests/init_integration.rs
@@ -624,20 +624,29 @@ fn test_run_init_all_updates_both_clients() {
     let claude_desktop_command = claude_desktop_config_value["mcpServers"]["symforge"]["command"]
         .as_str()
         .unwrap();
-    // The registered command is the wrapper in the Desktop CONFIG dir (npm
-    // wipes the binary's bin dir on every swap); the wrapper itself launches
-    // the stable binary by absolute path.
-    let desktop_config_dir = claude_desktop_config
-        .parent()
-        .expect("desktop config has a parent dir");
+    // Windows: the registered command is the wrapper in the Desktop CONFIG dir
+    // (npm wipes the binary's bin dir on every swap); the wrapper launches the
+    // stable binary by absolute path. Non-Windows: no wrapper is generated —
+    // the command is the stable binary itself.
+    #[cfg(windows)]
+    {
+        let desktop_config_dir = claude_desktop_config
+            .parent()
+            .expect("desktop config has a parent dir");
+        assert!(
+            claude_desktop_command.contains(&desktop_config_dir.display().to_string()),
+            "Claude Desktop command must point at the wrapper in the config dir: {claude_desktop_command}"
+        );
+        let wrapper_script = read_text(&desktop_config_dir.join("symforge-desktop.cmd"));
+        assert!(
+            wrapper_script.contains(&stable_bin_dir.display().to_string()),
+            "the wrapper must launch the stable binary by absolute path: {wrapper_script}"
+        );
+    }
+    #[cfg(not(windows))]
     assert!(
-        claude_desktop_command.contains(&desktop_config_dir.display().to_string()),
-        "Claude Desktop command must point at the wrapper in the config dir: {claude_desktop_command}"
-    );
-    let wrapper_script = read_text(&desktop_config_dir.join("symforge-desktop.cmd"));
-    assert!(
-        wrapper_script.contains(&stable_bin_dir.display().to_string()),
-        "the wrapper must launch the stable binary by absolute path: {wrapper_script}"
+        claude_desktop_command.contains(&stable_bin_dir.display().to_string()),
+        "Claude Desktop command must be the stable binary path on non-Windows: {claude_desktop_command}"
     );
 
     let codex_config = read_text(&home.path().join(".codex").join("config.toml"));


### PR DESCRIPTION
test_run_init_all_updates_both_clients asserted the Windows config-dir wrapper unconditionally; on Linux no wrapper is generated (the registered command is the stable binary), so verify-main-push failed on the Linux runner after #435 merged and blocked the 8.13.4 release cut. cfg-gates the assertions: Windows checks the config-dir wrapper + absolute binary path in the script; non-Windows checks the binary path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified; it restores CI on Linux after Windows-specific assertions were added.
> 
> **Overview**
> **`test_run_init_all_updates_both_clients`** no longer assumes Windows-only Claude Desktop MCP registration. The test now **`#[cfg(windows)]`** checks that the registered command points at the config-dir **`symforge-desktop.cmd`** wrapper and that the wrapper script references the stable binary path. On **`#[cfg(not(windows))`**, it asserts the registered command is the stable binary path directly, since init does not generate a desktop wrapper on those platforms.
> 
> Comments in the test were updated to document this split behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55bfce0e4f75d0c2892ea03371f19b9277dda67c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->