### PR TITLE
fix: address 2026-07-07 beta dogfood findings (F5/F6/B2/B4/B5/F8)

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -598,6 +598,19 @@ pub fn event_name_for(subcommand: &HookSubcommand) -> &'static str {
 fn pre_tool_suggestion(input: &HookInput) -> String {
     let tool = input.tool_name.as_deref().unwrap_or("");
     let cwd = input.cwd.as_deref().unwrap_or("");
+
+    // Suppress hints for targets outside the workspace root: SymForge cannot
+    // serve paths outside the indexed repo (e.g. %TEMP% task outputs, other
+    // repos), so the hint would be pure noise. Fail-open silent.
+    let target = input
+        .tool_input
+        .as_ref()
+        .and_then(|ti| ti.file_path.as_deref().or(ti.path.as_deref()))
+        .unwrap_or("");
+    if is_outside_workspace(target, cwd) {
+        return String::new();
+    }
+
     let file = extract_file_path(input, cwd);
     let pattern = input
         .tool_input
@@ -665,6 +678,34 @@ fn workflow_for_subcommand(subcommand: Option<&HookSubcommand>, input: &HookInpu
         Some(HookSubcommand::PreTool) => pre_tool_workflow(input),
         None => HookWorkflow::PassThrough,
     }
+}
+
+/// True when `target` is an absolute path that does not live under the
+/// workspace root (`root`, falling back to the hook's current directory).
+///
+/// SymForge tools resolve paths relative to the indexed project root, so an
+/// absolute path outside it (temp dirs, other repos) can never be served and
+/// must not produce an efficiency hint. Relative and empty targets are always
+/// treated as in-workspace. Cheap by design: string prefix check after
+/// normalization, no filesystem access beyond an optional `current_dir`.
+fn is_outside_workspace(target: &str, root: &str) -> bool {
+    if target.is_empty() || !std::path::Path::new(target).is_absolute() {
+        return false;
+    }
+    let root_norm = if root.is_empty() {
+        match std::env::current_dir() {
+            Ok(d) => normalize_path_for_match(&d),
+            // Fail-open: cannot determine the root, keep existing behavior.
+            Err(_) => return false,
+        }
+    } else {
+        normalize_path_for_match(std::path::Path::new(root))
+    };
+    if root_norm.is_empty() {
+        return false;
+    }
+    let target_norm = normalize_path_for_match(std::path::Path::new(target));
+    target_norm != root_norm && !target_norm.starts_with(&format!("{root_norm}/"))
 }
 
 /// Returns true when a read should stay conservative and fail open instead of
@@ -1901,6 +1942,70 @@ mod tests {
         assert!(
             s.contains("replace_symbol_body"),
             "should suggest replace_symbol_body: {s}"
+        );
+    }
+
+    #[test]
+    fn test_pre_tool_suggestion_read_outside_workspace_is_empty() {
+        // B5: Read of a %TEMP%-style path outside the repo root must not hint —
+        // get_file_context cannot serve paths outside every indexed root.
+        let temp_target = std::env::temp_dir()
+            .join("claude")
+            .join("tasks")
+            .join("1.output");
+        let input = HookInput {
+            tool_name: Some("Read".to_string()),
+            tool_input: Some(HookToolInput {
+                file_path: Some(temp_target.to_string_lossy().into_owned()),
+                ..Default::default()
+            }),
+            cwd: Some("/repo".to_string()),
+            ..Default::default()
+        };
+        let s = pre_tool_suggestion(&input);
+        assert!(s.is_empty(), "should not hint outside the workspace: {s}");
+    }
+
+    #[test]
+    fn test_pre_tool_suggestion_read_in_repo_absolute_still_hints() {
+        // In-repo absolute path under cwd keeps the hint. Use a real absolute
+        // path so the check is exercised on every platform.
+        let cwd = std::env::current_dir().unwrap();
+        let target = cwd.join("src").join("main.rs");
+        let input = HookInput {
+            tool_name: Some("Read".to_string()),
+            tool_input: Some(HookToolInput {
+                file_path: Some(target.to_string_lossy().into_owned()),
+                ..Default::default()
+            }),
+            cwd: Some(cwd.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let s = pre_tool_suggestion(&input);
+        assert!(
+            s.contains("get_file_context"),
+            "in-repo absolute read should still hint: {s}"
+        );
+    }
+
+    #[test]
+    fn test_pre_tool_suggestion_grep_outside_workspace_is_empty() {
+        // B5: Grep scoped to a directory outside the repo root must not hint.
+        let temp_dir = std::env::temp_dir().join("scratch");
+        let input = HookInput {
+            tool_name: Some("Grep".to_string()),
+            tool_input: Some(HookToolInput {
+                pattern: Some("helper".to_string()),
+                path: Some(temp_dir.to_string_lossy().into_owned()),
+                ..Default::default()
+            }),
+            cwd: Some("/repo".to_string()),
+            ..Default::default()
+        };
+        let s = pre_tool_suggestion(&input);
+        assert!(
+            s.is_empty(),
+            "should not hint for grep outside the workspace: {s}"
         );
     }
 

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1167,6 +1167,117 @@ fn tracked_path_set_for_build_dir_rescue(root: &Path) -> Option<std::collections
     Some(tracked.into_iter().collect())
 }
 
+/// Env var opting back INTO full indexing of untracked generated-output
+/// directories (F5). Default OFF — when unset, files under an untracked
+/// directory matching [`is_generated_output_dir_name`] are demoted to Tier-2
+/// metadata-only. Set to a truthy value (`1`, `true`, `yes`, `on`) to restore
+/// the previous behavior (full Tier-1 admission).
+pub const INDEX_GENERATED_OUTPUT_ENV: &str = "SYMFORGE_INDEX_GENERATED_OUTPUT";
+
+/// Returns `true` when the operator opted back into indexing untracked
+/// generated-output dirs. Same truthy spellings as [`exclude_untracked_enabled`].
+fn index_generated_output_enabled() -> bool {
+    std::env::var(INDEX_GENERATED_OUTPUT_ENV)
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
+/// Conservative name heuristic for machine-generated output directories.
+///
+/// Deliberately small: only names that are overwhelmingly build/cache output in
+/// practice (`dist`, `build`, `out`, `output`, `cache`, `.cache`, `generated`,
+/// `*-out`, `*-output`). False positives are bounded by the tracked-file guard
+/// in [`untracked_generated_output_demotions`]: a dir with ANY tracked file
+/// beneath it is never demoted.
+pub fn is_generated_output_dir_name(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    matches!(
+        n.as_str(),
+        "dist" | "build" | "out" | "output" | "cache" | ".cache" | "generated"
+    ) || n.ends_with("-out")
+        || n.ends_with("-output")
+}
+
+/// F5: compute the set of discovered file paths to demote to Tier-2 because
+/// they live under an UNTRACKED generated-output directory.
+///
+/// Field-report motivation: a single untracked (not gitignored) JSON cache dump
+/// (`graphify-out/cache`, 963 files) contributed 86% of a 327k-symbol index.
+/// Untracked dirs whose name matches [`is_generated_output_dir_name`] are
+/// machine output the operator never chose to version; demote their files to
+/// Tier-2 metadata-only (path stays searchable, no symbol extraction).
+///
+/// Conservative guarantees:
+/// - A directory with ANY git-tracked file beneath it is NEVER demoted
+///   (tracked = the operator chose to version it; this also preserves the
+///   SF-012(B) tracked-rescue contract, e.g. a committed `frontend/dist`).
+/// - Non-git trees / unreadable git index → empty set (fail open: admit,
+///   exactly the current behavior).
+/// - `SYMFORGE_INDEX_GENERATED_OUTPUT=1` → empty set (explicit opt-in).
+pub fn untracked_generated_output_demotions(
+    root: &Path,
+    entries: &[DiscoveredEntry],
+) -> std::collections::HashSet<String> {
+    if index_generated_output_enabled() {
+        return std::collections::HashSet::new();
+    }
+    let Some(tracked) = tracked_path_set_for_build_dir_rescue(root) else {
+        return std::collections::HashSet::new();
+    };
+    untracked_generated_output_demotions_inner(entries, &tracked)
+}
+
+/// Env-free core of [`untracked_generated_output_demotions`], unit-testable
+/// without process-global state.
+fn untracked_generated_output_demotions_inner(
+    entries: &[DiscoveredEntry],
+    tracked: &std::collections::HashSet<String>,
+) -> std::collections::HashSet<String> {
+    use std::collections::{HashMap, HashSet};
+
+    // Candidate-dir decision cache: prefix -> has any tracked file beneath it.
+    // ponytail: O(candidates * tracked) linear scans; prefix trie if this shows
+    // up in load profiles.
+    let mut dir_has_tracked: HashMap<String, bool> = HashMap::new();
+    let mut demoted: HashSet<String> = HashSet::new();
+
+    for entry in entries {
+        let rel = entry.relative_path.as_str();
+        if tracked.contains(rel) {
+            continue; // tracked file: never demoted by this policy
+        }
+        // Shallowest DIRECTORY component (never the file name) matching the
+        // generated-output heuristic defines the candidate directory prefix.
+        let Some((dirs, _file)) = rel.rsplit_once('/') else {
+            continue; // root-level file, no directory to classify
+        };
+        let mut candidate: Option<&str> = None;
+        let mut end = 0usize;
+        for comp in dirs.split('/') {
+            end += comp.len();
+            if is_generated_output_dir_name(comp) {
+                candidate = Some(&rel[..end]);
+                break;
+            }
+            end += 1; // the '/' separator
+        }
+        let Some(candidate) = candidate else { continue };
+        let has_tracked = *dir_has_tracked
+            .entry(candidate.to_string())
+            .or_insert_with(|| {
+                let prefix = format!("{candidate}/");
+                tracked.iter().any(|t| t.starts_with(&prefix))
+            });
+        if !has_tracked {
+            demoted.insert(entry.relative_path.clone());
+        }
+    }
+    demoted
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1598,6 +1709,177 @@ mod tests {
             assert!(
                 paths.contains(&"src/main.rs"),
                 "normal source must be discovered: {paths:?}"
+            );
+        }
+    }
+
+    mod generated_output_demotion {
+        use super::*;
+        use std::process::Command;
+
+        // Serializes the opt-in test (which mutates the process-global
+        // SYMFORGE_INDEX_GENERATED_OUTPUT) against the sibling tests that read it via
+        // `untracked_generated_output_demotions`. Without this, parallel cargo test
+        // runs let the opt-in window leak into a reader and flip its expected tier.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        fn init_git(root: &Path) -> impl Fn(&[&str]) + '_ {
+            let run = move |args: &[&str]| {
+                Command::new("git")
+                    .args(args)
+                    .current_dir(root)
+                    .output()
+                    .expect("git command");
+            };
+            run(&["init"]);
+            run(&["config", "user.email", "test@test.com"]);
+            run(&["config", "user.name", "Test"]);
+            run
+        }
+
+        #[test]
+        fn generated_output_dir_name_matcher_is_conservative() {
+            for name in [
+                "dist",
+                "build",
+                "out",
+                "output",
+                "cache",
+                ".cache",
+                "generated",
+                "graphify-out",
+                "codegen-output",
+                "Dist",
+            ] {
+                assert!(is_generated_output_dir_name(name), "{name} should match");
+            }
+            for name in ["src", "docs", "outline", "scout", "distros", "builder"] {
+                assert!(!is_generated_output_dir_name(name), "{name} must NOT match");
+            }
+        }
+
+        #[test]
+        fn untracked_cache_dir_is_demoted_tracked_dist_is_not() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let tmp = TempDir::new().unwrap();
+            let root = tmp.path();
+            let run = init_git(root);
+
+            // Tracked source + a TRACKED build-output dir (operator chose to
+            // version it — SF-012(B) contract: never demote tracked files).
+            create_file(root, "src/main.rs", "fn main() {}");
+            create_file(root, "frontend/dist/bundle.js", "var x = 1;");
+            run(&["add", "src", "frontend"]);
+            run(&["commit", "-m", "initial"]);
+
+            // The field-report shape: an UNTRACKED, non-gitignored JSON cache dump.
+            create_file(root, "graphify-out/cache/a.json", "{\"k\": 1}");
+            create_file(root, "graphify-out/cache/b.json", "{\"k\": 2}");
+            // Untracked file in a NORMAL dir: not demoted by this policy.
+            create_file(root, "src/new_module.rs", "fn newer() {}");
+
+            let entries = discover_all_files(root).unwrap();
+            let demoted = untracked_generated_output_demotions(root, &entries);
+
+            assert!(
+                demoted.contains("graphify-out/cache/a.json")
+                    && demoted.contains("graphify-out/cache/b.json"),
+                "untracked generated-output files must be demoted: {demoted:?}"
+            );
+            assert!(
+                !demoted.contains("frontend/dist/bundle.js"),
+                "tracked build output must NOT be demoted: {demoted:?}"
+            );
+            assert!(
+                !demoted.contains("src/main.rs") && !demoted.contains("src/new_module.rs"),
+                "normal source (tracked or not) must NOT be demoted: {demoted:?}"
+            );
+        }
+
+        #[test]
+        fn generated_dir_with_any_tracked_file_is_fully_admitted() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let tmp = TempDir::new().unwrap();
+            let root = tmp.path();
+            let run = init_git(root);
+
+            // One tracked file inside `out/` protects the WHOLE dir, including
+            // untracked siblings — when uncertain, admit.
+            create_file(root, "out/kept.json", "{}");
+            run(&["add", "out"]);
+            run(&["commit", "-m", "initial"]);
+            create_file(root, "out/generated.json", "{\"g\": true}");
+
+            let entries = discover_all_files(root).unwrap();
+            let demoted = untracked_generated_output_demotions(root, &entries);
+            assert!(
+                demoted.is_empty(),
+                "a generated-output dir containing a tracked file must not be demoted: {demoted:?}"
+            );
+        }
+
+        #[test]
+        fn non_git_tree_demotes_nothing() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let tmp = TempDir::new().unwrap();
+            create_file(tmp.path(), "dist/bundle.js", "var x = 1;");
+            create_file(tmp.path(), "src/main.rs", "fn main() {}");
+
+            let entries = discover_all_files(tmp.path()).unwrap();
+            let demoted = untracked_generated_output_demotions(tmp.path(), &entries);
+            assert!(
+                demoted.is_empty(),
+                "no git evidence → fail open, admit everything: {demoted:?}"
+            );
+        }
+
+        #[test]
+        fn opt_in_env_restores_full_indexing() {
+            let _lock = ENV_LOCK.lock().unwrap();
+            let tmp = TempDir::new().unwrap();
+            let root = tmp.path();
+            let run = init_git(root);
+            create_file(root, "src/main.rs", "fn main() {}");
+            run(&["add", "src"]);
+            run(&["commit", "-m", "initial"]);
+            create_file(root, "graphify-out/cache/a.json", "{}");
+
+            let entries = discover_all_files(root).unwrap();
+
+            // Env-free core demotes (proves the policy is live) …
+            let tracked: std::collections::HashSet<String> =
+                std::iter::once("src/main.rs".to_string()).collect();
+            let demoted = untracked_generated_output_demotions_inner(&entries, &tracked);
+            assert!(demoted.contains("graphify-out/cache/a.json"), "{demoted:?}");
+
+            // … and the opt-in env gate empties the set. The module `ENV_LOCK`
+            // (held above) serializes this writer against the sibling readers of
+            // SYMFORGE_INDEX_GENERATED_OUTPUT; this guard restores the prior
+            // value on drop, before the lock is released.
+            struct EnvGuard(Option<std::ffi::OsString>);
+            #[allow(unsafe_code)] // test-only env guard; sole writer of this var.
+            impl Drop for EnvGuard {
+                fn drop(&mut self) {
+                    // SAFETY: single test mutating this var; restored on drop.
+                    unsafe {
+                        match &self.0 {
+                            Some(v) => std::env::set_var(INDEX_GENERATED_OUTPUT_ENV, v),
+                            None => std::env::remove_var(INDEX_GENERATED_OUTPUT_ENV),
+                        }
+                    }
+                }
+            }
+            let _guard = EnvGuard(std::env::var_os(INDEX_GENERATED_OUTPUT_ENV));
+            #[allow(unsafe_code)]
+            // SAFETY: single test mutating this var; guard restores prior state.
+            unsafe {
+                std::env::set_var(INDEX_GENERATED_OUTPUT_ENV, "1")
+            };
+
+            let demoted = untracked_generated_output_demotions(root, &entries);
+            assert!(
+                demoted.is_empty(),
+                "opt-in must restore full indexing: {demoted:?}"
             );
         }
     }

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -600,6 +600,14 @@ pub enum SkipReason {
     /// accounting and minted a false "File not found"). The path stays searchable
     /// as metadata; only symbol extraction is skipped.
     UnsupportedLanguage,
+    /// F5: file demoted to Tier-2 because it lives under an untracked
+    /// generated-output directory (`dist`, `build`, `out`, `cache`, `*-out`, …)
+    /// with no git-tracked file anywhere beneath it. Such dirs are
+    /// machine-generated corpora (JSON cache dumps, build artifacts) that can
+    /// dominate the symbol index. Tracked files are never demoted by this
+    /// policy, and `SYMFORGE_INDEX_GENERATED_OUTPUT=1` opts back into full
+    /// indexing. Non-git trees are unaffected (fail open: admit).
+    GeneratedOutput,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -612,6 +620,10 @@ impl std::fmt::Display for SkipReason {
             SkipReason::DependencyLockfile => write!(f, "lockfile"),
             SkipReason::Untracked => write!(f, "untracked"),
             SkipReason::UnsupportedLanguage => write!(f, "unsupported language"),
+            SkipReason::GeneratedOutput => write!(
+                f,
+                "untracked generated output (SYMFORGE_INDEX_GENERATED_OUTPUT=1 to index)"
+            ),
         }
     }
 }

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -1506,9 +1506,15 @@ pub(crate) struct AdmitParseResult {
 /// `exclude_untracked_set` carries the SF-009 opt-in semantics: `None` (the
 /// default and the fail-open result for non-git trees) demotes nothing; `Some`
 /// demotes recognized-extension files that are not git-tracked to Tier 2.
+///
+/// `generated_output_demotions` carries the F5 policy: discovered file paths
+/// under UNTRACKED generated-output dirs (see
+/// `discovery::untracked_generated_output_demotions`) are demoted to Tier 2
+/// without reading their content. An empty set demotes nothing.
 pub(crate) fn admit_and_parse_entries(
     entries: &[crate::discovery::DiscoveredEntry],
     exclude_untracked_set: &Option<std::collections::HashSet<String>>,
+    generated_output_demotions: &std::collections::HashSet<String>,
 ) -> AdmitParseResult {
     use crate::discovery::{classify_admission, unsupported_language_decision};
     // `AdmissionTier` and `SkippedFile` are already imported at module scope.
@@ -1566,6 +1572,28 @@ pub(crate) fn admit_and_parse_entries(
                         return Some(AdmissionOutcome::Skip(sf));
                     }
                     AdmissionTier::Normal => {}
+                }
+
+                // F5: untracked generated-output demotion. Decided at discovery
+                // time (dir-level git evidence); checked here BEFORE any file
+                // read so a 900-file JSON cache dump costs zero I/O. Empty set
+                // (the default for git-less trees and under the
+                // `SYMFORGE_INDEX_GENERATED_OUTPUT` opt-in) demotes nothing.
+                if generated_output_demotions.contains(&entry.relative_path) {
+                    let sf = SkippedFile {
+                        path: entry.relative_path.clone(),
+                        size: entry.file_size,
+                        extension: entry
+                            .absolute_path
+                            .extension()
+                            .and_then(|e| e.to_str())
+                            .map(|s| s.to_string()),
+                        decision: crate::domain::index::AdmissionDecision::skip(
+                            AdmissionTier::MetadataOnly,
+                            crate::domain::index::SkipReason::GeneratedOutput,
+                        ),
+                    };
+                    return Some(AdmissionOutcome::Skip(sf));
                 }
 
                 // Phase 2: we tentatively have Tier-1. If the file has no recognized
@@ -1805,6 +1833,12 @@ impl LiveIndex {
         // alone is sufficient here.
         let exclude_untracked_set = discovery::tracked_path_set_for_exclusion(root);
 
+        // F5: demote files under untracked generated-output dirs (dist/build/
+        // out/cache/*-out/… with no tracked file beneath) to Tier-2. Empty for
+        // non-git trees and under `SYMFORGE_INDEX_GENERATED_OUTPUT=1`.
+        let generated_output_demotions =
+            discovery::untracked_generated_output_demotions(root, &all_entries);
+
         // 2. Run the shared admission + parse pipeline. This classifies every
         //    discovered file into Tier 1/2/3, records Tier-2/3 files in
         //    `skipped_files`, reads admitted files under the in-flight byte
@@ -1815,7 +1849,11 @@ impl LiveIndex {
             files,
             skipped_files,
             cb_state,
-        } = admit_and_parse_entries(&all_entries, &exclude_untracked_set);
+        } = admit_and_parse_entries(
+            &all_entries,
+            &exclude_untracked_set,
+            &generated_output_demotions,
+        );
 
         let load_duration = start.elapsed();
         info!(
@@ -2043,6 +2081,11 @@ impl LiveIndex {
         // the `skipped_files` registry agree across both discovery paths.
         let exclude_untracked_set = discovery::tracked_path_set_for_exclusion(root);
 
+        // F5: same untracked generated-output demotion as `load`, so initial
+        // load and reload report identical tiering.
+        let generated_output_demotions =
+            discovery::untracked_generated_output_demotions(root, &all_entries);
+
         // 2. Run the shared admission + parse pipeline (identical to the one
         //    `LiveIndex::load` uses). This reads admitted files under the
         //    in-flight byte governor, parses in parallel, applies the circuit
@@ -2051,7 +2094,11 @@ impl LiveIndex {
             files: new_files,
             skipped_files,
             cb_state: new_cb,
-        } = admit_and_parse_entries(&all_entries, &exclude_untracked_set);
+        } = admit_and_parse_entries(
+            &all_entries,
+            &exclude_untracked_set,
+            &generated_output_demotions,
+        );
 
         let load_duration = start.elapsed();
         info!(

--- a/src/parsing/config_extractors/markdown.rs
+++ b/src/parsing/config_extractors/markdown.rs
@@ -1,6 +1,4 @@
-use super::{
-    ConfigExtractor, EditCapability, ExtractionOutcome, ExtractionResult, escape_key_segment,
-};
+use super::{ConfigExtractor, EditCapability, ExtractionOutcome, ExtractionResult};
 use crate::domain::{SymbolKind, SymbolRecord};
 use std::collections::HashMap;
 
@@ -172,7 +170,7 @@ impl ConfigExtractor for MarkdownExtractor {
 
         let total_bytes = content.len() as u32;
 
-        // Build symbols. Stack holds (level, escaped_segment) for path building.
+        // Build symbols. Stack holds (level, segment) for path building.
         let mut stack: Vec<(u32, String)> = Vec::new();
         // Duplicate counter keyed by base path (before disambiguation suffix).
         let mut seen_paths: HashMap<String, u32> = HashMap::new();
@@ -186,17 +184,22 @@ impl ConfigExtractor for MarkdownExtractor {
                 stack.pop();
             }
 
-            // Build dot-joined path.
-            let escaped = escape_key_segment(&header.text);
+            // Build dot-joined path from the raw heading text. Section names
+            // are display-facing and looked up by exact full-name match only —
+            // nothing splits them back into segments (unlike TOML key paths),
+            // so `.`/`[`/`]` in a heading stay human-readable instead of being
+            // escaped to `~1`/`~2`/`~3`. A heading like "A.B" colliding with a
+            // nested A > B path falls into the existing #N duplicate handling.
+            let segment = header.text.clone();
             let base_path = if stack.is_empty() {
-                escaped.clone()
+                segment.clone()
             } else {
                 let parent: String = stack
                     .iter()
                     .map(|(_, n)| n.as_str())
                     .collect::<Vec<_>>()
                     .join(".");
-                format!("{}.{}", parent, escaped)
+                format!("{}.{}", parent, segment)
             };
 
             // Disambiguate duplicates.
@@ -208,7 +211,7 @@ impl ConfigExtractor for MarkdownExtractor {
                 format!("{}#{}", base_path, count)
             };
 
-            stack.push((level, escaped));
+            stack.push((level, segment));
 
             // Byte range: this header's start -> byte before next header at same or higher level (or EOF).
             let byte_end: u32 = headers[hi + 1..]
@@ -291,6 +294,25 @@ mod tests {
         assert_eq!(syms.len(), 2);
         assert_eq!(syms[0].name, "Install");
         assert_eq!(syms[1].name, "Install#2");
+    }
+
+    // Dogfood B2: heading punctuation must stay human-readable — no `~1`/`~2`/`~3`
+    // key-escaping leaking into display names.
+    #[test]
+    fn test_heading_with_dots_and_brackets_stays_readable() {
+        let syms = extract(b"# SymForge 8.13.0 beta issues\n## [FIXED upstream] note\n");
+        assert_eq!(syms.len(), 2);
+        assert_eq!(syms[0].name, "SymForge 8.13.0 beta issues");
+        assert_eq!(
+            syms[1].name,
+            "SymForge 8.13.0 beta issues.[FIXED upstream] note"
+        );
+        assert!(
+            !syms.iter().any(|s| s.name.contains("~1")
+                || s.name.contains("~2")
+                || s.name.contains("~3")),
+            "escape encoding must not leak into section names"
+        );
     }
 
     #[test]

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -813,15 +813,12 @@ impl SymForgeServer {
         // (`run_pre_apply_gates`) still fails fast; THIS is the actual guarantee
         // at the write.
         //
-        // EXACT-BYTE comparison (`base == disk`) is correct here ONLY because
-        // the compact `if_match` path never reroutes: `StelEditRequest` carries
-        // no `working_directory`, so `resolved_path` is always the indexed file
-        // and `file.content` is its exact (line-ending-preserving) bytes. If
-        // `if_match` is ever plumbed through a worktree reroute, the base would
-        // be a rebased target whose line endings may differ, and this guard MUST
-        // then reconcile with `edit::line_ending_insensitive_eq` like
-        // `guard_batch_reroute_divergence` does — an exact-byte compare would
-        // spuriously reject on a pure CRLF/LF difference.
+        // EXACT-BYTE comparison (`base == disk`) stays correct under a worktree
+        // reroute (F6: `StelEditRequest.working_directory` now reaches here):
+        // `rebase_edit_base_for_reroute` guarantees `file.content` is either
+        // byte-identical to the target or freshly re-read FROM the target, so
+        // base and disk are the same file's bytes — line-ending differences
+        // between worktree and index never enter this compare.
         let write_report = match edit::guarded_atomic_write_file(
             &resolved_path,
             &file.content,

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -9740,19 +9740,14 @@ impl SymForgeServer {
         &self,
         params: Parameters<crate::stel::StelEditRequest>,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-        // Gate KEPT (unlike `status`, Wave 1 Fix 4): `symforge_edit` routes through
-        // the STEL economics/ledger apply path, the compact-surface invariant the
-        // A-019 golden replay pins. On full the caller has the legacy edit tools
-        // (replace_symbol_body / edit_within_symbol / …) this facade fuses — the
-        // message names that path. Pinned by tests/stel_symforge_edit.rs.
-        if super::surface_probe::surface_profile_from_env()
-            != super::surface_probe::SurfaceProfile::Compact
-        {
-            return Ok(ResultStatus::new(OutcomeClass::InvalidRequest).into_call_tool_result(
-                "symforge_edit STEL handler requires SYMFORGE_SURFACE=compact; use legacy edit tools on the full surface",
-            ));
-        }
-
+        // Gate REMOVED (beta finding B4, 2026-07-07): the full surface exposes
+        // and documents `symforge_edit` as the preferred editing facade, so
+        // hard-refusing it there was a self-inflicted failure. The handler below
+        // already translates every op to the same internal legacy tools
+        // (replace_symbol_body / insert_symbol / edit_within_symbol) on both
+        // surfaces — no compact-only invariant lives in this dispatch. The
+        // `symforge` READ facade keeps its gate: its economics/golden-replay
+        // path (A-019) is compact-specific.
         self.symforge_edit_stel_handler(&params.0).await
     }
 
@@ -9792,6 +9787,17 @@ impl SymForgeServer {
                 };
             match run_pre_apply_gates(&self.index, request, &abs_path) {
                 Ok(PreApplyOutcome::Ready(symbol)) => resolved_symbol = Some(symbol),
+                // F6: the already-applied check compares against the INDEXED
+                // copy, but a `working_directory` apply targets a worktree whose
+                // copy may still lack the change — short-circuiting would skip
+                // the routed write. Proceed to dispatch; the legacy tool rebases
+                // onto the worktree target and a truly-identical splice is a
+                // harmless idempotent rewrite.
+                Ok(PreApplyOutcome::AlreadyApplied(symbol))
+                    if request.working_directory.is_some() =>
+                {
+                    resolved_symbol = Some(symbol);
+                }
                 Ok(PreApplyOutcome::AlreadyApplied(symbol)) => {
                     let plan = build_edit_plan(request).expect("validated edit request");
                     let decision = evaluate_edit_plan(&plan);
@@ -9931,9 +9937,9 @@ impl SymForgeServer {
         // Wave-1 defect fix (2026-07-02): NO surface gate here. `status` is a
         // read-only health/trust readout that the docs tell every client to call
         // at session start, so refusing it on `SYMFORGE_SURFACE=full` was a
-        // self-inflicted failure with no invariant behind it (unlike `symforge`/
-        // `symforge_edit`, whose gates guard the STEL economics/golden-replay
-        // path — kept, see those handlers). The body self-describes the active
+        // self-inflicted failure with no invariant behind it (unlike `symforge`,
+        // whose gate guards the STEL economics/golden-replay path — kept there;
+        // `symforge_edit` lost its gate too, beta B4). The body self-describes the active
         // surface via `render_stel_status_body`, so a full-surface `status` is
         // honest about where it ran.
 

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -1477,16 +1477,24 @@ fn symbol_context_text(
     files.sort();
 
     let mut evidence_anchors: Vec<String> = Vec::new();
+    // Files that contributed at least one anchor. The 3-anchor cap can exhaust
+    // on the first file(s); the evidence line must then say how many reference
+    // files it left unnamed instead of silently undercounting usage sites.
+    let mut anchored_files = 0usize;
     for file in &files {
         // safe: `files` is built from `map.keys()` immediately above; lookup cannot miss.
         let refs = map.get(file).unwrap();
         let mut sorted_refs = refs.clone();
         sorted_refs.sort_by_key(|(line, _, _)| *line);
+        let before = evidence_anchors.len();
         for (line, _, _) in &sorted_refs {
             if evidence_anchors.len() >= 3 {
                 break;
             }
             evidence_anchors.push(format!("{file}:{line}"));
+        }
+        if evidence_anchors.len() > before {
+            anchored_files += 1;
         }
         if evidence_anchors.len() >= 3 {
             break;
@@ -1567,11 +1575,21 @@ fn symbol_context_text(
             params.name
         )
     } else {
-        format!(
-            "symbol token `{}` anchored at {}",
-            params.name,
-            evidence_anchors.join(", ")
-        )
+        let more_files = files.len().saturating_sub(anchored_files);
+        if more_files > 0 {
+            format!(
+                "symbol token `{}` anchored at {} (+{} more files)",
+                params.name,
+                evidence_anchors.join(", "),
+                more_files
+            )
+        } else {
+            format!(
+                "symbol token `{}` anchored at {}",
+                params.name,
+                evidence_anchors.join(", ")
+            )
+        }
     };
     let scope = if let Some(path) = params.path.as_deref() {
         match params.symbol_line {
@@ -3230,6 +3248,57 @@ mod tests {
             result.contains("Evidence: symbol token `process` anchored at src/main.rs:5"),
             "got: {result}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_symbol_context_evidence_marks_uncovered_caller_files() {
+        // Dogfood F8: the Evidence header caps at 3 anchors, which one file can
+        // exhaust. With callers in 4 files it must append `(+N more files)`
+        // instead of silently naming only the anchored file(s).
+        let a = make_indexed_file(
+            "src/a.rs",
+            vec![],
+            vec![
+                make_reference("target", ReferenceKind::Call, 1),
+                make_reference("target", ReferenceKind::Call, 2),
+                make_reference("target", ReferenceKind::Call, 3),
+            ],
+            ParseStatus::Parsed,
+        );
+        let one_ref = |line| vec![make_reference("target", ReferenceKind::Call, line)];
+        let b = make_indexed_file("src/b.rs", vec![], one_ref(5), ParseStatus::Parsed);
+        let c = make_indexed_file("src/c.rs", vec![], one_ref(6), ParseStatus::Parsed);
+        let d = make_indexed_file("src/d.rs", vec![], one_ref(7), ParseStatus::Parsed);
+        let state = make_state(vec![
+            ("src/a.rs", a),
+            ("src/b.rs", b),
+            ("src/c.rs", c),
+            ("src/d.rs", d),
+        ]);
+
+        let params = SymbolContextParams {
+            name: "target".to_string(),
+            file: None,
+            path: None,
+            symbol_kind: None,
+            symbol_line: None,
+        };
+        let result = symbol_context_handler(State(state), Query(params))
+            .await
+            .unwrap();
+        assert!(
+            result.contains(
+                "Evidence: symbol token `target` anchored at src/a.rs:1, src/a.rs:2, src/a.rs:3 (+3 more files)"
+            ),
+            "evidence must flag caller files the anchor cap left unnamed; got: {result}"
+        );
+        // The body still lists every caller file.
+        for file in ["src/a.rs", "src/b.rs", "src/c.rs", "src/d.rs"] {
+            assert!(
+                result.contains(file),
+                "body must list {file}; got: {result}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/stel/edit_planner.rs
+++ b/src/stel/edit_planner.rs
@@ -185,6 +185,14 @@ pub fn build_edit_plan(request: &StelEditRequest) -> Result<StelPlan, EditValida
         args["idempotency_key"] = serde_json::json!(key);
     }
 
+    // Worktree routing (beta finding F6): all three internal tools accept
+    // `working_directory` and run it through the worktree-awareness edit hook.
+    // Dropping it here was the contamination bug — a facade edit issued from a
+    // git worktree silently landed in the shared indexed root.
+    if let Some(cwd) = &request.working_directory {
+        args["working_directory"] = serde_json::json!(cwd);
+    }
+
     Ok(StelPlan {
         plan_id: edit_plan_id(request),
         intent: IntentBucket::Edit,
@@ -331,6 +339,47 @@ mod tests {
         assert_eq!(
             plan.steps[0].args["if_match"], "fn helper() { old }",
             "if_match must be forwarded into the replace_symbol_body plan args"
+        );
+    }
+
+    #[test]
+    fn build_edit_plan_forwards_working_directory() {
+        // F6: dropping `working_directory` at planning was the worktree
+        // contamination bug — a facade edit issued from a git worktree landed
+        // in the shared indexed root instead of the worktree copy.
+        for (op, key) in [
+            (None, "working_directory"),
+            (Some(StelEditOp::InsertAfter), "working_directory"),
+        ] {
+            let plan = build_edit_plan(&StelEditRequest {
+                path: "src/lib.rs".to_string(),
+                symbol: Some("helper".to_string()),
+                body: Some("fn helper() {}".to_string()),
+                op,
+                working_directory: Some("/repos/wt_one".to_string()),
+                ..Default::default()
+            })
+            .expect("valid edit request");
+            assert_eq!(
+                plan.steps[0].args[key], "/repos/wt_one",
+                "working_directory must be forwarded into the {} plan args",
+                plan.steps[0].tool
+            );
+        }
+    }
+
+    #[test]
+    fn build_edit_plan_omits_working_directory_when_absent() {
+        let plan = build_edit_plan(&StelEditRequest {
+            path: "src/lib.rs".to_string(),
+            symbol: Some("helper".to_string()),
+            body: Some("fn helper() {}".to_string()),
+            ..Default::default()
+        })
+        .expect("valid edit request");
+        assert!(
+            plan.steps[0].args.get("working_directory").is_none(),
+            "absent working_directory must not appear in plan args"
         );
     }
 

--- a/src/stel_core/types.rs
+++ b/src/stel_core/types.rs
@@ -161,6 +161,14 @@ pub struct StelEditRequest {
     /// Replay guard for committed apply (forwarded to legacy `replace_symbol_body`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idempotency_key: Option<String>,
+    // Caller's working directory (absolute): routes the write into the matching
+    // git worktree instead of the indexed root. Hidden from the compact
+    // symforge_edit schema (A-025 byte budget) but still deserialized — the
+    // worktree-awareness hook injects it at call time, so routing works without
+    // advertising an advanced field on the token-sensitive compact surface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub working_directory: Option<String>,
 }
 
 /// Edit intent for `symforge_edit` (L0 routes structural mutations here).

--- a/tests/stel_symforge_edit.rs
+++ b/tests/stel_symforge_edit.rs
@@ -84,26 +84,37 @@ fn ledger_meta_from_output(output: &str) -> symforge::stel::LedgerEnvelopeMeta {
 }
 
 #[tokio::test]
-async fn symforge_edit_rejects_non_compact_surface() {
+async fn symforge_edit_preview_succeeds_on_full_surface() {
+    // Beta finding B4: the full surface exposes `symforge_edit` as the
+    // preferred editing facade, so it must work there — it falls through to
+    // the same internal legacy tools instead of erroring.
     let _guard = stel_surface_env::COMPACT_ENV_LOCK.lock().await;
     let _surface = stel_surface_env::set_symforge_surface("full");
 
-    let (dir, _) = temp_rust_repo("fn foo() {}\n");
-    let server = server_for_repo(dir.path(), "edit-non-compact");
-    let output = dispatch_symforge_edit(
+    let (dir, file_path) = temp_rust_repo("fn foo() { old }\n");
+    let before = std::fs::read(&file_path).expect("read file before edit");
+    let server = server_for_repo(dir.path(), "edit-full-surface");
+    let result = dispatch_symforge_edit_result(
         &server,
         &StelEditRequest {
             path: "src/lib.rs".to_string(),
             symbol: Some("foo".to_string()),
-            body: Some("fn foo() { 1 }".to_string()),
+            body: Some("fn foo() { new }".to_string()),
             ..Default::default()
         },
     )
     .await;
+    let output = tool_result_text(&result);
     assert!(
-        output.contains("requires SYMFORGE_SURFACE=compact"),
-        "unexpected output:\n{output}"
+        !output.contains("requires SYMFORGE_SURFACE=compact"),
+        "full surface must not refuse symforge_edit:\n{output}"
     );
+    for needle in ["Chosen tool: replace_symbol_body", "[DRY RUN]"] {
+        assert!(output.contains(needle), "missing `{needle}` in:\n{output}");
+    }
+    assert_eq!(outcome_class(&result), "found", "output:\n{output}");
+    let after = std::fs::read(&file_path).expect("read file after edit");
+    assert_eq!(before, after, "preview must not mutate source bytes");
 }
 
 #[tokio::test]

--- a/tests/worktree_awareness.rs
+++ b/tests/worktree_awareness.rs
@@ -442,6 +442,51 @@ async fn ac3_working_directory_at_known_worktree_writes_to_worktree() {
     );
 }
 
+/// F6 (beta finding): the `symforge_edit` facade must forward
+/// `working_directory` into the internal edit tool so a facade apply issued
+/// from a git worktree lands in the worktree's copy — not the shared indexed
+/// root. Before the fix `StelEditRequest` had no `working_directory` field,
+/// so every facade edit silently contaminated the indexed checkout.
+#[tokio::test]
+async fn symforge_edit_facade_routes_apply_into_worktree() {
+    let _env = WorktreePolicyEnvGuard::remove();
+    let fx = WorktreeFixture::new(&[("src/lib.rs", HELLO_RS)]);
+    let wt_arg = fx.worktree_root.to_str().unwrap().to_string();
+
+    let result = fx
+        .server
+        .dispatch_tool_result_for_tests(
+            "symforge_edit",
+            json!({
+                "path": "src/lib.rs",
+                "symbol": "hello",
+                "body": "fn hello() {\n    println!(\"HELLO_FACADE\");\n}",
+                "apply": true,
+                "working_directory": wt_arg,
+            }),
+        )
+        .await
+        .expect("symforge_edit dispatch");
+    let result = serde_json::to_value(&result).expect("serialize CallToolResult");
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("symforge_edit result must contain text content");
+
+    // §2.3 response shape — the rerouted facade write must self-describe.
+    assert_contains(text, "rerouted: true");
+
+    let wt_after = fx.read_worktree("src/lib.rs");
+    assert!(
+        wt_after.contains("HELLO_FACADE"),
+        "worktree copy must receive the facade write: {wt_after}",
+    );
+    let indexed_after = fx.read_indexed("src/lib.rs");
+    assert!(
+        !indexed_after.contains("HELLO_FACADE"),
+        "indexed copy must NOT be touched by a rerouted facade apply: {indexed_after}",
+    );
+}
+
 /// AC4: `working_directory` at a path that is NOT a recognized worktree
 /// returns an error and writes zero bytes.
 #[tokio::test]


### PR DESCRIPTION
Six field-reported fixes from the 8.13.x dogfood logs, verified by four Opus agents + full local gates.

- **F6 (worktree edit contamination)** — edit ops thread the caller's `working_directory` through to the write, so a worktree-directed edit lands in that worktree's copy, never silently on the daemon's indexed root; a target outside both the index root and the worktree tree errors loudly instead of remapping. Enforced across all single-symbol + batch paths and the `symforge_edit` facade.
- **B4 (symforge_edit dead on full surface)** — the facade falls through to the legacy edit handlers on both surfaces instead of erroring `requires SYMFORGE_SURFACE=compact`.
- **F5 (index bloat)** — untracked generated-output dirs (`dist/build/out/output/cache/.cache/generated`, `*-out`, no tracked file beneath) demote to metadata-only by default; `SYMFORGE_INDEX_GENERATED_OUTPUT=1` restores full indexing. Tracked-file rescue contract preserved. Fixes the reported 86%-of-index untracked cache case.
- **B2 (markdown section names mangled)** — heading display names no longer leak the config key-escape encoding (`8.13.0` → `8~113~10`).
- **F8 (evidence header undercount)** — `get_symbol_context` Evidence line appends `(+N more files)` when the anchor cap leaves callers unnamed.
- **B5 (hook hint noise)** — the PreToolUse efficiency hint suppresses itself for Read/Grep targets outside the workspace root (e.g. `%TEMP%`).

Plus: `#[schemars(skip)]` on `StelEditRequest.working_directory` to keep the compact `symforge_edit` schema under the A-025 1500 B budget (field still deserialized so the worktree hook's injected value routes).

Gates: fmt --check, clippy --all-targets -D warnings, full test suite (--test-threads=1), release build — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch index admission (could skip files operators expect indexed), edit routing/worktrees (wrong path = wrong writes), and hook/edit facade behavior; mitigations are conservative heuristics, opt-in env, and broad test coverage.
> 
> **Overview**
> Addresses six field-reported issues from 8.13.x dogfood.
> 
> **Worktree edits (F6):** `StelEditRequest` gains `working_directory` (schema-hidden on compact); the edit planner forwards it to legacy tools, guarded writes stay byte-correct after reroute, and worktree applies no longer short-circuit on “already applied” against the indexed copy only.
> 
> **Indexing (F5):** Untracked files under heuristic generated-output dirs (`dist`, `build`, `cache`, `*-out`, etc.) with no tracked file beneath them are demoted to Tier-2 metadata-only before read/parse; `SYMFORGE_INDEX_GENERATED_OUTPUT=1` opts back in. Tracked paths and non-git trees are unchanged.
> 
> **Surfaces & UX:** `symforge_edit` no longer requires `SYMFORGE_SURFACE=compact` (B4). PreToolUse SymForge hints are suppressed when Read/Grep targets absolute paths outside the workspace root (B5). Markdown heading symbols use raw text instead of config key escaping (B2). `get_symbol_context` Evidence adds `(+N more files)` when the three-anchor cap hides other caller files (F8).
> 
> Tests cover each behavior; integration tests replace the old “rejects full surface” expectation for `symforge_edit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccd0c8fbdf959e446357e6ec5c132607dfe9f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->