### PR TITLE
fix(edit): honor worktree reroute when a passthrough hook registers later (F6 daemon routing)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7540,6 +7540,334 @@ mod tests {
         wait_for_path_absent(&daemon_home.path().join(LEGACY_DAEMON_PORT_FILE)).await;
     }
 
+    /// F6 regression: a `symforge_edit` apply carrying `working_directory`
+    /// must route the write into the sibling git worktree through the DAEMON
+    /// dispatch path (front-end proxy → daemon `execute_tool_call` →
+    /// `edit_within_symbol`), NOT into the daemon's indexed root; and a
+    /// `working_directory` that is not a recognized worktree must error loudly
+    /// instead of silently writing to the indexed root.
+    ///
+    /// This is the path the field bug lived on: the in-process direct-dispatch
+    /// tests (`tests/worktree_awareness.rs`) never exercised the daemon's own
+    /// `execute_tool_call` server, so a daemon that resolved edits through the
+    /// no-op `DefaultEditHook` (worktree routing not effective) passed every
+    /// existing test while writing to the wrong tree in production.
+    #[tokio::test]
+    async fn test_symforge_edit_apply_routes_into_worktree_through_daemon_proxy() {
+        let _env_lock = env_lock().await;
+        let daemon_home = TempDir::new().expect("daemon home");
+        let _home_guard = EnvVarGuard::set("SYMFORGE_HOME", daemon_home.path());
+
+        // A real git repo (main checkout) with one committed symbol.
+        let project = project_dir("symforge-wt-route-main");
+        let main_root = project.path().to_path_buf();
+        let main_file = main_root.join("src").join("lib.rs");
+        std::fs::write(&main_file, "pub fn wt_edit() -> u32 { 1 }\n").expect("write source");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(&main_root)
+                .args(args)
+                .output()
+                .unwrap_or_else(|e| panic!("git {args:?} spawn: {e}"));
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "t@t.test"]);
+        git(&["config", "user.name", "t"]);
+        git(&["config", "commit.gpgsign", "false"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "init"]);
+
+        // A sibling worktree (outside the main checkout) on a new branch.
+        let wt_parent = TempDir::new().expect("worktree parent");
+        let worktree_root = wt_parent.path().join("wt_one");
+        git(&[
+            "worktree",
+            "add",
+            worktree_root.to_str().expect("utf-8 worktree path"),
+            "-b",
+            "feature",
+        ]);
+        let worktree_file = worktree_root.join("src").join("lib.rs");
+
+        let handle = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let base_url = format!("http://127.0.0.1:{}", handle.port);
+        let http = authed_client(&handle);
+
+        let opened = http
+            .post(format!("{base_url}/v1/sessions/open"))
+            .json(&OpenProjectRequest {
+                project_root: main_root.display().to_string(),
+                client_name: "wt-route".to_string(),
+                pid: Some(std::process::id()),
+            })
+            .send()
+            .await
+            .expect("open request")
+            .error_for_status()
+            .expect("open status")
+            .json::<OpenProjectResponse>()
+            .await
+            .expect("open body");
+
+        let client = DaemonSessionClient::new_for_test(
+            base_url.clone(),
+            opened.project_id.clone(),
+            opened.session_id.clone(),
+            opened.project_name.clone(),
+        )
+        .with_project_root(main_root.clone());
+        let server = crate::protocol::SymForgeServer::new_daemon_proxy(client);
+
+        let indexed = server
+            .index_folder(Parameters(IndexFolderInput {
+                path: main_root.display().to_string(),
+                idempotency_key: None,
+                add: None,
+            }))
+            .await;
+        assert!(
+            indexed.starts_with("Indexed "),
+            "daemon proxy index_folder must succeed, got: {indexed}"
+        );
+        // Prove the DAEMON holds the index and the edit below runs on the daemon
+        // dispatch path, not a front-end local fallback (which would also route
+        // because THIS process registered the hook via `new_daemon_proxy`). An
+        // empty front-end index means the daemon executed the edit.
+        assert_eq!(
+            server.index().published_state().file_count,
+            0,
+            "front-end proxy index must be empty — the daemon must serve the edit"
+        );
+
+        // (1) Routed apply: working_directory = the real worktree. The write
+        // must land in the WORKTREE copy and leave the indexed root untouched.
+        let routed = server
+            .symforge_edit_facade_tool(Parameters(crate::stel::StelEditRequest {
+                path: "src/lib.rs".to_string(),
+                symbol: Some("wt_edit".to_string()),
+                body: Some("pub fn wt_edit() -> u32 { 2 }".to_string()),
+                apply: Some(true),
+                working_directory: Some(worktree_root.display().to_string()),
+                ..Default::default()
+            }))
+            .await
+            .expect("symforge_edit dispatch");
+        let routed_body =
+            serde_json::to_value(&routed).expect("serialize routed result")["content"][0]["text"]
+                .as_str()
+                .expect("routed result text")
+                .to_string();
+
+        assert!(
+            routed_body.contains("rerouted: true"),
+            "worktree apply must report rerouted: true through the daemon path, got:\n{routed_body}"
+        );
+        let worktree_after = std::fs::read_to_string(&worktree_file).expect("read worktree file");
+        assert!(
+            worktree_after.contains("{ 2 }"),
+            "worktree copy must receive the routed edit, got:\n{worktree_after}\n\nbody:\n{routed_body}"
+        );
+        let main_after = std::fs::read_to_string(&main_file).expect("read main file");
+        assert!(
+            main_after.contains("{ 1 }") && !main_after.contains("{ 2 }"),
+            "indexed root must NOT be contaminated by a routed worktree edit, got:\n{main_after}\n\nbody:\n{routed_body}"
+        );
+
+        // (2) A working_directory that is not a recognized worktree must error
+        // loudly (not silently write to the indexed root).
+        let stray = TempDir::new().expect("stray dir");
+        let stray_result = server
+            .symforge_edit_facade_tool(Parameters(crate::stel::StelEditRequest {
+                path: "src/lib.rs".to_string(),
+                symbol: Some("wt_edit".to_string()),
+                body: Some("pub fn wt_edit() -> u32 { 9 }".to_string()),
+                apply: Some(true),
+                working_directory: Some(stray.path().display().to_string()),
+                ..Default::default()
+            }))
+            .await
+            .expect("symforge_edit dispatch");
+        let stray_body = serde_json::to_value(&stray_result).expect("serialize stray result")
+            ["content"][0]["text"]
+            .as_str()
+            .expect("stray result text")
+            .to_string();
+        assert!(
+            stray_body.contains("WorkingDirectoryNotARecognizedWorktree"),
+            "a non-worktree working_directory must error loudly, got:\n{stray_body}"
+        );
+        let main_after_stray = std::fs::read_to_string(&main_file).expect("read main after stray");
+        assert!(
+            main_after_stray.contains("{ 1 }") && !main_after_stray.contains("{ 9 }"),
+            "a rejected non-worktree edit must not write to the indexed root, got:\n{main_after_stray}\n\nbody:\n{stray_body}"
+        );
+
+        let _ = handle.shutdown_tx.send(());
+        wait_for_path_absent(&daemon_home.path().join(LEGACY_DAEMON_PORT_FILE)).await;
+    }
+
+    /// F6 root-cause guard: drive `edit_within_symbol` DIRECTLY against the
+    /// daemon's HTTP tool endpoint (the exact route the front-end proxy POSTs
+    /// to) with NO front-end `SymForgeServer` constructed in this test. That
+    /// isolation matters because the edit-hook registry is PROCESS-GLOBAL and
+    /// order-sensitive: the daemon registers BOTH `WorktreeAwareEditHook`
+    /// (via `SymForgeServer::new`) and the observer-only `FrecencyBumpHook`
+    /// (via `LiveIndex::load`), and the field bug was `edit_hooks::resolve`
+    /// picking only the LAST-registered hook — so when frecency registered
+    /// after the worktree hook, its default (no-op) `resolve_target_path`
+    /// shadowed worktree routing and every `working_directory` edit
+    /// contaminated the indexed root. This test indexes through the daemon
+    /// (registering frecency) so the resolve order matches production, then
+    /// asserts routing still holds.
+    #[tokio::test]
+    async fn test_daemon_http_edit_within_routes_into_worktree_without_frontend_server() {
+        let _env_lock = env_lock().await;
+        let daemon_home = TempDir::new().expect("daemon home");
+        let _home_guard = EnvVarGuard::set("SYMFORGE_HOME", daemon_home.path());
+
+        let project = project_dir("symforge-wt-http-main");
+        let main_root = project.path().to_path_buf();
+        let main_file = main_root.join("src").join("lib.rs");
+        std::fs::write(&main_file, "pub fn wt_edit() -> u32 { 1 }\n").expect("write source");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(&main_root)
+                .args(args)
+                .output()
+                .unwrap_or_else(|e| panic!("git {args:?} spawn: {e}"));
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "t@t.test"]);
+        git(&["config", "user.name", "t"]);
+        git(&["config", "commit.gpgsign", "false"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "init"]);
+
+        let wt_parent = TempDir::new().expect("worktree parent");
+        let worktree_root = wt_parent.path().join("wt_one");
+        git(&[
+            "worktree",
+            "add",
+            worktree_root.to_str().expect("utf-8 worktree path"),
+            "-b",
+            "feature",
+        ]);
+        let worktree_file = worktree_root.join("src").join("lib.rs");
+
+        let handle = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let base_url = format!("http://127.0.0.1:{}", handle.port);
+        let http = authed_client(&handle);
+
+        let opened = http
+            .post(format!("{base_url}/v1/sessions/open"))
+            .json(&OpenProjectRequest {
+                project_root: main_root.display().to_string(),
+                client_name: "wt-http".to_string(),
+                pid: Some(std::process::id()),
+            })
+            .send()
+            .await
+            .expect("open request")
+            .error_for_status()
+            .expect("open status")
+            .json::<OpenProjectResponse>()
+            .await
+            .expect("open body");
+        let session_id = opened.session_id;
+
+        // Raw HTTP tool call to the daemon — the same route `call_tool_value`
+        // uses. No `SymForgeServer` exists in this test process.
+        let call_tool = |tool: &str, params: serde_json::Value| {
+            let url = format!("{base_url}/v1/sessions/{session_id}/tools/{tool}");
+            let http = http.clone();
+            async move {
+                http.post(url)
+                    .json(&params)
+                    .send()
+                    .await
+                    .expect("tool request")
+                    .error_for_status()
+                    .expect("tool status")
+                    .text()
+                    .await
+                    .expect("tool body")
+            }
+        };
+
+        let indexed = call_tool(
+            "index_folder",
+            serde_json::json!({ "path": main_root.display().to_string() }),
+        )
+        .await;
+        assert!(
+            indexed.starts_with("Indexed "),
+            "daemon index_folder must succeed, got: {indexed}"
+        );
+
+        // (1) Routed edit through the daemon HTTP endpoint.
+        let routed = call_tool(
+            "edit_within_symbol",
+            serde_json::json!({
+                "path": "src/lib.rs",
+                "name": "wt_edit",
+                "old_text": "{ 1 }",
+                "new_text": "{ 2 }",
+                "working_directory": worktree_root.display().to_string(),
+            }),
+        )
+        .await;
+        assert!(
+            routed.contains("rerouted: true"),
+            "daemon must route the worktree edit (rerouted: true), got:\n{routed}"
+        );
+        let worktree_after = std::fs::read_to_string(&worktree_file).expect("read worktree file");
+        assert!(
+            worktree_after.contains("{ 2 }"),
+            "worktree copy must receive the routed edit, got:\n{worktree_after}\n\nresp:\n{routed}"
+        );
+        let main_after = std::fs::read_to_string(&main_file).expect("read main file");
+        assert!(
+            main_after.contains("{ 1 }") && !main_after.contains("{ 2 }"),
+            "indexed root must NOT be contaminated by a routed worktree edit, got:\n{main_after}\n\nresp:\n{routed}"
+        );
+
+        // (2) Non-worktree working_directory must error loudly, not write to root.
+        let stray = TempDir::new().expect("stray dir");
+        let stray_resp = call_tool(
+            "edit_within_symbol",
+            serde_json::json!({
+                "path": "src/lib.rs",
+                "name": "wt_edit",
+                "old_text": "{ 1 }",
+                "new_text": "{ 9 }",
+                "working_directory": stray.path().display().to_string(),
+            }),
+        )
+        .await;
+        assert!(
+            stray_resp.contains("WorkingDirectoryNotARecognizedWorktree"),
+            "a non-worktree working_directory must error loudly, got:\n{stray_resp}"
+        );
+        let main_after_stray = std::fs::read_to_string(&main_file).expect("read main after stray");
+        assert!(
+            main_after_stray.contains("{ 1 }") && !main_after_stray.contains("{ 9 }"),
+            "a rejected non-worktree edit must not write to the indexed root, got:\n{main_after_stray}\n\nresp:\n{stray_resp}"
+        );
+
+        let _ = handle.shutdown_tx.send(());
+        wait_for_path_absent(&daemon_home.path().join(LEGACY_DAEMON_PORT_FILE)).await;
+    }
+
     /// Regression: a daemon-proxy `index_folder` switch must invalidate any
     /// stale in-process index that a prior local fallback populated for the OLD
     /// project. Without the fix, the server keeps serving the old project from

--- a/src/protocol/edit_hooks.rs
+++ b/src/protocol/edit_hooks.rs
@@ -94,20 +94,42 @@ pub fn register(hook: Box<dyn EditHook>) {
 }
 
 /// Resolve the target path by walking registered hooks in reverse-registration
-/// order and returning the first result.
+/// order and returning the first hook that makes an ACTIVE routing decision.
 ///
-/// Because [`DefaultEditHook`] is pre-registered and its default impl always
-/// returns `Ok`, this function only returns `Err` when a feature hook explicitly
-/// fails the resolution.
+/// A hook makes an active decision when it returns an error (reject the edit)
+/// or an actual reroute (`rerouted == true`). Observer-only hooks — e.g.
+/// [`crate::live_index::frecency::FrecencyBumpHook`], which overrides only
+/// `after_edit_committed` — inherit the DEFAULT [`EditHook::resolve_target_path`],
+/// which returns a passthrough (`rerouted == false`, target == indexed). Such a
+/// passthrough must NOT shadow an earlier hook's reroute/error: doing so made
+/// worktree routing silently depend on registration order (F6 — when the
+/// frecency hook registered after [`crate::worktree::WorktreeAwareEditHook`],
+/// `next_back()` picked the frecency passthrough and every `working_directory`
+/// edit contaminated the indexed root). So skip passthrough results and keep
+/// looking; only when no hook makes an active decision do we return a
+/// passthrough (byte-identical to pre-hook behavior — the most-recently-
+/// registered hook's passthrough, exactly what `next_back()` used to yield).
+///
+/// Because [`DefaultEditHook`] is pre-registered and always returns `Ok`, this
+/// function only returns `Err` when a feature hook explicitly fails resolution.
 pub fn resolve(ctx: &EditContext) -> Result<ResolvedTarget, String> {
     let reg = registry().read();
-    // Walk hooks most-recently-registered first so feature hooks win over the default.
-    if let Some(hook) = reg.iter().next_back() {
-        return hook.resolve_target_path(ctx);
+    let mut passthrough: Option<ResolvedTarget> = None;
+    for hook in reg.iter().rev() {
+        let resolved = hook.resolve_target_path(ctx)?;
+        if resolved.rerouted {
+            return Ok(resolved);
+        }
+        if passthrough.is_none() {
+            passthrough = Some(resolved);
+        }
     }
-    // Defensive — the registry is seeded with DefaultEditHook on first access, so this
-    // branch is unreachable in practice.
-    DefaultEditHook.resolve_target_path(ctx)
+    // The registry is seeded with DefaultEditHook, so a passthrough is always
+    // produced unless a hook errored above; the fallback is defensive.
+    match passthrough {
+        Some(resolved) => Ok(resolved),
+        None => DefaultEditHook.resolve_target_path(ctx),
+    }
 }
 
 /// Invoke [`EditHook::after_edit_committed`] on every registered hook.
@@ -190,5 +212,67 @@ mod tests {
         let resolved = DefaultEditHook.resolve_target_path(&ctx).expect("resolves");
         assert_eq!(resolved.target_path, abs);
         assert!(!resolved.rerouted);
+    }
+
+    #[test]
+    fn resolve_prefers_active_reroute_over_later_passthrough_hook() {
+        // Root-cause regression (F6): `resolve` must honor an ACTIVE reroute from an
+        // earlier-registered hook even when a LATER-registered observer-only hook
+        // (mirroring `FrecencyBumpHook`, which overrides only `after_edit_committed`)
+        // inherits the default passthrough. The old `next_back()` returned only the
+        // last hook, so a passthrough observer registered after the worktree hook
+        // silently killed routing and every `working_directory` edit hit the indexed
+        // root. Using a unique sentinel `relative_path` keeps these hooks inert for
+        // every other test that shares this process-global registry.
+        const SENTINEL: &str = "F6_SENTINEL_REROUTE";
+
+        struct ReroutingHook;
+        impl EditHook for ReroutingHook {
+            fn resolve_target_path(&self, ctx: &EditContext) -> Result<ResolvedTarget, String> {
+                if ctx.relative_path == SENTINEL {
+                    Ok(ResolvedTarget {
+                        target_path: PathBuf::from("/worktree").join(ctx.relative_path),
+                        indexed_path: ctx.indexed_absolute_path.to_path_buf(),
+                        rerouted: true,
+                    })
+                } else {
+                    let abs = ctx.indexed_absolute_path.to_path_buf();
+                    Ok(ResolvedTarget {
+                        target_path: abs.clone(),
+                        indexed_path: abs,
+                        rerouted: false,
+                    })
+                }
+            }
+        }
+
+        // Observer-only: overrides ONLY after_edit_committed, exactly like
+        // FrecencyBumpHook, so its resolve_target_path is the default passthrough.
+        struct ObserverOnlyHook;
+        impl EditHook for ObserverOnlyHook {
+            fn after_edit_committed(&self, _ctx: &EditContext, _p: &Path) {}
+        }
+
+        // Register the router FIRST, the observer LAST — the order that broke prod.
+        register(Box::new(ReroutingHook));
+        register(Box::new(ObserverOnlyHook));
+
+        let repo_root = PathBuf::from("/repo");
+        let abs = repo_root.join(SENTINEL);
+        let ctx = EditContext {
+            relative_path: SENTINEL,
+            indexed_absolute_path: &abs,
+            repo_root: &repo_root,
+            working_directory: Some(Path::new("/worktree")),
+        };
+        let resolved = resolve(&ctx).expect("resolves");
+        assert!(
+            resolved.rerouted,
+            "an active reroute must win over a later observer-only passthrough hook"
+        );
+        assert_eq!(
+            resolved.target_path,
+            PathBuf::from("/worktree").join(SENTINEL)
+        );
     }
 }


### PR DESCRIPTION
F6 worktree routing was silently dead in the **daemon-served** edit path: an edit with `working_directory` at a git worktree wrote to the indexed (main) checkout, and a non-worktree `working_directory` produced no error. Confirmed live against a running daemon (`rerouted:false`, `wrote_to` = indexed root).

**Root cause:** `edit_hooks::resolve` used `next_back()` — last-registered hook wins. `WorktreeAwareEditHook` (routes) and `FrecencyBumpHook` (observer-only; its `resolve_target_path` is the default passthrough) both register on the process-global registry. A warm daemon boots from a snapshot, so the cold `LiveIndex::load` that registers frecency runs on a later index op and lands *after* the worktree hook — then `resolve` returned the frecency passthrough and every routed edit contaminated the indexed root. The existing tests passed because they used an in-process path with a favorable order; nothing covered the daemon dispatch.

**Fix:** `resolve` walks hooks in reverse and returns the first ACTIVE decision (error, or `rerouted == true`), skipping passthroughs; falls back to the most-recently-registered passthrough only when no hook acts (byte-identical to prior no-reroute behavior). Order-independent; fixes all 4 single-symbol + 3 batch edit paths. In-process path unchanged (worktree_awareness 27/27); A-025 `#[schemars(skip)]` untouched.

**Regression tests** (close the gap that let this ship green):
- `resolve_prefers_active_reroute_over_later_passthrough_hook` — deterministic unit guard; **panics under old `next_back()`, passes under the fix** (independently confirmed by reverting `resolve` and running it).
- `test_symforge_edit_apply_routes_into_worktree_through_daemon_proxy` — full STEL→planner→proxy→daemon path.
- `test_daemon_http_edit_within_routes_into_worktree_without_frontend_server` — raw HTTP to the daemon endpoint with no front-end server, so the daemon's own registration order is tested.

Gates: fmt --check, clippy --all-targets -D warnings, full test suite (--test-threads=1), release build — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core edit path resolution used by all symbol/batch edits; behavior is intentionally different when multiple hooks register, but passthrough-only cases are preserved and coverage targets the production daemon ordering bug.
> 
> **Overview**
> Fixes **F6** worktree routing on the daemon edit path: edits with `working_directory` were landing on the indexed checkout because `edit_hooks::resolve` only consulted the **last** registered hook, so observer-only **`FrecencyBumpHook`** (default passthrough) could override **`WorktreeAwareEditHook`** when it registered later.
> 
> **`resolve`** now walks hooks in reverse and returns the first **active** decision (error or `rerouted: true`), skipping passthroughs; if none act, behavior matches the old “most recent passthrough” fallback.
> 
> Adds a unit test for reroute-over-passthrough ordering plus two daemon tests: **`symforge_edit`** through the front-end proxy and raw HTTP **`edit_within_symbol`** without a local **`SymForgeServer`**, asserting worktree writes, main checkout untouched, and **`WorkingDirectoryNotARecognizedWorktree`** for invalid dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81117802dc8cd59bd48b36dc724cb17645316fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->