### PR TITLE
fix(surface): SFBENCH correctness & safety (spec 019)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Failure should degrade safely:
 - parser failures should isolate a file, not poison a run
 - bad symbol spans should never be served silently
 
-Current v7.13.x recovery contract:
+Current v8.14.0 recovery contract:
 
 - `checkpoint_now(verify_after_write=true)` is the explicit checkpoint path for
   forcing `.symforge/index.bin` persistence before risky operations.
@@ -119,7 +119,7 @@ Current v7.13.x recovery contract:
 
 ## MCP Surface
 
-The shipped v7.13.x MCP surface includes tools, resources, and prompts. Do not
+The shipped v8.14.0 MCP surface includes tools, resources, and prompts. Do not
 design for tools only.
 
 The **default** `tools/list` surface is the full **36-tool** surface below
@@ -127,17 +127,18 @@ The **default** `tools/list` surface is the full **36-tool** surface below
 `symforge_edit`, `status` — is a documented opt-in escape hatch via
 `SYMFORGE_SURFACE=compact`:
 
-- Runtime and index: `health`, `health_compact`, `index_folder`,
-  `checkpoint_now`, `analyze_file_impact`, `what_changed`, `diff_symbols`,
-  `validate_file_syntax`
+- Runtime and index: `health`, `health_compact`, `status`, `index_folder`,
+  `checkpoint_now`, `analyze_file_impact`, `detect_impact`, `what_changed`,
+  `diff_symbols`, `validate_file_syntax`
 - Read and search: `get_repo_map`, `get_file_context`, `get_file_content`,
   `get_symbol`, `get_symbol_context`, `inspect_match`, `search_symbols`,
-  `search_text`, `search_files`, `find_references`, `find_dependents`
+  `search_text`, `search_files`, `find_references`, `find_dependents`,
+  `symforge_retrieve`
 - Guidance: `explore`, `ask`, `conventions`, `edit_plan`,
   `context_inventory`, `investigation_suggest`
 - Structural edits: `replace_symbol_body`, `edit_within_symbol`,
   `insert_symbol`, `delete_symbol`, `batch_edit`, `batch_insert`,
-  `batch_rename`
+  `batch_rename`, `symforge_edit`
 
 Ranking signal invariants:
 - `search_symbols`, `search_text`, `search_files`, `explore`, `ask`, and
@@ -150,18 +151,20 @@ Current resources:
 
 - Static repository resources: `symforge://repo/health`,
   `symforge://repo/outline`, `symforge://repo/map`,
-  `symforge://repo/changes/uncommitted`
+  `symforge://repo/changes/uncommitted`, `symforge://tools/catalog`,
+  `symforge://glossary`
 - Templates: `symforge://file/context`, `symforge://file/content`,
   `symforge://symbol/detail`, `symforge://symbol/context`
 
 Current prompts:
 
-- `symforge-review`, `symforge-architecture`, `symforge-triage`,
-  `symforge-onboard`, `symforge-refactor`, `symforge-debug`
+- `symforge-admin`, `symforge-review`, `symforge-architecture`,
+  `symforge-triage`, `symforge-onboard`, `symforge-refactor`,
+  `symforge-debug`
 
 Name migration and deferred-surface table:
 
-| Old, removed, or future name | Current v7.13.x status |
+| Old, removed, or future name | Current v8.14.0 status |
 |---|---|
 | `get_repo_outline` | Use `get_repo_map`; repository outline also exists as a resource. |
 | `get_file_outline` | Use `get_file_context`. |

--- a/specs/019-sfbench-surface-correctness/contracts/tool-behavior.md
+++ b/specs/019-sfbench-surface-correctness/contracts/tool-behavior.md
@@ -1,0 +1,100 @@
+# Phase 1 — Observable contract deltas
+
+Each delta is the *observable* before→after behavior a fail-first test asserts.
+No schema/persistence change; these are behavior corrections to existing tools.
+"Before" is verified-2026-07-12 source behavior; re-confirm at implementation.
+
+## `batch_rename` (US1)
+
+| Aspect | Before | After |
+|---|---|---|
+| Write set on a common name | every bare-name ref across the index, incl. unrelated files | only refs proven to resolve to the target identity |
+| Name-only / dynamic matches | written silently | non-writable by default; reported as uncertain |
+| Exact binding unavailable | proceeds and writes | fails closed (no staged write) |
+| `dry_run` default | `false` (apply writes immediately) | unchanged default, but apply cannot write unproven matches |
+| Trust label | `Constrained` even for name-derived matches | reflects real binding confidence; never "constrained" over name-only |
+| Recorded harness result | `SF-batch_rename-002` → "source mutation escaped the frozen allowlist" | same case writes zero unrelated bytes |
+
+**Invariant**: no source byte outside the resolved-identity reference set is
+ever written. Uncertain matches are disclosed, not applied.
+
+## `detect_impact` (US2)
+
+| Aspect | Before | After |
+|---|---|---|
+| Changed-symbol seed | every symbol of every changed file | only body-diff added/modified/removed symbols |
+| Comment-only / whitespace edit | reports changed symbols | reports zero changed symbols |
+| Call-edge resolution | caller → every same-bare-name def repo-wide | scoped to resolved/qualified target; no edge invented when unresolved |
+| Blast node identity | bare name (duplicate indistinguishable `main`) | carries path/kind; distinct nodes distinguishable |
+| Entry-point tag | any `fn main` → Critical | only the actual reachable entry point |
+| Leaf-edit output | ~20 changed / 11 blast / 1278 tokens | 1 changed + hop-1 `{mid}`, bounded tokens |
+
+## `analyze_file_impact` (US2, secondary)
+
+| Aspect | Before | After |
+|---|---|---|
+| Same-file callers | filtered out (`fp != path`) | included and typed as calls |
+| Caller lookup | residual bare-name `find_references_for_name(...,None,false)` | typed identity; **existing parent-type narrowing preserved** |
+
+## `search_symbols` / `search_text` / `find_references` (US3)
+
+| Aspect | Before | After |
+|---|---|---|
+| Matching-local `project` selector | refused (blanket `local_cross_project_refusal`) | proceeds; equals no-selector result |
+| Foreign selector | refused | still refused, typed invalid-request |
+| `projects` incl. `"*"` | inconsistent (blanket refuse here; under-refuse elsewhere) | consistent: match-local proceed, foreign/over-broad refuse |
+
+## `find_dependents` (US3)
+
+| Aspect | Before | After |
+|---|---|---|
+| `from .mod import x` importer | missed (relative import dropped) | reported, resolved via import-prefix depth vs importer package |
+| Same-stem unrelated module | can appear as false consumer | excluded |
+
+## `symforge_edit` (US4)
+
+| Aspect | Before | After |
+|---|---|---|
+| Identical `{key, request, if_match}` replay | rejected by now-stale `if_match` (3/3) | returns stored result, zero writes |
+| Same key, changed request | (n/a — rejected earlier) | idempotency conflict |
+| New key, stale `if_match` | fails concurrency | still fails concurrency (unchanged) |
+
+## watcher cold start (US5b)
+
+| Aspect | Before | After |
+|---|---|---|
+| Tracked edit after cold start | `GenerationMismatch` → removed, never re-indexed (watcher captured pre-reload gen) | indexed (gen re-synced with the fire-and-forget cold reload) |
+| Genuine in-flight stale mutation | fenced/rejected (correct) | still fenced/rejected (fence untouched) |
+
+## `health` (US5a)
+
+| Aspect | Before | After |
+|---|---|---|
+| "reconcile repairs" count | includes `GenerationMismatch` no-ops | only `StaleReindexed`/`StaleRemoved` |
+| Rejected mismatch attempts | folded into repairs | surfaced separately or omitted |
+
+## `status(reset_calibration=true)` daemon (US5c)
+
+| Aspect | Before | After |
+|---|---|---|
+| Durable calibration after reset (daemon) | untouched; response `Found` (silent no-op) | proxy-owned durable store cleared to `deferred`; honest receipt |
+| Local (non-daemon) reset | clears correctly | unchanged |
+
+## `validate_file_syntax` (US6)
+
+| Aspect | Before | After |
+|---|---|---|
+| Valid UTF-8-BOM JSON | rejected at 1:1 | `ok`, identical accounting to no-BOM |
+| JSONC (trailing commas/comments) | `ok` (deliberate) | `ok` (unchanged — must not regress) |
+| Genuinely malformed JSON | fails | fails at oracle location (unchanged) |
+| `estimate=true` | inert (ignored) | tagged estimate within tolerance, or flag removed |
+
+## Cross-cutting invariants (all items)
+
+- Determinism: identical state → identical output/order (deterministic
+  tie-breaks where ordering changes).
+- Frecency-neutral: read/discovery paths (US2/US3/US6) write no frecency.
+- Transport parity: shared handler/formatter changes (US1 label, US2 blast node,
+  US5 counter) assert stdio↔serve parity.
+- Embed: `cargo check --no-default-features --features embed` green.
+- Fail-closed: US1/US4 never write on uncertainty/replay-mismatch.

--- a/specs/019-sfbench-surface-correctness/plan.md
+++ b/specs/019-sfbench-surface-correctness/plan.md
@@ -220,13 +220,31 @@ Disk discipline (CLAUDE.md): `target/` is on E:. Run full gates locally, but
   `projects` incl. `"*"`. **RED (import)**: Python pkg with `from .b import f`;
   assert `find_dependents(pkg/b.py)` includes `pkg/a.py` and excludes an
   unrelated same-stem module.
-- **GREEN**: centralize selector validation so all selector-bearing tools use
-  one guard covering both params and both directions (match-local → proceed;
-  foreign/over-broad → typed refuse) — **do not** naively swap the three tools to
-  `foreign_project_refusal` (it takes only singular `project` and, per P2-10,
-  under-refuses `projects=["*"]`). Add a `relative_import` capture to
-  `PYTHON_XREF_QUERY` and resolve the target by counting `import_prefix` dots
-  against the importer's package directory.
+- **GREEN**: the new guard for the three tools MUST satisfy ALL THREE
+  simultaneously (verified against `tests/serve_http_attach.rs:354`
+  `cross_project_targeting_is_refused_over_http`, which is test-locked):
+  1. a selector that **resolves to the bound project** (name / key / root, like
+     `foreign_project_refusal`) → **proceed** (`None`) — this is the benchmark's
+     actual fix (matching-local currently wrongly refused);
+  2. a **foreign** (`"other-proj"`), **multi** (`["a","b"]`), or **wildcard**
+     (`["*"]`) selector → **refuse** (the locked test asserts refusal on exactly
+     these three);
+  3. the no-daemon refusal message MUST still contain the substring
+     **"/mcp HTTP transport"** (the locked test asserts this) — so DO NOT reuse
+     `foreign_project_refusal`'s "not available on this connection" wording
+     verbatim; the transport-honest message must be preserved for the no-daemon
+     path. This is a constraint the benchmark report and the first-pass review
+     both missed — a naive swap to `foreign_project_refusal` breaks the message
+     assertion even though it satisfies (1) and (2).
+  Cleanest shape: extend `local_cross_project_refusal` to take the bound project
+  identity and return `None` when the selector resolves to it, else the existing
+  transport-naming refusal — covering both `project` and `projects`. Also add a
+  `relative_import` capture to `PYTHON_XREF_QUERY` and resolve the target by
+  counting `import_prefix` dots against the importer's package directory.
+- **NOTE (verified)**: the `/mcp` cross-project refusal is DELIBERATE D16
+  containment (see `docs/reviews/symforge-defect-ledger.md:82,102`), NOT a bug to
+  remove. The bug is only that it's **over-broad** — it refuses a matching-local
+  selector too. Narrow it to foreign/multi/wildcard; keep the containment.
 - **NEIGHBORS**: `get_symbol`/`search_files`/`get_file_context` selector paths
   (must stay correct); daemon vs local path (selector bug only manifests
   local); `find_dependents` TS/Go cyclic/aliased import cases; 017 selector

--- a/specs/019-sfbench-surface-correctness/plan.md
+++ b/specs/019-sfbench-surface-correctness/plan.md
@@ -175,15 +175,17 @@ Disk discipline (CLAUDE.md): `target/` is on E:. Run full gates locally, but
   reparse (`tools.rs` ~L10859 `changed_paths_between_refs`); enumerate removed
   symbols from the base parse (they are absent from the current index). The
   "smaller/faster" claim must be re-validated against this added base-parse cost.
-  (b) scope edge resolution so a call does not fan out to every same-bare-name
-  def **BUT keep a bare-name fallback when the callee definition carries no
-  resolvable owner** (review B2) — `SymbolRecord` has no owner field today, so an
-  unconditional owner-equality rule would drop the edge asserted by
-  `compute_impact_reaches_across_qualified_module_call` (`main` → `a::call_a`).
-  Rule: prefer an owner/qualified-scoped edge when both sides resolve an owner;
-  otherwise fall back to bare-name match. Duplicate-`main` fan-out is cut by the
-  formatter carrying identity (c), not by dropping legitimate module-sibling
-  edges. (c) formatter emits path/kind so duplicate `main` nodes are
+  (b) scope edge resolution by **callee-name ambiguity** (refined design, same
+  principle as US1): when a `Call` ref's name resolves to **exactly one
+  definition** in `defs_by_name`, link it (bare-name is correct and unambiguous —
+  this preserves `compute_impact_reaches_across_qualified_module_call`, where
+  `call_a` has one def); when it resolves to **multiple** definitions, the call
+  cannot be attributed to a specific one from syntax alone, so **do not fan out
+  to all of them** — either use the module-qualifier from the call site if
+  present to disambiguate, or drop the ambiguous edge rather than invent N wrong
+  ones. This is what cuts the duplicate-`main` explosion (`main` is multiply
+  defined) without dropping the legitimate single-def module-sibling edge.
+  Formatter identity (c) is the backstop for any remaining same-name nodes. (c) formatter emits path/kind so duplicate `main` nodes are
   distinguishable; (d) tighten `analyze_file_impact`'s residual bare-name lookup
   to typed identity while keeping same-file callers and the parent-type
   narrowing.

--- a/specs/019-sfbench-surface-correctness/plan.md
+++ b/specs/019-sfbench-surface-correctness/plan.md
@@ -1,0 +1,432 @@
+# Implementation Plan: SFBENCH Surface Correctness & Safety
+
+**Branch**: `019-sfbench-surface-correctness` | **Date**: 2026-07-12 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/019-sfbench-surface-correctness/spec.md`
+
+## Summary
+
+Eight independently-verified defects from the SFBENCH-1.0 8.14.0 benchmark
+(six from the initial grading + two surfaced by the adversarial review of this
+very spec), fixed in verified-severity order, each with a **fail-first
+regression test**, landed and gated independently. Two safety/correctness P0
+(`batch_rename` unsafe write, `detect_impact` identity), two P1 (selector +
+Python relative import; **watcher cold-start staleness — added after the review
+refuted my own refutation**), four lower (replay P2, health counter P2, daemon
+calibration-reset no-op P2, BOM/estimate P3). Severity order:
+US1 → US2 → US3 → US5b → US4 → US5a → US5c → US6. The benchmark's meta P0 is
+excluded (verified non-bug).
+
+> [!IMPORTANT]
+> **Code is gospel; no document is trusted — including this plan and the
+> benchmark report.** Every file:line below is a *verified-at-2026-07-12
+> starting anchor*, not scripture. **Step 0 of every item is to re-confirm the
+> anchor against live source** (`get_symbol` / `get_symbol_context` /
+> `search_text`). If the code moved, the guard already changed, or the behavior
+> no longer reproduces, the item is **re-opened** — write the failing test
+> first and let the *running test*, not the prose, decide whether a bug exists.
+> A benchmark says a thing is broken; only a red test on current source proves
+> it, and only a green gate proves it fixed.
+
+## Technical Context
+
+**Language/Version**: Rust 2024 (single crate `symforge`). No new dependencies.
+
+**Primary Dependencies**: tree-sitter (Tier-0 xref, pinned `tree-sitter-python`
+0.25.0), `git2`, in-process `LiveIndex`, STEL controller, MCP protocol surface,
+`serde_json` (config validation). No new deps introduced.
+
+**Storage**: in-process `LiveIndex` + local `.symforge/` snapshots. No external
+store, no schema/persistence change (Constitution I).
+
+**Testing**: `cargo test --all-targets -- --test-threads=1`; per-story
+fail-first regression tests colocated with the touched tool's `#[cfg(test)]`
+module or under `tests/`; controlled-graph assertions reuse the SFBENCH fixture
+shape (`sfbench_entry → sfbench_mid → sfbench_leaf`, `sfbench_duplicate`,
+`sfbench_rename_me`) where a local equivalent is cheaper.
+
+**Target Platform**: local dev host (Windows/Linux/macOS); stdio + `serve`.
+
+**Project Type**: single-crate Rust MCP server. Not web/mobile.
+
+**Performance Goals**: no regression. US2 makes `detect_impact` *smaller* and
+faster (fewer seed symbols, scoped edges). US1 adds identity checks on an
+already-bounded reference set. No path becomes super-linear.
+
+**Constraints**: Constitution I–VIII (below). Frecency-neutral read paths,
+deterministic ordering, embed build green, stdio↔serve parity, full gate,
+fail-closed mutation safety.
+
+**Scale/Scope**: six surgical fixes. US1/US2 share a small identity concept but
+are landed as **separate commits with separate tests**; the rest are disjoint.
+
+## Constitution Check
+
+*GATE: evaluated against constitution v1.0.0, all eight principles. Re-check
+after each item lands.*
+
+| # | Principle | Assessment | Verdict |
+|---|-----------|------------|---------|
+| I | Local-First In-Process Index | All fixes read/act on the existing `LiveIndex`; no second index, no external store. US2 tightens graph projection *within* the one index. | PASS |
+| II | MCP-Native Surface | No new tools. Behavior corrections to `batch_rename`, `detect_impact`, `analyze_file_impact`, three search tools, `symforge_edit`, `health`, `validate_file_syntax`. No chat injection, no client-tool shadowing. | PASS |
+| III | Trust Envelopes | **US1 strengthens** (label reflects real binding confidence; unsafe writes become disclosed-uncertain). US5 strengthens health honesty (no no-op overcount). US2 blast nodes carry identity. No disclosure removed. | PASS |
+| IV | Determinism & Recovery | **US1 is a fail-closed mutation-safety fix** (core of this principle). US2/US3 keep deterministic ordering; tests assert determinism and zero-write on uncertain/replay paths. | PASS |
+| V | Frecency Invariant | US2/US3/US6 are discovery/read paths and MUST NOT write frecency; US1/US4 are mutation paths whose frecency behavior is unchanged. Frecency-neutrality assertion on touched read paths. | PASS |
+| VI | Embed Isolation | Changes live in parsing/query/graph/protocol/edit paths present in `embed`; no server/network dep added. `cargo check --no-default-features --features embed` gate per item. | PASS |
+| VII | Transport Parity | All behaviors flow through shared handlers/formatters both transports call. Any shared formatter/signature change (US1 label, US2 blast node, US5 counter) carries a parity assertion. | PASS (verify per item) |
+| VIII | Verification Before Done | Full gate + embed check + fail-first test per story, on current source, before any completion claim. **No item is "done" on a green document — only on a green gate.** | PASS |
+
+**No violations → Complexity Tracking empty. Cleared for Phase 0.**
+
+## The fix loop (applied to every item, in order)
+
+Each item is one pass of a fixed, test-first loop. Do **not** batch items; land
+and gate one at a time so a regression is attributable.
+
+```text
+0. RE-CONFIRM  Locate the real code by symbol name (not the cached line number).
+               Read it. Confirm the defect still reproduces conceptually. If the
+               anchor moved or a guard already exists → re-open, adjust, or drop.
+1. RED         Write the smallest failing test that encodes the acceptance
+               scenario against CURRENT source. Run it. WATCH IT FAIL for the
+               right reason (assert the actual wrong output, not just "errors").
+2. GREEN       Make the minimal change that binds identity / scopes the seed /
+               fixes the ordering. No speculative abstraction; smallest diff that
+               turns the test green and holds the acceptance scenario.
+3. GATE        cargo fmt --check; cargo check; cargo clippy --all-targets
+               -D warnings; cargo test --all-targets -- --test-threads=1;
+               cargo check --no-default-features --features embed. (release
+               build + npm at end-of-feature.) Green before moving on.
+4. NEIGHBORS   Rerun the neighbor cases the change could disturb (listed per
+               item). Confirm no adjacent regression.
+5. COMMIT      One conventional commit per item on this branch. Then next item.
+```
+
+Disk discipline (CLAUDE.md): `target/` is on E:. Run full gates locally, but
+`cargo clean` before ending a heavy session; `cargo clean` first if
+`target/debug` is already large.
+
+---
+
+## Item order and per-item plan
+
+### Item 1 — US1 `batch_rename` fail-closed identity binding (P0 SAFETY, MVP)
+
+- **Starting anchors (re-confirm first)**: `execute_batch_rename`
+  (`src/protocol/edit.rs`, ~L2256–2618): target resolved only for def site;
+  `find_references_for_name(&input.name, None, false)` (~L2287, name-only, no
+  scope); `code_only` language-class filter (~L2296/L2320); qualified scan
+  (~L2334); `dry_run.unwrap_or(false)` apply-default (~L2405); write loop
+  (`atomic_write_file`). Trust label `MatchType::Constrained`
+  (`src/protocol/edit_tools.rs`, "project-wide constrained references").
+  Reference lookup: `src/live_index/query.rs` `find_references_for_name` /
+  `collect_refs_for_key` (simple-name reverse index).
+- **RED**: fixture with a **shared method name** having 2+ unrelated owners
+  (e.g. `Target::run` in file A + unrelated `Widget::run` / Flask handler `run`
+  in file B). `batch_rename(name="run", path="A")` **apply**; assert file B
+  byte-hash unchanged and B's sites reported uncertain. **Python arm is the
+  mandatory gating fixture** (that is where the recorded escape happened).
+  Explicitly **forbid the honeytrap shape**: the existing green test
+  `test_batch_rename_scopes_common_name_to_target` renames the *unique* struct
+  `Target` and asserts an untouched-by-construction `new` — a plausible-looking
+  "common name" test that exercises nothing. The RED test must rename a shared
+  name with real ambiguity.
+- **GREEN (corrected — review B3)**: key writability on **index-wide name
+  ambiguity**, NOT on "has resolved identity". Bare-name Tier-0 refs never carry
+  identity, so identity-keying would demote *every* rename and regress the green
+  tests. Rule: **name with exactly 1 definition → keep all bare-name refs
+  writable + "constrained" (unchanged); name with 2+ definitions → demote
+  name-only refs to uncertain / non-writable, correct the label; if no ref of an
+  ambiguous name can be safely bound → fail closed.** Honest ceiling
+  (`research.md`): Tier-0 xref carries no resolved identity for dynamic
+  languages, so for an ambiguous name the safe default is uncertain, not "guess".
+- **MUST-NOT-REGRESS (named)**: `batch_rename_updates_definition_and_callers`
+  (asserts the bare `old_name();` site IS rewritten + "constrained"),
+  `batch_rename_bumps_definition_and_call_site`, and the frecency-ranking rename
+  path. These pass because those names are unique in their fixtures.
+- **NEIGHBORS**: all `batch_rename` language cases; `find_references` (shared
+  lookup); `symforge_edit` rename intent; `batch_edit`/`batch_insert` rollback
+  behavior (shared write path).
+- **DONE WHEN**: SC-001. Zero unrelated writes across Rust/Python/TS + one of
+  Go/Java/C++; ambiguity test green; label honest; gate green.
+
+### Item 2 — US2 `detect_impact` changed-symbol delta + scoped edges (P0 CORRECTNESS)
+
+- **Starting anchors (re-confirm first)**: seed loop
+  (`src/protocol/tools.rs`, ~L7463–7476, seeds every `file.symbols` of each
+  changed path as `SymbolId{path,name,kind}`); `GraphProjection::from_index`
+  (`src/live_index/graph.rs`, L66–133, `defs_by_name` keyed on bare name; Pass 2
+  links each `Call` to *every* same-name def); `is_entry_point` (graph.rs
+  L275–277, matches any `fn main`); Symbols-scope formatter (tools.rs ~L7493,
+  drops path/kind); `analyze_file_impact` same-file filter
+  (`src/sidecar/handlers.rs`:1326) + bare-name lookup (:1323) **with** existing
+  parent-type narrowing (:1305–1321) — do not remove that. Prior evidence:
+  `specs/015-cbm-capability-ports/contracts/detect-impact.md:104–111` (the
+  291K/54MB explosion + 200-truncation band-aid).
+- **RED**: controlled graph; body-only edit to `sfbench_leaf`. Assert exactly
+  `{sfbench_leaf}` changed and hop-1 `{sfbench_mid}`. Second test: two `run`
+  defs → change one → assert the other never enters the blast and nodes carry
+  path/kind. Third: comment-only shift → zero changed symbols.
+- **GREEN**: (a) seed only genuinely added/modified/removed symbols by comparing
+  body hashes, not all symbols of the file. **Sizing (review M4)**: this is
+  **net-new machinery**, not a seed tweak — the live index holds only *current*
+  bodies and `SymbolRecord` has no per-symbol body hash (only file-level
+  `content_hash`). Source the base bodies by reusing `diff_symbols`' git-blob
+  reparse (`tools.rs` ~L10859 `changed_paths_between_refs`); enumerate removed
+  symbols from the base parse (they are absent from the current index). The
+  "smaller/faster" claim must be re-validated against this added base-parse cost.
+  (b) scope edge resolution so a call does not fan out to every same-bare-name
+  def **BUT keep a bare-name fallback when the callee definition carries no
+  resolvable owner** (review B2) — `SymbolRecord` has no owner field today, so an
+  unconditional owner-equality rule would drop the edge asserted by
+  `compute_impact_reaches_across_qualified_module_call` (`main` → `a::call_a`).
+  Rule: prefer an owner/qualified-scoped edge when both sides resolve an owner;
+  otherwise fall back to bare-name match. Duplicate-`main` fan-out is cut by the
+  formatter carrying identity (c), not by dropping legitimate module-sibling
+  edges. (c) formatter emits path/kind so duplicate `main` nodes are
+  distinguishable; (d) tighten `analyze_file_impact`'s residual bare-name lookup
+  to typed identity while keeping same-file callers and the parent-type
+  narrowing.
+- **CAVEAT (verified)**: fixing the seed alone is insufficient — hop-1+ still
+  over-connects via bare-name edges. Both (a) and (b) are required. The RED test
+  MUST include the two-same-name case (SC-002 clause 2); a green on the
+  unique-name leaf edit alone does NOT prove (b). The entry-point-collapse clause
+  needs a fixture with a reachable duplicate `main` (the SFBENCH fixture has
+  none) — add one or mark that clause untested-on-fixture.
+- **MUST-NOT-REGRESS (named)**: `compute_impact_reaches_across_qualified_module_call`
+  (graph.rs ~L419), the risk-tier tests, and 018's `code_only` data-file
+  defaulting.
+- **NEIGHBORS**: all `graph.rs` `compute_impact` tests; `diff_symbols`
+  (shares the delta concept); `what_changed`; `analyze_file_impact` cases;
+  018's `code_only` data-file defaulting (must remain intact).
+- **DONE WHEN**: SC-002. Leaf edit → 1 changed + 1 hop-1; comment shift → 0;
+  no duplicate/unrelated blast nodes; 015 explosion no longer reproduces without
+  relying on truncation; gate green.
+
+### Item 3 — US3 selector consistency + Python relative import (P1 CORRECTNESS)
+
+- **Starting anchors (re-confirm first)**: `search_symbols`
+  (`src/protocol/tools.rs`:4986), `search_text` (:5149), `find_references`
+  (:7941) call `local_cross_project_refusal` (tools.rs:2787–2804, refuses any
+  selector); siblings call `foreign_project_refusal` (tools.rs:6785, allows
+  matching-local). `PYTHON_XREF_QUERY` (`src/parsing/xref.rs`:72–121) — no
+  `relative_import` capture; consumers `find_dependents_for_file` +
+  `matches_target_import`/`matches_target_stem` (`src/live_index/query.rs`:364–392).
+- **RED (selector)**: for each of the three tools, a matching-local selector
+  currently refuses — assert it *should* succeed and equal the no-selector
+  result; a foreign selector asserts typed refusal. Cover both `project` and
+  `projects` incl. `"*"`. **RED (import)**: Python pkg with `from .b import f`;
+  assert `find_dependents(pkg/b.py)` includes `pkg/a.py` and excludes an
+  unrelated same-stem module.
+- **GREEN**: centralize selector validation so all selector-bearing tools use
+  one guard covering both params and both directions (match-local → proceed;
+  foreign/over-broad → typed refuse) — **do not** naively swap the three tools to
+  `foreign_project_refusal` (it takes only singular `project` and, per P2-10,
+  under-refuses `projects=["*"]`). Add a `relative_import` capture to
+  `PYTHON_XREF_QUERY` and resolve the target by counting `import_prefix` dots
+  against the importer's package directory.
+- **NEIGHBORS**: `get_symbol`/`search_files`/`get_file_context` selector paths
+  (must stay correct); daemon vs local path (selector bug only manifests
+  local); `find_dependents` TS/Go cyclic/aliased import cases; 017 selector
+  ranking work.
+- **DONE WHEN**: SC-003 + relative-import dependent test green; both selector
+  parameters consistent both directions; gate green.
+
+### Item 4 — US4 `symforge_edit` replay-before-concurrency (P2 CORRECTNESS)
+
+- **Starting anchors (re-confirm first)**: `symforge_edit_stel_handler` local
+  apply branch (`src/protocol/tools.rs`:10040–10159) runs `run_pre_apply_gates`
+  **before** `begin_mutation_replay`; `if_match` guard in
+  `src/stel/edit_apply.rs`:71–149 (~L130–137) rejects with no idempotency
+  exemption (`pre_apply_rejects_if_match_mismatch` test :259–281); replay lookup
+  `begin_tool_replay` (`src/protocol/idempotency.rs`:439) reached only later.
+- **RED**: apply `{key, request, if_match}`; replay identical → assert stored
+  result + zero writes (currently rejected 3/3). Plus: same key + changed
+  request → conflict; new key + stale `if_match` → concurrency fail.
+- **GREEN**: perform a **non-reserving** exact replay probe (read-only, does not
+  consume the reservation) before `run_pre_apply_gates`; on an identical
+  key+request hit, return the stored result without re-validating the now-stale
+  `if_match`. Keep `FirstExecution` vs `Replay` reservation semantics intact.
+  Caveat (verified): the probe's request hash must be computed so `if_match`
+  presence does not reintroduce the mismatch.
+- **NEIGHBORS**: granular edit tools' replay (`replace_symbol_body`,
+  `edit_within_symbol`, `delete_symbol`); STEL concurrency tests; idempotency
+  conflict tests.
+- **DONE WHEN**: SC-004; conflict + concurrency guards still fire; gate green.
+
+### Item 5b — US5b watcher cold-start generation staleness (P1 CORRECTNESS)
+
+> **Scheduling**: this is P1 and should land in the P1 wave (with/after Item 3),
+> BEFORE the P2 items — the item numbering keeps the watcher cluster together but
+> the severity order is US1, US2, US3, **US5b**, US4, US5a, US5c, US6.
+
+- **Starting anchors (re-confirm first — verified 2026-07-12)**: cold-start
+  bootstrap in `src/main.rs`: `tokio::task::spawn_blocking(|| bg_index.reload(
+  &bg_root))` is **fire-and-forget** (not awaited; `reload` bumps
+  `project_generation` at `src/live_index/store.rs`:800), then the watcher is
+  spawned unconditionally via `run_watcher` (~`main.rs`:432) which captures
+  `expected_gen` **once** at `src/watcher/mod.rs`:721. Cheap spawn wins the race
+  vs the ~220 ms reload → captures pre-reload gen → all later
+  `freshen_file_if_stale` / `reconcile_stale_files_with_stop` see
+  `GenerationMismatch` → file removed, never re-indexed. (Contrast: daemon
+  `reload_with` `daemon.rs`:2761–2772 and stdio `index_folder` tools.rs:6931–6971
+  DO restart the watcher — those are fine.)
+- **RED**: cold-start a snapshot-less repo with a deterministic seam that lets the
+  reload bump the generation before the watcher captures it (or observe
+  captured-vs-current gen); modify a tracked file; assert it is **indexed**, not
+  `GenerationMismatch`-removed, and `expected_gen == current_project_generation()`.
+- **GREEN** (pick one, justify in `research.md`): (i) **await** the cold-start
+  reload before spawning the watcher (reorder `main.rs` so the watcher captures
+  the post-reload gen — simplest, small latency cost to first-watch); or (ii) have
+  `run_watcher_with_stop` **re-read** `current_project_generation()` per committed
+  reconcile/watcher batch instead of capturing once; or (iii) subscribe the
+  watcher to generation changes. Keep the generation fence for genuine
+  concurrency races intact.
+- **NEIGHBORS**: daemon/index_folder restart paths (must stay correct); watcher
+  generation-fence tests (`lsn_b1f83a91` established this pattern); snapshot-warm
+  start; US5a counter (shares the same reconcile path).
+- **DONE WHEN**: SC-005a; cold-start edit indexed; fence still rejects real
+  in-flight stale mutations; gate green.
+
+### Item 5a — US5a health reconcile-repair counter honesty (P2 OBSERVABILITY)
+
+- **Starting anchors (re-confirm first)**: `reconcile_stale_files_with_stop`
+  (`src/watcher/mod.rs`:505) counts every `true` from
+  `freshen_file_if_stale_at_generation` (:487), which returns `true` for
+  `FreshenResult::GenerationMismatch` (a no-op) as well as real
+  `StaleReindexed`/`StaleRemoved`; surfaced by health
+  (`src/protocol/format.rs`:1903–1909, 2055–2079).
+- **RED**: reconcile pass over generation-mismatched files (no real reindex);
+  assert reported repair count is 0 for those; genuine stale files still count;
+  rejected attempts surfaced separately.
+- **GREEN**: distinguish `GenerationMismatch` from real repairs in the counter;
+  count only `StaleReindexed`/`StaleRemoved`; expose rejected attempts as a
+  distinct figure (or omit), never as "repairs".
+- **NOTE**: causally linked to US5b — fixing the cold-start race drains most of
+  the `GenerationMismatch` no-ops. Land US5b first; this counter fix is the
+  honest-signal backstop for the residual legitimate-race window.
+- **NEIGHBORS**: health full + compact formatters; watcher generation-fence
+  tests; any snapshot-restore health test.
+- **DONE WHEN**: SC-005b; health repair count excludes no-ops; gate green.
+
+### Item 5c — US5c daemon `status(reset_calibration=true)` durable reset (P2 CORRECTNESS)
+
+- **Starting anchors (re-confirm first — verified via review)**: `status_stel_tool`
+  (`src/protocol/tools.rs`:10256) calls `proxy_tool_call("status", &request)`
+  (passing `reset_calibration` through), overlays proxy-owned lines (:10268), and
+  **returns early at :10272** with `OutcomeClass::Found` — never reaching the
+  actual reset in `render_stel_status_body` (:10302–10303). The daemon worker is
+  storeless; the proxy owns the durable store but never calls its own
+  `reset_calibration()` (`src/protocol/mod.rs`:540–546) in this path.
+- **RED**: daemon mode with durable calibration samples; call
+  `status(reset_calibration=true)`; assert durable samples/constants clear to
+  `deferred`; equivalent local reset behaves identically.
+- **GREEN**: in the daemon-proxy `status` path, apply calibration reset to the
+  proxy-owned durable store before/after proxying, and emit an honest reset
+  receipt (do not report success on state the storeless worker cannot touch).
+- **NEIGHBORS**: local (non-daemon) reset (must stay correct); `status` identity
+  fields; STEL calibration/ledger tests.
+- **DONE WHEN**: SC-005c; daemon + local reset both clear to `deferred`; gate
+  green.
+
+### Item 6 — US6 `validate_file_syntax` BOM + estimate (P3 CORRECTNESS)
+
+- **Starting anchors (re-confirm first)**: `normalize_jsonc`
+  (`src/parsing/config_extractors/json.rs`, ~L22) → `blank_trailing_commas`
+  (~L32), no BOM strip; `JsonExtractor::extract` (json.rs:154,
+  `serde_json::from_slice`); handler `validate_file_syntax`
+  (`src/protocol/tools.rs`:7838) never reads `input.estimate`
+  (`src/protocol/read_tools.rs`:402). JSON routes through the config-extractor
+  path (`src/parsing/mod.rs`:45), **not** tree-sitter — the report's stated root
+  cause is false; do not touch the tree-sitter dispatch.
+- **RED**: valid JSON with vs without leading UTF-8 BOM → both `ok`, identical
+  span accounting. Malformed JSON → still fails at oracle location. JSONC
+  (trailing commas/comments) → still `ok` (guard against regressing
+  `test_jsonc_trailing_commas_now_parse`, `test_tsconfig_jsonc_*`).
+- **GREEN**: strip a leading UTF-8 BOM in `normalize_jsonc` before `serde_json`.
+  Either wire `estimate` into the handler (tagged, within tolerance) or remove it
+  from the input contract — no inert flag.
+- **NEIGHBORS**: all JSON/JSONC/TOML/YAML validation tests; config extractor
+  round-trips.
+- **DONE WHEN**: SC-006; BOM `ok`, JSONC `ok`, malformed fails; `estimate`
+  honored or removed; gate green.
+
+---
+
+## End-of-feature verification (before PR)
+
+- Full gate on the whole branch: `cargo fmt --check`, `cargo check`,
+  `cargo clippy --all-targets -- -D warnings`,
+  `cargo test --all-targets -- --test-threads=1`, `cargo build --release`,
+  `cd npm && npm test`, plus `cargo check --no-default-features --features embed`.
+- Confirm every US has a fail-first test that is now green, and that the
+  originally-red assertions encode the *actual wrong output* the benchmark
+  measured (not a weaker proxy).
+- Live re-check of the two P0s through the running MCP surface on a disposable
+  clone (drive the tool, observe the real result) — code is gospel, and "the
+  test passes" is confirmed by exercising the tool, not only `cargo test`.
+- `cargo clean` to clear debug artifacts (disk discipline).
+- Merge via `gh pr merge <N> --merge --delete-branch --body "PR #<N>"` (release-
+  please double-count guard).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-sfbench-surface-correctness/
+├── spec.md              # Prioritized user stories (verified findings only)
+├── plan.md              # This file — the per-item fix loop
+├── research.md          # Phase 0 — per-item root cause, verified verdict, honest ceilings
+├── contracts/
+│   └── tool-behavior.md # Phase 1 — observable contract deltas per tool
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+Single-crate Rust. Items touch mostly-disjoint files:
+
+```text
+src/
+├── protocol/
+│   ├── edit.rs          # US1: execute_batch_rename identity binding + honest label
+│   ├── edit_tools.rs    # US1: MatchType label; US4 granular replay neighbors
+│   ├── tools.rs         # US2: detect_impact seed + formatter; US3: 3 selector guards; US4: symforge_edit handler; US6: validate handler
+│   ├── read_tools.rs    # US6: estimate flag contract
+│   ├── format.rs        # US5: health repair-count formatting; parity checks
+│   └── idempotency.rs   # US4: replay probe ordering
+├── stel/
+│   └── edit_apply.rs    # US4: run_pre_apply_gates vs replay ordering
+├── live_index/
+│   ├── graph.rs         # US2: from_index edge scoping + blast node identity
+│   └── query.rs         # US1/US3: find_references_for_name; find_dependents import resolution
+├── parsing/
+│   ├── xref.rs          # US3: PYTHON_XREF_QUERY relative_import capture
+│   └── config_extractors/json.rs  # US6: normalize_jsonc BOM strip
+├── sidecar/
+│   └── handlers.rs      # US2: analyze_file_impact same-file caller + typed lookup
+└── watcher/
+    └── mod.rs           # US5: reconcile repair-count semantics
+
+tests/                   # per-item fail-first regression tests (or colocated #[cfg(test)])
+```
+
+**Structure Decision**: Single project (Option 1). No new modules. US1 and US2
+share the *concept* of resolved identity but are separate commits with separate
+tests; all six items land and gate independently in verified-severity order
+(US1 → US2 → US3 → US4 → US5 → US6).
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.
+
+## Notes on trust
+
+This plan is derived from a benchmark report that was **not trusted**: a 7-agent
+skeptical source review re-graded every finding, refuted P0-04 entirely,
+downgraded P0-03 and P1-05, and corrected the root causes of P1-05 and P1-06.
+The plan carries the *verified* set only. Per the same discipline, this plan's
+own anchors are provisional until re-confirmed against live source at
+implementation time — the red test on current code is the arbiter, not any
+document.

--- a/specs/019-sfbench-surface-correctness/research.md
+++ b/specs/019-sfbench-surface-correctness/research.md
@@ -1,0 +1,226 @@
+# Phase 0 Research — SFBENCH Surface Correctness
+
+Per-item: the **verified** root cause (source-confirmed, not report-trusted),
+the observed benchmark evidence where it exists, the chosen approach, and the
+honest ceiling. Anchors are the 2026-07-12 verified state and must be
+re-confirmed at implementation time (code is gospel).
+
+## Evidence provenance
+
+Three independent legs were used; a finding is only in-scope if it has at least
+the source leg:
+
+1. **Source** — the actual current code exhibits the behavior (read via
+   symforge `get_symbol`/`get_file_content`, cited file:line).
+2. **Skeptical review** — a rust-pro agent tasked to *refute* the finding could
+   not, and graded verdict + severity + fix-soundness (2026-07-12 workflow).
+3. **Observed run** — a recorded SFBENCH trial in
+   `C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface` measured the failure.
+
+The benchmark *report* (a document) was **not** trusted; these three legs were
+reconstructed independently. P0-04 failed all three (non-bug) and is excluded.
+
+---
+
+## US1 — `batch_rename` unsafe write (P0)
+
+- **Source**: `execute_batch_rename` (`src/protocol/edit.rs`) resolves the
+  target only to locate the definition, then collects refs via
+  `find_references_for_name(&input.name, None, false)` — a bare-name reverse
+  lookup with no path/identity scope — and writes every match; `code_only`
+  filters by language class, not identity; `dry_run` defaults `false`. Trust
+  label `MatchType::Constrained` overstates safety.
+- **Observed run**: `SF-batch_rename-002` in `runs/formal-broad-v1-20260712.jsonl`
+  recorded a `case_error` with `error_type: RunnerError`,
+  `message: "source mutation escaped the frozen allowlist"` — the harness's
+  before/after source fingerprints caught `batch_rename` writing files outside
+  the declared allowlist during an actual run. This is measured, not asserted.
+  (The happy `SF-batch_rename-001` PASSes and is the only batch_rename row in the
+  happy-v2 adjudicated set — the aggregate "PASS" there is happy-path only and
+  does not contradict the adverse escape.)
+- **Approach**: bind writes to resolved identity; name-only/dynamic/textual
+  matches non-writable by default and reported uncertain; fail closed when exact
+  binding is unavailable; honest trust label.
+- **Ceiling**: Tier-0 tree-sitter xref carries no resolved identity for dynamic
+  languages (Python). A fully sound binding is impossible there from syntax
+  alone, so the *safe* default for name-only matches is uncertain/non-writable,
+  not "guess and write". This is the correct fail-closed ceiling, not a
+  limitation to be engineered away in this feature.
+
+## US2 — `detect_impact` confidently wrong (P0)
+
+- **Source**: seed loop (`src/protocol/tools.rs` ~L7463–7476) pushes every
+  symbol of each changed file; `GraphProjection::from_index`
+  (`src/live_index/graph.rs` L66–133) links each `Call` to *every* same-bare-name
+  definition (doc comment: "the over-approximation the v1 resolver will later
+  narrow"); formatter drops path/kind; `is_entry_point` tags any `fn main`.
+- **Observed run**: `SF-detect_impact-001` adjudicated **FAIL /
+  INVALID_INCORRECT**, direct payload **1278 cl100k tokens** (vs an 82-token
+  lower-bound baseline) — matches the report's measured figure.
+- **Prior internal evidence**: the project's own contract
+  `specs/015-cbm-capability-ports/contracts/detect-impact.md:104–111` records a
+  291K-changed-symbol / 54MB "explosion" from this exact path, mitigated only by
+  a 200-entry truncation. The root cause was known and deferred.
+- **Report correction (verified)**: the finding conflated `detect_impact` (the
+  explosion) with `analyze_file_impact` (a separate tool that already has
+  parent-type narrowing at `src/sidecar/handlers.rs:1305–1321` and only a
+  *residual* bare-name lookup). US2 fixes the former fully and tightens the
+  latter's residual lookup without removing its narrowing.
+- **Approach**: body-hash `SymbolDelta` seed + owner/qualified-scoped edges +
+  identity-bearing blast nodes. Both seed and edge fixes are required — a perfect
+  seed still over-connects at hop-1+ through bare-name edges.
+- **Ceiling**: where the xref genuinely cannot resolve a call target, do not
+  invent an edge (same honest-ceiling discipline as US1) rather than fall back to
+  every same-name def.
+
+## US3 — selector refusal + Python relative import (P1)
+
+- **Source**: `search_symbols`/`search_text`/`find_references`
+  (`src/protocol/tools.rs`:4986/5149/7941) call `local_cross_project_refusal`
+  (refuses any selector) while siblings use `foreign_project_refusal` (allows
+  matching-local). `PYTHON_XREF_QUERY` (`src/parsing/xref.rs`:72–121) has no
+  `relative_import` capture — verified against pinned `tree-sitter-python`
+  0.25.0 `node-types.json` (`import_from_statement.module_name` may be
+  `relative_import`, unhandled).
+- **Observed run**: `search_symbols`, `search_text`, `find_references`,
+  `find_dependents`, `get_file_context` all adjudicated **FAIL** in the summary,
+  consistent with the selector + import defects.
+- **Approach**: one centralized selector guard covering `project` + `projects`
+  and both directions (match-local proceed / foreign+over-broad refuse — do not
+  regress the P2-10 `projects=["*"]` under-refusal). Add `relative_import`
+  capture and resolve by counting `import_prefix` dots vs the importer's package.
+- **Ceiling / dependency**: this is the small, targeted slice of the larger
+  "typed identity end-to-end" theme; it does not attempt the full identity
+  refactor, only what these three tools + `find_dependents` need.
+
+## US4 — `symforge_edit` replay-before-concurrency (P2)
+
+- **Source**: `symforge_edit_stel_handler` (`src/protocol/tools.rs`:10040–10159)
+  runs `run_pre_apply_gates` (`src/stel/edit_apply.rs`:71–149, if_match guard
+  ~L130–137, unconditional per test `pre_apply_rejects_if_match_mismatch`) before
+  `begin_mutation_replay` (`src/protocol/idempotency.rs`:439).
+- **Observed run**: `symforge_edit` adjudicated **FAIL** (6 samples); the report
+  attributes 3/3 replay rejection to this ordering.
+- **Approach**: non-reserving read-only replay probe before the gates; return
+  stored result on identical key+request; keep reservation + genuine concurrency
+  semantics.
+- **Refuted sub-claim**: insertion whitespace — `build_insert_before` already
+  emits the blank separator; the single-`\n` case is intentional doc-comment
+  tightening; `insert_symbol` and `batch_insert` already share the layout
+  function. Not in scope.
+
+## US5b — watcher cold-start generation staleness (P1) [ADDED BY REVIEW]
+
+- **Source (verified first-hand 2026-07-12)**: cold-start bootstrap in
+  `src/main.rs` fires `tokio::task::spawn_blocking(|| bg_index.reload(&bg_root))`
+  **fire-and-forget** (not awaited — control returns to
+  `index.published_state()` immediately), which bumps `project_generation`
+  (`src/live_index/store.rs`:800). The watcher is then spawned unconditionally
+  (~`main.rs`:432) and captures `expected_gen` once at
+  `src/watcher/mod.rs`:721. The cheap spawn wins the race vs the ~220 ms reload →
+  captures pre-reload gen → later `freshen_file_if_stale` /
+  `reconcile_stale_files_with_stop` see `GenerationMismatch` → file removed,
+  never re-indexed, no self-heal.
+- **My earlier refutation was WRONG**: I checked only the daemon `reload_with`
+  and stdio `index_folder` paths (which DO restart the watcher) and generalized
+  "every reload path restarts the watcher." The cold-start bootstrap does not.
+  The adversarial review caught this by reading `main.rs` directly. This is a
+  real correctness bug on the common cold-start path, not a P2 counter issue.
+- **Approach**: await the cold-start reload before spawning the watcher, OR
+  re-read the generation per committed reconcile batch, OR subscribe to
+  generation changes. Keep the generation fence intact (it correctly rejects
+  genuine in-flight stale mutations — that half of my analysis held).
+
+## US5a — health reconcile-repair counter (P2)
+
+- **Source**: `reconcile_stale_files_with_stop` (`src/watcher/mod.rs`:505) counts
+  every `true` from `freshen_file_if_stale_at_generation` (:487), which returns
+  `true` for `FreshenResult::GenerationMismatch` (a no-op) as well as real
+  repairs; surfaced by health (`src/protocol/format.rs`:1903–1909, 2055–2079).
+- **Real (the surviving half)**: the counter over-counts `GenerationMismatch`
+  no-ops as repairs. This is genuine and **causally linked to US5b** — the
+  cold-start race is what *produces* most of those no-ops; fixing US5b drains
+  them, and this counter fix is the honest-signal backstop for the residual
+  legitimate-race window.
+- **Approach**: count only `StaleReindexed`/`StaleRemoved`; surface rejected
+  mismatch attempts separately.
+
+## US5c — daemon `status(reset_calibration=true)` silent no-op (P2) [ADDED BY REVIEW]
+
+- **Source (verified via review)**: `status_stel_tool` (`src/protocol/tools.rs`:10256)
+  proxies with `reset_calibration` passed through, overlays proxy-owned lines
+  (:10268), and returns early at :10272 with `OutcomeClass::Found` — never
+  reaching the actual reset in `render_stel_status_body` (:10302–10303). The
+  proxy owns the durable calibration store but never calls its own
+  `reset_calibration()` (`src/protocol/mod.rs`:540–546); the daemon worker it
+  proxies to is storeless. Durable calibration is untouched; the caller is told
+  it succeeded.
+- **Wrongly omitted**: the first draft dropped the `status` FAIL into "economics"
+  without recording it. It is a trust-envelope state defect, the class 019
+  carries. The review restored it as US5c.
+- **Approach**: apply calibration reset to the proxy-owned durable store in the
+  daemon path; honest receipt on the no-store path.
+
+## US6 — `validate_file_syntax` BOM + estimate (P3)
+
+- **Source**: JSON validation uses `serde_json` via the config-extractor path
+  (`src/parsing/mod.rs`:45), **not** tree-sitter (the report's stated root cause
+  is false). `normalize_jsonc` (`src/parsing/config_extractors/json.rs` ~L22)
+  does not strip a leading UTF-8 BOM, so `serde_json` rejects valid BOM JSON at
+  1:1. `estimate` (`src/protocol/read_tools.rs`:402) is never read by the handler
+  (`tools.rs`:7838).
+- **Refuted sub-claim**: trailing-comma acceptance is deliberate JSONC/tsconfig
+  support (`test_jsonc_trailing_commas_now_parse`, `test_tsconfig_jsonc_*`).
+  "Fixing" it would regress shipped behavior. Not a defect.
+- **Approach**: strip leading BOM in `normalize_jsonc`; honor or remove
+  `estimate`. Preserve JSONC tolerance and correct malformed-input rejection.
+
+## Excluded — P0-04 meta (non-bug)
+
+`meta` is a measurement-only A-019 L0 A/B probe (`surface_probe.rs`:244) that
+tied then **lost** to `compact-3` (`docs/research/A-019-l0-surface-choice.md`)
+and is never advertised to users (CLAUDE.md documents only full + compact). The
+surface guard (`tools.rs`:9613–9622) is by-design; the intended probe-relay path
+works. The benchmark graded an experimental measurement surface as if shipping —
+a benchmark artifact. If ever actioned, the only reasonable move is deleting the
+retired variant; it is not a correctness/safety obligation and is not a story.
+
+## Economics themes deferred (real, but not this feature)
+
+The report's strongest *non-correctness* findings — full-surface schema tax
+(17,894 vs 1,163 cl100k), compact-as-default, verbose mutation receipts, CCR
+mandatory-retrieval cost — are real and measured but are **economics**, not
+safety/correctness. They belong to a separate spec so this feature stays a
+tight, verifiable correctness/safety slice. Recorded here so they are not lost.
+
+## Contract-tightening deferred (real, but not a wrong answer)
+
+- **`what_changed` drops git status classes + rename mapping**: `src/git.rs`
+  `uncommitted_paths` collects only the path string and discards `entry.status()`
+  and rename source/dest, so `what_changed` cannot report
+  staged/unstaged/added/deleted/renamed. Verified real, but the *paths returned
+  are correct* — this is missing-information / contract-tightening (the report's
+  own P2-10), not a wrong result. Deferred, recorded here so `what_changed` is
+  not later read as verified-clean.
+
+## Adversarial review corrections (2026-07-12) — before → after
+
+This spec was red-teamed by 4 source-grounded reviewers + a judge *after* the
+first draft. The review found real defects **in the spec**. What changed:
+
+| # | First draft (WRONG) | Corrected |
+|---|---|---|
+| B1 | P0-03 refuted; only a P2 counter fix (US5) | US5b added at **P1** — stdio cold-start watcher goes permanently stale (`main.rs` fire-and-forget reload bumps gen after watcher captures it). My "every reload restarts the watcher" generalization was false for cold start. |
+| B2 | US2 edge fix: "owner-scoped; don't invent an edge if unresolved" | Would drop the green `compute_impact_reaches_across_qualified_module_call` edge (`SymbolRecord` has no owner). Added explicit **bare-name fallback** when the callee has no resolvable owner. |
+| B3 | US1: name-only matches non-writable "by default" / key on resolved identity | Would regress `batch_rename_updates_definition_and_callers` (bare refs never have identity). Re-keyed on **index-wide name ambiguity** (1 def → write; 2+ → demote). |
+| M1 | daemon `status(reset_calibration)` no-op dropped into "economics" | Restored as **US5c** (P2) — real trust-envelope state defect. |
+| M2 | SC-002 = leaf edit → 1 changed + 1 hop-1 | Fixture names are globally unique → passes with seed fix alone, blind to the edge fix. SC-002 now requires **both** the leaf case AND a two-same-name case. |
+| M3 | FR-004 asserts no duplicate-`main` collapse | SFBENCH fixture has **no `main`** → clause untestable on it. Now requires a `main`-bearing fixture or explicit untested-on-fixture marking. |
+| M4 | US2 seed = "compare body hashes" (implied small) | Net-new machinery: needs **base-ref reparse** (reuse `diff_symbols` git-blob parse); `SymbolRecord` has only file-level `content_hash`. Sized accordingly; "smaller/faster" claim to be re-validated. |
+
+**Held up under attack (do NOT re-litigate)**: P0-04 meta exclusion (non-shipping
+probe), P1-05 JSON trailing-comma downgrade (deliberate JSONC, shipped tests),
+US4 insertion-whitespace refutation (layout already shared, single-`\n`
+intentional), US3 daemon-path safety (proxy short-circuits before local refusal).
+The core scope and the three exclusions survived; the fixes and one downgrade did
+not, which is exactly what the review was for.

--- a/specs/019-sfbench-surface-correctness/research.md
+++ b/specs/019-sfbench-surface-correctness/research.md
@@ -58,6 +58,40 @@ reconstructed independently. P0-04 failed all three (non-bug) and is excluded.
   The type-scoped reasoning only held for the struct-rename honeytrap (`Target`
   has 1 def). This is why the rule was wrong: it generalized from the honeytrap.
 
+## US1b/US2b — qualifier→owner recall recovery (SUPERIOR fix, research-verified 2026-07-12)
+
+The initial US1/US2 fixes are SOUND but lose recall: an ambiguous name demotes
+(batch_rename) or drops (detect_impact edges) ALL name-only matches, including
+legitimate `Target::method` sites. A tech-researcher investigation (STAY AND FIX,
+high confidence, source-grounded) proved the recall is **recoverable at Tier-0
+with existing machinery** — refuting the spec's earlier "SymbolRecord has no
+owner → must fall back to bare name" assumption:
+
+- `ReferenceRecord.qualified_name: Option<String>` (`src/domain/index.rs`:496)
+  ALREADY retains the qualifier (`Target::new` keeps `Target`; `a::call_a` keeps
+  `a`), built at `src/parsing/xref.rs`:1462-1493.
+- The definition's owner = innermost enclosing `Impl` symbol, found via the
+  EXISTING `find_enclosing_symbol` (`index.rs`:549) + impl-name parse
+  (`src/parsing/languages/rust.rs`:159-191).
+- The write range is already LEAF-only (`xref.rs`:1489), so rewriting
+  `Target::new` never touches the qualifier — recovery is surgical.
+
+**Rule 1 (qualifier→owner match), gated by a uniqueness guard**: keep a
+reference/edge when its immediate qualifier == the resolved target's owner name,
+BUT only if no OTHER ambiguous def shares that owner name (twin `impl Target` in
+two files → qualifier does not disambiguate → MUST demote/drop). Reuse
+`resolve_ambiguous_callee`'s existing "matched more than one → None" drop guard
+(`graph.rs`:322-325). Bare unqualified calls stay demoted/dropped (the sound
+ceiling — defer to the semantic tier). **The twin-owner uniqueness guard is the
+single soundness-critical test.**
+
+**Verdict**: reject `github/stack-graphs` (archived read-only 2025-09-09;
+20 grammars = 20 DSL rule-sets; violates the dependency-freshness invariant).
+Targeted qualifier-match wins on recall-per-soundness-risk. Enable Rust first,
+extend per-grammar with a fixture each. This UPGRADES US1/US2 from
+sound-but-low-recall to sound-AND-high-recall — a proper fix, not a heuristic
+ceiling. Reversible (additive, guard-gated; the fallback IS the shipped behavior).
+
 ## US2 — `detect_impact` confidently wrong (P0)
 
 - **Source**: seed loop (`src/protocol/tools.rs` ~L7463–7476) pushes every

--- a/specs/019-sfbench-surface-correctness/research.md
+++ b/specs/019-sfbench-surface-correctness/research.md
@@ -46,6 +46,17 @@ reconstructed independently. P0-04 failed all three (non-bug) and is excluded.
   alone, so the *safe* default for name-only matches is uncertain/non-writable,
   not "guess and write". This is the correct fail-closed ceiling, not a
   limitation to be engineered away in this feature.
+- **Implementation correction (found during Item 1 RED, 2026-07-12)**: the spec
+  originally said demote only the bare `ref_sites` and keep `qualified_confident`
+  writable "because it's type-scoped". That is FALSE for a *method* rename:
+  `find_qualified_usages("new")` (qualified_usages.rs:164-169) matches any `new`
+  adjacent to `::`, so `SomeOther::new` lands in `qualified_confident` too
+  (empirically dumped: byte (56,59) in BOTH sets). Correct rule (Option 1): when
+  `input.name` is index-ambiguous (2+ defs), demote **both** `ref_sites` AND
+  `qualified_confident` to uncertain/surfaced-only; keep only the definition site
+  confident. Both green regression tests are unique names (1 def) → unaffected.
+  The type-scoped reasoning only held for the struct-rename honeytrap (`Target`
+  has 1 def). This is why the rule was wrong: it generalized from the honeytrap.
 
 ## US2 — `detect_impact` confidently wrong (P0)
 

--- a/specs/019-sfbench-surface-correctness/spec.md
+++ b/specs/019-sfbench-surface-correctness/spec.md
@@ -1,0 +1,536 @@
+# Feature Specification: SFBENCH Surface Correctness & Safety
+
+**Feature Branch**: `019-sfbench-surface-correctness`
+
+**Created**: 2026-07-12
+
+**Status**: Draft
+
+**Input**: The SFBENCH-1.0 full-surface benchmark of `symforge 8.14.0`
+(`docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-report.md`)
+alleged four P0 and several P1 defects. Every finding was **independently
+re-verified against current source** by a 7-agent skeptical review
+(2026-07-12); the benchmark's severities were **not** taken at face value. This
+spec carries only the findings that survived verification, at their *verified*
+severity, and explicitly records what the report got wrong so settled work is
+not re-opened.
+
+> [!IMPORTANT]
+> Spec 018 (dogfood surface hardening) is already merged. 018 made
+> `detect_impact` / `what_changed` **default to source-focused** so *data files*
+> don't dominate the blast radius. US2 here is a **different, deeper** layer:
+> even with only source symbols, `detect_impact` over-approximates because it
+> seeds *every* symbol of a changed file and links call edges by *bare name*
+> across the whole repo. 018 removed data-file noise; 019 fixes symbol-identity
+> coarseness. Do not revert or duplicate 018's `code_only` defaulting.
+
+## Verification summary (what is in scope and why)
+
+> [!IMPORTANT]
+> **This spec was adversarially reviewed against source (2026-07-12) and the
+> review found real defects IN THIS SPEC — it is the amended (post-review)
+> version.** The severities and stories below reflect the amendments. See
+> `research.md` § "Adversarial review corrections" for the full before/after.
+> The load-bearing change: **P0-03 was wrongly refuted** — the *stdio cold-start*
+> path IS a real permanent-staleness bug (US5b, P1), separate from the counter
+> over-count (US5a, P2). And a new state defect (daemon `reset_calibration`
+> no-op, US5c) surfaced. US1/US2 fix rules were corrected to not regress green
+> tests; US2 oracle was strengthened.
+
+| Report ID | Report sev | Verified verdict | Verified sev | Story |
+|---|---|---|---|---|
+| P0-01 `batch_rename` unsafe multi-file write | P0 | **CONFIRMED** | **P0** | US1 |
+| P0-02 `detect_impact` confidently wrong | P0 | **CONFIRMED** | **P0** | US2 |
+| P1-04 selector refusal + Python relative-import drop | P1 | **CONFIRMED** | **P1** | US3 |
+| P1-06a `symforge_edit` same-key replay rejected by stale `if_match` | P1 | **CONFIRMED** | **P2** | US4 |
+| P0-03b watcher cold-start permanent staleness | P0 | **CONFIRMED (review)** — refutation was wrong for stdio cold-start | **P1** | US5b |
+| P0-03a watcher "reconcile repairs" over-counts no-ops | P0 | **CONFIRMED** | **P2** | US5a |
+| P1-07 daemon `status(reset_calibration=true)` silent no-op | P1 | **CONFIRMED (review)** — was wrongly omitted | **P2** | US5c |
+| P1-05 `validate_file_syntax` rejects valid BOM JSON; inert `estimate` | P1 | PLAUSIBLE (root cause refuted; BOM real) | **P3** | US6 |
+
+**Out of scope — verified NOT a product bug:**
+
+- **P0-04 (meta surface advertises one unrunnable tool)** — `meta` is a
+  *measurement-only* A-019 L0 A/B probe that already tied then **lost** the
+  selection to `compact-3` and is never advertised to users. The guard is
+  by-design; the intended probe-relay path works. No fix. (If desired later,
+  the only reasonable action is deleting the retired variant — tracked as a
+  cleanup note in `research.md`, not a story here.)
+
+**Corrections folded into the stories (report was partly wrong):**
+
+- P0-02 conflated `detect_impact` (the real explosion: seed + bare-name edges)
+  with `analyze_file_impact` (a separate, *partially guarded* tool). US2 fixes
+  the former and only tightens the latter's residual name-only lookup.
+- P1-05's stated root cause ("JSON uses permissive tree-sitter") is **false** —
+  JSON already uses `serde_json`. Trailing-comma tolerance is **deliberate
+  JSONC/tsconfig support** with dedicated tests and MUST NOT be "fixed". Only
+  the BOM-rejection and the inert `estimate` flag are real. US6 is scoped to
+  exactly those.
+- P1-06's insertion-whitespace sub-claim is **refuted** (layout is already
+  shared; single-`\n` before doc-commented items is intentional). US4 carries
+  only the replay-ordering half.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — `batch_rename` never writes code it cannot prove is the target (Priority: P0 — SAFETY, MVP)
+
+An agent renames a method on a real polyglot repo. Today, `batch_rename` with a
+**common name** (e.g. Python `run`) scoped to one file resolves the target only
+to locate the *definition*, then collects references by **bare name across the
+whole index** and writes **every** match — including unrelated same-named
+definitions in other packages/files — because `dry_run` defaults to `false` and
+`code_only` filters only by *language class*, not by symbol identity. The result
+is falsely labeled a "constrained" rename. This is a source-write escape.
+
+**Why this priority**: A tool that silently rewrites unrelated source on a
+common name is the single most dangerous behavior on the surface — it corrupts
+code the user never named. It is a fail-closed safety obligation (Constitution:
+Determinism & Recovery; Trust Envelopes) and outranks every economics or
+correctness item.
+
+**Independent Test**: On a fixture with two unrelated definitions sharing a name
+(`Target::run` in file A, an unrelated `Widget::run` / Flask handler `run` in
+file B), call `batch_rename(name="run", path="A", ...)` at apply. Confirm **zero
+bytes change in file B** and that file B's references are reported as *uncertain
+/ not written*, not silently rewritten. Fully testable on its own.
+
+> [!IMPORTANT]
+> **Writability is keyed on index-wide name AMBIGUITY, not on "has resolved
+> identity"** (adversarial-review correction B3). Tier-0 bare-name references
+> *never* carry resolved identity, so keying on identity would demote every
+> rename and regress the green tests `batch_rename_updates_definition_and_callers`
+> and `batch_rename_bumps_definition_and_call_site` (which require the bare
+> `old_name()` call site to be rewritten and labeled "constrained"). The rule:
+> **a name with exactly ONE definition in the index → all bare-name refs stay
+> writable and "constrained" (unchanged behavior); a name with 2+ definitions →
+> name-only refs are demoted to uncertain / non-writable and the trust label
+> reflects that.**
+
+**Acceptance Scenarios**:
+
+1. **Given** two unrelated same-named symbols in different files (name is
+   index-ambiguous), **When** `batch_rename` targets one by path, **Then** only
+   references bound to the target are written; unrelated same-name sites are left
+   untouched and surfaced as uncertain.
+2. **Given** an index-ambiguous name where exact binding of a given reference is
+   unavailable (dynamic language, name-only match), **When** apply runs, **Then**
+   that reference is **not written** and is reported as uncertain — never
+   silently rewritten. If NO reference can be safely bound, the tool fails closed
+   (aborts before staging any write).
+3. **Given** a genuinely unambiguous, single-definition symbol (name has exactly
+   one definition in the index), **When** `batch_rename` runs, **Then** its
+   existing behavior, full reference set, writes, and "constrained" label are
+   **unchanged** (the fix removes unsafe writes on ambiguous names, not safe ones
+   on unique names — the two green regression tests must still pass).
+4. **Given** any rename result, **When** the trust envelope is emitted, **Then**
+   the match label reflects the *actual* binding confidence — "constrained" only
+   when the name is unambiguous or the ref is identity-bound; never "constrained"
+   over name-only matches of an ambiguous name.
+
+---
+
+### User Story 2 — `detect_impact` reports the symbols that actually changed and the calls that actually reach them (Priority: P0 — CORRECTNESS)
+
+An agent asks "what does this change affect?" after a one-line edit to a leaf
+function. Today `detect_impact` seeds **every symbol in every changed file** as
+"changed" (a 1-line edit in a 20-symbol file reports 20 changed symbols), and
+the impact graph links each call to **every same-bare-name definition in the
+repo**, so unrelated functions and duplicate `main` nodes flood the blast
+radius. The output is confidently wrong and far larger than a competent
+`git diff` + reference walk.
+
+**Why this priority**: `detect_impact` is a core "what breaks" tool; a wrong,
+inflated answer trains agents to distrust the surface and costs tokens. The
+project's own contract already recorded a 291K-symbol / 54MB "explosion" from
+this path and only band-aided it with truncation — the root cause is still live.
+
+**Independent Test**: On the controlled fixture graph
+(`sfbench_entry → sfbench_mid → sfbench_leaf`), edit only `sfbench_leaf`'s body
+and call `detect_impact`. Assert exactly **one** changed symbol (`sfbench_leaf`)
+and a hop-1 blast of exactly `{sfbench_mid}`.
+
+> [!IMPORTANT]
+> **The leaf-edit-on-the-unique-name fixture is NOT sufficient on its own**
+> (adversarial-review corrections M2/M3). Because `sfbench_leaf`/`sfbench_mid`
+> are globally unique names, that test passes whether or not the *edge* fix (b)
+> ships — it only exercises the *seed* fix (a). The gating test MUST ALSO include
+> the two-same-name case (Scenario 3) and, for the entry-point clause (FR-004),
+> a fixture that actually contains a reachable duplicate `main` (the current
+> SFBENCH fixture has **no** `main` function, so it cannot trigger the
+> entry-point collapse). Add a `main`-bearing, multi-owner element to the US2
+> fixture, or explicitly mark the entry-point clause untested-on-fixture — do not
+> self-certify FR-004 from a fixture that structurally cannot exercise it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a body-only edit to one function in a multi-symbol file, **When**
+   `detect_impact` runs, **Then** only that function is a changed (hop-0) symbol
+   — sibling symbols in the same file are not reported as changed.
+2. **Given** a comment-only / whitespace shift, **When** `detect_impact` runs,
+   **Then** it yields **zero** changed symbols.
+3. **Given** two unrelated definitions named `run`, **When** the blast radius is
+   computed from a change to one, **Then** the other never enters the blast set,
+   and every blast node carries disambiguating identity (path/kind), not a bare
+   name — no indistinguishable duplicate nodes.
+4. **Given** an added file and a deleted file, **When** `detect_impact` runs,
+   **Then** added/removed symbols are classified correctly and the blast set is
+   seeded only from genuinely added/modified/removed symbols.
+5. **Given** the separate `analyze_file_impact` path, **When** a same-file caller
+   exists, **Then** it is included and typed as a call (residual name-only
+   lookup tightened), preserving 018's existing parent-type narrowing.
+
+---
+
+### User Story 3 — Local project selectors work, and Python relative imports are resolved (Priority: P1 — CORRECTNESS)
+
+An agent working in a bound project passes a **matching** `project` selector to
+`search_symbols` / `search_text` / `find_references`. Today those three tools
+refuse **any** selector (they call the wrong refusal guard), while sibling tools
+accept a matching-local selector — an inconsistent, surprising failure.
+Separately, Python `from .protocol import x` (relative import) is dropped by the
+xref query, so `find_dependents` misses the real importer and a same-stem
+fallback can invent a false consumer.
+
+**Why this priority**: Selector inconsistency and false/missing dependents
+undermine navigation trust across the most-used read tools, and the import gap
+feeds P0-02's identity problem. Lower frequency and blast radius than the P0
+safety/correctness items, so P1.
+
+**Independent Test (selector)**: In a single bound project, call each of the
+three tools with a `project` selector equal to the bound project's name/key/root
+and confirm the call **succeeds** (same result as no selector), while a *foreign*
+selector is still refused with a typed invalid-request. **Independent Test
+(import)**: index a Python package where `pkg/a.py` does `from .b import f`;
+confirm `find_dependents` on `pkg/b.py` includes `pkg/a.py` and does **not**
+include an unrelated same-stem module.
+
+**Acceptance Scenarios**:
+
+1. **Given** a selector matching the bound project (name, key, or root), **When**
+   `search_symbols` / `search_text` / `find_references` run, **Then** the call
+   proceeds and returns the same result as the no-selector call.
+2. **Given** a foreign or non-matching selector, **When** those tools run,
+   **Then** they refuse with a typed invalid-request (foreign, not blanket).
+3. **Given** both singular `project` and plural `projects` (incl. `"*"`), **When**
+   any selector-bearing tool runs, **Then** matching-local proceeds and
+   foreign/over-broad is refused consistently across both parameters and both
+   directions (no regression of the P2-10 `projects=["*"]` under-refusal).
+4. **Given** a Python relative import `from .mod import x` (and `..mod`), **When**
+   `find_dependents` runs on the imported module, **Then** the importing file is
+   reported, resolved by counting the relative prefix against the importer's
+   package — and a same-stem unrelated module is not.
+
+---
+
+### User Story 4 — `symforge_edit` idempotent replay returns the stored result instead of failing on a now-stale `if_match` (Priority: P2 — CORRECTNESS)
+
+An agent re-sends an identical `symforge_edit` apply (same idempotency key, same
+request, including the original `if_match`) — the intended idempotent retry.
+Today the pre-apply concurrency gate validates `if_match` **before** the replay
+lookup, and after the first successful apply the body has changed, so the stale
+`if_match` no longer matches and the replay is rejected (observed 3/3). A replay
+carrying only the idempotency key (no `if_match`) already works.
+
+**Why this priority**: Correct idempotent-retry semantics matter for reliable
+apply-with-retry, but the caller has a working path (key-only replay) and no
+data is corrupted, so P2 rather than P0/P1.
+
+**Independent Test**: Apply an edit with `{idempotency_key, if_match}`; re-send
+the identical request. Assert the second call returns the **stored** result and
+writes **zero** bytes. Then send the same key with a *changed* request and assert
+it conflicts; and a new key with a stale `if_match` still fails concurrency.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed apply, **When** the identical `{key, request, if_match}`
+   is replayed, **Then** the stored result is returned and no bytes are written.
+2. **Given** the same key but a changed request/hash, **When** replayed, **Then**
+   it is rejected as an idempotency conflict.
+3. **Given** a new key whose `if_match` does not match current state, **When**
+   applied, **Then** it fails the concurrency guard (fix must not weaken genuine
+   optimistic-concurrency protection).
+
+---
+
+### User Story 5b — Watcher does not go permanently stale after cold-start indexing (Priority: P1 — CORRECTNESS)
+
+> [!CAUTION]
+> **This story exists because the adversarial review (2026-07-12) refuted my
+> own earlier refutation.** I originally claimed "every reload path restarts the
+> watcher, so permanent staleness does not exist" and downgraded P0-03 to a
+> counter-only P2. That is **false for the stdio cold-start path**, verified in
+> source below. This is a real correctness bug on the *common* cold-start case.
+
+On a cold start with no persisted snapshot, `src/main.rs` fires
+`bg_index.reload(&bg_root)` **fire-and-forget** on a blocking thread (not
+awaited) — which bumps the project generation — and then, without synchronizing,
+spawns the file watcher, which captures `expected_gen` **once**. The cheap
+watcher spawn almost always wins the race against the ~220 ms full-tree reload,
+so it captures the *pre-reload* generation. Every later watcher/reconcile
+operation then sees `current_project_generation() != expected_gen` →
+`GenerationMismatch` → the tracked file is **removed and never re-indexed**.
+Because the reconcile loop is pinned to the same stale generation, it cannot
+self-heal. The daemon `reload_with` and stdio `index_folder` paths *do* restart
+the watcher (which is why they are fine); the cold-start bootstrap does not.
+
+**Why this priority**: A watcher that silently stops indexing edits on a
+freshly-started cold repo is a correctness failure of the core promise (the
+index tracks the working tree). It is common (cold start is the default
+first-run path), but it is recoverable by restart and does not corrupt data, so
+P1 rather than P0.
+
+**Independent Test**: Cold-start a snapshot-less repo (force the fire-and-forget
+reload to bump the generation before the watcher captures it — e.g. deterministic
+ordering hook or a seam that lets the test observe the captured vs current
+generation). Modify a tracked source file. Assert the change is **indexed**
+(reconcile repairs it) rather than `GenerationMismatch`-removed, and that
+`current_project_generation() == expected_gen` holds for the running watcher.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cold start whose background reload bumps the generation after the
+   watcher spawns, **When** a tracked file is modified, **Then** the edit is
+   indexed (not permanently rejected as a generation mismatch).
+2. **Given** the fix, **When** the daemon `reload_with` / `index_folder` restart
+   paths run, **Then** their existing correct behavior is unchanged.
+3. **Given** a genuine in-flight stale mutation (a real concurrency race), **When**
+   it is applied, **Then** it is still correctly fenced/rejected — the fix
+   re-syncs the cold-start generation, it does not remove the generation guard.
+
+**Fix direction** (choose one, decide in `plan.md`/`research.md`): await the
+cold-start reload before spawning the watcher (reorder in `main.rs`), OR have
+`run_watcher_with_stop` re-read `current_project_generation()` per committed
+reconcile/watcher batch instead of capturing once, OR subscribe the watcher to
+generation changes.
+
+---
+
+### User Story 5a — Health "reconcile repairs" counts real repairs, not generation-mismatch no-ops (Priority: P2 — OBSERVABILITY)
+
+An operator reads `health` after an index reload and sees a "reconcile repairs"
+count that includes files where reconciliation actually **did nothing** (a
+generation mismatch was correctly rejected, repairing zero bytes). The number
+overstates repair activity during any restart/reset window.
+
+> [!NOTE]
+> This is the *narrow, real* half of the benchmark's P0-03 that survived
+> verification (the counter over-counts). It is **causally linked to US5b**: the
+> flood of `GenerationMismatch` no-ops that inflate this counter is largely
+> *produced by* the cold-start staleness race — fixing US5b drains most of them.
+> Fix both; do not treat this counter fix as the whole of P0-03.
+
+**Why this priority**: Honest health signals matter (Trust Envelopes /
+Observability), but this is a reporting overcount, not lost correctness — P2.
+
+**Independent Test**: Force a reconcile pass over files whose freshen result is
+`GenerationMismatch` (no actual reindex/remove) and assert the reported repair
+count is **zero** for those, while genuine `StaleReindexed`/`StaleRemoved` files
+still count. Rejected attempts are surfaced separately, not as repairs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reconcile pass over generation-mismatched files, **When** `health`
+   reports repairs, **Then** those no-op files contribute **zero** to the repair
+   count.
+2. **Given** genuinely stale files that are reindexed/removed, **When** `health`
+   reports, **Then** they are counted as repairs as before.
+3. **Given** rejected (mismatch) attempts, **When** `health` reports, **Then**
+   they are surfaced as a distinct, honestly-labeled figure (or omitted), never
+   folded into "repairs".
+
+---
+
+### User Story 5c — Daemon `status(reset_calibration=true)` actually resets durable calibration (Priority: P2 — CORRECTNESS/TRUST)
+
+> [!CAUTION]
+> **Added by the adversarial review** — this was a `status` FAIL the first draft
+> wrongly dropped into the deferred "economics" bucket. It is a trust-envelope
+> state defect, exactly the class 019 carries.
+
+In the default daemon-proxy topology, `status(reset_calibration=true)` returns a
+success-shaped response (`OutcomeClass::Found`) but **resets nothing**:
+`status_stel_tool` proxies to the storeless daemon worker and returns early after
+overlaying proxy-owned status lines, before ever reaching the actual reset logic
+in `render_stel_status_body`. The proxy owns the durable calibration store but
+never calls its own `reset_calibration()`; the worker it proxies to has no store.
+So durable calibration is left byte-identical while the caller is told it
+succeeded.
+
+**Why this priority**: A documented operator action that silently no-ops while
+reporting success is a real correctness/honesty defect, but it affects an
+infrequent maintenance operation and corrupts no data — P2.
+
+**Independent Test**: In daemon mode with durable calibration samples present,
+call `status(reset_calibration=true)`; assert the durable samples/constants are
+cleared to `deferred` afterward, and that an equivalent local (non-daemon) reset
+behaves identically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a daemon with durable calibration state, **When**
+   `status(reset_calibration=true)` runs, **Then** the proxy-owned durable store
+   is reset to `deferred` and the response honestly reports the reset.
+2. **Given** the no-store worker path, **When** reset is requested, **Then** the
+   response does not falsely claim success on state it cannot touch (honest
+   receipt).
+3. **Given** the local (non-daemon) path, **When** reset runs, **Then** its
+   existing correct clearing behavior is unchanged.
+
+---
+
+### User Story 6 — `validate_file_syntax` accepts valid BOM-prefixed JSON and honors (or drops) `estimate` (Priority: P3 — CORRECTNESS)
+
+A caller validates a JSON file saved with a UTF-8 BOM (valid per RFC 8259).
+Today `validate_file_syntax` rejects it at line 1 col 1 because `normalize_jsonc`
+does not strip a leading BOM before `serde_json`. Separately, the `estimate`
+input flag is defined but never read by the handler.
+
+> [!NOTE]
+> The benchmark also claimed trailing-comma JSON is wrongly accepted. That is
+> **deliberate JSONC/tsconfig support** (dedicated tests
+> `test_jsonc_trailing_commas_now_parse`, `test_tsconfig_jsonc_*`). It is **not**
+> a defect and MUST NOT be "fixed" — doing so regresses shipped behavior. This
+> story is scoped to BOM handling and the inert `estimate` flag only.
+
+**Why this priority**: BOM-prefixed JSON is uncommon and the tool already returns
+an honest failure (not a crash), so low impact — P3. Bundled because both are
+tiny, same-tool, low-risk fixes.
+
+**Independent Test**: Validate a byte-identical valid JSON file with and without a
+leading UTF-8 BOM; assert both report `ok` with identical byte/span accounting.
+Validate a genuinely malformed JSON and assert it still fails at the oracle
+location. Confirm `estimate=true` either returns a tagged estimate within
+tolerance or the flag is removed from the schema.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid JSON with a leading UTF-8 BOM, **When** validated, **Then** it
+   reports `ok`, matching the same file without a BOM.
+2. **Given** genuinely malformed JSON (not JSONC), **When** validated, **Then** it
+   still reports failure at the correct location (no regression).
+3. **Given** shipped JSONC (trailing commas / comments), **When** validated,
+   **Then** it still reports `ok` (018/existing behavior preserved).
+4. **Given** `estimate=true`, **When** validated, **Then** the response is a
+   tagged estimate within declared tolerance, or `estimate` is removed from the
+   input contract (no silent inert flag).
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `batch_rename` writability MUST be keyed on **index-wide name
+  ambiguity**: a name with exactly one definition keeps its current writable +
+  "constrained" behavior; a name with 2+ definitions demotes name-only /
+  dynamic / textual matches to uncertain / non-writable. If NO reference of an
+  ambiguous name can be safely bound, it MUST fail closed (no staged write). It
+  MUST NOT regress `batch_rename_updates_definition_and_callers` /
+  `batch_rename_bumps_definition_and_call_site`. (US1)
+- **FR-002**: `batch_rename` trust labels MUST reflect actual binding confidence;
+  a "constrained" label MUST NOT be applied to name-only matches of an
+  index-ambiguous name. (US1)
+- **FR-003**: `detect_impact` MUST seed the changed-symbol set only from
+  genuinely added/modified/removed symbols (body-level delta), not from every
+  symbol of a changed file. This requires a **base-ref symbol source** (reuse
+  `diff_symbols`' git-blob reparse) since the live index holds only current
+  bodies — it is net-new machinery, not a seed tweak. (US2)
+- **FR-004**: `detect_impact` blast nodes MUST carry disambiguating identity
+  (path/kind) and MUST NOT link a call to unrelated same-bare-name definitions,
+  **while preserving the existing cross-module edge** asserted by
+  `compute_impact_reaches_across_qualified_module_call` — i.e. keep a bare-name
+  fallback when the callee definition carries no resolvable owner. Entry-point
+  tagging MUST NOT collapse distinct `main` symbols (tested only against a
+  fixture that actually contains a reachable duplicate `main`). (US2)
+- **FR-005**: `analyze_file_impact` MUST include same-file callers and resolve
+  callers with typed (not bare-name) identity, preserving 018's parent-type
+  narrowing. (US2)
+- **FR-006**: `search_symbols`, `search_text`, `find_references` MUST accept a
+  selector matching the bound project and refuse only foreign/over-broad
+  selectors, consistently for both `project` and `projects` (no regression of
+  the P2-10 `projects=["*"]` under-refusal). (US3)
+- **FR-007**: Python relative imports (`from .x import`, `from ..x import`) MUST
+  be captured and resolved against the importer's package for
+  `find_dependents`. (US3)
+- **FR-008**: An identical idempotent `symforge_edit` replay MUST return the
+  stored result without writing bytes, without being rejected by a now-stale
+  `if_match`; genuine concurrency/conflict protection MUST remain. (US4)
+- **FR-009a**: The watcher MUST NOT go permanently stale after cold-start
+  indexing — its generation MUST be re-synced with (or captured after) the
+  fire-and-forget cold-start reload, so tracked edits are indexed, not
+  `GenerationMismatch`-removed. The generation fence for genuine concurrency
+  races MUST remain. (US5b)
+- **FR-009b**: Health repair counts MUST count only successful reindex/remove and
+  MUST NOT count generation-mismatch no-ops as repairs. (US5a)
+- **FR-009c**: Daemon `status(reset_calibration=true)` MUST reset the
+  proxy-owned durable calibration store (not silently no-op while reporting
+  success). (US5c)
+- **FR-010**: `validate_file_syntax` MUST accept valid UTF-8-BOM JSON and MUST
+  either honor or remove the `estimate` flag, while preserving JSONC tolerance
+  and correct rejection of genuinely malformed input. (US6)
+
+### Key Entities
+
+- **Resolved symbol identity** — the (project, path, language, kind, qualified
+  owner, name, duplicate-ordinal) tuple that distinguishes one definition from a
+  same-named other. Central to US1, US2, US3; today the graph `SymbolId` carries
+  only `{path, name, kind}`.
+- **Changed-symbol delta** — the body-level added/modified/removed set that must
+  replace "all symbols of a changed file" as the impact seed. (US2)
+- **Binding confidence** — identity-constrained vs name-derived-uncertain;
+  gates both what `batch_rename` writes and what trust label it emits. (US1)
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `batch_rename` on a name with **2+ unrelated owners** writes zero
+  unrelated bytes and labels the unbound sites uncertain, in every supported
+  language fixture (Rust, Python, TS, one of Go/Java/C++), with the **Python arm
+  mandatory-gating** (that is where the escape was measured). A **unique**-name
+  rename still writes and labels "constrained" as before (green regression tests
+  pass). The struct-rename honeytrap shape (renaming a unique struct and
+  asserting an untouched-by-construction method) is explicitly forbidden as the
+  oracle. (US1)
+- **SC-002**: `detect_impact` satisfies BOTH: (1) the leaf edit returns exactly
+  one changed symbol and one hop-1 caller and a comment-only shift returns zero
+  (seed fix); AND (2) on a **two-unrelated-same-name** case, changing one leaves
+  the other out of the blast and every blast node carries path/kind (edge fix).
+  A green result on (1) alone does NOT satisfy SC-002. (US2)
+- **SC-003**: A matching-local selector succeeds and a foreign selector is
+  refused across all three tools and both selector parameters; the Python
+  relative-import dependent is found and a same-stem module is excluded. (US3)
+- **SC-004**: Identical idempotent `symforge_edit` replay returns the stored
+  result with zero writes; changed-request conflict and new-key concurrency still
+  fire. (US4)
+- **SC-005a**: After cold start, a tracked edit is indexed (not
+  `GenerationMismatch`-removed). (US5b)
+- **SC-005b**: Reconcile generation-mismatch no-ops contribute zero to the health
+  repair count. (US5a)
+- **SC-005c**: Daemon `status(reset_calibration=true)` clears durable calibration
+  to `deferred`. (US5c)
+- **SC-006**: Valid BOM JSON validates `ok`; JSONC still `ok`; malformed still
+  fails. (US6)
+- **SC-007**: The full gate (`fmt --check`, `check`, `clippy -D warnings`, full
+  test suite `--test-threads=1`, release build, npm tests) is green, plus the
+  embed no-default-features check, with a fail-first regression test for every
+  story, AND every named must-not-regress test still green
+  (`batch_rename_updates_definition_and_callers`,
+  `batch_rename_bumps_definition_and_call_site`,
+  `compute_impact_reaches_across_qualified_module_call`, the risk-tier tests,
+  the JSONC tests). (all)
+
+## Scope boundaries
+
+- **In scope**: US1, US2, US3, US4, US5b, US5a, US5c, US6 (verified real defects,
+  including the two added by adversarial review), at verified severity.
+- **Out of scope**: P0-04 meta (verified non-bug); the report's refuted claims
+  (JSON tree-sitter root cause, insertion whitespace — the "permanent watcher
+  staleness" claim is now IN scope as US5b after the review corrected my
+  refutation); the full "typed identity end-to-end" refactor beyond what US1–US3
+  need; economics/schema-tax work (surface-tax, compact-default, receipt
+  compaction) and the pure contract-tightening `what_changed` status/rename gap
+  (paths returned are correct) — real report themes but not correctness/safety,
+  deferred to a separate spec and recorded in `research.md` so they are not read
+  as verified-clean.

--- a/specs/019-sfbench-surface-correctness/spec.md
+++ b/specs/019-sfbench-surface-correctness/spec.md
@@ -4,7 +4,10 @@
 
 **Created**: 2026-07-12
 
-**Status**: Draft
+**Status**: Implemented (2026-07-12) — all 8 stories landed on branch
+`019-sfbench-surface-correctness`, each RED-first + full-gate-green; the two P0s
+additionally upgraded with a research-verified qualifier→owner recall recovery.
+Pending final integrated branch gate + PR.
 
 **Input**: The SFBENCH-1.0 full-surface benchmark of `symforge 8.14.0`
 (`docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-report.md`)

--- a/src/idempotency.rs
+++ b/src/idempotency.rs
@@ -456,6 +456,40 @@ pub fn begin_tool_replay(
     }
 }
 
+/// NON-RESERVING, read-only replay probe for a tool request.
+///
+/// Unlike [`begin_tool_replay`], this NEVER reserves a record and NEVER mutates
+/// store state. It answers a single question: "does an identical
+/// key+request already have a stored result?"
+///
+/// - `Ok(Some(response))` — an existing record for this key whose request hash
+///   matches; returns the replay response text. The caller may short-circuit
+///   and return it without writing any bytes.
+/// - `Ok(None)` — no record exists for this key. The caller must fall through
+///   to its normal execution path (which reserves via `begin_tool_replay`).
+/// - `Err(Conflict)` — a record exists for this key but the incoming request
+///   hash differs; the caller must surface the conflict, NOT replay.
+///
+/// This is the read-only sibling of `check_or_reserve`'s `FirstExecution`-vs
+/// `Replay` decision: it observes the `Replay`/`Conflict` outcomes without ever
+/// consuming a reservation, so a later `begin_tool_replay` on the miss path
+/// still sees a clean slate.
+pub fn probe_tool_replay(
+    store_root: &Path,
+    tool_name: &str,
+    raw_key: &str,
+    request: &Value,
+) -> Result<Option<String>, IdempotencyError> {
+    let key = IdempotencyKey::new(raw_key)?;
+    let request_hash = RequestHash::for_tool_request(tool_name, request)?;
+    let store = FileReplayStore::open(store_root)?;
+
+    match store.replay_if_present(&key, &request_hash)? {
+        Some(record) => Ok(Some(replay_response(&record))),
+        None => Ok(None),
+    }
+}
+
 fn same_normalized_path(left: &Path, right: &Path) -> bool {
     normalized_path_string(left) == normalized_path_string(right)
 }

--- a/src/live_index/disambiguation.rs
+++ b/src/live_index/disambiguation.rs
@@ -260,6 +260,48 @@ fn base_type_token(ty: &str) -> &str {
     ty.rsplit("::").next().unwrap_or(ty).trim()
 }
 
+/// Owner type name of the innermost `impl` block enclosing the symbol that
+/// starts at `def_start_line`, or `None` when no enclosing `impl` exists.
+///
+/// A method definition lives inside its `impl X` / `impl Trait for X` block; the
+/// index stores that block as a `SymbolKind::Impl` symbol whose `line_range`
+/// encloses the method's. We pick the INNERMOST such impl (latest start line,
+/// same "innermost" rule as [`crate::domain::find_enclosing_symbol`]) and parse
+/// its target-type token via [`container_target_type`] (`impl X` and
+/// `impl Trait for X` both → `X`). This is the shared owner-name primitive for
+/// 019 recall-recovery: both `batch_rename` and `detect_impact` compute a def's
+/// owner this way to match a call/ref's immediate qualifier against it.
+///
+/// ponytail: owner recovery is Rust-`impl`-shaped. Non-Rust grammars whose
+/// containers are not modeled as `SymbolKind::Impl` blocks (or whose display
+/// names don't parse via `container_target_type`) yield `None` here, so the
+/// qualifier→owner match simply does not fire and those languages keep today's
+/// demote/drop behavior. Widening owner recovery to more grammars is a future
+/// step, not this fix.
+pub(crate) fn enclosing_impl_owner(
+    symbols: &[SymbolRecord],
+    def_start_line: u32,
+) -> Option<String> {
+    let mut best: Option<(u32, &str)> = None; // (impl_start_line, owner_token)
+    for sym in symbols {
+        if sym.kind != SymbolKind::Impl {
+            continue;
+        }
+        let (start, end) = sym.line_range;
+        if def_start_line < start || def_start_line > end {
+            continue;
+        }
+        let Some(owner) = container_target_type(sym) else {
+            continue;
+        };
+        match best {
+            Some((best_start, _)) if start <= best_start => {}
+            _ => best = Some((start, owner)),
+        }
+    }
+    best.map(|(_, owner)| owner.to_string())
+}
+
 // ---------------------------------------------------------------------------
 // Cascading name resolution
 // ---------------------------------------------------------------------------

--- a/src/live_index/graph.rs
+++ b/src/live_index/graph.rs
@@ -118,7 +118,7 @@ impl GraphProjection {
                 // by the call site's module qualifier, else drop the edge.
                 let resolved: Option<&SymbolId> = match callees.as_slice() {
                     [only] => Some(only),
-                    many => resolve_ambiguous_callee(many, r.qualified_name.as_deref()),
+                    many => resolve_ambiguous_callee(many, r.qualified_name.as_deref(), index),
                 };
                 let Some(callee) = resolved else {
                     // ponytail: an ambiguous bare-name call with no resolving
@@ -289,30 +289,45 @@ pub struct BlastNode {
 }
 
 /// Disambiguate a `Call` to an ambiguous bare name (>1 same-name def) using the
-/// call site's `qualified_name` module segment (e.g. `"a::run"` -> module hint
-/// `"a"`). Returns `Some(def)` only when exactly ONE candidate's path matches
-/// the hint (file stem or a path component); otherwise `None`, so the caller
-/// drops the edge rather than fanning out to all N candidates.
+/// call site's `qualified_name` immediate qualifier (e.g. `"a::run"` -> hint
+/// `"a"`; `"Target::m"` -> hint `"Target"`). Returns `Some(def)` only when the
+/// hint picks exactly ONE candidate; otherwise `None`, so the caller drops the
+/// edge rather than fanning out to all N candidates.
 ///
-/// ponytail: the hint match is a syntactic path-segment heuristic, not real
-/// name resolution. It recovers the common `mod::name` case (the qualified
-/// module-call fixture) without inventing wrong edges; the resolver at
-/// C-S2-001 supersedes it. When the hint is absent or matches zero/multiple
-/// candidates, we return `None` (drop) — safety over recall.
+/// Two disambiguation signals are tried, both gated by the same "matched more
+/// than one -> None" discipline (safety over recall):
+///
+/// 1. **Module-stem match** (original): the hint == a candidate's file stem or a
+///    path component recovers the common `mod::name` case.
+/// 2. **Owner-name match** (019 recall-recovery): the hint == the target type of
+///    a candidate's enclosing `impl` block recovers `Target::method` calls that
+///    the module-stem match cannot. Computed from physical defs via
+///    [`enclosing_impl_owner`]; if two physical defs share that owner name
+///    (twin `impl Target` in different files), the hint does NOT disambiguate
+///    and we drop — mirroring the module-stem uniqueness guard.
+///
+/// ponytail: both matches are syntactic heuristics, not real name resolution;
+/// the resolver at C-S2-001 supersedes them. Owner-name recovery is
+/// Rust-`impl`-shaped (see [`enclosing_impl_owner`]) — non-Rust grammars whose
+/// containers aren't `SymbolKind::Impl` yield no owner and keep the drop path.
 fn resolve_ambiguous_callee<'a>(
     candidates: &'a [SymbolId],
     qualified_name: Option<&str>,
+    index: &LiveIndex,
 ) -> Option<&'a SymbolId> {
-    // Module hint = the segment before the last `::` (last `::` separates the
-    // module path from the called name). No `::` -> no hint -> drop.
+    // Immediate qualifier = the segment before the last `::` (last `::`
+    // separates the qualifier from the called leaf name). No `::` -> no hint.
     let qn = qualified_name?;
     let module_hint = qn.rsplit_once("::").map(|(head, _)| head)?;
-    // Use the innermost module segment (e.g. `crate::a` -> `a`).
+    // Use the innermost segment (e.g. `crate::a` -> `a`, `Target` -> `Target`).
     let hint = module_hint.rsplit("::").next().unwrap_or(module_hint);
     if hint.is_empty() {
         return None;
     }
+
+    // Signal 1: module-stem match (file stem or path component == hint).
     let mut matched: Option<&SymbolId> = None;
+    let mut stem_ambiguous = false;
     for cand in candidates {
         let path_matches = std::path::Path::new(&cand.path)
             .file_stem()
@@ -325,12 +340,54 @@ fn resolve_ambiguous_callee<'a>(
                 .any(|component| component == hint);
         if path_matches {
             if matched.is_some() {
-                return None; // hint matched more than one candidate -> ambiguous
+                stem_ambiguous = true;
+                break;
             }
             matched = Some(cand);
         }
     }
-    matched
+    if stem_ambiguous {
+        return None; // hint matched more than one candidate path -> ambiguous
+    }
+    if matched.is_some() {
+        return matched;
+    }
+
+    // Signal 2: owner-name match. For each physical def of the callee leaf name,
+    // compute its enclosing-`impl` owner type and match it against the hint.
+    // Keep the edge only when EXACTLY ONE physical def's owner == hint (the
+    // uniqueness guard); a shared owner name (twin `impl Target`) -> drop.
+    let leaf = &candidates.first()?.name;
+    let mut owner_matched: Option<&SymbolId> = None;
+    for cand in candidates {
+        let Some(file) = index.files.get(&cand.path) else {
+            continue;
+        };
+        // A candidate `SymbolId` collapses same-name/kind defs in one file, so
+        // scan every physical def of the leaf name in this file and check each
+        // one's owner independently (twin `impl` in the SAME file is caught).
+        let mut file_owner_hits = 0usize;
+        for phys in &file.symbols {
+            if phys.name != *leaf || phys.kind != cand.kind {
+                continue;
+            }
+            if crate::live_index::enclosing_impl_owner(&file.symbols, phys.line_range.0).as_deref()
+                == Some(hint)
+            {
+                file_owner_hits += 1;
+            }
+        }
+        if file_owner_hits == 0 {
+            continue;
+        }
+        // >1 owner-matching def in one file, or a second file already matched
+        // -> the hint can't disambiguate. Drop (soundness over recall).
+        if file_owner_hits > 1 || owner_matched.is_some() {
+            return None;
+        }
+        owner_matched = Some(cand);
+    }
+    owner_matched
 }
 
 /// A `fn main` is the conventional program entry point across every language
@@ -538,6 +595,97 @@ mod tests {
             hits <= 1,
             "bare ambiguous run() must not link drive to BOTH run defs \
              (reaches_a={reaches_a} reaches_b={reaches_b})"
+        );
+    }
+
+    // 019 recall-recovery: an ambiguous callee `m` (2 defs, `impl Target` and
+    // `impl Other`) called as `Target::m()` must edge ONLY to Target's `m`
+    // (owner-name recovery), not fan out and not drop. The immediate qualifier
+    // `Target` == the enclosing-impl owner of exactly ONE candidate def.
+    #[test]
+    fn ambiguous_call_recovers_edge_via_unique_owner_qualifier() {
+        let graph = build_graph(&[
+            (
+                "a.rs",
+                "pub struct Target;\nimpl Target {\n    pub fn m(&self) -> u32 { 1 }\n}\n",
+            ),
+            (
+                "b.rs",
+                "pub struct Other;\nimpl Other {\n    pub fn m(&self) -> u32 { 2 }\n}\n",
+            ),
+            ("caller.rs", "fn drive() -> u32 { Target::m(&Target) }\n"),
+        ]);
+        let drive = sym("caller.rs", "drive");
+        // Target::m() is a method; its SymbolId kind is Method, not Function.
+        let target_m = SymbolId {
+            path: "a.rs".to_string(),
+            name: "m".to_string(),
+            kind: SymbolKind::Method,
+        };
+        let other_m = SymbolId {
+            path: "b.rs".to_string(),
+            name: "m".to_string(),
+            kind: SymbolKind::Method,
+        };
+        let reaches_target = graph
+            .inbound_bfs(&target_m, 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        let reaches_other = graph
+            .inbound_bfs(&other_m, 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        assert!(
+            reaches_target,
+            "Target::m() must edge to Target's m (owner-name recovery)"
+        );
+        assert!(
+            !reaches_other,
+            "Target::m() must NOT edge to Other's m (wrong owner)"
+        );
+    }
+
+    // 019 recall-recovery soundness: TWIN OWNERS. Two `impl Target` in distinct
+    // files, each with `fn m`. A `Target::m()` call cannot disambiguate between
+    // them (both owners are named "Target"), so the edge is DROPPED, not
+    // fanned out. This is the uniqueness-guard case.
+    #[test]
+    fn ambiguous_call_with_twin_owner_qualifier_drops_edge() {
+        let graph = build_graph(&[
+            (
+                "a.rs",
+                "pub struct Target;\nimpl Target {\n    pub fn m(&self) -> u32 { 1 }\n}\n",
+            ),
+            (
+                "c.rs",
+                "impl Target {\n    pub fn m(&self) -> u32 { 2 }\n}\n",
+            ),
+            ("caller.rs", "fn drive() -> u32 { Target::m(&Target) }\n"),
+        ]);
+        let drive = sym("caller.rs", "drive");
+        let a_m = SymbolId {
+            path: "a.rs".to_string(),
+            name: "m".to_string(),
+            kind: SymbolKind::Method,
+        };
+        let c_m = SymbolId {
+            path: "c.rs".to_string(),
+            name: "m".to_string(),
+            kind: SymbolKind::Method,
+        };
+        let reaches_a = graph
+            .inbound_bfs(&a_m, 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        let reaches_c = graph
+            .inbound_bfs(&c_m, 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        let hits = usize::from(reaches_a) + usize::from(reaches_c);
+        assert_eq!(
+            hits, 0,
+            "twin `impl Target` owners cannot disambiguate Target::m() -> \
+             edge must be dropped (reaches_a={reaches_a} reaches_c={reaches_c})"
         );
     }
 }

--- a/src/live_index/graph.rs
+++ b/src/live_index/graph.rs
@@ -60,9 +60,17 @@ pub struct GraphProjection {
 
 impl GraphProjection {
     /// Build the projection from a frozen index snapshot. Nodes are every
-    /// symbol definition; edges are caller -> callee for each `Call` reference,
-    /// where the callee is every same-name definition in the repo (syntactic,
-    /// name-based — the over-approximation the v1 resolver will later narrow).
+    /// symbol definition; edges are caller -> callee for each `Call` reference.
+    ///
+    /// Callee resolution is ambiguity-scoped (019 detect_impact correctness):
+    /// a `Call` whose bare name maps to exactly ONE definition links that def
+    /// (bare-name resolution is correct and unambiguous). A name that maps to
+    /// MULTIPLE defs is NOT fanned out to all of them — the old v1 behavior
+    /// linked every same-name def, so a call to `run()` became an edge to every
+    /// `run` in the repo, exploding `detect_impact`'s blast radius with wrong
+    /// callers. Instead we try to disambiguate via the call site's
+    /// `qualified_name` module segment; if that does not pick exactly one def,
+    /// the edge is dropped rather than inventing N wrong edges.
     pub fn from_index(index: &LiveIndex) -> Self {
         // Pass 1: collect every definition keyed by name.
         let mut defs_by_name: HashMap<&str, Vec<SymbolId>> = HashMap::new();
@@ -105,15 +113,30 @@ impl GraphProjection {
                 let Some(callees) = defs_by_name.get(r.name.as_str()) else {
                     continue;
                 };
-                for callee in callees {
-                    if *callee == caller {
-                        continue; // skip self-recursion edges
-                    }
-                    in_edges
-                        .entry(callee.clone())
-                        .or_default()
-                        .push(caller.clone());
+                // Ambiguity-scoped callee resolution (SAME principle as Item 1's
+                // ambiguity gate): one def -> link it; many defs -> disambiguate
+                // by the call site's module qualifier, else drop the edge.
+                let resolved: Option<&SymbolId> = match callees.as_slice() {
+                    [only] => Some(only),
+                    many => resolve_ambiguous_callee(many, r.qualified_name.as_deref()),
+                };
+                let Some(callee) = resolved else {
+                    // ponytail: an ambiguous bare-name call with no resolving
+                    // qualifier is dropped (0 edges) rather than fanned out to
+                    // all N same-name defs. A real name resolver (C-S2-001)
+                    // would recover the true edge; until then, dropping keeps
+                    // detect_impact's blast radius honest instead of confidently
+                    // wrong. Ceiling: cross-file overloads that share a name and
+                    // carry no module qualifier lose their (single) true edge.
+                    continue;
+                };
+                if *callee == caller {
+                    continue; // skip self-recursion edges
                 }
+                in_edges
+                    .entry(callee.clone())
+                    .or_default()
+                    .push(caller.clone());
             }
         }
 
@@ -263,6 +286,51 @@ pub struct BlastNode {
     pub symbol: SymbolId,
     pub hop: u32,
     pub risk: RiskTier,
+}
+
+/// Disambiguate a `Call` to an ambiguous bare name (>1 same-name def) using the
+/// call site's `qualified_name` module segment (e.g. `"a::run"` -> module hint
+/// `"a"`). Returns `Some(def)` only when exactly ONE candidate's path matches
+/// the hint (file stem or a path component); otherwise `None`, so the caller
+/// drops the edge rather than fanning out to all N candidates.
+///
+/// ponytail: the hint match is a syntactic path-segment heuristic, not real
+/// name resolution. It recovers the common `mod::name` case (the qualified
+/// module-call fixture) without inventing wrong edges; the resolver at
+/// C-S2-001 supersedes it. When the hint is absent or matches zero/multiple
+/// candidates, we return `None` (drop) — safety over recall.
+fn resolve_ambiguous_callee<'a>(
+    candidates: &'a [SymbolId],
+    qualified_name: Option<&str>,
+) -> Option<&'a SymbolId> {
+    // Module hint = the segment before the last `::` (last `::` separates the
+    // module path from the called name). No `::` -> no hint -> drop.
+    let qn = qualified_name?;
+    let module_hint = qn.rsplit_once("::").map(|(head, _)| head)?;
+    // Use the innermost module segment (e.g. `crate::a` -> `a`).
+    let hint = module_hint.rsplit("::").next().unwrap_or(module_hint);
+    if hint.is_empty() {
+        return None;
+    }
+    let mut matched: Option<&SymbolId> = None;
+    for cand in candidates {
+        let path_matches = std::path::Path::new(&cand.path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|stem| stem == hint)
+            .unwrap_or(false)
+            || cand
+                .path
+                .split(['/', '\\'])
+                .any(|component| component == hint);
+        if path_matches {
+            if matched.is_some() {
+                return None; // hint matched more than one candidate -> ambiguous
+            }
+            matched = Some(cand);
+        }
+    }
+    matched
 }
 
 /// A `fn main` is the conventional program entry point across every language
@@ -438,5 +506,38 @@ mod tests {
     fn compute_impact_empty_changed_set_yields_empty_blast() {
         let graph = build_graph(&[("lib.rs", "pub fn core() -> u32 { 1 }\n")]);
         assert!(compute_impact(&graph, &[], 5).is_empty());
+    }
+
+    // PART B (019 detect_impact fix): a bare `run()` call must NOT fan out to
+    // every `run` definition in the repo. When the callee name is ambiguous and
+    // the call site carries no disambiguating qualifier, the edge is dropped
+    // rather than inventing N wrong caller->callee edges. Changing either `run`
+    // must therefore reach AT MOST the correctly-scoped one — never both.
+    #[test]
+    fn ambiguous_bare_call_does_not_fan_out_to_all_same_name_defs() {
+        let graph = build_graph(&[
+            ("a.rs", "pub fn run() -> u32 { 1 }\n"),
+            ("b.rs", "pub fn run() -> u32 { 2 }\n"),
+            ("caller.rs", "fn drive() -> u32 { run() }\n"),
+        ]);
+        // Inspect the raw call edges, not the deduped blast (compute_impact
+        // collapses a node reached from two seeds into one entry, which would
+        // mask the fan-out). `drive` must be an inbound caller of AT MOST one
+        // `run` def, not both.
+        let drive = sym("caller.rs", "drive");
+        let reaches_a = graph
+            .inbound_bfs(&sym("a.rs", "run"), 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        let reaches_b = graph
+            .inbound_bfs(&sym("b.rs", "run"), 2, 100)
+            .iter()
+            .any(|(id, _)| *id == drive);
+        let hits = usize::from(reaches_a) + usize::from(reaches_b);
+        assert!(
+            hits <= 1,
+            "bare ambiguous run() must not link drive to BOTH run defs \
+             (reaches_a={reaches_a} reaches_b={reaches_b})"
+        );
     }
 }

--- a/src/live_index/mod.rs
+++ b/src/live_index/mod.rs
@@ -1,6 +1,7 @@
 mod context_bundle;
 pub mod coupling;
 mod disambiguation;
+pub(crate) use disambiguation::enclosing_impl_owner;
 pub mod frecency;
 pub mod git_temporal;
 // Program 015 SP-0A spike -> C-S1A-002: name-based call graph + inbound BFS,

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -211,6 +211,7 @@ fn find_reexporters<'a>(
             if matches_target_import(
                 &file.language,
                 target_language,
+                file_path.as_str(),
                 reference,
                 target_stem,
                 target_module_path,
@@ -364,6 +365,7 @@ fn import_languages_compatible(
 fn matches_target_import(
     importer_language: &LanguageId,
     target_language: &LanguageId,
+    importer_path: &str,
     reference: &ReferenceRecord,
     stem: &str,
     module_path: Option<&str>,
@@ -379,6 +381,25 @@ fn matches_target_import(
         return false;
     }
 
+    // Python relative imports (`from .b import f`) carry their leading
+    // import_prefix dots in `qualified_name` (".b", "..pkg"). They name a module
+    // in the IMPORTER's own package, so they must resolve package-aware against
+    // the importer path — never via the package-blind same-stem fallback, which
+    // would wrongly match an unrelated same-stem module in another package.
+    if *importer_language == LanguageId::Python
+        && let Some(qualified) = reference.qualified_name.as_deref()
+        && qualified.starts_with('.')
+    {
+        return match resolve_python_relative_import(importer_path, qualified) {
+            // Resolved to a concrete dotted module — match ONLY the target whose
+            // module path equals it (exact package + module), nothing by stem.
+            Some(resolved) => module_path == Some(resolved.as_str()),
+            // Unresolvable (dots escape the workspace root) — fail closed rather
+            // than fall back to the stem match and invent a foreign dependent.
+            None => false,
+        };
+    }
+
     matches_target_stem(&reference.name, stem)
         || reference
             .qualified_name
@@ -389,6 +410,56 @@ fn matches_target_import(
             })
             .unwrap_or(false)
         || matches_target_module(target_language, &reference.name, module_path)
+}
+
+/// Resolve a Python relative from-import (e.g. `.b`, `..pkg.mod`) to an absolute
+/// dotted module path, relative to the importing file's package.
+///
+/// The leading dots are the `import_prefix`: one dot = the importer's own
+/// package (the file's directory), each additional dot climbs one package up.
+/// The remaining text (after the dots) is the module path within that package.
+///
+/// Example: importer `pkg/sub/a.py`, `..mod` → package `pkg/sub` climbs 1 level
+/// to `pkg`, then module `mod` → `pkg.mod`.
+///
+/// Returns `None` when the dots climb above the indexed workspace root (the
+/// module lives outside the index and cannot be matched to a known file).
+fn resolve_python_relative_import(importer_path: &str, relative_text: &str) -> Option<String> {
+    let dots = relative_text.chars().take_while(|&c| c == '.').count();
+    if dots == 0 {
+        return None;
+    }
+    let module_tail = relative_text[dots..].trim_matches('.');
+
+    // The importer's package = the components of its directory path.
+    let normalized = importer_path.replace('\\', "/");
+    let dir = normalized
+        .rsplit_once('/')
+        .map(|(dir, _)| dir)
+        .unwrap_or("");
+    let mut package: Vec<&str> = if dir.is_empty() {
+        Vec::new()
+    } else {
+        dir.split('/').filter(|c| !c.is_empty()).collect()
+    };
+
+    // One dot stays in the current package; each extra dot climbs one level.
+    let climb = dots - 1;
+    if climb > package.len() {
+        // Escapes above the workspace root — outside the index.
+        return None;
+    }
+    package.truncate(package.len() - climb);
+
+    if !module_tail.is_empty() {
+        package.extend(module_tail.split('.').filter(|c| !c.is_empty()));
+    }
+
+    if package.is_empty() {
+        None
+    } else {
+        Some(package.join("."))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2815,6 +2886,7 @@ impl LiveIndex {
                     matches_target_import(
                         &file.language,
                         &target_language,
+                        file_path.as_str(),
                         reference,
                         stem,
                         module_path.as_deref(),
@@ -2971,6 +3043,7 @@ impl LiveIndex {
                             matches_target_import(
                                 &file.language,
                                 &target_language,
+                                file_path.as_str(),
                                 reference,
                                 re_stem,
                                 re_module_path.as_deref(),
@@ -6355,6 +6428,52 @@ impl Actor for MyActor {
             dep_paths.len(),
             1,
             "only the same-language Python importer should match, got: {dep_paths:?}"
+        );
+    }
+
+    #[test]
+    fn test_find_dependents_python_relative_import_resolves_to_own_package_only() {
+        // `pkg/a.py` does `from .b import f`; the single-dot relative import names
+        // the `b` module in a.py's OWN package (pkg/), i.e. `pkg/b.py`. A same-stem
+        // module in an UNRELATED package (`other/b.py`) must NOT be reported: the
+        // relative prefix pins resolution to the importer's package, so the naive
+        // same-stem fallback must not fire for it.
+        let rel_import = make_ref("b", Some(".b"), ReferenceKind::Import, None, 0);
+        let mut f_importer = make_file_with_refs("pkg/a.py", vec![rel_import], HashMap::new());
+        f_importer.language = LanguageId::Python;
+
+        let mut f_target = make_file_with_refs("pkg/b.py", vec![], HashMap::new());
+        f_target.language = LanguageId::Python;
+        f_target.symbols = vec![make_symbol("f")];
+
+        // Unrelated same-stem module in a different package, with NO relative import
+        // of its own — must never be dragged in as a dependent of pkg/b.py.
+        let mut f_other = make_file_with_refs("other/b.py", vec![], HashMap::new());
+        f_other.language = LanguageId::Python;
+
+        let index = make_index(
+            vec![
+                ("pkg/a.py", f_importer),
+                ("pkg/b.py", f_target),
+                ("other/b.py", f_other),
+            ],
+            false,
+        );
+
+        let deps = index.find_dependents_for_file("pkg/b.py");
+        let dep_paths: Vec<&str> = deps.iter().map(|(p, _)| *p).collect();
+        assert!(
+            dep_paths.contains(&"pkg/a.py"),
+            "`from .b import f` in pkg/a.py must make it a dependent of pkg/b.py, got: {dep_paths:?}"
+        );
+
+        // The relative import must NOT invent pkg/a.py as a dependent of other/b.py
+        // (different package): the single dot pins it to pkg/.
+        let other_deps = index.find_dependents_for_file("other/b.py");
+        let other_paths: Vec<&str> = other_deps.iter().map(|(p, _)| *p).collect();
+        assert!(
+            !other_paths.contains(&"pkg/a.py"),
+            "a single-dot relative import in pkg/a.py must NOT resolve to other/b.py, got: {other_paths:?}"
         );
     }
 

--- a/src/parsing/config_extractors/json.rs
+++ b/src/parsing/config_extractors/json.rs
@@ -20,8 +20,25 @@ pub struct JsonExtractor;
 /// sequence never occurs in strict JSON outside string literals, so it is safe
 /// globally; string contents are respected in both passes.
 fn normalize_jsonc(input: &[u8]) -> Vec<u8> {
-    let stripped = strip_json_comments(input);
+    let stripped = strip_json_comments(&blank_leading_bom(input));
     blank_trailing_commas(&stripped)
+}
+
+/// Blank a leading 3-byte UTF-8 BOM (`EF BB BF`) at byte offset 0 to three
+/// spaces. A BOM is valid at the start of a JSON document (RFC 8259) but
+/// `serde_json` rejects it; blanking (rather than stripping) keeps every byte
+/// offset and line number unchanged, so diagnostics and symbol spans stay
+/// accurate. `serde_json` tolerates the leading whitespace. Only a BOM at
+/// offset 0 is treated as a BOM — an identical byte sequence mid-document is
+/// ordinary content and is left untouched.
+fn blank_leading_bom(input: &[u8]) -> Vec<u8> {
+    let mut out = input.to_vec();
+    if out.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        out[0] = b' ';
+        out[1] = b' ';
+        out[2] = b' ';
+    }
+    out
 }
 
 /// Blank any trailing comma (a `,` followed only by whitespace before `}` or
@@ -894,5 +911,53 @@ mod tests {
         );
         assert!(result.symbols.iter().any(|s| s.name == "url"));
         assert!(result.symbols.iter().any(|s| s.name == "pattern"));
+    }
+
+    #[test]
+    fn test_utf8_bom_json_validates_and_preserves_offsets() {
+        // A UTF-8 BOM (EF BB BF) is valid at the start of a JSON file per
+        // RFC 8259, but serde_json rejects it. The normalizer must blank the
+        // leading BOM to 3 spaces (offset-preserving), so BOM-prefixed JSON
+        // parses AND every symbol lands at the same byte offset it would with
+        // the BOM replaced by three plain spaces at the head of the buffer.
+        let bom = b"\xEF\xBB\xBF{\"a\": 1, \"b\": 2}";
+        let bom_result = JsonExtractor.extract(bom);
+        assert!(
+            matches!(bom_result.outcome, ExtractionOutcome::Ok),
+            "valid JSON with a leading UTF-8 BOM must validate OK"
+        );
+        assert!(bom_result.symbols.iter().any(|s| s.name == "a"));
+        assert!(bom_result.symbols.iter().any(|s| s.name == "b"));
+
+        // Control: the SAME document with the 3 BOM bytes replaced by 3 spaces
+        // is what the blanking produces. Offsets/spans must be byte-identical,
+        // proving the BOM handling did not shift any offset.
+        let spaced = b"   {\"a\": 1, \"b\": 2}";
+        let spaced_result = JsonExtractor.extract(spaced);
+        assert!(matches!(spaced_result.outcome, ExtractionOutcome::Ok));
+
+        for name in ["a", "b"] {
+            let bom_sym = find_sym(&bom_result.symbols, name);
+            let spaced_sym = find_sym(&spaced_result.symbols, name);
+            assert_eq!(
+                bom_sym.byte_range, spaced_sym.byte_range,
+                "BOM handling must preserve byte offsets for key {name}"
+            );
+            assert_eq!(
+                bom_sym.line_range, spaced_sym.line_range,
+                "BOM handling must preserve line numbers for key {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_without_bom_control_still_ok() {
+        // The plain (no-BOM) control must remain valid — the BOM fix must not
+        // regress ordinary JSON.
+        let content = br#"{"a": 1, "b": 2}"#;
+        let result = JsonExtractor.extract(content);
+        assert!(matches!(result.outcome, ExtractionOutcome::Ok));
+        assert!(result.symbols.iter().any(|s| s.name == "a"));
+        assert!(result.symbols.iter().any(|s| s.name == "b"));
     }
 }

--- a/src/parsing/xref.rs
+++ b/src/parsing/xref.rs
@@ -83,6 +83,12 @@ const PYTHON_XREF_QUERY: &str = r#"
 (import_from_statement module_name: (dotted_name (identifier) @ref.import))
 (import_from_statement name: (dotted_name (identifier) @ref.import))
 
+; Relative from-imports: from .b import f / from ..pkg import y
+; The module lives on a `relative_import` node (import_prefix dots + optional
+; dotted_name). Capture the whole node so its text ("." / ".b" / "..pkg")
+; reaches the consumer, which resolves it against the importer's package.
+(import_from_statement module_name: (relative_import) @ref.import_relative)
+
 ; Import alias: import numpy as np
 (aliased_import name: (dotted_name (identifier) @import.original) alias: (identifier) @import.alias)
 
@@ -1394,6 +1400,7 @@ pub fn extract_references(
         let mut ref_qualified_call: Option<Node> = None;
         let mut ref_method_call: Option<Node> = None;
         let mut ref_import: Option<Node> = None;
+        let mut ref_import_relative: Option<Node> = None;
         let mut ref_type: Option<Node> = None;
         let mut ref_macro: Option<Node> = None;
         let mut import_original: Option<Node> = None;
@@ -1416,6 +1423,9 @@ pub fn extract_references(
                 }
                 "ref.import" => {
                     ref_import = Some(node);
+                }
+                "ref.import_relative" => {
+                    ref_import_relative = Some(node);
                 }
                 "ref.type" => {
                     ref_type = Some(node);
@@ -1542,6 +1552,25 @@ pub fn extract_references(
 
             for import_text in import_texts {
                 push_import_reference(&mut references, &import_text, import_node);
+            }
+        }
+
+        // Python relative from-import: `from .b import f` / `from ..pkg import y`.
+        // The captured `relative_import` node text is the module path WITH its
+        // leading import_prefix dots (".b", "..pkg", or a bare "."/".." when no
+        // module segment follows). Preserve the dots verbatim in `qualified_name`
+        // so the dependents resolver can count them against the importer's
+        // package; `push_import_reference` reduces the trailing segment to the
+        // reference `name`. A bare "."/".." (no dotted_name) names no module, so
+        // there is nothing to emit.
+        if let Some(rel_node) = ref_import_relative
+            && let Ok(rel_text) = rel_node.utf8_text(source_bytes)
+        {
+            let rel_text = rel_text.trim();
+            if rel_text.trim_start_matches('.').is_empty() {
+                // `from . import x` — package-only import, no module segment.
+            } else {
+                push_import_reference(&mut references, rel_text, rel_node);
             }
         }
 
@@ -2497,6 +2526,44 @@ fn run() {
             refs.iter().any(|r| r.kind == ReferenceKind::Import),
             "should have Import ref, refs: {:?}",
             refs
+        );
+    }
+
+    #[test]
+    fn test_python_relative_import_single_dot_captures_module_with_prefix() {
+        // `from .b import f` — the module lives on a `relative_import` node
+        // (import_prefix `.` + dotted_name `b`), which the pre-fix query did not
+        // capture at all, so `find_dependents` missed the real importer.
+        let (refs, _) = parse_and_extract("from .b import f", LanguageId::Python);
+        let import_ref = refs
+            .iter()
+            .find(|r| r.kind == ReferenceKind::Import && r.name == "b")
+            .unwrap_or_else(|| {
+                panic!("relative import `.b` should yield an Import ref, refs: {refs:?}")
+            });
+        // The leading dot MUST be preserved on the qualified path so the consumer
+        // can resolve the module against the importer's package.
+        assert_eq!(
+            import_ref.qualified_name.as_deref(),
+            Some(".b"),
+            "relative import qualified_name should retain the import_prefix dots, refs: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn test_python_relative_import_parent_dot_captures_module_with_prefix() {
+        // `from ..pkg import y` — two dots (parent package) + dotted_name `pkg`.
+        let (refs, _) = parse_and_extract("from ..pkg import y", LanguageId::Python);
+        let import_ref = refs
+            .iter()
+            .find(|r| r.kind == ReferenceKind::Import && r.name == "pkg")
+            .unwrap_or_else(|| {
+                panic!("relative import `..pkg` should yield an Import ref, refs: {refs:?}")
+            });
+        assert_eq!(
+            import_ref.qualified_name.as_deref(),
+            Some("..pkg"),
+            "parent relative import should retain both leading dots, refs: {refs:?}"
         );
     }
 

--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -2291,7 +2291,7 @@ pub(crate) fn execute_batch_rename(
     };
 
     // Filter ref_sites by code_only
-    let ref_sites: Vec<(String, (u32, u32))> = if input.code_only.unwrap_or(false) {
+    let mut ref_sites: Vec<(String, (u32, u32))> = if input.code_only.unwrap_or(false) {
         ref_sites
             .into_iter()
             .filter(|(path, _)| {
@@ -2351,6 +2351,50 @@ pub(crate) fn execute_batch_rename(
         } else {
             qualified_uncertain.push((usage.file_path, usage.line, usage.context));
         }
+    }
+
+    // Phase 2c: Ambiguity gate (P0 safety).
+    // Count how many DEFINITIONS the index holds for `input.name`. The bare-name
+    // reverse-index refs (`ref_sites`) and the unscoped qualified matches
+    // (`qualified_confident`) both key on the leaf name only, so for a name with
+    // 2+ definitions they cannot be attributed to the resolved target definition
+    // (e.g. renaming `Target::new` must not rewrite `SomeOther::new`). When the
+    // name is ambiguous, demote BOTH sets into the uncertain/surfaced-only set;
+    // only the definition site stays confident. A unique name (1 definition)
+    // leaves both sets untouched — behavior unchanged.
+    let def_count = {
+        let guard = index.read();
+        guard
+            .files
+            .values()
+            .flat_map(|file| file.symbols.iter())
+            .filter(|sym| sym.name == input.name)
+            .count()
+    };
+    if def_count >= 2 {
+        // Convert each demoted (path, byte_range) site into an uncertain
+        // (path, line, context) tuple so it flows through the existing
+        // uncertain-warning block instead of the confident write set.
+        let demote = |path: &str, start: u32, sink: &mut Vec<(String, u32, String)>| {
+            let content = file_contents
+                .iter()
+                .find(|(p, _)| p == path)
+                .map(|(_, c)| c.as_slice())
+                .unwrap_or(&[]);
+            let text = String::from_utf8_lossy(content);
+            let start = (start as usize).min(text.len());
+            let line = text[..start].bytes().filter(|&b| b == b'\n').count() + 1;
+            let context = text.lines().nth(line - 1).unwrap_or("").trim().to_string();
+            sink.push((path.to_string(), line as u32, context));
+        };
+        for (path, (start, _)) in &ref_sites {
+            demote(path, *start, &mut qualified_uncertain);
+        }
+        for (path, (start, _)) in &qualified_confident {
+            demote(path, *start, &mut qualified_uncertain);
+        }
+        ref_sites.clear();
+        qualified_confident.clear();
     }
 
     // Phase 3: Group rename sites by file.

--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -2259,7 +2259,11 @@ pub(crate) fn execute_batch_rename(
     input: &BatchRenameInput,
 ) -> Result<String, String> {
     // Phase 1: Resolve the definition and find the name within its body.
-    let (def_name_range, language) = {
+    // `target_owner` is the resolved target's enclosing-`impl` owner type (019
+    // recall-recovery): for `Target::new`, `Some("Target")`. `None` when the
+    // def is not inside an `impl` (free fn, non-Rust container) — those keep the
+    // ambiguity demote/drop behavior unchanged.
+    let (def_name_range, language, target_owner) = {
         let guard = index.read();
         let file = guard
             .get_file(&input.path)
@@ -2278,33 +2282,38 @@ pub(crate) fn execute_batch_rename(
             })?;
         let abs_start = sym.byte_range.0 + name_offset as u32;
         let abs_end = abs_start + input.name.len() as u32;
-        ((abs_start, abs_end), file.language.clone())
+        let owner = crate::live_index::enclosing_impl_owner(&file.symbols, sym.line_range.0);
+        ((abs_start, abs_end), file.language.clone(), owner)
     };
 
-    // Phase 2: Find all references across the project.
-    let ref_sites: Vec<(String, (u32, u32))> = {
+    // Phase 2: Find all references across the project. Carry each ref's
+    // `qualified_name` (019 recall-recovery): the immediate qualifier lets the
+    // ambiguity gate recover `Target::new()` call sites whose qualifier matches
+    // the resolved target's owner.
+    let ref_sites: Vec<(String, (u32, u32), Option<String>)> = {
         let guard = index.read();
         let refs = guard.find_references_for_name(&input.name, None, false);
         refs.into_iter()
-            .map(|(path, rr)| (path.to_string(), rr.byte_range))
+            .map(|(path, rr)| (path.to_string(), rr.byte_range, rr.qualified_name.clone()))
             .collect()
     };
 
     // Filter ref_sites by code_only
-    let mut ref_sites: Vec<(String, (u32, u32))> = if input.code_only.unwrap_or(false) {
-        ref_sites
-            .into_iter()
-            .filter(|(path, _)| {
-                let ext = path.rsplit('.').next().unwrap_or("");
-                match crate::domain::index::LanguageId::from_extension(ext) {
-                    None => false,
-                    Some(lang) => !crate::parsing::config_extractors::is_config_language(&lang),
-                }
-            })
-            .collect()
-    } else {
-        ref_sites
-    };
+    let mut ref_sites: Vec<(String, (u32, u32), Option<String>)> =
+        if input.code_only.unwrap_or(false) {
+            ref_sites
+                .into_iter()
+                .filter(|(path, _, _)| {
+                    let ext = path.rsplit('.').next().unwrap_or("");
+                    match crate::domain::index::LanguageId::from_extension(ext) {
+                        None => false,
+                        Some(lang) => !crate::parsing::config_extractors::is_config_language(&lang),
+                    }
+                })
+                .collect()
+        } else {
+            ref_sites
+        };
 
     // Phase 2b: Supplemental qualified-path scan with confidence classification.
     // The xref index tracks call targets (e.g. "new" in Widget::new()), not
@@ -2353,15 +2362,20 @@ pub(crate) fn execute_batch_rename(
         }
     }
 
-    // Phase 2c: Ambiguity gate (P0 safety).
+    // Phase 2c: Ambiguity gate (P0 safety) with owner-name recall recovery.
     // Count how many DEFINITIONS the index holds for `input.name`. The bare-name
     // reverse-index refs (`ref_sites`) and the unscoped qualified matches
     // (`qualified_confident`) both key on the leaf name only, so for a name with
     // 2+ definitions they cannot be attributed to the resolved target definition
-    // (e.g. renaming `Target::new` must not rewrite `SomeOther::new`). When the
-    // name is ambiguous, demote BOTH sets into the uncertain/surfaced-only set;
-    // only the definition site stays confident. A unique name (1 definition)
-    // leaves both sets untouched — behavior unchanged.
+    // by the leaf alone (e.g. renaming `Target::new` must not rewrite
+    // `SomeOther::new`).
+    //
+    // 019 recall-recovery: a qualified ref whose IMMEDIATE QUALIFIER equals the
+    // resolved target's `impl` OWNER (`Target::new()` when renaming Target's
+    // `new`) IS attributable and stays writable — BUT ONLY when that owner name
+    // is UNIQUE among the ambiguous defs' owners. If two unrelated `impl Target`
+    // exist, the qualifier can't disambiguate, so we fall back to demoting. Bare
+    // (unqualified) refs and refs whose qualifier != owner still demote.
     let def_count = {
         let guard = index.read();
         guard
@@ -2372,6 +2386,86 @@ pub(crate) fn execute_batch_rename(
             .count()
     };
     if def_count >= 2 {
+        // Owner-uniqueness guard: count how many defs of `input.name` share the
+        // resolved target's owner name. Recovery is sound only when EXACTLY ONE
+        // does (mirrors resolve_ambiguous_callee's "matched >1 -> drop"). A `None`
+        // target owner (free fn / non-Rust container) never recovers.
+        let owner_is_unique = if let Some(owner) = target_owner.as_deref() {
+            let guard = index.read();
+            let same_owner_defs = guard
+                .files
+                .values()
+                .flat_map(|file| {
+                    file.symbols.iter().filter_map(move |sym| {
+                        if sym.name != input.name {
+                            return None;
+                        }
+                        crate::live_index::enclosing_impl_owner(&file.symbols, sym.line_range.0)
+                    })
+                })
+                .filter(|o| o == owner)
+                .count();
+            same_owner_defs == 1
+        } else {
+            false
+        };
+
+        // Immediate qualifier of a `qualified_name` string: the segment right
+        // before the leaf (`Target::new` -> `Target`; `a::b::Foo::new` -> `Foo`).
+        let immediate_qualifier = |qn: &str| -> Option<String> {
+            let segs: Vec<&str> = qn
+                .split(['.', ':'])
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            match segs.len() {
+                0 | 1 => None,
+                n => Some(segs[n - 2].to_string()),
+            }
+        };
+        // Immediate qualifier for a byte-scanned match: the identifier ending at
+        // the `::` immediately before the leaf at `leaf_start`.
+        let qualifier_before = |content: &[u8], leaf_start: u32| -> Option<String> {
+            let leaf_start = leaf_start as usize;
+            if leaf_start < 2
+                || leaf_start > content.len()
+                || content[leaf_start - 2] != b':'
+                || content[leaf_start - 1] != b':'
+            {
+                return None;
+            }
+            let end = leaf_start - 2;
+            let mut start = end;
+            while start > 0 {
+                let b = content[start - 1];
+                if b == b'_' || b.is_ascii_alphanumeric() {
+                    start -= 1;
+                } else {
+                    break;
+                }
+            }
+            if start == end {
+                return None;
+            }
+            // Guard the byte slice against multi-byte UTF-8 splits before decode.
+            while start < end && (content[start] & 0b1100_0000) == 0b1000_0000 {
+                start += 1;
+            }
+            std::str::from_utf8(&content[start..end])
+                .ok()
+                .map(|s| s.to_string())
+        };
+
+        // Keep-writable predicate: recovery only when the owner is unique AND the
+        // ref's immediate qualifier equals that owner.
+        let recovers = |qualifier: Option<&str>| -> bool {
+            owner_is_unique
+                && match (qualifier, target_owner.as_deref()) {
+                    (Some(q), Some(owner)) => q == owner,
+                    _ => false,
+                }
+        };
+
         // Convert each demoted (path, byte_range) site into an uncertain
         // (path, line, context) tuple so it flows through the existing
         // uncertain-warning block instead of the confident write set.
@@ -2387,14 +2481,36 @@ pub(crate) fn execute_batch_rename(
             let context = text.lines().nth(line - 1).unwrap_or("").trim().to_string();
             sink.push((path.to_string(), line as u32, context));
         };
-        for (path, (start, _)) in &ref_sites {
-            demote(path, *start, &mut qualified_uncertain);
+
+        // Partition ref_sites: keep owner-recovered, demote the rest.
+        let mut kept_refs: Vec<(String, (u32, u32), Option<String>)> = Vec::new();
+        for (path, range, qn) in ref_sites.drain(..) {
+            let qualifier = qn.as_deref().and_then(immediate_qualifier);
+            if recovers(qualifier.as_deref()) {
+                kept_refs.push((path, range, qn));
+            } else {
+                demote(&path, range.0, &mut qualified_uncertain);
+            }
         }
-        for (path, (start, _)) in &qualified_confident {
-            demote(path, *start, &mut qualified_uncertain);
+        ref_sites = kept_refs;
+
+        // Partition qualified_confident the same way, parsing the qualifier out
+        // of the scanned file content (byte-scan matches carry no qualified_name).
+        let mut kept_qual: Vec<(String, (u32, u32))> = Vec::new();
+        for (path, range) in qualified_confident.drain(..) {
+            let content = file_contents
+                .iter()
+                .find(|(p, _)| *p == path)
+                .map(|(_, c)| c.as_slice())
+                .unwrap_or(&[]);
+            let qualifier = qualifier_before(content, range.0);
+            if recovers(qualifier.as_deref()) {
+                kept_qual.push((path, range));
+            } else {
+                demote(&path, range.0, &mut qualified_uncertain);
+            }
         }
-        ref_sites.clear();
-        qualified_confident.clear();
+        qualified_confident = kept_qual;
     }
 
     // Phase 3: Group rename sites by file.
@@ -2406,7 +2522,7 @@ pub(crate) fn execute_batch_rename(
         .entry(input.path.clone())
         .or_default()
         .push(def_name_range);
-    for (path, range) in &ref_sites {
+    for (path, range, _qn) in &ref_sites {
         by_file.entry(path.clone()).or_default().push(*range);
     }
     for (path, range) in &qualified_confident {

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -511,6 +511,98 @@ fn begin_mutation_replay<T: Serialize>(
     }
 }
 
+/// NON-RESERVING replay probe mirroring [`begin_mutation_replay`]'s hashing.
+///
+/// The request hash MUST be computed over exactly the same value
+/// `begin_mutation_replay` stores (the typed tool `input`, with
+/// `idempotency_key` stripped, hashed under `tool_name`). Reproducing that
+/// transformation here — rather than hashing a facade-level request — is what
+/// makes an identical `symforge_edit` apply replay hit the record the legacy
+/// tool stored on the first apply.
+///
+/// Returns:
+/// - `Ok(Some(response))` — identical key+request already has a stored result;
+///   the caller returns it and writes zero bytes.
+/// - `Ok(None)` — no reservation exists (first execution, or `dry_run`, or no
+///   key); the caller proceeds through its normal gates.
+/// - `Err(output)` — an idempotency conflict (same key, different request) or a
+///   store error, already formatted for return to the client.
+fn probe_mutation_replay<T: Serialize>(
+    repo_root: &Path,
+    tool_name: &str,
+    input: &T,
+    idempotency_key: Option<&str>,
+    dry_run: bool,
+) -> Result<Option<String>, String> {
+    if dry_run {
+        return Ok(None);
+    }
+    let Some(raw_key) = idempotency_key else {
+        return Ok(None);
+    };
+
+    let mut request = serde_json::to_value(input)
+        .map_err(|error| crate::idempotency::format_tool_error(&error.into()))?;
+    if let serde_json::Value::Object(map) = &mut request {
+        map.remove("idempotency_key");
+    }
+
+    crate::idempotency::probe_tool_replay(repo_root, tool_name, raw_key, &request)
+        .map_err(|error| crate::idempotency::format_tool_error(&error))
+}
+
+/// NON-RESERVING replay probe for a `symforge_edit` apply, keyed off the plan
+/// step the facade will dispatch.
+///
+/// The `symforge_edit` local-apply path runs `run_pre_apply_gates` (including
+/// the Replace `if_match` guard) BEFORE the legacy tool's own
+/// `begin_mutation_replay`. After a first successful apply the body has changed,
+/// so an identical replay carrying the ORIGINAL `if_match` would be wrongly
+/// rejected by that now-stale guard before the replay lookup could serve the
+/// stored result. This probe runs FIRST and short-circuits an identical
+/// key+request replay without re-validating `if_match`.
+///
+/// `step_args` is the planner's step args (which already carry the injected
+/// `idempotency_key` and, for Replace, `if_match`). Deserializing it into the
+/// SAME typed input the legacy tool receives, then reusing
+/// [`probe_mutation_replay`], guarantees the probe hashes the exact value the
+/// legacy tool stored on the first apply — so `if_match` presence never
+/// reintroduces a hash mismatch.
+///
+/// Returns the same tri-state as [`probe_mutation_replay`]:
+/// `Ok(Some(stored_response))` on an identical replay hit (return it, zero
+/// writes), `Ok(None)` on a miss (proceed through the normal gates), and
+/// `Err(output)` on an idempotency conflict or store error.
+pub(crate) fn probe_symforge_edit_apply_replay(
+    repo_root: &Path,
+    step_tool: &str,
+    step_args: &serde_json::Value,
+    idempotency_key: Option<&str>,
+) -> Result<Option<String>, String> {
+    // A dry_run never reserves, so it can never have a stored result to replay.
+    // The facade only reaches this probe on apply, but honor the flag defensively.
+    let dry_run = step_args
+        .get("dry_run")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+
+    macro_rules! probe_as {
+        ($input:ty) => {{
+            let input: $input = serde_json::from_value(step_args.clone())
+                .map_err(|error| crate::idempotency::format_tool_error(&error.into()))?;
+            probe_mutation_replay(repo_root, step_tool, &input, idempotency_key, dry_run)
+        }};
+    }
+
+    match step_tool {
+        "replace_symbol_body" => probe_as!(edit::ReplaceSymbolBodyInput),
+        "insert_symbol" => probe_as!(edit::InsertSymbolInput),
+        "edit_within_symbol" => probe_as!(edit::EditWithinSymbolInput),
+        // No other tool is a `symforge_edit` apply target; nothing to replay.
+        _ => Ok(None),
+    }
+}
+
 fn complete_mutation_replay(
     idempotency: &Option<crate::idempotency::ActiveReplay>,
     output: &mut String,

--- a/src/protocol/read_tools.rs
+++ b/src/protocol/read_tools.rs
@@ -407,9 +407,6 @@ pub(crate) struct ValidateFileSyntaxInput {
     #[serde(default)]
     pub project: Option<String>,
     pub path: String,
-    /// When true, return an approximate token cost estimate instead of actual content.
-    #[serde(default, deserialize_with = "lenient_bool")]
-    pub estimate: Option<bool>,
 }
 
 /// Input for `find_dependents`.

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -26927,11 +26927,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_rename_ambiguous_method_demotes_bare_refs() {
-        // Renaming the SHARED METHOD `new` scoped to Target::new must NOT rewrite
-        // SomeOther::new. `new` has 2 definitions (Target::new, SomeOther::new),
-        // so the bare-name reverse-index refs AND the unscoped qualified matches
-        // are all ambiguous: they are demoted to the uncertain/surfaced-only set.
-        // Only the definition site is renamed.
+        // Renaming the SHARED METHOD `new` scoped to Target::new. `new` has 2
+        // definitions (Target::new, SomeOther::new), so the leaf name alone is
+        // ambiguous. 019 recall-recovery: a call whose IMMEDIATE QUALIFIER equals
+        // the resolved target's UNIQUE `impl` owner IS attributable and stays
+        // writable, so `Target::new()` is RECOVERED (Target and SomeOther are
+        // DISTINCT owner names -> Target is unique). The core SAFETY invariant is
+        // preserved: `SomeOther::new()` (wrong owner) is NEVER rewritten. Before
+        // the recovery upgrade this test asserted main.rs was byte-identical; the
+        // upgrade makes the qualified Target::new() site the correct write, while
+        // the wrong-owner site stays untouched.
         use crate::protocol::edit::BatchRenameInput;
 
         let dir = tempfile::tempdir().unwrap();
@@ -26970,7 +26975,7 @@ mod tests {
             code_only: None,
             working_directory: None,
         };
-        let result = server.batch_rename(Parameters(input)).await;
+        let _result = server.batch_rename(Parameters(input)).await;
 
         // The definition site (Target::new in lib.rs) IS renamed.
         let lib = std::fs::read_to_string(src_dir.join("lib.rs")).unwrap();
@@ -26984,24 +26989,187 @@ mod tests {
             "SomeOther::new definition must be untouched, got: {lib}"
         );
 
-        // main.rs must be BYTE-IDENTICAL to the original: neither call site is a
-        // safe write because `new` is ambiguous across 2 definitions.
+        // RECOVERY: Target::new() call site rewritten to Target::make_new()
+        // because "Target" is a unique owner among `new`'s defs.
+        let main = std::fs::read_to_string(src_dir.join("main.rs")).unwrap();
+        assert!(
+            main.contains("Target::make_new()"),
+            "Target::new() call site must be recovered (unique owner), got: {main}"
+        );
+        // CORE SAFETY: SomeOther::new() (wrong owner) is NEVER rewritten.
+        assert!(
+            main.contains("SomeOther::new()"),
+            "SomeOther::new() call site must be untouched, got: {main}"
+        );
+        assert!(
+            !main.contains("SomeOther::make_new"),
+            "SomeOther::new() must never be rewritten, got: {main}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_rename_ambiguous_method_recovers_unique_owner_calls() {
+        // 019 recall-recovery: `new` is ambiguous (Target::new in a.rs,
+        // Other::new in b.rs). Renaming Target::new must RECOVER the
+        // `Target::new()` call site (Target is a UNIQUE owner among `new`'s
+        // owners) while leaving `Other::new()` and any bare `new()` untouched.
+        use crate::protocol::edit::BatchRenameInput;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let a_content =
+            b"pub struct Target;\nimpl Target {\n    pub fn new() -> Self { Target }\n}\n";
+        let b_content = b"pub struct Other;\nimpl Other {\n    pub fn new() -> Self { Other }\n}\n";
+        // A bare (unqualified) `new()` call carries NO qualifier, so it must
+        // stay demoted (the "bare still demotes" invariant).
+        let main_content =
+            b"fn make() { let _a = Target::new(); let _b = Other::new(); let _c = new(); }\n";
+        std::fs::write(src_dir.join("a.rs"), a_content).unwrap();
+        std::fs::write(src_dir.join("b.rs"), b_content).unwrap();
+        std::fs::write(src_dir.join("main.rs"), main_content).unwrap();
+
+        let mut files = vec![];
+        for (path, content) in [
+            ("src/a.rs", a_content as &[u8]),
+            ("src/b.rs", b_content as &[u8]),
+            ("src/main.rs", main_content as &[u8]),
+        ] {
+            let result = crate::parsing::process_file(path, content, LanguageId::Rust);
+            let indexed =
+                crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+            files.push((path.to_string(), indexed));
+        }
+        let index = make_live_index_ready(files);
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+
+        // Target the `new` in a.rs (Target::new).
+        let input = BatchRenameInput {
+            project: None,
+            path: "src/a.rs".to_string(),
+            name: "new".to_string(),
+            kind: None,
+            symbol_line: Some(3),
+            new_name: "make_new".to_string(),
+            dry_run: None,
+            idempotency_key: None,
+            code_only: None,
+            working_directory: None,
+        };
+        let _result = server.batch_rename(Parameters(input)).await;
+
+        // Definition site renamed.
+        let a = std::fs::read_to_string(src_dir.join("a.rs")).unwrap();
+        assert!(
+            a.contains("pub fn make_new() -> Self { Target }"),
+            "Target::new definition must be renamed, got: {a}"
+        );
+        // Other::new definition untouched.
+        let b = std::fs::read_to_string(src_dir.join("b.rs")).unwrap();
+        assert!(
+            b.contains("pub fn new() -> Self { Other }"),
+            "Other::new definition must be untouched, got: {b}"
+        );
+        // RECOVERY: Target::new() call site rewritten to Target::make_new().
+        let main = std::fs::read_to_string(src_dir.join("main.rs")).unwrap();
+        assert!(
+            main.contains("Target::make_new()"),
+            "Target::new() call site must be RECOVERED (unique owner), got: {main}"
+        );
+        // SAFETY: Other::new() call site never touched.
+        assert!(
+            main.contains("Other::new()"),
+            "Other::new() call site must be untouched (wrong owner), got: {main}"
+        );
+        assert!(
+            !main.contains("Other::make_new"),
+            "Other::new() must never be rewritten, got: {main}"
+        );
+        // BARE-DEMOTE invariant: the unqualified `new()` call has no qualifier
+        // to attribute, so it must NOT be rewritten (stays ` new()`, not
+        // ` make_new()`).
+        assert!(
+            main.contains("let _c = new();"),
+            "bare unqualified new() must stay demoted (not rewritten), got: {main}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_rename_twin_owner_demotes_both_call_sites() {
+        // 019 recall-recovery SOUNDNESS (twin-owner guard): TWO `impl Target`
+        // (a.rs and c.rs), both with `fn new`. Renaming one Target::new must
+        // NOT rewrite EITHER `Target::new()` call site — the qualifier
+        // "Target" cannot disambiguate between the two same-owner defs, so the
+        // uniqueness guard fires and both call sites are demoted. This is the
+        // test a demolition of the guard would target; it MUST pass.
+        use crate::protocol::edit::BatchRenameInput;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let a_content =
+            b"pub struct Target;\nimpl Target {\n    pub fn new() -> Self { Target }\n}\n";
+        // Second `impl Target` in a different file, same owner name.
+        let c_content = b"impl Target {\n    pub fn new() -> Self { Target }\n}\n";
+        let main_content = b"fn make() { let _a = Target::new(); }\n";
+        std::fs::write(src_dir.join("a.rs"), a_content).unwrap();
+        std::fs::write(src_dir.join("c.rs"), c_content).unwrap();
+        std::fs::write(src_dir.join("main.rs"), main_content).unwrap();
+
+        let mut files = vec![];
+        for (path, content) in [
+            ("src/a.rs", a_content as &[u8]),
+            ("src/c.rs", c_content as &[u8]),
+            ("src/main.rs", main_content as &[u8]),
+        ] {
+            let result = crate::parsing::process_file(path, content, LanguageId::Rust);
+            let indexed =
+                crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+            files.push((path.to_string(), indexed));
+        }
+        let index = make_live_index_ready(files);
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+
+        // Rename the Target::new in a.rs (line 3).
+        let input = BatchRenameInput {
+            project: None,
+            path: "src/a.rs".to_string(),
+            name: "new".to_string(),
+            kind: None,
+            symbol_line: Some(3),
+            new_name: "make_new".to_string(),
+            dry_run: None,
+            idempotency_key: None,
+            code_only: None,
+            working_directory: None,
+        };
+        let result = server.batch_rename(Parameters(input)).await;
+
+        // Definition site (a.rs) IS renamed.
+        let a = std::fs::read_to_string(src_dir.join("a.rs")).unwrap();
+        assert!(
+            a.contains("pub fn make_new() -> Self { Target }"),
+            "targeted Target::new definition must be renamed, got: {a}"
+        );
+
+        // SOUNDNESS: the Target::new() call site must NOT be rewritten — the
+        // twin `impl Target` in c.rs makes the "Target" qualifier ambiguous.
         let main = std::fs::read_to_string(src_dir.join("main.rs")).unwrap();
         assert_eq!(
             main.as_bytes(),
             main_content as &[u8],
-            "main.rs must be byte-unchanged for ambiguous method rename, got: {main}"
+            "twin-owner ambiguity must demote the call site (no write), got: {main}"
         );
         assert!(
             !main.contains("make_new"),
-            "no call site in main.rs may be rewritten, got: {main}"
+            "no call site may be rewritten under twin-owner ambiguity, got: {main}"
         );
-
-        // The demoted bare refs must be surfaced as uncertain / not applied, so the
-        // result does NOT silently claim `constrained` coverage over them.
+        // Must be surfaced as uncertain, not silently claimed.
         assert!(
             result.contains("Uncertain matches") || result.contains("NOT applied"),
-            "ambiguous bare refs must be surfaced as uncertain, got: {result}"
+            "demoted twin-owner call must be surfaced as uncertain, got: {result}"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -26657,6 +26657,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_rename_ambiguous_method_demotes_bare_refs() {
+        // Renaming the SHARED METHOD `new` scoped to Target::new must NOT rewrite
+        // SomeOther::new. `new` has 2 definitions (Target::new, SomeOther::new),
+        // so the bare-name reverse-index refs AND the unscoped qualified matches
+        // are all ambiguous: they are demoted to the uncertain/surfaced-only set.
+        // Only the definition site is renamed.
+        use crate::protocol::edit::BatchRenameInput;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let lib_content =
+            b"pub struct Target;\nimpl Target {\n    pub fn new() -> Self { Target }\n}\npub struct SomeOther;\nimpl SomeOther {\n    pub fn new() -> Self { SomeOther }\n}\n";
+        let main_content = b"fn make() { let _a = Target::new(); let _b = SomeOther::new(); }\n";
+        std::fs::write(src_dir.join("lib.rs"), lib_content).unwrap();
+        std::fs::write(src_dir.join("main.rs"), main_content).unwrap();
+
+        let mut files = vec![];
+        for (path, content) in [
+            ("src/lib.rs", lib_content as &[u8]),
+            ("src/main.rs", main_content as &[u8]),
+        ] {
+            let result = crate::parsing::process_file(path, content, LanguageId::Rust);
+            let indexed =
+                crate::live_index::store::IndexedFile::from_parse_result(result, content.to_vec());
+            files.push((path.to_string(), indexed));
+        }
+        let index = make_live_index_ready(files);
+        let server = make_server_with_root(index, Some(dir.path().to_path_buf()));
+
+        // Target the `new` at line 3 (Target::new), NOT SomeOther::new (line 7).
+        let input = BatchRenameInput {
+            project: None,
+            path: "src/lib.rs".to_string(),
+            name: "new".to_string(),
+            kind: None,
+            symbol_line: Some(3),
+            new_name: "make_new".to_string(),
+            dry_run: None,
+            idempotency_key: None,
+            code_only: None,
+            working_directory: None,
+        };
+        let result = server.batch_rename(Parameters(input)).await;
+
+        // The definition site (Target::new in lib.rs) IS renamed.
+        let lib = std::fs::read_to_string(src_dir.join("lib.rs")).unwrap();
+        assert!(
+            lib.contains("pub fn make_new() -> Self { Target }"),
+            "Target::new definition must be renamed, got: {lib}"
+        );
+        // SomeOther::new definition in lib.rs is a distinct symbol — untouched.
+        assert!(
+            lib.contains("pub fn new() -> Self { SomeOther }"),
+            "SomeOther::new definition must be untouched, got: {lib}"
+        );
+
+        // main.rs must be BYTE-IDENTICAL to the original: neither call site is a
+        // safe write because `new` is ambiguous across 2 definitions.
+        let main = std::fs::read_to_string(src_dir.join("main.rs")).unwrap();
+        assert_eq!(
+            main.as_bytes(),
+            main_content as &[u8],
+            "main.rs must be byte-unchanged for ambiguous method rename, got: {main}"
+        );
+        assert!(
+            !main.contains("make_new"),
+            "no call site in main.rs may be rewritten, got: {main}"
+        );
+
+        // The demoted bare refs must be surfaced as uncertain / not applied, so the
+        // result does NOT silently claim `constrained` coverage over them.
+        assert!(
+            result.contains("Uncertain matches") || result.contains("NOT applied"),
+            "ambiguous bare refs must be surfaced as uncertain, got: {result}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_batch_insert_adds_to_multiple_files() {
         use crate::protocol::edit::{BatchInsertInput, InsertPosition, InsertTarget};
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -13630,7 +13630,6 @@ mod tests {
             .validate_file_syntax(Parameters(super::ValidateFileSyntaxInput {
                 project: None,
                 path: "Cargo.toml".to_string(),
-                estimate: None,
             }))
             .await;
 
@@ -14108,7 +14107,6 @@ mod tests {
             .validate_file_syntax(Parameters(super::ValidateFileSyntaxInput {
                 project: None,
                 path: "broken.py".to_string(),
-                estimate: None,
             }))
             .await;
 
@@ -14143,7 +14141,6 @@ mod tests {
             .validate_file_syntax(Parameters(super::ValidateFileSyntaxInput {
                 project: None,
                 path: "broken.rs".to_string(),
-                estimate: None,
             }))
             .await;
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -10224,6 +10224,52 @@ impl SymForgeServer {
                             .into_call_tool_result(message));
                     }
                 };
+
+            // US4 (019): NON-RESERVING replay probe BEFORE `run_pre_apply_gates`.
+            // The Replace `if_match` guard inside the gates compares against the
+            // CURRENT symbol body, which has already changed after a first
+            // successful apply — so an identical idempotent replay carrying the
+            // ORIGINAL `if_match` would be wrongly rejected there before the
+            // replay lookup could serve the stored result. This probe short
+            // circuits an identical key+request replay without re-validating the
+            // now-stale `if_match`. It NEVER reserves and NEVER mutates store
+            // state (read-only `replay_if_present`), so the reservation the
+            // legacy tool takes on the miss path is untouched. A miss falls
+            // through to the gates (preserving new-key optimistic concurrency);
+            // a same-key/different-request hit surfaces the store's conflict
+            // rather than silently replaying.
+            if let Some(key) = request.idempotency_key.as_deref()
+                && let Some(repo_root) = self.capture_repo_root()
+            {
+                // A planning failure here is re-surfaced by the authoritative
+                // `build_edit_plan` call below; don't duplicate the error path.
+                if let Ok(probe_plan) = build_edit_plan(request) {
+                    let step = probe_plan
+                        .steps
+                        .first()
+                        .expect("edit planner always emits at least one step");
+                    match super::edit_tools::probe_symforge_edit_apply_replay(
+                        &repo_root,
+                        &step.tool,
+                        &step.args,
+                        Some(key),
+                    ) {
+                        Ok(Some(stored_response)) => {
+                            self.session_context.record_summary_output(
+                                "symforge_edit",
+                                handler::estimate_tokens(&stored_response),
+                            );
+                            return statused_tool_result(stored_response, OutcomeClass::Found);
+                        }
+                        Ok(None) => {}
+                        Err(output) => {
+                            return Ok(ResultStatus::new(OutcomeClass::InvalidRequest)
+                                .into_call_tool_result(output));
+                        }
+                    }
+                }
+            }
+
             match run_pre_apply_gates(&self.index, request, &abs_path) {
                 Ok(PreApplyOutcome::Ready(symbol)) => resolved_symbol = Some(symbol),
                 // F6: the already-applied check compares against the INDEXED
@@ -28440,6 +28486,169 @@ mod tests {
         assert!(
             !on_disk.contains("old"),
             "negative control must replace the old body:\n{on_disk}"
+        );
+    }
+
+    /// US4 (019): an identical idempotent `symforge_edit` apply replay — same
+    /// `idempotency_key`, same request INCLUDING the original `if_match` — must
+    /// return the STORED result and write ZERO bytes, NOT be rejected by the now
+    /// stale `if_match` guard.
+    ///
+    /// Before this fix, the local-apply branch ran `run_pre_apply_gates`' Replace
+    /// `if_match` guard BEFORE any replay lookup. After the first apply the body
+    /// changed, so the original `if_match` no longer matched the current body and
+    /// the replay was wrongly rejected with "if_match does not match current
+    /// symbol body". A non-reserving replay probe now short-circuits the identical
+    /// key+request replay before that guard.
+    #[tokio::test]
+    async fn symforge_edit_idempotent_replay_short_circuits_stale_if_match() {
+        use crate::stel::StelEditRequest;
+
+        let original = "fn target() { old }\n";
+        let (dir, server) = setup_loaded_edit_test(&[("src/lib.rs", original)]);
+        let file_path = dir.path().join("src/lib.rs");
+        let _surface = EnvVarGuard::set("SYMFORGE_SURFACE", "compact");
+
+        let request = StelEditRequest {
+            path: "src/lib.rs".to_string(),
+            symbol: Some("target".to_string()),
+            if_match: Some(original.trim().to_string()),
+            body: Some("fn target() { agent_edit }".to_string()),
+            apply: Some(true),
+            idempotency_key: Some("replay-key-1".to_string()),
+            ..Default::default()
+        };
+
+        // First apply: commits the write.
+        let first = server
+            .symforge_edit_facade_tool(Parameters(request.clone()))
+            .await
+            .expect("first symforge_edit dispatch");
+        let first_serialized = serde_json::to_value(&first).expect("serialize first");
+        let first_text = tool_result_text(&first_serialized);
+        assert!(
+            first_text.contains("Write semantics: atomic write + reindex"),
+            "first apply must commit the write:\n{first_text}"
+        );
+
+        let after_first = std::fs::read_to_string(&file_path).expect("read after first apply");
+        assert!(
+            after_first.contains("agent_edit"),
+            "first apply must land the edit:\n{after_first}"
+        );
+
+        // Replay: IDENTICAL request (same key, same if_match, same body). The
+        // body on disk has changed, so the original if_match no longer matches
+        // the current body — yet the replay must succeed by returning the stored
+        // result, writing ZERO new bytes.
+        let replay = server
+            .symforge_edit_facade_tool(Parameters(request.clone()))
+            .await
+            .expect("replay symforge_edit dispatch");
+        let replay_serialized = serde_json::to_value(&replay).expect("serialize replay");
+        let replay_text = tool_result_text(&replay_serialized);
+
+        assert!(
+            !replay_text.contains("if_match does not match current symbol body"),
+            "idempotent replay must NOT be rejected by the stale if_match guard:\n{replay_text}"
+        );
+        assert_ne!(
+            replay_serialized["_meta"][RESULT_STATUS_META_KEY]["outcome_class"],
+            serde_json::json!(OutcomeClass::InvalidRequest.as_str()),
+            "idempotent replay must not classify as an invalid request:\n{replay_text}"
+        );
+
+        // ZERO new bytes: the on-disk content is byte-identical after the replay.
+        let after_replay = std::fs::read_to_string(&file_path).expect("read after replay");
+        assert_eq!(
+            after_first, after_replay,
+            "idempotent replay must write zero bytes (byte-identical file)"
+        );
+    }
+
+    /// US4 (019): a replay carrying the SAME `idempotency_key` but a CHANGED
+    /// request (different body) must be an idempotency conflict, NOT a silent
+    /// replay of the stored result. The non-reserving probe must surface the
+    /// store's `Conflict` rather than swallowing it.
+    #[tokio::test]
+    async fn symforge_edit_same_key_changed_request_is_conflict_not_replay() {
+        use crate::stel::StelEditRequest;
+
+        let original = "fn target() { old }\n";
+        let (_dir, server) = setup_loaded_edit_test(&[("src/lib.rs", original)]);
+        let _surface = EnvVarGuard::set("SYMFORGE_SURFACE", "compact");
+
+        let first = StelEditRequest {
+            path: "src/lib.rs".to_string(),
+            symbol: Some("target".to_string()),
+            if_match: Some(original.trim().to_string()),
+            body: Some("fn target() { agent_edit }".to_string()),
+            apply: Some(true),
+            idempotency_key: Some("conflict-key-1".to_string()),
+            ..Default::default()
+        };
+        server
+            .symforge_edit_facade_tool(Parameters(first))
+            .await
+            .expect("first apply");
+
+        // Same key, DIFFERENT body → the request hash differs.
+        let changed = StelEditRequest {
+            path: "src/lib.rs".to_string(),
+            symbol: Some("target".to_string()),
+            if_match: Some(original.trim().to_string()),
+            body: Some("fn target() { different_edit }".to_string()),
+            apply: Some(true),
+            idempotency_key: Some("conflict-key-1".to_string()),
+            ..Default::default()
+        };
+        let result = server
+            .symforge_edit_facade_tool(Parameters(changed))
+            .await
+            .expect("conflict dispatch");
+        let conflict_serialized = serde_json::to_value(&result).expect("serialize conflict");
+        let output = tool_result_text(&conflict_serialized);
+        assert!(
+            output.contains("Idempotency conflict"),
+            "same key + changed request must be a conflict, not a silent replay:\n{output}"
+        );
+    }
+
+    /// US4 (019) MUST-NOT-REGRESS: a NEW idempotency key whose `if_match` does
+    /// not match the current body has no stored result, so the probe returns
+    /// `None` and the genuine optimistic-concurrency guard still rejects it.
+    #[tokio::test]
+    async fn symforge_edit_new_key_stale_if_match_still_rejected() {
+        use crate::stel::StelEditRequest;
+
+        let original = "fn target() { old }\n";
+        let (_dir, server) = setup_loaded_edit_test(&[("src/lib.rs", original)]);
+        let _surface = EnvVarGuard::set("SYMFORGE_SURFACE", "compact");
+
+        let request = StelEditRequest {
+            path: "src/lib.rs".to_string(),
+            symbol: Some("target".to_string()),
+            // if_match does NOT match the current body.
+            if_match: Some("fn target() { wrong }".to_string()),
+            body: Some("fn target() { agent_edit }".to_string()),
+            apply: Some(true),
+            idempotency_key: Some("fresh-key-1".to_string()),
+            ..Default::default()
+        };
+        let result = server
+            .symforge_edit_facade_tool(Parameters(request))
+            .await
+            .expect("stale if_match dispatch");
+        let serialized = serde_json::to_value(&result).expect("serialize");
+        let output = tool_result_text(&serialized);
+        assert!(
+            output.contains("if_match does not match current symbol body"),
+            "a new key with stale if_match must still be rejected by the concurrency guard:\n{output}"
+        );
+        assert_eq!(
+            serialized["_meta"][RESULT_STATUS_META_KEY]["outcome_class"],
+            serde_json::json!(OutcomeClass::InvalidRequest.as_str()),
+            "stale-if_match rejection must classify as an invalid request:\n{output}"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -10454,6 +10454,21 @@ impl SymForgeServer {
             .to_string(),
         );
         if let Some(result) = self.proxy_tool_call("status", &request).await {
+            // US5c (P2 correctness/trust): `reset_calibration=true` MUST reset the
+            // PROXY-owned durable store HERE. The proxy owns `stel_ledger_store`;
+            // the storeless worker it proxied to resets nothing, so without this
+            // the call returned success-shaped `Found` while the durable
+            // calibration was left byte-identical — a silent no-op. Reset BEFORE
+            // building `proxy_owned_status_lines` below so the overlaid
+            // calibration lines reflect the post-reset (`deferred`) state, not
+            // stale pre-reset samples. The receipt mirrors the local path's
+            // `reset_note` wording and is appended to the body so the operator
+            // sees the reset actually happened (or an honest no-store note).
+            let reset_receipt = if request.reset_calibration == Some(true) {
+                Some(self.proxy_reset_calibration_receipt())
+            } else {
+                None
+            };
             // D2-ROOT: the daemon worker owns the populated INDEX but has an EMPTY
             // session ledger + NO durable store, so its proxied body reads
             // `ledger_events: 0`, `last_ledger_*: none`, `durable_ledger:
@@ -10468,7 +10483,12 @@ impl SymForgeServer {
             let result = overlay_proxy_status_lines(result, &self.proxy_owned_status_lines());
             // Mirror `health`: warn loudly if the daemon we proxied to runs an
             // older binary than this front-end.
-            let body = append_daemon_staleness_warning(result, env!("CARGO_PKG_VERSION"));
+            let mut body = append_daemon_staleness_warning(result, env!("CARGO_PKG_VERSION"));
+            // Surface the honest reset receipt, mirroring the local path's
+            // `format!("{body}\n{note}")` placement.
+            if let Some(note) = reset_receipt {
+                body = format!("{body}\n{note}");
+            }
             return statused_tool_result(body, OutcomeClass::Found);
         }
 
@@ -10629,6 +10649,44 @@ impl SymForgeServer {
             ctx = ctx.with_calibration_verdict(verdict);
         }
         crate::stel::render_proxy_owned_lines(&ctx)
+    }
+
+    /// US5c (P2 correctness/trust): reset the PROXY-owned durable calibration
+    /// store and return an honest receipt line.
+    ///
+    /// In the default daemon-proxy topology the PROXY owns `stel_ledger_store`;
+    /// the storeless daemon worker it proxies to has nothing to reset. So a
+    /// `status(reset_calibration=true)` MUST reset HERE, or it returns a
+    /// success-shaped `Found` while the durable calibration is left
+    /// byte-identical — a silent no-op that lies to the operator. Called by the
+    /// proxy branch of [`Self::status_stel_tool`] BEFORE building
+    /// [`Self::proxy_owned_status_lines`], so the overlaid calibration lines
+    /// reflect the post-reset (`deferred`) state, not stale pre-reset samples.
+    ///
+    /// The receipt wording mirrors `render_stel_status_body`'s `reset_note` (the
+    /// local/no-daemon path) verbatim, so the operator sees identical honest
+    /// language whether the reset ran locally or through the proxy: a real
+    /// cleared-sample count with a store, or the "no durable store" no-op note
+    /// without one.
+    #[cfg(feature = "server")]
+    pub(crate) fn proxy_reset_calibration_receipt(&self) -> String {
+        match self.reset_calibration() {
+            Some(cleared) => format!(
+                "calibration_reset: cleared {cleared} sample(s) + active tuning (state -> deferred)"
+            ),
+            None => {
+                "calibration_reset: no durable store; in-memory calibration is already deferred"
+                    .to_string()
+            }
+        }
+    }
+
+    /// Embed/no-`server` builds have no durable calibration store wired, so the
+    /// reset is an honest no-op — mirrors the `reset_calibration() == None` arm
+    /// of the local path.
+    #[cfg(not(feature = "server"))]
+    pub(crate) fn proxy_reset_calibration_receipt(&self) -> String {
+        "calibration_reset: no durable store; in-memory calibration is already deferred".to_string()
     }
 
     /// Daemon-side `status` entry point (TR-01 / FR-006).
@@ -11449,6 +11507,96 @@ mod tests {
         assert!(
             bare_overlaid.contains("durable_ledger: unavailable"),
             "a no-store proxy stays unavailable after overlay:\n{bare_overlaid}"
+        );
+    }
+
+    /// US5c (P2 correctness/trust): in the daemon-proxy topology,
+    /// `status(reset_calibration=true)` MUST actually reset the PROXY-owned
+    /// durable calibration store (the proxy owns it; the storeless worker it
+    /// proxies to resets nothing) AND surface an honest receipt. Before the fix
+    /// the proxy branch returned success-shaped `Found` while leaving the durable
+    /// store byte-identical — a silent no-op. This pins the reset + receipt the
+    /// proxy branch now performs, and that the post-reset verdict overlaid onto
+    /// the worker body reads `deferred`, not the stale pre-reset `accumulating`.
+    #[test]
+    fn daemon_proxy_reset_calibration_clears_proxy_store_and_reports_receipt() {
+        use crate::stel::calibration::CalibrationVerdict;
+        use crate::stel::ledger_store::StelLedgerStore;
+
+        let client = crate::daemon::DaemonSessionClient::new_for_test(
+            "http://127.0.0.1:1".to_string(),
+            "p".to_string(),
+            "s".to_string(),
+            "proj".to_string(),
+        );
+        // Seed the PROXY's durable store with samples so calibration accumulates
+        // HERE — exactly the state a real proxy carries while the worker is blind.
+        let store =
+            StelLedgerStore::open_in_memory("proxy-reset").expect("in-memory durable store");
+        store.record(&sample_durable_event());
+        store.record(&sample_durable_event());
+        let proxy =
+            SymForgeServer::new_daemon_proxy(client).with_stel_ledger_store(Arc::new(store));
+
+        // Precondition: the proxy store is accumulating (2 samples).
+        match proxy.durable_calibration_verdict() {
+            Some(CalibrationVerdict::Accumulating { n, .. }) => assert_eq!(n, 2),
+            other => panic!("expected accumulating precondition, got {other:?}"),
+        }
+
+        // The proxy-branch reset the fix performs: clear the PROXY-owned store and
+        // return an honest receipt. This is what `status_stel_tool`'s proxy branch
+        // invokes when `reset_calibration == Some(true)`.
+        let receipt = proxy.proxy_reset_calibration_receipt();
+
+        // 1) The durable store was actually cleared to deferred (the reset is real,
+        //    not a success-shaped no-op).
+        assert_eq!(
+            proxy.durable_calibration_verdict(),
+            Some(CalibrationVerdict::Deferred),
+            "reset_calibration in the proxy branch must clear the proxy's durable store to deferred"
+        );
+
+        // 2) The receipt mirrors `render_stel_status_body`'s reset_note wording, and
+        //    reports the 2 cleared samples honestly.
+        assert_eq!(
+            receipt, "calibration_reset: cleared 2 sample(s) + active tuning (state -> deferred)",
+            "proxy reset receipt must mirror the local reset_note wording"
+        );
+
+        // 3) The proxy-owned overlay lines built AFTER the reset reflect the
+        //    post-reset (deferred) state, not the stale pre-reset accumulating one.
+        let overlaid = super::overlay_proxy_status_lines(
+            worker_full_status_body(),
+            &proxy.proxy_owned_status_lines(),
+        );
+        assert!(
+            overlaid.contains("calibration: deferred"),
+            "overlay after reset must show deferred calibration:\n{overlaid}"
+        );
+        assert!(
+            !overlaid.contains("calibration: accumulating"),
+            "overlay after reset must NOT show stale accumulating calibration:\n{overlaid}"
+        );
+    }
+
+    /// Honesty for the no-store proxy: `reset_calibration=true` in the proxy
+    /// branch with NO durable store attached must NOT claim a reset it did not
+    /// perform — it returns the honest "no durable store" receipt, matching the
+    /// local path's wording.
+    #[test]
+    fn daemon_proxy_reset_calibration_no_store_reports_honest_no_op() {
+        let client = crate::daemon::DaemonSessionClient::new_for_test(
+            "http://127.0.0.1:1".to_string(),
+            "p".to_string(),
+            "s".to_string(),
+            "proj".to_string(),
+        );
+        let bare = SymForgeServer::new_daemon_proxy(client);
+        assert_eq!(
+            bare.proxy_reset_calibration_receipt(),
+            "calibration_reset: no durable store; in-memory calibration is already deferred",
+            "a no-store proxy must report the honest no-op receipt, not a false reset"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2772,37 +2772,6 @@ fn find_references_evidence(view: &crate::live_index::FindReferencesView) -> Str
     anchored_search_evidence(anchors, "reference anchors")
 }
 
-/// Feature 012 (Phase 3), Principle VII honesty: a cross-project read targets
-/// the daemon-owned working set, which does not exist on the local (`/mcp` HTTP,
-/// stdio/embed, or daemon-degraded) execution path. When a `project`/`projects`
-/// param is present and we are about to run LOCALLY, return an honest refusal
-/// instead of silently ignoring the target and serving the active project only.
-/// Returns the refusal message when the request is cross-project, else `None`.
-///
-/// C-stopgap (D16): on the `/mcp` HTTP transport there is no daemon behind the
-/// handler (`proxy_tool_call` short-circuits to `None` because `daemon_client`
-/// is `None`), so this is the guard that contains D16's silent-wrong half —
-/// `/mcp` loudly refuses cross-project targeting rather than silently serving the
-/// single bound index. `tests/serve_http_attach.rs` locks it end-to-end.
-fn local_cross_project_refusal(
-    project: Option<&str>,
-    projects: Option<&[String]>,
-) -> Option<String> {
-    let has_project = project.map(|p| !p.trim().is_empty()).unwrap_or(false);
-    let has_projects = projects.map(|p| !p.is_empty()).unwrap_or(false);
-    if has_project || has_projects {
-        Some(
-            "Cross-project queries (project/projects) require the daemon: the \
-             working set of open projects lives on the daemon transport, not on \
-             the /mcp HTTP transport, stdio/embed, or while the daemon is \
-             unreachable. Start the daemon to query across projects."
-                .to_string(),
-        )
-    } else {
-        None
-    }
-}
-
 fn find_references_kind_filter(kind_filter: Option<&str>) -> Option<ReferenceKind> {
     match kind_filter {
         Some("call") => Some(ReferenceKind::Call),
@@ -4982,8 +4951,8 @@ impl SymForgeServer {
         }
         // Feature 012 (Phase 3): no daemon here -> no working set. Honest refusal
         // for a cross-project request instead of a silent single-project answer.
-        if let Some(refusal) =
-            local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
+        if let Some(refusal) = self
+            .local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
         {
             return refusal;
         }
@@ -5145,8 +5114,8 @@ impl SymForgeServer {
         }
         // Feature 012 (Phase 3): honest refusal for a cross-project request with
         // no daemon (no working set on the local path).
-        if let Some(refusal) =
-            local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
+        if let Some(refusal) = self
+            .local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
         {
             return refusal;
         }
@@ -6765,6 +6734,32 @@ impl SymForgeServer {
         })
     }
 
+    /// True when an explicit `project`/`projects` selector RESOLVES TO THE BOUND
+    /// project: it equals the bound project name, the bound root's deterministic
+    /// project key, or the bound root path (either slash flavor). Shared by both
+    /// project-refusal guards so the two agree on what "local" means; an empty or
+    /// whitespace-only selector is treated as absent (returns false — the caller
+    /// decides how to handle "no selector").
+    fn selector_matches_bound_project(&self, selector: &str) -> bool {
+        let selector = selector.trim();
+        if selector.is_empty() {
+            return false;
+        }
+        if selector == self.project_name {
+            return true;
+        }
+        if let Some(root) = self.capture_repo_root().as_deref() {
+            if selector == crate::daemon::project_key(root) {
+                return true;
+            }
+            let root_text = root.display().to_string();
+            if selector == root_text || selector == root_text.replace('\\', "/") {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Task 4: local/embedded servers are bound to exactly ONE project. When a
     /// tool call reaches local execution (stdio/embed, or a degraded daemon
     /// fallback) carrying an explicit `project` selector that does not match
@@ -6775,19 +6770,10 @@ impl SymForgeServer {
     /// or matches.
     pub(crate) fn foreign_project_refusal(&self, project: Option<&str>) -> Option<String> {
         let selector = project.map(str::trim).filter(|p| !p.is_empty())?;
-        if selector == self.project_name {
+        if self.selector_matches_bound_project(selector) {
             return None;
         }
         let bound_root = self.capture_repo_root();
-        if let Some(root) = bound_root.as_deref() {
-            if selector == crate::daemon::project_key(root) {
-                return None;
-            }
-            let root_text = root.display().to_string();
-            if selector == root_text || selector == root_text.replace('\\', "/") {
-                return None;
-            }
-        }
         Some(format!(
             "project '{selector}' is not available on this connection: this server is bound \
              to the single project '{}'{}. Explicit project routing requires the daemon \
@@ -6798,6 +6784,64 @@ impl SymForgeServer {
                 .map(|root| format!(" ({})", root.display()))
                 .unwrap_or_default()
         ))
+    }
+
+    /// Feature 012 (Phase 3), Principle VII honesty: a cross-project read targets
+    /// the daemon-owned working set, which does not exist on the local (`/mcp` HTTP,
+    /// stdio/embed, or daemon-degraded) execution path. `search_symbols`,
+    /// `search_text`, and `find_references` gate their no-daemon local path on this
+    /// guard. Returns the refusal message when the request is GENUINELY
+    /// cross-project, else `None` (proceed).
+    ///
+    /// C-stopgap (D16): on the `/mcp` HTTP transport there is no daemon behind the
+    /// handler (`proxy_tool_call` short-circuits to `None` because `daemon_client`
+    /// is `None`), so this contains D16's silent-wrong half — `/mcp` LOUDLY refuses
+    /// cross-project targeting rather than silently serving the single bound index.
+    /// `tests/serve_http_attach.rs` locks it end-to-end.
+    ///
+    /// The containment is deliberately NARROW: a selector that RESOLVES TO THE BOUND
+    /// project (its name, its root's project key, or its root path) is answerable
+    /// locally, so it PROCEEDS — only foreign, multi-project, or wildcard (`*`)
+    /// selectors, which need the daemon working set, are refused. This shares
+    /// `selector_matches_bound_project` with `foreign_project_refusal` so both guards
+    /// agree on what counts as local; only the refusal MESSAGE differs (this one
+    /// names the `/mcp` transport for the no-daemon path).
+    fn local_cross_project_refusal(
+        &self,
+        project: Option<&str>,
+        projects: Option<&[String]>,
+    ) -> Option<String> {
+        // Gather every non-empty selector from both the singular and plural params.
+        let mut selectors: Vec<&str> = Vec::new();
+        if let Some(p) = project.map(str::trim).filter(|p| !p.is_empty()) {
+            selectors.push(p);
+        }
+        if let Some(list) = projects {
+            selectors.extend(list.iter().map(|p| p.trim()).filter(|p| !p.is_empty()));
+        }
+
+        // No selector at all -> proceed on the normal single-project path.
+        if selectors.is_empty() {
+            return None;
+        }
+
+        // A wildcard, or ANY selector that does not resolve to the bound project,
+        // requires the daemon working set -> refuse honestly. Only when EVERY
+        // selector resolves to the bound project can we answer locally.
+        let all_local = selectors
+            .iter()
+            .all(|selector| *selector != "*" && self.selector_matches_bound_project(selector));
+        if all_local {
+            return None;
+        }
+
+        Some(
+            "Cross-project queries (project/projects) require the daemon: the \
+             working set of open projects lives on the daemon transport, not on \
+             the /mcp HTTP transport, stdio/embed, or while the daemon is \
+             unreachable. Start the daemon to query across projects."
+                .to_string(),
+        )
     }
 
     /// Reindex a directory from scratch — replaces the current index, restarts watcher, triggers
@@ -8047,8 +8091,8 @@ impl SymForgeServer {
         }
         // Feature 012 (Phase 3): honest refusal for a cross-project request with
         // no daemon (no working set on the local path).
-        if let Some(refusal) =
-            local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
+        if let Some(refusal) = self
+            .local_cross_project_refusal(params.0.project.as_deref(), params.0.projects.as_deref())
         {
             return refusal;
         }
@@ -15162,6 +15206,90 @@ mod tests {
         assert!(
             !conflict.starts_with("Indexed "),
             "conflict must not report synthetic indexing success: {conflict}"
+        );
+    }
+
+    #[test]
+    fn local_cross_project_refusal_allows_matching_local_selector() {
+        // SUB-FIX A: search_symbols/search_text/find_references gate their no-daemon
+        // local path on `local_cross_project_refusal`. It must PROCEED (return None,
+        // same as no selector) when the selector RESOLVES TO THE BOUND PROJECT — by
+        // name, by the bound root's project key, or by the root path — and only
+        // refuse foreign/multi/wildcard targets. Pre-fix it refused ANY non-empty
+        // selector, wrongly rejecting a matching-local one.
+        let repo = TempDir::new().expect("tempdir");
+        let root = repo.path().to_path_buf();
+        let server = make_server_with_root(make_live_index_empty(), Some(root.clone()));
+
+        // No selector at all -> proceed (control).
+        assert!(
+            server.local_cross_project_refusal(None, None).is_none(),
+            "no selector must proceed"
+        );
+
+        // Matching-local by project NAME -> proceed (the fix).
+        assert!(
+            server
+                .local_cross_project_refusal(Some("test_project"), None)
+                .is_none(),
+            "a selector equal to the bound project name must PROCEED, not refuse"
+        );
+
+        // Matching-local by the bound root's deterministic project key -> proceed.
+        let key = crate::daemon::project_key(&root);
+        assert!(
+            server
+                .local_cross_project_refusal(Some(key.as_str()), None)
+                .is_none(),
+            "a selector equal to the bound root's project key must PROCEED"
+        );
+
+        // Matching-local by root PATH (forward-slash form) -> proceed.
+        let root_fwd = root.display().to_string().replace('\\', "/");
+        assert!(
+            server
+                .local_cross_project_refusal(Some(root_fwd.as_str()), None)
+                .is_none(),
+            "a selector equal to the bound root path must PROCEED"
+        );
+
+        // Matching-local through the PLURAL `projects` selector -> proceed.
+        let plural_local = vec!["test_project".to_string()];
+        assert!(
+            server
+                .local_cross_project_refusal(None, Some(plural_local.as_slice()))
+                .is_none(),
+            "a plural projects=[bound name] must PROCEED"
+        );
+
+        // Foreign singular selector -> refuse, and the message must still name the
+        // /mcp transport (the D16 containment wording is preserved).
+        let foreign = server
+            .local_cross_project_refusal(Some("other-proj"), None)
+            .expect("a foreign project selector must still refuse");
+        assert!(
+            foreign.contains("/mcp HTTP transport"),
+            "the foreign refusal must still name the /mcp transport, got: {foreign}"
+        );
+
+        // Wildcard -> refuse (cross-project unanswerable without a daemon working set).
+        let wildcard = vec!["*".to_string()];
+        assert!(
+            server
+                .local_cross_project_refusal(None, Some(wildcard.as_slice()))
+                .expect("wildcard projects must refuse")
+                .contains("/mcp HTTP transport"),
+            "wildcard refusal must name the /mcp transport"
+        );
+
+        // Multiple distinct non-bound projects -> refuse.
+        let multi = vec!["a".to_string(), "b".to_string()];
+        assert!(
+            server
+                .local_cross_project_refusal(None, Some(multi.as_slice()))
+                .expect("multi-project projects must refuse")
+                .contains("/mcp HTTP transport"),
+            "multi-project refusal must name the /mcp transport"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -7460,17 +7460,114 @@ impl SymForgeServer {
         // default removed, so an empty/shrunken blast radius is self-describing.
         let source_filtered_out = unfiltered_changed_total.saturating_sub(changed_files.len());
 
+        // PART A (019): the seed is a BODY delta, not every symbol of a changed
+        // file. Reparse each changed file's BASE blob and its CURRENT working
+        // tree with the same extractor `diff_symbols` uses
+        // (`extract_symbols_for_diff` -> name+body-hash pairs), then seed only
+        // the symbols whose body was added, modified, or removed. A 1-line edit
+        // in a 20-symbol file now seeds 1 symbol, not 20; a comment/whitespace
+        // shift that leaves every body byte-identical seeds 0.
+        //
+        // Base ref: mirror `merge_git_changed_paths`'s OWN base selection so the
+        // body-delta compares against the same base the changed-file set came
+        // from. `since=<ref>` diffs `<ref>...HEAD`; the `WORKTREE` sentinel and
+        // `base_branch` both diff against the committed tip / branch, with the
+        // working tree as the current side. A mismatched base (e.g. always HEAD)
+        // would find zero deltas for a committed `since` range on a clean tree.
+        let since_trimmed = params
+            .0
+            .since
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let seed_base_ref = match since_trimmed {
+            Some("WORKTREE") => "HEAD",
+            Some(since_ref) => since_ref,
+            None => base_branch.as_deref().unwrap_or("HEAD"),
+        };
         let (changed_symbols, blast_radius) = {
             let guard = self.index.read();
             let mut changed_symbols: Vec<crate::live_index::graph::SymbolId> = Vec::new();
             for path in &changed_files {
-                if let Some(file) = guard.files.get(path) {
-                    for sym in &file.symbols {
-                        changed_symbols.push(crate::live_index::graph::SymbolId {
-                            path: path.clone(),
-                            name: sym.name.clone(),
-                            kind: sym.kind,
-                        });
+                // Kind lookup for the CURRENT symbols comes from the live index;
+                // removed symbols (absent from current) default to Function to
+                // match the graph's own entry-point default.
+                let kind_by_name: HashMap<&str, crate::domain::SymbolKind> = guard
+                    .files
+                    .get(path)
+                    .map(|f| {
+                        f.symbols
+                            .iter()
+                            .map(|s| (s.name.as_str(), s.kind))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let base_content = repo
+                    .file_at_ref(seed_base_ref, path)
+                    .unwrap_or_default()
+                    .unwrap_or_default();
+                let current_content = repo
+                    .file_from_workdir(path)
+                    .unwrap_or_default()
+                    .unwrap_or_default();
+
+                // Unsupported/config languages return None from the extractor;
+                // we cannot body-diff them, so fall back to seeding every
+                // indexed symbol of the file (the old conservative behavior)
+                // rather than silently seeding nothing.
+                let base_syms = crate::parsing::extract_symbols_for_diff(&base_content, path);
+                let current_syms = crate::parsing::extract_symbols_for_diff(&current_content, path);
+                let (Some(base_syms), Some(current_syms)) = (base_syms, current_syms) else {
+                    if let Some(file) = guard.files.get(path) {
+                        for sym in &file.symbols {
+                            changed_symbols.push(crate::live_index::graph::SymbolId {
+                                path: path.clone(),
+                                name: sym.name.clone(),
+                                kind: sym.kind,
+                            });
+                        }
+                    }
+                    continue;
+                };
+
+                // ponytail: name-keyed body-hash maps, matching `diff_symbols`'
+                // own name-keyed comparison. Same-name overloads in one file
+                // collapse to their last body hash; a resolver-aware seed
+                // (C-S2-001) would key on a stable symbol id instead.
+                let base_by_name: HashMap<&str, &str> = base_syms
+                    .iter()
+                    .map(|(n, h)| (n.as_str(), h.as_str()))
+                    .collect();
+                let current_by_name: HashMap<&str, &str> = current_syms
+                    .iter()
+                    .map(|(n, h)| (n.as_str(), h.as_str()))
+                    .collect();
+
+                let mut seed = |name: &str| {
+                    changed_symbols.push(crate::live_index::graph::SymbolId {
+                        path: path.clone(),
+                        name: name.to_string(),
+                        kind: kind_by_name
+                            .get(name)
+                            .copied()
+                            .unwrap_or(crate::domain::SymbolKind::Function),
+                    });
+                };
+
+                // Added (in current, not base) or modified (body hash differs).
+                for (name, cur_hash) in &current_by_name {
+                    match base_by_name.get(name) {
+                        None => seed(name),
+                        Some(base_hash) if base_hash != cur_hash => seed(name),
+                        _ => {}
+                    }
+                }
+                // Removed (in base, not current) — seeded so downstream callers
+                // of a deleted symbol still appear in the blast radius.
+                for name in base_by_name.keys() {
+                    if !current_by_name.contains_key(name) {
+                        seed(name);
                     }
                 }
             }
@@ -7490,7 +7587,20 @@ impl SymForgeServer {
             match params.0.scope {
                 ImpactScope::Symbols => blast_radius
                     .iter()
-                    .map(|node| (node.symbol.name.clone(), node.hop, node.risk))
+                    // PART C (019): carry disambiguating identity. Two blast
+                    // nodes that share a bare name (e.g. `main` in different
+                    // files, or two `run`s the graph kept distinct) must render
+                    // as distinct `path::name` entries, not collapse into one
+                    // indistinguishable `"main"`. The path already disambiguates
+                    // same-name defs across files; kind is folded into the node
+                    // identity by the graph, so `path::name` is sufficient here.
+                    .map(|node| {
+                        (
+                            format!("{}::{}", node.symbol.path, node.symbol.name),
+                            node.hop,
+                            node.risk,
+                        )
+                    })
                     .collect(),
                 ImpactScope::Files => {
                     let mut by_file: HashMap<String, (u32, crate::live_index::graph::RiskTier)> =
@@ -18801,6 +18911,165 @@ mod tests {
         assert!(
             result.contains("include_data"),
             "the disclosure must name the include_data recovery lever: {result}"
+        );
+    }
+
+    /// PART C (019 detect_impact fix): scope=symbols blast entries must carry
+    /// disambiguating identity (path), so two entry points named `main` in
+    /// different files render as DISTINCT lines instead of collapsing into two
+    /// indistinguishable `"main"` entries. RED on the pre-fix formatter, which
+    /// emitted only `node.symbol.name`.
+    #[tokio::test]
+    async fn test_detect_impact_symbols_scope_disambiguates_same_name_nodes() {
+        let repo = init_git_repo();
+        fs::create_dir_all(repo.path().join("src")).expect("create src dir");
+        // Commit a base `core`, then modify it in the working tree so core.rs
+        // is a changed SOURCE file that seeds the blast.
+        fs::write(
+            repo.path().join("src/core.rs"),
+            "pub fn core() -> u32 { 1 }\n",
+        )
+        .expect("write core");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-m", "init", "-q"]);
+        fs::write(
+            repo.path().join("src/core.rs"),
+            "pub fn core() -> u32 { 2 }\n",
+        )
+        .expect("modify core");
+
+        // Index: `core` plus two files whose `main` (enclosing index 0) calls it.
+        // `core` is a UNIQUE name -> PART B one-def rule links both callers.
+        let core_file = make_file(
+            "src/core.rs",
+            b"pub fn core() -> u32 { 2 }\n",
+            vec![make_symbol("core", SymbolKind::Function, 0, 0)],
+        );
+        let a_file = make_file_with_refs(
+            "src/a.rs",
+            b"fn main() { core(); }\n",
+            vec![make_symbol("main", SymbolKind::Function, 0, 0)],
+            vec![make_ref("core", None, ReferenceKind::Call, 0, Some(0))],
+        );
+        let b_file = make_file_with_refs(
+            "src/b.rs",
+            b"fn main() { core(); }\n",
+            vec![make_symbol("main", SymbolKind::Function, 0, 0)],
+            vec![make_ref("core", None, ReferenceKind::Call, 0, Some(0))],
+        );
+        let server = make_server_with_root(
+            make_live_index_ready(vec![core_file, a_file, b_file]),
+            Some(repo.path().to_path_buf()),
+        );
+        let result = server
+            .detect_impact(Parameters(super::DetectImpactInput {
+                base_branch: None,
+                since: Some("WORKTREE".to_string()),
+                depth: 2,
+                scope: super::ImpactScope::Symbols,
+                include_untracked: true,
+                include_data: None,
+            }))
+            .await;
+        // Both `main` entry points are in the blast; their labels must be
+        // distinct (path-qualified), not two bare `"main"` collapses.
+        assert!(
+            result.contains("src/a.rs::main") && result.contains("src/b.rs::main"),
+            "two same-name blast nodes must render as distinct path-qualified \
+             entries: {result}"
+        );
+    }
+
+    /// PART A (019 detect_impact fix): the seed must be a BODY delta, not every
+    /// symbol of a changed file. Editing ONLY one function's body in a
+    /// multi-symbol file must seed exactly that ONE symbol as changed — not all
+    /// symbols in the file. RED on the pre-fix seed loop, which pushed every
+    /// `file.symbols` entry.
+    #[tokio::test]
+    async fn test_detect_impact_seeds_only_body_changed_symbols() {
+        let repo = init_git_repo();
+        fs::create_dir_all(repo.path().join("src")).expect("create src dir");
+        let base = "pub fn kept() -> u32 { 1 }\npub fn changed() -> u32 { 2 }\n";
+        let modified = "pub fn kept() -> u32 { 1 }\npub fn changed() -> u32 { 99 }\n";
+        fs::write(repo.path().join("src/multi.rs"), base).expect("write base");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-m", "init", "-q"]);
+        fs::write(repo.path().join("src/multi.rs"), modified).expect("modify changed body");
+
+        // Index mirrors the working tree (both symbols present).
+        let multi_file = make_file(
+            "src/multi.rs",
+            modified.as_bytes(),
+            vec![
+                make_symbol("kept", SymbolKind::Function, 0, 0),
+                make_symbol("changed", SymbolKind::Function, 1, 1),
+            ],
+        );
+        let server = make_server_with_root(
+            make_live_index_ready(vec![multi_file]),
+            Some(repo.path().to_path_buf()),
+        );
+        let result = server
+            .detect_impact(Parameters(super::DetectImpactInput {
+                base_branch: None,
+                since: Some("WORKTREE".to_string()),
+                depth: 2,
+                scope: super::ImpactScope::Symbols,
+                include_untracked: true,
+                include_data: None,
+            }))
+            .await;
+        assert!(
+            result.contains("\"changed\""),
+            "the edited function must be seeded as changed: {result}"
+        );
+        assert!(
+            !result.contains("\"kept\""),
+            "an unedited sibling symbol must NOT be seeded as changed: {result}"
+        );
+    }
+
+    /// PART A (019): a comment/whitespace-only shift that leaves every function
+    /// body byte-identical must seed ZERO changed symbols. RED on the pre-fix
+    /// loop, which seeded all symbols regardless of body deltas.
+    #[tokio::test]
+    async fn test_detect_impact_whitespace_only_change_seeds_nothing() {
+        let repo = init_git_repo();
+        fs::create_dir_all(repo.path().join("src")).expect("create src dir");
+        let base = "pub fn a() -> u32 { 1 }\npub fn b() -> u32 { 2 }\n";
+        // Add a leading comment line: symbol bodies are byte-identical, only
+        // their file position shifts.
+        let shifted = "// unrelated comment\npub fn a() -> u32 { 1 }\npub fn b() -> u32 { 2 }\n";
+        fs::write(repo.path().join("src/ws.rs"), base).expect("write base");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-m", "init", "-q"]);
+        fs::write(repo.path().join("src/ws.rs"), shifted).expect("comment-only shift");
+
+        let ws_file = make_file(
+            "src/ws.rs",
+            shifted.as_bytes(),
+            vec![
+                make_symbol("a", SymbolKind::Function, 1, 1),
+                make_symbol("b", SymbolKind::Function, 2, 2),
+            ],
+        );
+        let server = make_server_with_root(
+            make_live_index_ready(vec![ws_file]),
+            Some(repo.path().to_path_buf()),
+        );
+        let result = server
+            .detect_impact(Parameters(super::DetectImpactInput {
+                base_branch: None,
+                since: Some("WORKTREE".to_string()),
+                depth: 2,
+                scope: super::ImpactScope::Symbols,
+                include_untracked: true,
+                include_data: None,
+            }))
+            .await;
+        assert!(
+            result.contains("0 changed symbol(s)"),
+            "a comment/whitespace-only shift must seed zero changed symbols: {result}"
         );
     }
 

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -498,16 +498,71 @@ fn freshen_file_if_stale_at_generation(
     )
 }
 
+/// Resolve the generation the watcher should fence its mutations against for
+/// the commit boundary about to run.
+///
+/// The watcher snapshots `spawn_gen` ONCE at spawn (`run_watcher_with_stop`).
+/// On COLD START the fire-and-forget `bg_index.reload(&bg_root)` bumps the
+/// project generation AFTER that snapshot, so a fence pinned to `spawn_gen`
+/// would reject (and remove) every subsequent edit forever. This heals that:
+/// when the generation has advanced but the live index STILL serves our own
+/// `repo_root`, the advance was a same-project reload (cold-start or in-place
+/// reindex) and we adopt the current generation so mutations commit again.
+///
+/// The fence stays correct for the genuine cross-project race: a retarget
+/// reload swaps `indexed_root` to a DIFFERENT root, so we keep the stale
+/// `spawn_gen` and the store's under-lock check rejects the now-foreign
+/// mutation (see `slipped_past_cancellation_fence_increments_counter`).
+///
+/// Ordering: `reload` publishes the new live index (with its new
+/// `indexed_root`) BEFORE bumping the generation (`AcqRel`), and we read the
+/// generation before the live root, so a `spawn_gen`-equal read never pairs an
+/// old generation with a new root. The value returned here is only a *better
+/// guess* than the frozen snapshot — the store re-checks the generation under
+/// its write lock, so any residual race still rejects rather than corrupts.
+pub(crate) fn effective_fence_generation(
+    shared: &SharedIndex,
+    repo_root: &Path,
+    spawn_gen: u64,
+) -> u64 {
+    let current_gen = shared.current_project_generation();
+    if current_gen == spawn_gen {
+        return spawn_gen;
+    }
+    // Generation advanced since spawn. Adopt it only if the live index still
+    // serves our repo_root (same-project reload); otherwise keep the stale
+    // spawn generation so the store fence rejects the foreign mutation.
+    let target = crate::live_index::store::normalize_root(repo_root);
+    let same_root = shared
+        .read()
+        .indexed_root
+        .as_deref()
+        .map(crate::live_index::store::normalize_root)
+        .is_some_and(|root| root == target);
+    if same_root { current_gen } else { spawn_gen }
+}
+
 /// Walk all indexed files and re-index any whose on-disk mtime differs from
 /// the stored value. Returns the number of stale files re-indexed.
 ///
 /// Called on watcher overflow and by the periodic reconciliation timer.
+///
+/// `spawn_gen` is the watcher's spawn-time generation snapshot. The fence value
+/// actually used for each file is re-synced via [`effective_fence_generation`]
+/// so a same-root reload (cold-start heal) no longer permanently rejects, while
+/// a cross-project retarget still rejects.
 pub(crate) fn reconcile_stale_files_with_stop(
     repo_root: &Path,
     shared: &SharedIndex,
     should_stop: impl Fn() -> bool,
     expected_gen: u64,
 ) -> usize {
+    // Re-sync the fence to the CURRENT generation when the live index still
+    // serves our repo_root, so a same-root reload that advanced the generation
+    // after watcher spawn (cold start) no longer permanently rejects. A
+    // cross-project retarget keeps the stale spawn generation and is rejected.
+    let fence_gen = effective_fence_generation(shared, repo_root, expected_gen);
+
     let paths: Vec<String> = {
         let index = shared.read();
         index.all_files().map(|(p, _)| p.clone()).collect()
@@ -519,7 +574,7 @@ pub(crate) fn reconcile_stale_files_with_stop(
             break;
         }
         let abs_path = repo_root.join(relative_path);
-        if freshen_file_if_stale_at_generation(relative_path, &abs_path, shared, expected_gen) {
+        if freshen_file_if_stale_at_generation(relative_path, &abs_path, shared, fence_gen) {
             stale_count += 1;
         }
     }
@@ -824,12 +879,20 @@ pub async fn run_watcher_with_stop(
                         // per-workspace guard against concurrent refreshes.
                         let root_for_coupling = repo_root.clone();
                         let stop_for_coupling = Arc::clone(&stop_token);
-                        let expected_gen_for_coupling = expected_gen;
+                        let spawn_gen_for_coupling = expected_gen;
                         let shared_for_coupling = shared.clone();
                         tokio::task::spawn_blocking(move || {
                             if stop_for_coupling.load(Ordering::Acquire) {
                                 return;
                             }
+                            // Re-sync against a same-root reload (cold start) so
+                            // the coupling refresh heals like the file reconcile;
+                            // a retarget keeps the stale spawn gen and no-ops.
+                            let expected_gen_for_coupling = effective_fence_generation(
+                                &shared_for_coupling,
+                                &root_for_coupling,
+                                spawn_gen_for_coupling,
+                            );
                             crate::live_index::coupling::refresh_on_reconcile_tick(
                                 &root_for_coupling,
                                 expected_gen_for_coupling,
@@ -848,9 +911,19 @@ pub async fn run_watcher_with_stop(
                             let root_clone = repo_root.clone();
                             let watcher_info_clone = watcher_info.clone();
                             let stop_for_events = Arc::clone(&stop_token);
-                            let expected_gen_for_events = expected_gen;
+                            let spawn_gen_for_events = expected_gen;
                             let mut trackers = std::mem::take(&mut burst_trackers);
                             match tokio::task::spawn_blocking(move || {
+                                // Re-sync the fence at the commit boundary: a
+                                // same-root reload (cold start) that advanced the
+                                // generation after watcher spawn must no longer
+                                // reject events; a cross-project retarget still
+                                // keeps the stale spawn gen and is rejected.
+                                let expected_gen_for_events = effective_fence_generation(
+                                    &shared_clone,
+                                    &root_clone,
+                                    spawn_gen_for_events,
+                                );
                                 process_events(
                                     events,
                                     &root_clone,
@@ -1768,6 +1841,114 @@ mod tests {
         assert!(
             index.get_file("src/b.rs").is_some(),
             "B file should survive stale-generation reconcile"
+        );
+    }
+
+    /// Cold-start regression: a SAME-ROOT reload (the fire-and-forget
+    /// `bg_index.reload(&bg_root)` main.rs runs when no snapshot exists) bumps
+    /// the project generation AFTER the watcher captured `expected_gen` at spawn.
+    /// The watcher's reconcile must SELF-HEAL against that advance — re-index the
+    /// edited file — instead of pinning the stale spawn generation and removing
+    /// the file forever via `GenerationMismatch`.
+    ///
+    /// Distinguishing signal: the live index still serves the watcher's own
+    /// `repo_root` (`indexed_root` unchanged), so the advance is a same-project
+    /// reload, not a cross-project retarget (which `indexed_root` would show and
+    /// which `slipped_past_cancellation_fence_increments_counter` proves must
+    /// still be rejected).
+    #[test]
+    fn cold_start_same_root_reload_reconcile_heals_not_removes() {
+        let project = TempDir::new().unwrap();
+        let src_dir = project.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let rel = "src/heals.rs";
+        let abs = project.path().join(rel);
+        std::fs::write(&abs, b"fn before() {}").unwrap();
+
+        // Load the index for our project; this is the state the watcher spawns
+        // against. `spawn_gen` is exactly what `run_watcher_with_stop` snapshots
+        // once at L721.
+        let shared = crate::live_index::LiveIndex::load(project.path()).unwrap();
+        let spawn_gen = shared.current_project_generation();
+        assert!(
+            shared.read().get_file(rel).is_some(),
+            "precondition: file indexed after load"
+        );
+
+        // Simulate the cold-start fire-and-forget reload: SAME root, generation
+        // advances past the watcher's spawn snapshot.
+        shared.reload(project.path()).unwrap();
+        assert_ne!(
+            shared.current_project_generation(),
+            spawn_gen,
+            "reload must advance the project generation past the spawn snapshot"
+        );
+
+        // Edit the tracked file on disk (bump mtime + change content) so the
+        // reconcile sweep sees it as stale and tries to re-index it.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&abs, b"fn before() {}\nfn healed() {}").unwrap();
+
+        // Reconcile pinned to the STALE spawn generation, exactly as the watcher
+        // does today (`expected_gen_for_reconcile = expected_gen`).
+        let _ = reconcile_stale_files_with_stop(project.path(), &shared, || false, spawn_gen);
+
+        // The edit must be INDEXED, not GenerationMismatch-removed.
+        let index = shared.read();
+        let file = index.get_file(rel).unwrap_or_else(|| {
+            panic!(
+                "cold-start same-root reload must NOT remove the edited file; \
+                 stale spawn generation self-healed instead of rejecting"
+            )
+        });
+        assert!(
+            file.symbols.iter().any(|s| s.name == "healed"),
+            "the reconcile must re-index the edited file so the new symbol appears"
+        );
+    }
+
+    /// `effective_fence_generation` must ADOPT a generation advanced by a
+    /// same-root reload (cold-start heal) but KEEP the stale spawn generation
+    /// after a cross-project retarget (so the store fence still rejects the now
+    /// foreign mutation). This is the exact discriminator the cold-start fix
+    /// relies on; the store's own under-lock generation check remains the final
+    /// arbiter for any residual race.
+    #[test]
+    fn effective_fence_generation_adopts_same_root_keeps_after_retarget() {
+        let project_a = TempDir::new().unwrap();
+        let project_b = TempDir::new().unwrap();
+        std::fs::create_dir_all(project_a.path().join("src")).unwrap();
+        std::fs::create_dir_all(project_b.path().join("src")).unwrap();
+        std::fs::write(project_a.path().join("src/a.rs"), b"fn a() {}").unwrap();
+        std::fs::write(project_b.path().join("src/b.rs"), b"fn b() {}").unwrap();
+
+        let shared = crate::live_index::LiveIndex::load(project_a.path()).unwrap();
+        let spawn_gen = shared.current_project_generation();
+
+        // No reload yet: the effective fence is the spawn snapshot unchanged.
+        assert_eq!(
+            effective_fence_generation(&shared, project_a.path(), spawn_gen),
+            spawn_gen,
+            "no generation advance -> keep spawn snapshot"
+        );
+
+        // Same-root reload: adopt the advanced generation (cold-start heal).
+        shared.reload(project_a.path()).unwrap();
+        let after_same_root = shared.current_project_generation();
+        assert_ne!(after_same_root, spawn_gen);
+        assert_eq!(
+            effective_fence_generation(&shared, project_a.path(), spawn_gen),
+            after_same_root,
+            "same-root reload -> adopt the current generation so mutations commit"
+        );
+
+        // Cross-project retarget: KEEP the stale spawn generation so the store
+        // fence rejects a mutation now computed against a foreign index.
+        shared.reload(project_b.path()).unwrap();
+        assert_eq!(
+            effective_fence_generation(&shared, project_a.path(), spawn_gen),
+            spawn_gen,
+            "cross-project retarget -> keep stale spawn gen so the fence rejects"
         );
     }
 

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -484,20 +484,6 @@ pub(crate) fn freshen_file_if_stale(
     }
 }
 
-fn freshen_file_if_stale_at_generation(
-    relative_path: &str,
-    abs_path: &Path,
-    shared: &SharedIndex,
-    expected_gen: u64,
-) -> bool {
-    matches!(
-        freshen_file_if_stale(relative_path, abs_path, shared, expected_gen),
-        FreshenResult::StaleReindexed
-            | FreshenResult::StaleRemoved
-            | FreshenResult::GenerationMismatch
-    )
-}
-
 /// Resolve the generation the watcher should fence its mutations against for
 /// the commit boundary about to run.
 ///
@@ -574,8 +560,14 @@ pub(crate) fn reconcile_stale_files_with_stop(
             break;
         }
         let abs_path = repo_root.join(relative_path);
-        if freshen_file_if_stale_at_generation(relative_path, &abs_path, shared, fence_gen) {
-            stale_count += 1;
+        // Count ONLY genuine repairs. A `GenerationMismatch` outcome is a no-op
+        // that repaired zero bytes (the store rejected the stale-generation
+        // mutation, incrementing `rejected_stale_mutations` instead), so folding
+        // it into the repair count would falsely inflate health's "reconcile
+        // repairs" figure during any restart/reset window.
+        match freshen_file_if_stale(relative_path, &abs_path, shared, fence_gen) {
+            FreshenResult::StaleReindexed | FreshenResult::StaleRemoved => stale_count += 1,
+            FreshenResult::Fresh | FreshenResult::GenerationMismatch => {}
         }
     }
 
@@ -1827,11 +1819,13 @@ mod tests {
         let rejected_before = shared.current_rejected_stale_mutations();
         shared.reload(project_b.path()).unwrap();
 
-        let stale = reconcile_stale_files_with_stop(project_a.path(), &shared, || false, stale_gen);
+        let repairs =
+            reconcile_stale_files_with_stop(project_a.path(), &shared, || false, stale_gen);
 
         assert_eq!(
-            stale, 1,
-            "stale doomed reconcile should visit B's path once"
+            repairs, 0,
+            "a GenerationMismatch reconcile repairs zero bytes; it is a rejected \
+             mutation, not a repair, so it must not count toward the repair total"
         );
         assert!(
             shared.current_rejected_stale_mutations() > rejected_before,
@@ -1904,6 +1898,64 @@ mod tests {
         assert!(
             file.symbols.iter().any(|s| s.name == "healed"),
             "the reconcile must re-index the edited file so the new symbol appears"
+        );
+    }
+
+    /// Repair-count honesty: `reconcile_stale_files_with_stop` returns the number
+    /// of GENUINE repairs (files actually re-indexed or removed), which health
+    /// renders as "reconcile repairs". A `GenerationMismatch` outcome is a NO-OP
+    /// that repaired zero bytes (a cross-project retarget kept the stale fence and
+    /// the store rejected the mutation), so it must NOT inflate the repair count.
+    ///
+    /// This is deliberately distinct from the store's `rejected_stale_mutations`
+    /// counter, which DOES increment for the rejection (asserted by
+    /// `slipped_past_cancellation_fence_increments_counter`). The two figures
+    /// answer different questions: "how many files did we repair" vs. "how many
+    /// stale-generation mutations did the fence reject".
+    #[test]
+    fn reconcile_repair_count_excludes_generation_mismatch_noops() {
+        // --- Case 1: pure GenerationMismatch no-ops must NOT count as repairs. ---
+        let project_a = TempDir::new().unwrap();
+        let project_b = TempDir::new().unwrap();
+        std::fs::create_dir_all(project_a.path().join("src")).unwrap();
+        std::fs::create_dir_all(project_b.path().join("src")).unwrap();
+        std::fs::write(project_a.path().join("src/a.rs"), b"fn a() {}").unwrap();
+        std::fs::write(project_b.path().join("src/b.rs"), b"fn b() {}").unwrap();
+
+        let shared = crate::live_index::LiveIndex::load(project_a.path()).unwrap();
+        let stale_gen = shared.current_project_generation();
+        // Retarget to B: advances the generation AND swaps `indexed_root`, so
+        // `effective_fence_generation` keeps the stale spawn gen and every file
+        // reconcile below resolves to `GenerationMismatch` (a repaired-zero no-op).
+        shared.reload(project_b.path()).unwrap();
+
+        let repairs =
+            reconcile_stale_files_with_stop(project_a.path(), &shared, || false, stale_gen);
+        assert_eq!(
+            repairs, 0,
+            "GenerationMismatch no-ops repair zero bytes and must not inflate the \
+             repair count (they are rejected mutations, not repairs)"
+        );
+
+        // --- Case 2: a genuine StaleReindexed edit MUST count as a repair. ---
+        let project = TempDir::new().unwrap();
+        std::fs::create_dir_all(project.path().join("src")).unwrap();
+        let rel = "src/edited.rs";
+        let abs = project.path().join(rel);
+        std::fs::write(&abs, b"fn before() {}").unwrap();
+
+        let shared2 = crate::live_index::LiveIndex::load(project.path()).unwrap();
+        let expected_gen = shared2.current_project_generation();
+
+        // Edit the tracked file so the reconcile sweep sees it as stale.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&abs, b"fn before() {}\nfn after() {}").unwrap();
+
+        let repairs2 =
+            reconcile_stale_files_with_stop(project.path(), &shared2, || false, expected_gen);
+        assert_eq!(
+            repairs2, 1,
+            "a genuinely stale, re-indexed file must count as one repair"
         );
     }
 

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -493,7 +493,11 @@ fn estimate_parameter_on_read_tools() {
         "analyze_file_impact",
         "what_changed",
         "diff_symbols",
-        "validate_file_syntax",
+        // NOTE: validate_file_syntax is intentionally NOT here. Its output is a
+        // small, deterministic diagnostic (Status/Diagnostic/Byte span), so an
+        // `estimate` token-preview mode has no meaningful semantics — the field
+        // was removed rather than left as a silent inert flag. Do not re-add it
+        // without wiring real estimate behaviour into the handler.
     ];
 
     for tool_name in estimate_tools {

--- a/tests/detect_impact.rs
+++ b/tests/detect_impact.rs
@@ -39,9 +39,10 @@ fn git(args: &[&str], root: &Path) {
 /// Copy `tests/fixtures/cbm_impact` into a fresh tempdir, commit it, then
 /// make a real content edit to `src/a.rs` and commit again — the
 /// `commit_2_changes_src_a_rs` scenario from `expected_impact.json`. The edit
-/// only widens a comment; `call_a`'s call-graph edges (it still calls
-/// `core()`) are untouched, so the blast radius is driven purely by who
-/// calls `call_a`, not by what this specific edit changed.
+/// changes `call_a`'s BODY (so it is a genuine body-delta seed under the
+/// PART A (019) body-delta seed) while keeping its `core()` call, so `call_a`'s
+/// call-graph edges are untouched and the blast radius is driven purely by who
+/// calls `call_a`.
 fn bootstrap_fixture() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
@@ -65,8 +66,8 @@ fn bootstrap_fixture() -> tempfile::TempDir {
     fs::write(
         root.join("src/a.rs"),
         "use cbm_impact_fixture::core;\n\n\
-         // S1a fixture bootstrap: widened comment, same call graph.\n\
-         pub fn call_a() -> u32 {\n    core()\n}\n",
+         // S1a fixture bootstrap: real body change, same call graph.\n\
+         pub fn call_a() -> u32 {\n    core() + 1\n}\n",
     )
     .expect("rewrite src/a.rs");
     git(&["commit", "-am", "change a"], root);
@@ -132,7 +133,9 @@ async fn detect_impact_fixture_blast_matches_expected() {
         .as_array()
         .expect("blast_radius array");
     assert_eq!(blast.len(), 1, "unexpected blast radius: {blast:?}");
-    assert_eq!(blast[0]["symbol"], json!("main"));
+    // PART C (019): scope=symbols blast entries are path-qualified (`path::name`)
+    // so same-name nodes stay distinguishable.
+    assert_eq!(blast[0]["symbol"], json!("src/main.rs::main"));
     assert_eq!(blast[0]["hop"], json!(1));
     assert_eq!(blast[0]["risk"], json!("critical"));
 
@@ -335,9 +338,15 @@ async fn detect_impact_caps_large_changed_set() {
     git(&["add", "."], root);
     git(&["commit", "-m", "initial"], root);
 
-    // Second commit touches ONLY changed.rs, so the changed-file set is one file
-    // but its 211 symbols all enter changed_symbols.
-    changed.push_str("// widened comment, same symbols.\n");
+    // Second commit touches ONLY changed.rs and modifies EVERY symbol's body
+    // (not just a comment append), so all 211 symbols are genuine body-delta
+    // seeds under the PART A (019) body-delta seed. `core` keeps its name (so
+    // the 210 callers still resolve) but its body changes; each `pad_i` body is
+    // bumped too.
+    let mut changed = String::from("pub fn core() -> u32 {\n    1\n}\n");
+    for i in 0..210 {
+        changed.push_str(&format!("pub fn pad_{i}() -> u32 {{\n    {}\n}}\n", i + 1));
+    }
     fs::write(root.join("src/changed.rs"), &changed).expect("rewrite changed.rs");
     git(&["commit", "-am", "touch changed"], root);
 


### PR DESCRIPTION
## SFBENCH surface correctness & safety (spec 019)

Fixes 8 independently-verified defects from the SFBENCH-1.0 8.14.0 full-surface benchmark. Every finding was **re-verified against source** before spec, the spec itself was **adversarially reviewed** (which caught 3 blockers + 4 majors in the draft and corrected them), and each item was landed **RED-first → full-gate-green**, committed one at a time.

### Fixes (severity order)
- **US1 — `batch_rename` fail-closed (P0 safety):** collected references by bare name and wrote every match, so renaming a common method (`new`, `run`) rewrote unrelated same-named defs in other files (the harness caught a source-write escape). Now gated on index-wide name ambiguity.
- **US2 — `detect_impact` correctness (P0):** seeded every symbol of a changed file and linked calls to every same-bare-name def. Now: body-delta seed (reuses `diff_symbols` base-ref reparse), ambiguity-scoped edges, identity-bearing blast nodes.
- **US1b/US2b — recall upgrade (superior fix):** instead of dropping ambiguous references, resolve them via qualifier→owner match (new `enclosing_impl_owner`), gated by a twin-owner uniqueness guard so `Target::method` is recovered while staying sound. (A tech-research pass rejected adopting stack-graphs on dependency-freshness grounds.)
- **US3 — selectors + Python imports (P1):** matching-local `project` selectors now proceed (was blanket-refused) while the deliberate `/mcp` D16 containment and its test-locked message are preserved; Python relative imports (`from .b import f`) are captured and resolved package-aware.
- **US5b — watcher cold-start (P1):** fixed a real permanent-staleness bug on cold start (the spec's own earlier refutation was wrong) by re-syncing the generation fence, keeping the fence correct for cross-project retargets.
- **US5a — health (P2):** count only genuine reconcile repairs, not generation-mismatch no-ops.
- **US4 — `symforge_edit` (P2):** idempotent replay now short-circuits before the stale `if_match` guard.
- **US5c — `status(reset_calibration)` (P2):** now actually resets the proxy-owned durable store in daemon mode (was a silent no-op).
- **US6 — `validate_file_syntax` (P3):** accept valid BOM-prefixed JSON (offset-preserving); remove the inert `estimate` flag.

Excluded **P0-04 (meta)** as a verified non-bug (a retired measurement-only probe).

### Verification
- Every item RED-first; **final integrated branch gate green**: `cargo fmt --check`, `clippy --all-targets -D warnings`, `test --all-targets --test-threads=1`, `check --no-default-features --features embed`.
- Spec + research + contracts under `specs/019-sfbench-surface-correctness/`.

> [!NOTE]
> Merge with a non-conventional body to avoid the release-please double-count:
> `gh pr merge <N> --merge --delete-branch --body "PR #<N>"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8kGebUxEe12NtUpWF6w3Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fail-closed mutation (`batch_rename`), impact graph semantics, and edit idempotency ordering—areas where incorrect binding or replay ordering can corrupt source or mislead agents; mitigated by regression tests and spec-locked behavior.
> 
> **Overview**
> Addresses SFBENCH 8.14.0 surface defects with spec **019** (plan, contracts, research) and targeted runtime fixes. **AGENTS.md** is bumped to the v8.14.0 recovery/MCP catalog (full 36-tool surface, new resources/prompts).
> 
> **Safety & impact:** `batch_rename` gates writes on index-wide name ambiguity—ambiguous bare-name and qualified matches are demoted to uncertain instead of rewriting unrelated files—and can still recover `Type::method` sites when qualifier matches the target’s `impl` owner and that owner is unique (`enclosing_impl_owner`). `GraphProjection` stops fanning ambiguous `Call` edges to every same-name def; `resolve_ambiguous_callee` disambiguates via module stem or owner name with the same twin-owner drop discipline, with new graph tests.
> 
> **Navigation & validation:** Python `relative_import` is captured in xref and resolved package-aware in `find_dependents` (no same-stem false positives). JSON validation blanks a leading UTF-8 BOM without shifting spans; the unused `estimate` field is removed from `validate_file_syntax` input.
> 
> **Idempotency:** `probe_tool_replay` / `probe_symforge_edit_apply_replay` run a non-reserving replay check before `if_match` gates so identical `symforge_edit` retries return the stored result without re-writing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781285697d463be854306ec339ba3e9cfc0d3b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->