### PR TITLE
docs: full-surface benchmark protocol/report + document new tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Some valid code trips upstream tree-sitter grammar limitations (for example, Typ
 
 Every edit tool accepts an optional `working_directory` pointing at a sibling git worktree. Supplying it is **explicit routing consent**: SymForge validates the worktree, maps the indexed path into it, writes there, and reports both the indexed path and the actual write path (`wrote_to`, `indexed_path`, `rerouted`). Parallel agent sessions can each edit their own worktree against one shared index.
 
+### Renames that stay sound on ambiguous names
+
+`batch_rename` never rewrites a same-named symbol it cannot prove belongs to the target. When the index holds two or more definitions of a name, bare and unqualified references are surfaced as uncertain instead of written; a qualified reference is only kept writable when its immediate qualifier matches the resolved target's `impl` owner and that owner name is unique among the ambiguous definitions. This recovers the truly-bound `Owner::method` call sites while leaving the unattributable ones for the caller to decide. The resolution is Tier-0 syntactic qualifier matching, not type inference — it is honest about what it can and cannot attribute, without needing an LSP.
+
 ### Safe mutations: idempotency, tee snapshots, write-back invariants
 
 Mutating tools accept an `idempotency_key`; a retry with the same key and same canonical request replays the stored result without writing twice, and the same key with a different request returns a deterministic conflict. Before every edit lands, a **tee snapshot** preserves the pre-write file under `.symforge/tee/`. After every write, the index is rebuilt from the **persisted on-disk bytes**, never the in-memory buffer — if the OS wrote something different, the index reflects reality.
@@ -337,6 +341,7 @@ By default SymForge exposes the full **36-tool** surface below through MCP `tool
 |---|---|
 | `health` | Check index health, watcher state, parse resilience, runtime identity, sidecar state, and capability state |
 | `health_compact` | Smaller health summary for prompt budgets |
+| `status` | Trust-envelope and index-health summary with honest economics; also resets STEL calibration when asked (`reset_calibration`) |
 | `get_repo_map` | Get a bounded repository map |
 | `explore` | Explore a broad concept across symbols, files, and patterns with noise filtering and ranking reasons |
 | `ask` | Ask a natural-language codebase question and see route confidence, rationale, and the selected invocation |
@@ -368,6 +373,7 @@ By default SymForge exposes the full **36-tool** surface below through MCP `tool
 | `search_symbols` | Find functions, structs, classes, methods, types, modules, and other symbols |
 | `search_text` | Search text with enclosing symbol context; supports literal terms, OR terms, regex, and AST structural search |
 | `search_files` | Find and rank paths, resolve ambiguous paths, and optionally use frecency or co-change ranking |
+| `symforge_retrieve` | Retrieve the full output stored when CCR compressed a large result, by the hash from a search or discovery footer |
 
 ### Trace Impact
 
@@ -378,6 +384,7 @@ By default SymForge exposes the full **36-tool** surface below through MCP `tool
 | `what_changed` | Show changed files since a ref, timestamp, or current uncommitted state |
 | `diff_symbols` | Compare symbols between git refs |
 | `analyze_file_impact` | Reindex a changed file and report affected dependents |
+| `detect_impact` | Diff a base branch/ref against HEAD and report the blast radius (files or symbols, bounded hop depth) seeded from the symbols that actually changed |
 | `validate_file_syntax` | Report parser diagnostics with line and column locations |
 
 ### Edit
@@ -391,7 +398,8 @@ By default SymForge exposes the full **36-tool** surface below through MCP `tool
 | `delete_symbol` | Delete a symbol and its attached docs |
 | `batch_edit` | Apply multiple symbol-scoped edits atomically |
 | `batch_insert` | Insert before or after multiple symbols |
-| `batch_rename` | Rename a symbol and update references project-wide |
+| `batch_rename` | Rename a symbol and update its references project-wide, failing closed on ambiguity: when the name has multiple definitions, only references bound to the resolved target's owner are written; unattributable same-name references are surfaced, not rewritten |
+| `symforge_edit` | Structural edit facade: replace a whole symbol's source by name, previewing by default and committing with `apply:true`; `if_match` guards against a concurrent edit |
 
 ### Indexing
 
@@ -401,7 +409,7 @@ By default SymForge exposes the full **36-tool** surface below through MCP `tool
 | `checkpoint_now` | Atomically write the current in-memory index to `.symforge/index.bin`, optionally verifying after write |
 
 > [!NOTE]
-> The deprecated daemon compatibility name `trace_symbol` remains available through v7.x with an explicit deprecation warning and is planned for removal in v8.0. Generated client allow-lists do not grant it by default. Use `get_symbol_context` or `find_references`.
+> The daemon compatibility name `trace_symbol` is **retired**. The daemon still routes it and returns an explicit deprecation warning, but generated client allow-lists do not grant it by default. Use `get_symbol_context` with `sections=[...]` or `find_references` instead.
 
 ## MCP Resources And Prompts
 

--- a/docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md
+++ b/docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md
@@ -1,0 +1,741 @@
+# SymForge 8.14.0 full-surface benchmark protocol
+
+**Protocol ID**: `SFBENCH-1.0`  
+**Status**: draft until the generator, oracle, task-card, harness, campaign-config, and normalization hashes are recorded; measured runs are prohibited before then  
+**Freeze candidate date**: 2026-07-12  
+**System under test**: SymForge MCP 8.14.0  
+**Purpose**: give any capable LLM executor an unambiguous, reproducible procedure for testing every runtime-advertised SymForge tool on repositories outside the SymForge checkout.
+
+This document defines the test before results are collected. Do not change a task, baseline, oracle, tokenizer, repetition count, or repository commit after the first measured run. If a defect in the protocol is found, copy this file to a new protocol version, explain the change, and restart affected cases.
+
+## 1. Questions the benchmark must answer
+
+For every tool returned by MCP `tools/list`, report these dimensions separately:
+
+1. Does the tool accept and reject inputs as its schema and description claim?
+2. Is the result correct, complete enough for the task, deterministic, and honestly bounded?
+3. Does it improve the outcome of a coding task over competent ordinary tool use?
+4. What are its request, response, full-task, schema, indexing, and transcript-replay token costs?
+5. How many tokens does it save versus the baseline, and in which cases does it cost more?
+6. What are its cold-build, snapshot-warm, and process-warm latencies?
+7. What specific product or formatter change would improve it?
+
+Correctness gates economics. A short but wrong or incomplete response is not a saving. Its completion workflow includes every retry, fallback, follow-up read, CCR retrieval, and remediation call needed to satisfy the oracle.
+
+## 2. Hard rules for every executor
+
+- Create all clones, generated fixtures, snapshots, raw transcripts, and mutation worktrees outside the SymForge repository.
+- Run mutations only in disposable copies. Never mutate the source clone or the SymForge checkout.
+- Use the runtime MCP manifest as the tool inventory. Documentation is a comparison source, not the authority for what is callable.
+- Use a competent baseline: `rg`, bounded raw reads, Git read commands, repository-native parsers or compilers, and `apply_patch` for edits. A deliberate whole-file dump is not the primary baseline.
+- Give both arms the same task, answer format, time limit, call limit, model, model version, reasoning effort, seed, and context limit.
+- Start each paired arm in a fresh model session. Do not let trials see earlier transcripts or answers.
+- Keep raw output hashes and sanitized artifacts. Never hand-transcribe token counts.
+- Never trust SymForge's self-reported token estimate or savings claim as ground truth.
+- Report negative savings with a minus sign. Do not rename a regression as "reduced savings."
+- Never print or store a secret value. If a secret-like item is encountered, record only its name and `file:line`. Do not capture environment dumps or read credential files.
+- Do not execute untrusted third-party build scripts with user credentials. Prefer an isolated, credential-free process with network disabled for builds.
+
+## 3. Benchmark root and immutable inputs
+
+Use an absolute directory outside the repository. On this workstation:
+
+```powershell
+$PROJECT_ROOT = [IO.Path]::GetFullPath('C:\AI_STUFF\PROGRAMMING\symforge')
+$BENCH_ROOT = [IO.Path]::GetFullPath('C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface')
+
+if ($BENCH_ROOT.Equals($PROJECT_ROOT, [StringComparison]::OrdinalIgnoreCase) -or
+    $BENCH_ROOT.StartsWith(
+        $PROJECT_ROOT + [IO.Path]::DirectorySeparatorChar,
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+    throw 'Benchmark root must be outside the SymForge checkout.'
+}
+
+if (Test-Path -LiteralPath $BENCH_ROOT) {
+    throw "Refusing to reuse an existing campaign root: $BENCH_ROOT"
+}
+
+New-Item -ItemType Directory -Path $BENCH_ROOT | Out-Null
+$SOURCE_ROOT = Join-Path $BENCH_ROOT 'sources'
+$RUN_ROOT = Join-Path $BENCH_ROOT 'runs'
+$WORK_ROOT = Join-Path $BENCH_ROOT 'work'
+$ARTIFACT_ROOT = Join-Path $BENCH_ROOT 'artifacts'
+
+$ISOLATED_GIT_CONFIG = Join-Path $BENCH_ROOT 'gitconfig.empty'
+New-Item -ItemType File -Path $ISOLATED_GIT_CONFIG | Out-Null
+$env:GIT_CONFIG_NOSYSTEM = '1'
+$env:GIT_CONFIG_GLOBAL = $ISOLATED_GIT_CONFIG
+$env:GIT_LFS_SKIP_SMUDGE = '1'
+```
+
+Use a new root per campaign. Never recursively delete a computed path unless its resolved absolute path is first checked to remain under `$BENCH_ROOT`. Record the isolated Git configuration, Git/LFS versions, long-path behavior, filesystem case sensitivity, and executable-bit behavior in the lock manifest.
+
+The source mirrors are read-only after cloning. Ordinary measured cases use one materialization method only: a fresh independent local clone with no hardlinks under `$WORK_ROOT/<run-id>/<repo>/<case-id>`. Git worktrees are reserved for explicitly labeled worktree-routing compatibility cases.
+
+### 3.1 Public repository lock
+
+Clone these public repositories and detach at the full commit shown. These commits were resolved from each repository's authoritative Git remote on 2026-07-12.
+
+| Alias | Primary language/circumstance | URL | Frozen commit | History depth |
+|---|---|---|---|---:|
+| `ripgrep` | Rust, macros, modules, tests | `https://github.com/BurntSushi/ripgrep.git` | `d5b85d44057ff729a89be9c6549958c45d95aa99` | 128 |
+| `flask` | Python, decorators, packages | `https://github.com/pallets/flask.git` | `36e4a824f340fdee7ed50937ba8e7f6bc7d17f81` | 128 |
+| `zod` | TypeScript, monorepo-like packages and generated noise | `https://github.com/colinhacks/zod.git` | `912f0f51b0ced654d0069741e7160834dca742ee` | 128 |
+| `cobra` | Go, interfaces, packages, tests | `https://github.com/spf13/cobra.git` | `adbc8813901bba65827259daa8e22ff94ec1f30e` | 32 |
+| `gson` | Java, overloads, interfaces, generics | `https://github.com/google/gson.git` | `c9f3fd55854a743b66f857ace3c7b268ea3e2ef7` | 32 |
+| `fmt` | C++, templates, headers, source/tests | `https://github.com/fmtlib/fmt.git` | `7077b016cc19793e11f9b9aa3d909390acd3819b` | 32 |
+| `mojo` | Perl, real grammar edge cases | `https://github.com/mojolicious/mojo.git` | `6007271e9152aa0998129991030c3ed16eb407d0` | 32 |
+| `typescript` | Large TypeScript stress repository | `https://github.com/microsoft/TypeScript.git` | `637d5746b70257028fb95aad32ddec6b26ab0a14` | 128 |
+| `p-map` | Tiny JavaScript and declaration-file overhead control | `https://github.com/sindresorhus/p-map.git` | `3ada5f36632aca8df860c376856270b6d2ba2de8` | 32 |
+| `json-schema-suite` | Config-only negative control with many JSON files | `https://github.com/json-schema-org/JSON-Schema-Test-Suite.git` | `92acb61eb772a932c077d5ffa634ded719d2d738` | 32 |
+
+Required clone procedure:
+
+```powershell
+git init <source-path>
+git -C <source-path> config core.autocrlf false
+git -C <source-path> config core.eol lf
+git -C <source-path> config core.filemode false
+git -C <source-path> config core.longpaths true
+git -C <source-path> remote add origin <url>
+git -C <source-path> fetch --no-tags --depth=<history-depth> origin <full-commit>
+git -C <source-path> checkout --detach FETCH_HEAD
+git -C <source-path> rev-parse HEAD
+git -C <source-path> status --porcelain=v1
+```
+
+Do not use a partial clone: a lazy blob fetch would contaminate indexing latency and introduce network state. Do not initialize submodules or install dependencies during index measurements. The resolved hash must equal the table and status must be empty. Record Git version, filesystem type, case-sensitivity behavior, symlink support, file count, source bytes, and language counts. Do not update these clones during the campaign.
+
+After checkout, verify `git fsck --connectivity-only`, record `git rev-list --count HEAD` and `git show-ref`, prove no promisor/partial-clone configuration exists, and prove `git rev-list --objects --missing=print HEAD` reports no missing objects. Disable network for measured cases.
+
+Materialize an ordinary case with:
+
+```powershell
+git clone --local --no-hardlinks --no-checkout <source-path> <new-case-path>
+git -C <new-case-path> config core.autocrlf false
+git -C <new-case-path> config core.eol lf
+git -C <new-case-path> checkout --detach <full-commit>
+```
+
+The case path must not already exist. Filesystem/page-cache coldness is not implied by `cold_build`; if a separate OS-cold cohort is run, label it explicitly and do not pool it with index-cold results.
+
+### 3.2 Controlled oracle overlay
+
+Real repositories test realism; controlled overlays provide exact ground truth. Add a language-appropriate `sfbench_fixture/` directory only in disposable worktrees, never in source mirrors. The fixture generator must create the same logical graph in Rust, Python, TypeScript, Go, Java, C++, and Perl:
+
+```text
+sfbench_entry -> sfbench_mid -> sfbench_leaf
+sfbench_entry -> SfBenchWorker.run
+SfBenchWorker implements SfBenchProtocol
+sfbench_unused has no callers
+sfbench_rename_me has exactly four code references and two comment/string mentions
+sfbench_duplicate exists in two files
+sfbench_mutable contains two identical literals; the same literal also exists outside it
+sfbench_delete_me is isolated and surrounded by blank lines
+```
+
+Use these frozen markers:
+
+- source-only marker: `SF_BENCH_SOURCE_9F31`
+- test-only marker: `SF_BENCH_TEST_ONLY_9F31`
+- generated marker: `SF_BENCH_GENERATED_9F31`
+- vendor marker: `SF_BENCH_VENDOR_9F31`
+- repeated edit literal: `SF_BENCH_EDIT_OLD_9F31`
+- replacement literal: `SF_BENCH_EDIT_NEW_9F31`
+
+The overlay must also contain:
+
+- duplicate basenames in different directories;
+- nested class/module/function constructs;
+- at least one Unicode identifier or string before and inside a target symbol;
+- LF, CRLF, and no-final-newline files with precomputed SHA-256 hashes;
+- a deterministic binary file with NUL bytes and a deterministic source file larger than 60 KB with known start/middle/end anchors;
+- valid and malformed JSON, TOML, and YAML with known diagnostic lines;
+- source, test, generated, vendor, ignored, and personal-tooling-like paths;
+- a fixed seven-commit history with known symbol additions, removals, modifications, four repeated source/test co-changes, and unrelated changes interspersed;
+- staged, unstaged, untracked, renamed, added, and deleted worktree states;
+- a branch whose default comparison ref is not named `main`;
+- a non-Git directory;
+- a result set large enough to trigger CCR compression;
+- a stale-index case in which disk bytes change after a fetch;
+- recursive custom-type, dependency, and import cycles plus alias-heavy references;
+- symlinks and a loop only when the platform supports them.
+
+The executable generator is `research/full-surface-benchmark/fixture_generator.py`. Run it with `uv`; it must use fixed filenames, raw UTF-8 bytes, `.gitattributes` `-text` rules for exact-byte fixtures, fixed Git author/committer data, fixed timestamps, fixed branch/ref names, and a frozen commit graph. Hash the generator before each campaign and store its hash in the lock manifest.
+
+The generator writes the fixture plus an independently calculated oracle containing exact source hashes, line ranges, byte spans, symbol kinds, callers, callees, imports, implementors, dependent files, expected Git changes, and allowed mutation diffs. Never derive expected values from SymForge output. History-bearing mutation states are independent generated repositories, not new commits in worktrees that share a source mirror's object database. Optional symlink cases form a separate capability-gated cohort and are not pooled with platforms that skip them.
+
+## 4. Runtime inventory gate
+
+Start an isolated stdio process in each repository with explicit settings:
+
+```powershell
+$env:SYMFORGE_SURFACE = 'full'
+$env:SYMFORGE_NO_DAEMON = '1'
+$env:SYMFORGE_AUTO_INDEX = 'true'
+symforge
+```
+
+Use a separate daemon-enabled campaign for watcher, worktree, and multi-project cases. Never mix isolated and daemon results.
+
+At the start of every process:
+
+1. Send MCP `initialize` and `notifications/initialized`.
+2. Capture the complete raw `tools/list`, `resources/list`, resource templates, and prompts list.
+3. Capture `symforge --version`, executable SHA-256, transport, surface setting, and repository commit. On full call `health_compact`; on compact call `status`; meta has no health tool, so use the process/manifest evidence and the meta `symforge` probe cases below.
+4. Canonically serialize and hash each schema and the whole manifest.
+5. Compare the manifest with this protocol and the repository documentation.
+6. Test every returned tool, including an unexpected tool. Record an expected-but-absent tool as a surface failure.
+
+The full surface observed while freezing this protocol contains 36 tools:
+
+```text
+analyze_file_impact, ask, batch_edit, batch_insert, batch_rename,
+checkpoint_now, context_inventory, conventions, delete_symbol, detect_impact,
+diff_symbols, edit_plan, edit_within_symbol, explore, find_dependents,
+find_references, get_file_content, get_file_context, get_repo_map, get_symbol,
+get_symbol_context, health, health_compact, index_folder, insert_symbol,
+inspect_match, investigation_suggest, replace_symbol_body, search_files,
+search_symbols, search_text, status, symforge_edit, symforge_retrieve,
+validate_file_syntax, what_changed
+```
+
+The authoritative live `tools/list` full surface has exactly 36 tools; the Claude picker independently displays the same count but is not used as schema or completeness evidence. Benchmark preparation found that the `AGENTS.md` category list had become stale at 32 names; it was updated with the four live omissions: `detect_impact`, `status`, `symforge_edit`, and `symforge_retrieve`. The runtime itself was not missing tools. The `symforge` facade is compact-surface-only, so its absence from the full 36-tool manifest is expected; verify it only in the separate compact-surface inventory.
+
+Repeat inventory with `SYMFORGE_SURFACE=compact` and `SYMFORGE_SURFACE=meta`. The expected surface identities are:
+
+| Surface | Advertised tools |
+|---|---|
+| full | the 36 names above |
+| compact | `symforge`, `symforge_edit`, `status` |
+| meta | `symforge` only, as a measurement probe |
+
+This produces 40 `(surface, tool)` entries and 37 unique tool names. Use `(surface, tool, schema_hash)` as the identity because duplicate names may expose different schemas or descriptions. Test that tools hidden from compact/meta are absent from `tools/list` and rejected if called directly. Schema and no-op session costs are separate benchmark results.
+
+For HTTP parity, launch the same binary and case root in a credential-free process with `symforge serve --listen 127.0.0.1:0`, parse the selected loopback port without persisting unrelated process output, and connect to `/mcp` using Streamable HTTP. Do not pass an API key. Use the same initialize and call payloads as stdio. The frozen normalization allowlist is `research/full-surface-benchmark/parity-normalization.json`; it may normalize only typed protocol fields named by exact JSON pointer (currently the JSON-RPC request ID). Never regex-normalize freeform tool content: session/process IDs, ports, timestamps, durations, paths, counts, symbols, references, result order, completeness/trust fields, errors, and substantive content remain observable differences unless a future schema exposes a dedicated typed operational field.
+
+The non-tool surface also gets smoke coverage: read all six static resources, instantiate/read all four resource templates with safe controlled paths/symbols, and fetch all seven prompts with their declared arguments. Verify list/read/get behavior, MIME/text shape, project identity, and parity; record these results separately from per-tool economics. Runtime manifest counts and names are authoritative; at freeze time they include the added `symforge://tools/catalog`, `symforge://glossary`, and `symforge-admin` entries now reflected in `AGENTS.md`.
+
+## 5. Benchmark layers
+
+### Layer A: direct protocol conformance
+
+Invoke exact tool requests without asking an LLM to choose a tool. For every advertised parameter and enum variant, the coverage manifest must point to at least one case. Each tool needs, at minimum:
+
+- a normal happy path;
+- an empty or no-match path;
+- an invalid required argument or selector;
+- relevant boundary values below, at, and above documented caps;
+- conflicting mutually exclusive arguments where applicable;
+- at least two languages and three external repositories;
+- deterministic replay three times;
+- one normalized stdio versus HTTP parity case.
+
+Use pairwise parameter coverage rather than an uncontrolled Cartesian product. A successful response envelope is not proof of a correct response.
+
+### Layer B: paired LLM utility
+
+Run the same frozen task card in two fresh sessions. Each paired task has two SymForge modes:
+
+- `natural`: the agent may choose any available tool; this measures adoption and end-task utility;
+- `forced_workflow`: the task requires the named primary tool; this measures that tool's workflow economics independently of selection.
+
+For each mode compare:
+
+- `baseline`: shell/raw-file/Git/native parser/`apply_patch` only;
+- `symforge`: the same tools plus SymForge.
+
+The paired free-agent LLM baseline is the headline comparison. A third `recipe` arm runs a pre-registered shell command sequence as a secondary stable lower-bound sensitivity result. Do not compare an out-of-band recipe total with a full LLM task total as though they were the same measure. Do not allow LSPs, ctags, tree-sitter query tools, custom indexes, internet search, or SymForge in the baseline arm.
+
+Use a fixed final answer shape so prose style does not distort costs:
+
+```json
+{"answer":"...","evidence":[{"path":"...","line":1}]}
+```
+
+Measure tool selection separately from RPC correctness. If the natural agent fails to choose an available tool, record `selection_failure`; do not mislabel it as an RPC defect and do not hide its token cost. Forced-workflow trials are reported separately and never pooled with natural selection failures.
+
+### Layer C: stateful workflows
+
+Run these as explicit sequences:
+
+- cold source build, fresh-process snapshot restore, and process-warm query;
+- watcher convergence after an external disk edit;
+- first fetch, repeated fetch, `force_refresh`, and invalidation after a change;
+- CCR summary-only and CCR summary-plus-retrieval;
+- cross-session CCR handle rejection;
+- daemon multi-project add/query/routing;
+- worktree-aware edits;
+- checkpoint, restart, corrupted-copy quarantine, and source rebuild;
+- same idempotency key/same request replay and same key/different request conflict;
+- full, compact, and meta surface behavior.
+
+## 6. Standard task card
+
+Every case is a frozen YAML record:
+
+```yaml
+id: SF-<tool>-<nnn>
+primary_tool: <runtime tool name>
+claim_under_test: <one falsifiable claim>
+repo: <locked alias>
+commit: <full hash>
+language: <canonical language>
+preconditions: <exact setup commands or fixture state>
+cache_state: cold_build | snapshot_warm | process_warm | dirty
+transport: stdio | http
+surface: full | compact | meta
+execution_mode: direct_rpc | natural | forced_workflow | recipe
+critical: true | false
+task_prompt: <verbatim paired-LLM task>
+symforge_request: <canonical JSON arguments>
+baseline_recipe: <ordered competent commands>
+allowed_helpers: [rg, bounded_read, git_read, native_parser, apply_patch]
+forbidden_tools: [lsp, ctags, custom_index, internet, symforge_in_baseline]
+expected_answer: <exact value or set>
+expected_evidence: <exact path/line or allowed range>
+correctness_oracle: <script/manifest key>
+stop_condition: <objective completion condition>
+call_limit: <integer>
+timeout_seconds: <integer>
+mutation_allowlist: <paths or empty list>
+repetitions: <integer>
+```
+
+Executor procedure:
+
+1. Materialize a fresh disposable independent case clone; use a Git worktree only for a case explicitly labeled `worktree_compat`.
+2. Verify commit, fixture-manifest hash, source-tree hash, and clean/declared Git state.
+3. Establish the specified process, daemon, index, snapshot, and cache state.
+4. Start a fresh model session for the arm.
+5. Send the task verbatim and stop only on the declared condition, timeout, or call cap.
+6. Capture every request, response, retry, fallback, error, final answer, latency, and provider usage record through an in-memory/streaming sanitizer. Persist only sanitized bytes. If a secret-like value is detected, discard the value before persistence and retain only the rule name plus `file:line`.
+7. Calculate raw token counts in the non-persisted stream, then calculate persisted hashes and sanitized-artifact counts without writing the unsanitized value anywhere.
+8. Run the oracle out of band.
+9. Verify source hashes and allowed state changes.
+10. Repeat without changing the card.
+
+During either LLM arm, expose only the disposable case repository and the allowed tools. Deny the model access to the generator, oracle, result directories, earlier transcripts, and evaluator commands. Oracle evaluation runs in a separate process/context after the arm ends.
+
+## 7. Baseline policy
+
+The primary baseline is the competent free-agent LLM workflow using ordinary tools. The cheapest pre-registered competent recipe that satisfies the same oracle is a secondary lower-bound sensitivity arm. Typical recipes are:
+
+| SymForge family | Competent baseline |
+|---|---|
+| file/path search | `rg --files` piped to a bounded path match |
+| literal/regex search | scoped `rg -n`, with the same include/exclude policy |
+| symbol lookup | declaration-pattern `rg`, then one bounded line read |
+| callers/references | scoped whole-word `rg`, classification of imports/calls/types, bounded reads only where needed |
+| repo/file overview | `rg --files`, extension/directory aggregation, selected manifest reads |
+| Git changes | `git status`, `git diff --name-status`, `git diff -U0`, `git log` as required |
+| syntax | authoritative repository-native parser/compiler command |
+| single edit | bounded read plus `apply_patch`, then `git diff --check` and parser/test |
+| multi-edit/rename | `rg` discovery plus one atomic patch, then diff/parser/tests |
+| runtime/index state | nearest shell-observable state; if no equivalent exists, label `capability_only` and do not invent savings |
+
+Record a naive whole-file baseline only as a secondary sensitivity figure. Never use it for the headline.
+
+If a general-purpose baseline cannot provide equivalent information, the economics result is `N/A_CAPABILITY_GAIN`, not infinite savings. `index_folder`, `checkpoint_now`, and some runtime state fields are likely to need this label.
+
+## 8. Token accounting
+
+### 8.1 Tokenizers and raw units
+
+Provider-reported usage is primary when exposed. Also count the exact captured UTF-8 bytes with both `cl100k_base` and `o200k_base`; record the `tiktoken` package version and encoding hashes. The repository's historical token-cost work uses `cl100k_base`, so that is the continuity column. `o200k_base` is the cross-model sensitivity column.
+
+For each turn record, when available:
+
+- uncached input tokens;
+- cached input tokens;
+- reasoning tokens;
+- final-answer output tokens;
+- tool request tokens;
+- tool response tokens;
+- provider-billed total;
+- exact request/response UTF-8 bytes and both independent token counts.
+
+Unavailable provider fields are `null`, never zero. The primary total is the provider's documented billed/input-plus-output total for that model. Cached input is normally a subset of input, and reasoning tokens may be a subset of provider output; never add either a second time unless the provider explicitly documents disjoint counters. Independent `cl100k_base` and `o200k_base` counts are labeled estimates, not substitutes for provider-billed usage.
+
+### 8.2 Three economics views
+
+1. `direct_payload`: canonical tool name and arguments plus returned `content[*].text`.
+2. `paired_task_total`: complete provider usage from task prompt through the fixed final answer.
+3. `session_amortized`: surface schema, process/index setup, and history replay amortized over sessions of 1, 5, and 20 completed tasks.
+
+Also save full-wire JSON counts as a diagnostic. Do not silently mix content-only and wire-envelope numbers.
+
+Primary formulas:
+
+```text
+saved_tokens = baseline_total_tokens - symforge_total_tokens
+savings_percent = 100 * saved_tokens / baseline_total_tokens
+cost_multiplier = symforge_total_tokens / baseline_total_tokens
+negative_trial_rate = token_negative_trials / paired_trials
+```
+
+Aggregate token counts first, then calculate aggregate percentages. Do not average percentages. Report both a micro aggregate, pooled tokens for the declared workload, and a macro result that weights each task card/repository stratum equally. Keep tiny, normal, and stress strata separate so the TypeScript stress repository cannot hide small-task regressions.
+
+Measure schema tax using this no-op prompt in otherwise identical sessions:
+
+```text
+Reply exactly OK. Do not call a tool.
+```
+
+Run baseline-only, full, compact, and meta surfaces. Also tokenize the complete serialized `tools/list` and every individual schema. The full manifest size is a theoretical eager cost, not proof that a client sent all schemas to the model. On every model turn capture the exact model-visible tool definitions and their hash, including deferred tool-search or selected-schema exchanges, and separate cached from uncached schema tokens. The no-op prompt measures actual idle tax for that client only.
+
+Do not model schemas as a one-time session charge: clients may resend them on every turn. Measure real longitudinal 1-, 5-, and 20-task sessions and sum the actual model-visible schemas and transcript replay on each turn. Provider-reported task/session totals already containing schemas are reported directly without another schema addition. Only process/index setup that demonstrably occurs once is amortized with a formula.
+
+For indexing, report break-even only when both arms complete equivalent tasks:
+
+```text
+break_even_tasks = ceil(
+  (symforge_setup_cost - baseline_setup_cost) /
+  (baseline_query_cost - symforge_query_cost)
+)
+```
+
+If the denominator is zero or negative, report `no break-even observed`.
+
+### 8.3 Estimates, cache hits, and CCR
+
+For every tool advertising `estimate=true`, run estimate and actual calls on identical fresh arguments. Report median absolute percentage error and worst underestimation. The estimate call is not part of a normal task unless the task actually used it.
+
+For session cache behavior, count the first response, repeat response, forced refresh, extra turn, and later replay of prior content.
+
+For CCR, report two tasks:
+
+- a summary-only task whose oracle is satisfied without retrieval;
+- an exact-detail task that requires `symforge_retrieve`.
+
+The exact-detail total includes the summary, handle, retrieval request, retrieval response, extra model turn, and later transcript replay. Compare it with an uncompressed high-limit SymForge call and the competent baseline. CCR that saves on the first call but costs more after required retrieval is explicitly token-negative for that circumstance.
+
+## 9. Cache states, timing, and repetitions
+
+Use these terms only:
+
+- `cold_build`: no repository snapshot, new process/session, index built from source;
+- `snapshot_warm`: valid snapshot exists, process is new;
+- `process_warm`: same process and in-memory index after two discarded warmups, with fetch-cache state stated separately;
+- `dirty`: process-warm index followed by a controlled disk or Git mutation.
+
+Poll watcher tests for an observable indexed change. Do not sleep for an arbitrary fixed delay.
+
+Minimum repetitions:
+
+- direct correctness and error cases: 3 fresh identical sessions for determinism;
+- cold build and snapshot load: 5 independent starts;
+- warm RPC latency: 20 measured calls after 2 discarded warmups, split into first-warm, `force_refresh` warm, and repeated cache-hit cohorts rather than pooled;
+- paired LLM tasks: 5 paired seeds, or 3 only after deterministic sampling is demonstrated;
+- every tool: at least 3 external repositories from at least 2 language families;
+- mutation tools: live apply in at least Rust, Python, TypeScript, and one of Go/Java/C++/Perl.
+
+Randomize and counterbalance paired-arm order. Report median, IQR, p95, every failure/timeout, and a paired 95% bootstrap confidence interval for token delta. Never discard a slow or failed trial as an outlier.
+
+Same-session calls whose output should evolve because of cache hits, context inventory, frecency, CCR state, or idempotency are state-transition tests, not determinism repeats. Compare determinism only across fresh sessions with identical initial bytes and state.
+
+Measure RPC latency, process/daemon startup, index build, snapshot load, watcher convergence, paired end-to-end completion, peak RSS, CPU time, and `.symforge` disk growth separately.
+
+## 10. Frozen per-tool case matrix
+
+The first table contains the 36 full-surface tools shown in Claude. Every row is mandatory. `O` means controlled-overlay oracle; `N` means a native repository anchor verified independently before trials.
+
+| Tool | Required cases, repositories, and circumstances | Primary oracle and baseline |
+|---|---|---|
+| `health` | Healthy cold/warm/loading on `ripgrep`, `flask`, `typescript`; paged quarantine with malformed O files; `quarantine_limit` 0/10/1000/over-cap and `quarantine_offset` first/middle/final/out-of-range | Must respond while loading; counts/state agree with manifest, process, snapshot, and parser oracles; pagination has no gaps/duplicates; baseline file aggregation plus observable process/snapshot state |
+| `health_compact` | Same three sizes; healthy and parse-issue states; repeat after mutation | Required compact fields agree with `health`; compare tokens with full health and baseline aggregation |
+| `status` | Full and compact surfaces; ready/unready; isolated no-durable-store `reset_calibration` no-op and daemon/durable reset then recheck | Surface/version/wiring/index fields agree with manifest and health; durable reset affects calibration only, documented no-store no-op is honest; unsupported shell equivalent is capability-only |
+| `index_folder` | Cold retarget all locked public repos; unchanged retarget; missing/unreadable path; valid non-Git directory; same key/same args replay; same key/different args rejection; daemon `add=true` | Project identity, counts, watcher, idempotency, and downstream O search; a non-Git source directory remains valid; baseline has zero index setup plus per-task shell work, so report setup cost and break-even |
+| `checkpoint_now` | Write, verify-after-write, repeat, artifact export, restart/load, corrupt a disposable copy and verify quarantine/source recovery; non-writable/path-collision failure | Snapshot/artifact files and hashes, successful deserialize, honest failure, prior snapshot preserved, no partial temp/artifact; allowlist `.symforge/index.bin`, `.symforge/index.bin.zst`, `artifact.json`, and the documented `.gitattributes` hint; capability-only economics plus restart savings |
+| `analyze_file_impact` | O modify and `new_file=true` add in Rust, Python, TS; with/without co-change; file changed externally before call; deleted/missing path as an explicit adverse case | Exact symbol delta and dependent set for readable files; deleted/missing path must fail honestly without corrupting the index; baseline `git diff -U0` plus scoped `rg` references |
+| `what_changed` | Clean, staged, unstaged, untracked, rename/delete; ref/timestamp/path/language/code-only; symbol-diff fusion | Exact Git plumbing file set and O symbol diff; baseline `git status`/`git diff`/timestamp filter |
+| `diff_symbols` | O three-commit chain in Rust, Java, C++; full/compact/summary, path/language/code-only, invalid ref | Exact added/removed/modified symbol sets; baseline `git diff -U0` plus independent parser manifest |
+| `detect_impact` | Clean/no-change and changed O leaf in Rust/Go/Java; depth 1/2/5/over-cap; symbols/files; `WORKTREE`; include/exclude data and untracked; `since` precedence over `base_branch`; non-`main`/invalid refs | Exact three-hop reverse graph/risk tiers, over-depth warning, `--- impact payload ---` marker, JSON schema, and pagination; baseline Git change set plus scoped whole-word reference walk |
+| `validate_file_syntax` | Valid/malformed JSON/TOML/YAML, partial source, unindexed config, BOM/CRLF/Unicode, unsupported extension, missing path, estimate mode | Agreement with authoritative parser/compiler result and location when the parser exposes one; do not require a line where the contract does not promise it; baseline native parser output |
+| `get_repo_map` | Compact/tree/full on smallest, medium, and `typescript`; subtree/depth/max-files/max-tokens; full-output CCR | File/language/directory counts and required native/O anchors; baseline `rg --files` aggregation plus selected manifests |
+| `get_file_context` | O and native complex files in Python/Rust/TS; outline-only, imports, consumers, references, Git, tests; cache/repeat/force-refresh/stale disk | Exact symbol/import/consumer/reference sets and freshness; baseline declaration/import `rg`, bounded reads, Git log |
+| `get_file_content` | O full/range/offset-limit/around-line/match/occurrence/symbol/chunk; `header`/`show_line_numbers`; Unicode, CRLF, no newline, file over 60 KB; conflicting modes, unknown-field naming, and cap | Byte-for-byte selected hashes and documented headers; chunk reconstruction covers start/middle/end; unknown-field error names the bad parameter; baseline bounded raw read. Expect simple ranges to reveal any token-negative envelope cost |
+| `get_symbol` | Exact O symbol in four languages; omitted path; duplicate/overloaded ambiguity; kind/line disambiguation; batch slices; cache/estimate/force-refresh | Exact byte span/body/doc comments and honest ambiguity; baseline declaration `rg` plus one bounded read |
+| `get_symbol_context` | O entry/leaf/protocol and recursive custom-type cycle in Rust, Java, TS; default, bundle, sections, verbosity variants, tests, budget caps | Exact callers/callees/implementors/type deps and required definitions without recursion loops or duplicate closure entries; baseline multiple scoped searches and reads |
+| `inspect_match` | Line inside nested O symbol across Python/Java/C++; top-level line; invalid line; context/sibling limits/estimate | Exact enclosing symbol, parents, siblings, and excerpt; baseline bounded read plus independent outline manifest |
+| `search_files` | Exact/fuzzy/resolve duplicate basename; `current_file`, `debug_ranking`; path/vendor/personal filters; frecency; legacy `changed_with`; recommended `rank_by=path+cochange` with `anchor_path`; no-history/stale/disabled coupling; invalid project selectors | Exact file set, expected resolved path, known co-change counts/order, ranking signal invariants and honest fallbacks; baseline `rg --files` plus bounded path filtering and `git log --name-only` aggregation for coupling |
+| `search_symbols` | Exact/substring/browse O queries; kind/language/path; tests/generated/vendor; duplicate names; cap/CCR; single/multi-project | Precision, recall, top-k position, exact path/kind/line; browse returns one representative per exact name+kind in deterministic reference-count/kind/path/line order; baseline declaration-pattern `rg` and fixture manifest |
+| `search_text` | Exact markers; OR terms; regex/whole-word/case; group file/symbol/usage/names; test/noise filters; ranked/follow-refs; structural per language; invalid regex/pattern; CCR | Exact TP/FP/FN sets, grouping, callers, cap honesty; a test-only default query returns zero source hits plus the advertised suppressed-count hint, then exact hits with `include_tests=true`; baseline scoped `rg`; structural cases use independently parsed O manifest and are capability-only if no equivalent baseline |
+| `find_references` | O leaf/rename/protocol plus alias-heavy/common names across Rust/Go/Java/TS; compact/full, kind filters, implementations both directions; ambiguous/no refs; CCR | Exact call/import/type/implementation sets, precision/recall; baseline whole-word `rg` plus classification |
+| `find_dependents` | O imported module/file with cyclic and aliased imports across Python/TS/Go; compact/full/mermaid/dot; limits; symbol-shaped misuse | Exact importing-file set and edge kinds without recursion loops; graph syntax parses; baseline import-pattern `rg` |
+| `explore` | Native concepts `error handling`, `serialization`, `command parsing`; O concept with depth 1/2/3; filters/no-hit/CCR | Required fact rubric plus path precision and graph anchors; baseline competent sequence of file, text, symbol searches and bounded reads |
+| `ask` | Exact prompts: `where is sfbench_leaf defined`, `who calls sfbench_leaf`, `how does sfbench_entry work`, `what changed`, `find file sfbench_core`; malformed/vague question | Correct route and oracle answer. Compare with competent shell and with the optimal direct SymForge tool to expose routing overhead |
+| `conventions` | `ripgrep`, `flask`, `zod`, `gson`, `fmt`; naming, errors, tests, imports, layout; tiny O repo adverse case | Evaluator verifies statistics with an independent oracle script and sampled native files; baseline uses `rg --files`, scoped count searches, and a frozen stratified sample of bounded reads, not the oracle script |
+| `edit_plan` | Exact O symbol, file path, bare ambiguous symbol, missing target, high/zero-reference targets in four languages | Plan names correct impact and minimal tool sequence; baseline reference search plus Git context |
+| `context_inventory` | Empty session; known ordered fetch sequence; repeat/cache hits; multi-project; after mutation | Exact fetched file/symbol set and token estimates assessed for error/honest `~` labeling rather than exact equality; baseline client-side ledger. Expect possible token-negative small inventories |
+| `investigation_suggest` | After fetching only O entry, after fetching all dependencies, with focus/no focus, and with a dependency cycle across Rust/Python/TS | Suggests real not-yet-loaded dependencies, then does not repeat loaded items or loop on cycles; baseline client ledger plus O graph |
+| `replace_symbol_body` | Dry/apply O mutable in Rust/Python/TS/Java; CRLF/Unicode; ambiguity; presence-triggered concurrent disk-divergence guard; key replay/conflict; worktree routing | Exact allowlisted diff, bytes/newlines preserved, parser/tests pass, concurrent divergence and rejected writes change nothing; do not expect this granular tool to value-compare an arbitrary `if_match` string, which is a STEL preflight contract; baseline bounded read plus `apply_patch` |
+| `edit_within_symbol` | First/occurrence/near-line/replace-all on repeated O literal; identical text outside symbol; dry/apply/replay/conflict in four languages | Only intended in-symbol occurrences change; exact diff/parser oracle; baseline small `apply_patch`, likely strong token competitor |
+| `insert_symbol` | Before/after O anchors; nested indentation/doc attributes; duplicate name/line disambiguation; dry/apply/replay in four languages | Exact placement/indentation and byte-preservation diff; baseline declaration discovery, bounded anchor read, then `apply_patch` unless anchor bytes are supplied in the task |
+| `delete_symbol` | Isolated/doc-comment/attribute O symbols; overload disambiguation; dry/apply/replay; blank-line cleanup in four languages | Exact symbol range removed, adjacent bytes/newlines valid, parser/tests pass; baseline declaration discovery, bounded symbol read, then `apply_patch` |
+| `batch_edit` | Two files/mixed operations; shorthand/structured; overlap; one invalid selector; dry/apply/replay/conflict; worktree route | All-or-nothing exact diff and index update; invalid batch leaves every source hash unchanged; baseline declaration discovery, bounded reads, and one atomic multi-file patch |
+| `batch_insert` | Multiple valid targets across files/languages; indentation; one invalid target; dry/apply/replay/conflict | Exact insertions or total rollback; parser/tests; baseline target discovery, bounded anchor reads, then multi-file patch |
+| `batch_rename` | O symbol with four code and two non-code mentions; code-only on/off; duplicate/common name; dry/apply/replay/conflict across four languages | Exact reference precision/recall, uncertain matches untouched/reported, build passes; baseline `rg` discovery plus atomic patch |
+| `symforge_edit` | Preview default and apply for every supported op/intent; full-body flush-left; edit-within; insert; stale value-matched `if_match`; replay/conflict; parity with granular tools | Exact diff and trust envelope equal in effect to granular operation; compare tokens with granular tool and baseline discovery/read/patch workflow |
+| `symforge_retrieve` | Trigger from search/symbol/explore; valid hash; malformed/unknown; repeated; new-session/cross-project desired security invariant; summary-sufficient vs exact-needed | Retrieved text hash equals stored pre-compression payload; cross-session/project isolation is benchmark-required security behavior unless a governing contract says otherwise; compare combined workflow with uncompressed call and baseline |
+
+The 37th unique tool name is surface-specific and receives its own scorecard:
+
+| Tool/surface | Required cases, repositories, and circumstances | Primary oracle and baseline |
+|---|---|---|
+| `symforge` on compact and meta | Compact: fixed natural-language definition, callers, explanation, change, file, and exploration intents across O/Rust/Python/TS, empty/vague query, budget, invalid project, and parity with the granular route. Meta: schema-advertised measurement relay for safe read-only granular cases, missing relay fields, and an ordinary query that must fail with the documented compact-surface requirement rather than pretending to execute | Compact answer and routed-tool identity match direct granular facts; compare compact facade with competent ordinary tools and the direct granular workflow to expose routing overhead. Meta result matches its measurement-only description and never leaks or mutates unrelated state |
+
+### 10.1 Cross-cutting assertions
+
+- Test every advertised `project` and `projects` mode. Paths passed where IDs are required must fail with corrective guidance.
+- Test `max_tokens` at a deliberately small value, a normal value, and default.
+- Verify `estimate=true` against independent actual tokenization.
+- Verify discovery/guidance tools do not bump frecency; committed context reads and mutations do according to policy.
+- Verify source/test/generated/vendor/personal filters using controlled markers.
+- Normalize only documented nondeterministic fields when checking stdio/HTTP parity and replay. Ranked order changes count as nondeterminism.
+
+## 11. Mutation safety sequence
+
+Before each mutation case:
+
+1. Materialize a disposable worktree under the checked benchmark root.
+2. Hash every source file and record Git status.
+3. Declare exact allowed changed paths and expected `.symforge` artifacts.
+4. Use a unique deterministic idempotency key derived from protocol ID, run ID, and case ID.
+5. Run dry-run first when the tool offers it and prove zero source bytes changed.
+
+After each call:
+
+1. Verify only allowlisted bytes changed.
+2. Verify newline style, encoding, and unrelated file hashes.
+3. Run `git diff --check`, the authoritative parser/compiler, and focused tests.
+4. Verify successful edits appear in the index and rejected edits do not.
+5. Replay the same key/request and then the same key with one changed argument.
+6. Put one invalid operation into every batch rollback case.
+
+Any path escape, shared-checkout write, stale overwrite, unintended edit, partial batch, silent corrupt-snapshot service, or secret exposure is `UNSAFE` regardless of other scores.
+
+## 12. Correctness and verdicts
+
+Prefer automatic oracles:
+
+- search: precision, recall, top-k recall, expected rank;
+- symbol/reference: exact path, kind, line, byte span, and edge sets;
+- file content: exact hashes with CRLF and Unicode preserved;
+- Git/change tools: exact file and symbol sets;
+- syntax: agreement with authoritative parser/compiler diagnostics;
+- edits: exact allowlisted diff, parser/build/tests, unrelated hashes unchanged.
+
+Guidance tools use a frozen fact rubric. If an automatic oracle is impossible, use two blinded judges and a third only to resolve disagreement.
+
+Functional verdicts:
+
+- `PASS`: all critical cases pass and at least 95% of noncritical cases pass;
+- `PASS_WITH_LIMITATIONS`: critical cases pass and 80-94% of noncritical cases pass;
+- `FAIL`: a normal advertised path fails, a result is materially wrong, or pass rate is below 80%;
+- `UNSAFE`: any safety failure described above.
+
+`critical` is frozen in each task card. A timeout is a failed case. A natural-mode selection failure is an end-task utility failure but does not override a passing direct-RPC conformance result; report both. A forced-workflow timeout counts against the named tool's workflow result.
+
+Economics verdicts use this mutually exclusive precedence:
+
+1. `INVALID_INCORRECT`: the workflow did not satisfy the oracle, so apparent savings are invalid;
+2. `N/A_NO_EQUIVALENT_BASELINE`: no equivalent competent baseline exists;
+3. `TOKEN_NEGATIVE`: aggregate saved tokens are below zero;
+4. `TOKEN_MIXED`: aggregate saved tokens are nonnegative but at least 25% of paired trials are negative, or predefined scenario strata have opposing signs;
+5. `TOKEN_POSITIVE`: aggregate saved tokens are positive, the paired 95% CI lower bound is above zero, and the negative-trial rate is below 25%;
+6. `TOKEN_NEUTRAL`: every remaining correctness-valid result, normally a CI crossing zero with nonnegative aggregate and negative-trial rate below 25%.
+
+Do not fold latency into these grades. Flag a warm regression when it is both more than 25% and more than 250 ms slower than the baseline or granular equivalent.
+
+## 13. Machine-readable evidence
+
+Write one sanitized JSONL row per trial outside the repository:
+
+```json
+{
+  "protocol": "SFBENCH-1.0",
+  "run_id": "",
+  "case_id": "",
+  "tool": "",
+  "claim": "",
+  "repo": "",
+  "commit": "",
+  "language": "",
+  "transport": "",
+  "surface": "",
+  "cache_state": "",
+  "arm": "",
+  "execution_mode": "",
+  "critical": false,
+  "model": "",
+  "seed": null,
+  "request_sha256": "",
+  "response_sha256": "",
+  "status": "",
+  "correct": null,
+  "precision": null,
+  "recall": null,
+  "rpc_ms": null,
+  "end_to_end_ms": null,
+  "process_start_ms": null,
+  "index_build_ms": null,
+  "snapshot_load_ms": null,
+  "watcher_convergence_ms": null,
+  "peak_rss_bytes": null,
+  "cpu_ms": null,
+  "symforge_disk_growth_bytes": null,
+  "input_tokens": null,
+  "cached_input_tokens": null,
+  "reasoning_tokens": null,
+  "output_tokens": null,
+  "provider_total_tokens": null,
+  "direct_payload_tokens": null,
+  "tool_request_tokens": null,
+  "tool_response_tokens": null,
+  "final_answer_tokens": null,
+  "transcript_replay_tokens": null,
+  "full_tools_list_tokens": null,
+  "model_visible_schema_tokens": null,
+  "model_visible_schema_sha256": "",
+  "full_wire_tokens": null,
+  "request_cl100k": null,
+  "response_cl100k": null,
+  "request_o200k": null,
+  "response_o200k": null,
+  "fallback_calls": 0,
+  "source_sha256_before": "",
+  "source_sha256_after": "",
+  "oracle_result": "",
+  "turns": [
+    {
+      "turn_index": 0,
+      "model_visible_schema_sha256": "",
+      "model_visible_schema_tokens": null,
+      "assistant_tool_call_tokens": null,
+      "tool_result_tokens": null,
+      "final_answer_tokens": null,
+      "cached_input_tokens": null,
+      "provider_total_tokens": null
+    }
+  ],
+  "artifact_paths": []
+}
+```
+
+Raw safe text may remain under `$ARTIFACT_ROOT`; Git receives only sanitized aggregate JSON and the final Markdown report. A sanitizer must never log a matched secret value. It may log only the rule name and `file:line`.
+
+The final per-tool table must contain:
+
+```text
+Tool | Claims/parameters covered | Repos/languages | Passes/trials |
+Correctness or precision/recall | Baseline task tokens | SymForge task tokens |
+Saved tokens | Savings % | Cost multiplier | Token-negative trial rate |
+Worst token regression | Cold p50/p95 | Warm p50/p95 | Determinism |
+Functional verdict | Economics verdict | Finding IDs
+```
+
+Every finding needs a sanitized minimal reproduction, expected versus actual behavior, reproduction count, token and latency delta, affected repositories/languages, severity, and a concrete implementation suggestion.
+
+## 14. Improvement and enhancement analysis
+
+Conformance is only the floor. The final objective is a prioritized engineering brief that helps the SymForge coding agent make the product materially better.
+
+For every failed, partial, slow, noisy, or token-negative case, decompose the observed cost into these buckets:
+
+- full-surface and selected-tool schema tax;
+- tool-call argument cost;
+- response framing and trust-envelope cost;
+- repeated paths, headings, excerpts, facts, or hints;
+- irrelevant or low-ranked results;
+- extra turns caused by ambiguity, truncation, cache behavior, or CCR retrieval;
+- fallback and remediation calls needed to satisfy the oracle;
+- transcript replay of earlier tool output on later model turns;
+- index/setup cost and the actual task count needed to amortize it.
+
+Run a read-only counterfactual formatting analysis on each token-negative response. Remove or compact one output component at a time in a scratch artifact, preserve every oracle-required fact and honesty disclosure, and independently recount tokens. This estimates the maximum plausible saving from a formatter change without editing SymForge during the benchmark. Do not recommend removing trust or completeness disclosures merely because they cost tokens.
+
+Classify each opportunity:
+
+- `CORRECTNESS`: wrong, stale, incomplete, misleading, or nondeterministic behavior;
+- `SAFETY`: mutation, worktree, recovery, path, or secret-handling risk;
+- `SCHEMA`: tool description or schema context tax;
+- `FORMAT`: verbose or duplicated response text;
+- `DEFAULT`: a compact/existing mode should be the default for a common task;
+- `FUSION`: one tool could safely eliminate a follow-up call or round trip;
+- `CACHE_CCR`: caching or compression saves the first response but loses on the completed workflow;
+- `RANKING_FILTER`: poor relevance, recall, noise admission, or filtering;
+- `ERGONOMICS`: ambiguous parameters, weak errors, or unnecessary agent decision cost;
+- `LATENCY_RESOURCE`: slow RPC, indexing, snapshot, watcher, memory, CPU, or disk behavior;
+- `NEW_CAPABILITY`: a measured task gap that cannot be solved by tightening an existing path.
+
+Every proposed improvement must contain:
+
+```text
+Finding ID and category
+Affected tool(s), cases, repos, and languages
+Observed behavior versus advertised/desired behavior
+Reproduction rate and correctness impact
+Baseline, SymForge, and delta tokens for direct, full-task, and amortized views
+Measured cost breakdown and largest avoidable component
+Read-only counterfactual token count and estimated saving
+Concrete proposed behavior or output shape
+Facts/trust disclosures that must remain
+Likely implementation symbol/module, if evidence locates one
+Acceptance test derived from the frozen case
+Regression risks and neighboring cases to rerun
+Priority and rationale
+```
+
+Prioritize by measured user impact, not novelty:
+
+- `P0`: unsafe behavior, corruption, secret exposure, or silently wrong results;
+- `P1`: common advertised path fails, high-frequency task is materially incomplete, or full/session economics are strongly token-negative;
+- `P2`: reliable functionality with a meaningful measured token, latency, ranking, or ergonomics improvement;
+- `P3`: cosmetic, rare, or low-upside refinement.
+
+For economics priorities, report expected net change for 1-, 5-, and 20-task sessions and a transparent workload mix. Do not let a large win on one stress case hide many small regressions. Always include the strongest token-negative controls: exact filename search, unique literal search, same-range file read, known-line tiny symbol, plain `git status`, direct granular tool versus facade, and CCR with mandatory retrieval.
+
+If a tool works well and no measured improvement survives correctness constraints, say `NO CHANGE RECOMMENDED`. The report is not required to invent a fix for every tool.
+
+## 15. Coding-agent report structure
+
+The final Markdown report must be self-contained and ordered for implementation:
+
+1. Executive verdict: correctness, safety, aggregate token economics, surface tax, and the five highest-impact changes.
+2. Environment and frozen methodology: binary/schema hashes, repository pins, tokenizer/provider fields, cache states, baselines, and limitations.
+3. Portfolio economics: aggregate and per-session totals, negative-trial rate, break-even, and explicit cases where traditional tools win.
+4. Per-tool scorecard for all 36 full-surface tools plus the compact/meta-only `symforge` facade, including positive, neutral, negative, no-equivalent-baseline, and untested/blocked results.
+5. Findings ordered by `P0` through `P3`, each using the improvement record above.
+6. Enhancement backlog grouped by implementation area so related formatter/schema/index/edit fixes can be handled together.
+7. Acceptance-test checklist mapping every recommendation to a frozen case ID.
+8. Sanitized artifact index and exact reproduction commands.
+
+The report must distinguish measured fact, oracle judgment, and inference. It must never suggest a token optimization that lowers correctness, recall, mutation safety, determinism, or trust-envelope honesty.
+
+## 16. Stop and audit conditions
+
+Stop the affected campaign immediately on:
+
+- any source write outside the disposable worktree;
+- any secret value entering output or an artifact;
+- source mirror drift or commit mismatch;
+- an oracle generated from SymForge itself;
+- uncontrolled state leakage between trials;
+- a protocol change after measurements begin;
+- three consecutive harness failures with the same root cause.
+
+Preserve evidence, mark the case blocked or unsafe, and do not continue mutations until isolation is re-established.
+
+## 17. Required deliverables
+
+1. Frozen repository and fixture lock manifest.
+2. Runtime full/compact/meta manifest and schema hashes.
+3. Parameter-to-case coverage matrix for every advertised field and enum.
+4. Sanitized JSONL trial results and aggregate JSON.
+5. Per-tool Markdown report with positive and negative token economics, including a cost-component breakdown for every token-negative case.
+6. Ranked findings and enhancements for the SymForge coding agent, each with a minimal repro, measured upside, implementation direction, and proposed acceptance test.
+7. A limitations section listing unavailable provider usage fields, unsupported platform features, and capability-only comparisons.
+
+This protocol is complete only when every runtime-advertised tool has direct conformance evidence, at least three external-repository circumstances, paired token evidence where an equivalent baseline exists, and an explicit verdict. A green response envelope alone is never sufficient.

--- a/docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-report.md
+++ b/docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-report.md
@@ -1,0 +1,472 @@
+# SymForge 8.14.0 full-surface benchmark report
+
+**Date:** 2026-07-12  
+**Protocol:** `SFBENCH-1.0`  
+**System under test:** `symforge 8.14.0`  
+**Executable SHA-256:** `294ad9fae560ac217b10d685aa06c2a8fbaa63794d6f70bb92c2f5f61f9947fe`  
+**Primary tokenizer:** `tiktoken 0.13.0`, `cl100k_base`  
+**Sensitivity tokenizer:** `o200k_base`
+
+Evidence labels in this report mean:
+
+- **Measured:** taken from sanitized JSONL, not hand-counted.
+- **Oracle judgment:** independently checked against Git, parsers, frozen fixture hashes, or the case rubric.
+- **Inference:** an implementation recommendation derived from measured behavior and source inspection.
+
+## Executive verdict
+
+**Do not promote 8.14.0's full surface as a safe or token-efficient default without fixes.** The implementation has genuinely strong low-latency primitives, but the tested surface combines one unsafe mutator, several confidently wrong graph/dependency paths, a broken advertised meta surface, and a large eager schema tax.
+
+The strict happy campaign adjudicated all 36 full-surface tools plus the compact `symforge` facade:
+
+| Result | Tools | Meaning |
+|---|---:|---|
+| Pass | 16 | Satisfied the frozen happy oracle. |
+| Fail | 18 | Wrong, incomplete, byte-different, or violated a required replay/state contract. |
+| Manual/invalid | 3 | The rubric or benchmark setup was not sound enough to assign correctness. |
+
+The most serious result is `batch_rename`: a path-scoped request to rename Python method `run` returned success after rewriting nine sites across four files, including three unrelated Flask files. The runner detected the source-write escape only after the tool committed it. This is a P0 fail-closed issue.
+
+Correctness-adjusted direct economics were also unfavorable. Among the six happy scenarios with both a passing tool result and an information-equivalent, independently accepted baseline:
+
+| Scenario set | SymForge | Baseline | Extra SymForge tokens |
+|---|---:|---:|---:|
+| Six valid equivalent scenarios, median sum | 4,032 | 2,262 | **+1,770 (1.78×)** |
+
+Only `get_symbol` saved direct payload in that set: 184 versus 490, saving 306 tokens. `batch_edit`, happy-path `batch_rename`, `delete_symbol`, `edit_within_symbol`, and `replace_symbol_body` were correct but consumed 199–694 extra tokens each. With the default 17,894-token full schema amortized over 20 tasks, even `get_symbol` costs about 589 more tokens than its baseline. No tool demonstrated a verified net saving in that full-surface N=20 view.
+
+Raw apparent wins from `conventions`, `symforge_retrieve`, `get_file_context`, `what_changed`, and several failed graph tools are not savings:
+
+- the result was wrong or omitted required facts;
+- the baseline emitted materially more information;
+- or the baseline recipe itself was not competent/equivalent.
+
+Performance is a real strength. Most read RPCs completed in roughly 0.5–25 ms, structural mutations in roughly 29–43 ms, checkpointing in roughly 17 ms, and a fresh `index_folder` in roughly 220 ms on the principal fixture overlays. All six resources, four resource templates, and seven prompts completed their smoke test; 17 calls had about 2.05 ms p50 latency.
+
+The five highest-impact changes are:
+
+1. Make `batch_rename` identity-bound and fail closed before staging any uncertain reference.
+2. Fix the watcher generation race that permanently rejects edits after asynchronous cold reload.
+3. Introduce one typed symbol-delta/reference identity path for impact, callers, dependents, and context tools.
+4. Make compact the installation/default surface, repair or withdraw meta, and reduce schema/formatter tax.
+5. Fix syntax validation, insertion/replay/calibration contracts, then replace verbose edit responses with compact source-bound receipts.
+
+## Environment and frozen methodology
+
+The benchmark used ten pinned public repositories outside the SymForge checkout: ripgrep, Flask, Zod, Cobra, Gson, fmt, Mojo, TypeScript, p-map, and the JSON Schema Test Suite. Together they contain 83,909 tracked files and 410,204,240 bytes. A deterministic overlay supplied independently generated Rust, Python, TypeScript, Go, Java, C++, Perl, JSON, worktree, history, duplicate-name, and byte-exact fixtures.
+
+| Frozen input | Identity |
+|---|---|
+| Corpus manifest | `a8d154c61f2ff228e9b254851e06cd7d236766d4bf191abbd094b7934f041158` |
+| Fixture oracle | `eb1fd3d075a1a29626a25d4b65faa7124c83db9c0ed1109e2cb9dcc90b12fadd` |
+| Cases | `7bbf41fa3b6a827cd0aa50e37fde993447be7703645174005129aef2f2a8db58` |
+| Baseline patches | `c4116e246edac2aee8f32ce933e3a05bc169c3378da15ff4bfd3fac2cff9d935` |
+| Happy evidence | `4f3418ce3b949c9e504a936fd34a56a3c527571323f57753998ddbaac919dee1` |
+
+The frozen case inventory contains 115 cases: 37 happy, 38 adverse, 36 control, and four stateful. It declares 267 tool requests plus independent baselines and oracle checks. The strict happy run scheduled 117 fresh trial windows (three repetitions per ordinary case; five for checkpoint, health, and indexing). It captured 114 `case_complete` and three `case_error` windows, all three caused by the same reproducible `symforge_edit` replay failure. The artifact contains 4,092 JSONL records and 269 direct tool calls. The repaired adjudicator validates all 117 ordered trial windows with zero structural issues.
+
+Token accounting includes canonical tool request plus response payload for every task-role call. Estimate, oracle-reference, replay-diagnostic, and prerequisite roles are reported separately and are not silently summed into the headline. Provider totals would take precedence if available; no paid paired-provider campaign was authorized, so direct recipe results are sensitivity evidence rather than a provider-level LLM headline.
+
+Traditional baselines used `rg`, bounded reads, Git read commands, independent parsers, and patch application on the same disposable clone. Economics are scored only when both arms are correct and information-equivalent. Lower-bound and capability-only comparisons remain labeled as such.
+
+The broad one-repetition campaign is diagnostic, not formal economics. It uses declared stdio shadows for HTTP-primary cases and includes discarded warmups. It reached all 187 scheduled terminal windows across all 115 cases: 154 `case_complete`, 33 `case_error`, 379 direct calls, 4,716 JSONL rows, and 252,909,095 bytes. The 33 errors include confirmed product failures, all seven declared setup blockers, and benchmark materialization/baseline errors; they are classified separately rather than pooled. Its SHA-256 is `c57c615990332882b2f4c95c4e4093927d4dab75ddfe298ab005658471352f84`.
+
+All seven formerly unsupported setup states were then exercised in isolated diagnostics with a corrected explicit nonempty readiness gate. Snapshot quarantine and daemon additive-project behavior passed. The diagnostics found a permanent watcher-generation race, daemon calibration reset failure, local plural-project selector bug, and several failure paths that return `isError:false` despite clear failure text.
+
+| Former setup gap | Diagnostic result |
+|---|---|
+| Checkpoint temp-path collision | Prior 894,033-byte snapshot hash preserved; zero owned temps; error flag wrong. |
+| Corrupt snapshot/restart/quarantine | Pass after corrected readiness: corrupt bytes quarantined, source rebuilt, next restart restored snapshot. |
+| Same-session health mutation | Fail: watcher/reconcile remains stale and symbol never appears. |
+| Frecency seed | Pass: three legitimate context loads move target to rank 1; debug response grows 224→600 tokens. |
+| CCR malformed/unknown/foreign | Isolation pass; all invalid results incorrectly use `isError:false`. |
+| Daemon additive project | Home + added inventory and cross-project query pass; isolated refusal flag wrong. |
+| Durable calibration reset | Daemon fail; equivalent local reset passes. |
+
+## Portfolio economics
+
+### Surface tax
+
+| Surface | Tools | cl100k schema | Per 5 tasks | Per 20 tasks | o200k schema |
+|---|---:|---:|---:|---:|---:|
+| Full | 36 | 17,894 | 3,578.8 | 894.7 | 18,047 |
+| Compact | 3 | 1,163 | 232.6 | 58.15 | 1,183 |
+| Meta | 1 | 93 | 18.6 | 4.65 | 102 |
+
+Full to compact removes 93.5% of cl100k schema tokens. Full to meta removes 99.48%, but meta is unusable: it advertises only `symforge`, then that call returns an invalid-request error saying the handler requires compact while the suggested legacy tools are hidden.
+
+Schema decomposition shows this is not only a tool-count problem:
+
+| Counterfactual full manifest | cl100k | Reduction |
+|---|---:|---:|
+| Actual | 17,894 | — |
+| Remove property descriptions only | about 9,657 | 46.0% |
+| Remove tool descriptions only | about 14,511 | 18.9% |
+| Remove all descriptions | about 6,273 | 65.0% |
+
+Even the description-free 36-tool schema is 5.4× the complete compact schema. The product therefore needs both a smaller default inventory and shorter schemas.
+
+### Correctness-adjusted equivalent comparisons
+
+| Tool | SymForge | Baseline | Saved (`baseline − SF`) | Verdict |
+|---|---:|---:|---:|---|
+| `get_symbol` | 184 | 490 | **+306** | Positive direct payload |
+| `batch_rename` happy | 717 | 518 | -199 | Token-negative; adverse path unsafe |
+| `delete_symbol` | 611 | 245 | -366 | Token-negative |
+| `edit_within_symbol` | 693 | 329 | -364 | Token-negative |
+| `replace_symbol_body` | 691 | 238 | -453 | Token-negative |
+| `batch_edit` | 1,136 | 442 | -694 | Token-negative |
+
+At the default full N=20 surface allocation, add 894.7 tokens per task. `get_symbol` becomes 1,078.7 versus 490. Repeated use of a lazily exposed `get_symbol`-only schema would break even in roughly three tasks; the shipped eager full surface needs roughly 59 identical scenario savings merely to repay its schema.
+
+Independent broad controls reinforce that simple tasks often cost more even before schema:
+
+| Correct control | SymForge | Baseline | Extra tokens |
+|---|---:|---:|---:|
+| Exact CCR workflow | 3,361 | 1,031 | +2,330 |
+| `inspect_match` | 123 | 76 | +47 |
+| `find_references` | 124 | 94 | +30 |
+| `edit_plan` | 137 | 105 | +32 |
+| `find_dependents` | 99 | 83 | +16 |
+| `symforge_edit` facade | 279 | 251 | +28 |
+| `replace_symbol_body` | 128 | 126 | +2 |
+
+Broad controls also reproduced real payload savings for narrow reads (`get_symbol` 290 vs 695; `get_file_content` 59 vs 120). As with the happy `get_symbol` result, those wins disappear under the default full schema at ordinary session lengths.
+
+### Information-matched counterfactuals
+
+- `symforge_retrieve` was functionally exact for the bytes it stored, but the frozen happy baseline emitted 1,400 matches while SymForge stored only the first 100. The information-matched broad control measured 1,031 tokens: the 333-token summary-only path saves 698 (67.7%), while summary plus exact retrieval costs 3,361, or **+2,330 tokens / 3.26×**. CCR saves only when the summary prevents retrieval.
+- Mutation apply responses lose 65–77% of their tokens if repeated absolute routing/tee lines are removed. Removing the repeated safety envelope cuts 88–93%. A replay that performs zero writes still resends 416–766 tokens.
+- `get_file_context`'s final visible response saved only about nine tokens versus the raw fixture file while its footer claimed a much larger saving. The footer and trust prose consumed most of the claimed benefit.
+- `conventions` appeared to save more than 74,000 tokens only because its baseline dumped almost 74,000 raw match tokens. That baseline is invalid for an agent workflow.
+- Broad preview-only controls show useful compact primitives—`batch_edit` 193 vs 261, `delete_symbol` 97 vs 134, and `edit_within_symbol` 171 vs 221—but complete preview/apply/replay workflows reverse those savings. Report the branch, not the best call in isolation.
+- Repeat-read cache messages can cost more than replaying the answer: `get_file_content` original 59 vs sentinel 142; `get_file_context` original 110 vs sentinel 157. A cache should avoid server work without forcing the model to spend more tokens reconstructing prior context.
+
+### Latency
+
+Latency was rarely the limiting factor:
+
+| Operation | Observed p50 |
+|---|---:|
+| `get_symbol` | about 0.8 ms |
+| `status` compact/projects | about 0.8–1.3 ms |
+| `get_symbol_context` | about 10.4 ms |
+| `health` | about 11.2 ms |
+| `checkpoint_now` | about 17.0 ms |
+| `diff_symbols` | about 18.0 ms |
+| Structural applies | about 29–43 ms |
+| `detect_impact` | about 67.6 ms |
+| `index_folder` fresh | about 220 ms |
+
+The priority should be safety, semantics, surface design, and response size—not micro-optimizing already fast in-process calls.
+
+## Per-tool scorecard
+
+`SF/base` is median schema-free cl100k task-scenario payload. `LB` means lower-bound baseline, `cap` capability-only, and `invalid` means no numeric savings claim is allowed. Extra tokens are `SF − baseline`.
+
+| Tool | Strict verdict | SF/base | Economics and improvement |
+|---|---|---:|---|
+| `analyze_file_impact` | Fail | 108/180 LB | Apparent -72 is invalid; same-file caller omitted. Corrected two-call workflow is about 250, 37% above baseline. |
+| `ask` | Pass, verbose | 212/52 LB | +160; keep routing but default to terse route + answer. |
+| `batch_edit` | Pass, noisy | 1,136/442 | +694; plan handle and compact apply/replay receipt. |
+| `batch_insert` | Fail | 938/389 | +549 and wrong blank-line bytes. Share fixed insertion builder. |
+| `batch_rename` | **P0 fail overall** | 717/518 happy | Happy is +199; common-name adverse request rewrote unrelated files. Bind references to exact target identity. |
+| `checkpoint_now` | Pass data safety; signaling partial | 82/cap | Collision preserves prior snapshot and leaves no temp, but failure returns `isError:false`; corrupt snapshot quarantine/rebuild passes. |
+| `context_inventory` | Fail/benchmark-contaminated | 37/cap | Happy session was preflight-polluted; broad evidence proves failed lookups are recorded as fetched. Record only successful loads. |
+| `conventions` | Manual/fail on mixed corpus | 620/invalid | Rubric weak; cross-language overlays distort counts and canned appendix is large. Use dominant-language proportions and bounded evidence. |
+| `delete_symbol` | Pass, noisy | 611/245 | +366; exact bytes and replay safety, compact receipt needed. |
+| `detect_impact` | **P0 fail** | 1,278/82 LB | +1,196 while inventing 19 extra changed symbols and unrelated blast nodes. Replace file-wide seeds with body deltas. |
+| `diff_symbols` | Pass | 272/184 LB | +88 for richer typed delta; formatter can be tightened. |
+| `edit_plan` | Pass | 304/101 LB | +203; useful extra capability, but emit compact target/ref/steps by default. |
+| `edit_within_symbol` | Pass, noisy | 693/329 | +364; exact bounded edit, compact receipt needed. |
+| `explore` | Manual | 602/1,134 LB | Useful but relevance rubric missing; phrase ranking included unrelated `.parse()` sites. |
+| `find_dependents` | Fail | 130/48 LB | +82 and missed Python relative importer. Preserve/resolve relative module provenance. |
+| `find_references` | Fail | 296/61 LB | +235; matching local selector refused, estimate ignored, classification incomplete. |
+| `get_file_content` | Pass | 395/237 invalid | Exact bytes; range/full/offset need separate equivalent baselines and less framing. |
+| `get_file_context` | Fail | 431/586 LB | Apparent -155 invalid: false Flask consumer, missing facts, estimate/cache ordering bug. |
+| `get_repo_map` | Pass happy; conformance partial | 169/180 LB | Only 11 saved; unknown detail silently falls back and estimate is about 350% high. Validate enums and derive estimate. |
+| `get_symbol` | **Pass / best result** | 184/490 | Saves 306 direct; preserve exactness. Surface schema erases win at N=20. |
+| `get_symbol_context` | Fail strict graph/validation oracle | 784/503 LB | +281; unresolved call promoted, unknown sections accepted, tight bundles overclaim completeness, Java edges duplicate/overmatch. |
+| `health` | **P0 runtime fail** | 953–1,598/cap | Snapshot tiers are lost; watcher stays stale after reload; Zod health was about 23× a 41-token baseline. |
+| `health_compact` | Partial | 342/cap | 36% below full health but still verbose; can say Ready while failed files exist and inherits restore/watcher loss. |
+| `index_folder` | Partial | 92/cap | Counts/replay and daemon additive project work; response omits identity/replay and isolated refusal returns `isError:false`. |
+| `insert_symbol` | Fail | 658/225 | +433 and same blank-separator defect as batch insert. |
+| `inspect_match` | Pass | 137/139 LB | Saves two tokens and exact nested enclosure; no major change beyond shared terse trust metadata. |
+| `investigation_suggest` | Fail | 206/153 LB | +53; literal focus filtering removes valid call-graph candidates then claims no gaps. |
+| `replace_symbol_body` | Pass, noisy | 691/238 | +453; exact Unicode/newline/replay behavior, compact receipt needed. |
+| `search_files` | Pass happy; control partial | 224/62 simple lookup | Frecency can rank a loaded path first, but debug grows to 600 tokens and local `projects=["*"]` is silently ignored. |
+| `search_symbols` | Fail selector path | 153/56 | +97 and no result because matching project key is refused. |
+| `search_text` | Fail selector/structural validation | 223/121 | +102; selector fails and invalid recovery-parse pattern scans broadly instead of rejecting. |
+| `status` | Fail strict/stateful contract | 609/cap | Identity fields missing; daemon `reset_calibration=true` resets the storeless worker then overlays unchanged proxy state. |
+| `symforge_edit` | Fail replay | 722/baseline not reached | Preview/apply exact; identical same-key replay fails 3/3 before idempotency lookup. |
+| `symforge_retrieve` | Functional pass, branch-dependent | 333 or 3,361 / 1,031 fair | Summary-only saves 698; mandatory retrieval costs +2,330. Invalid/foreign handles isolate data but return `isError:false`. |
+| `validate_file_syntax` | Fail | 133/73 | +60; malformed trailing-comma JSON reported valid, valid BOM JSON rejected, estimate ignored. |
+| `what_changed` | Fail strict contract | 311/556 LB | Apparent -245 is missing information: all status classes and rename mapping discarded. |
+| `symforge` facade | Partial/fail | 2,306/245 LB | +2,061 across seven intents; `max_tokens:63` produced 823 tokens, orient noisy, meta intent misrouted. |
+
+## Findings
+
+### P0-01 — `batch_rename` can rewrite unrelated code
+
+**Measured:** `SF-batch_rename-002` requested `name="run"`, `path="sfbench_fixture/python/src/core.py"`, and `code_only=true`. SymForge returned success after changing nine sites in four files. Three modified files were unrelated native Flask files. The runner's frozen no-source-write policy caught the escape after commit.
+
+**Root cause:** `execute_batch_rename` calls a repository-wide name-only lookup at `src/protocol/edit.rs:2287`, then supplements it with a qualified-text scan around line 2309. Candidate staging is not bound to the selected definition's path, owner, kind, language, or stable symbol identity.
+
+**Change:** resolve one target `SymbolId`; only write references proven to resolve to that identity. Name-only, dynamic, or textual candidates must be uncertain and non-writable by default. Abort before staging if exact binding is unavailable.
+
+**Acceptance:** rerun `SF-batch_rename-002`; the call must fail closed with zero source hash changes. Add a real two-owner `Target::new` versus `SomeOther::new` test—the current “common name” test renames unique `Target` and does not exercise ambiguity.
+
+### P0-02 — impact analysis is confidently wrong and strongly token-negative
+
+**Measured:** changing only `sfbench_leaf` produced 20 changed symbols and 11 blast nodes, including indistinguishable duplicate `main` entries. Correct output is changed `{sfbench_leaf}` and hop-one blast `{sfbench_mid}`. Payload was 1,278 versus an 82-token lower-bound baseline.
+
+**Root cause:** `detect_impact` seeds every current symbol in every changed file at `src/protocol/tools.rs:7463-7476`. `GraphProjection::from_index` in `src/live_index/graph.rs:62-117` then connects calls globally by simple name. Formatting drops path/kind identity. Separately, `analyze_file_impact` filters same-file callers at `src/sidecar/handlers.rs:1326` and uses a name-only untyped lookup.
+
+**Change:** introduce a non-mutating `SymbolDelta` engine over base and target bytes, keyed by path, language, kind, qualified ancestry, and duplicate ordinal. Compare body hashes rather than line positions. Seed BFS only with true added/modified/removed symbols and keep exact identity in every blast node. Use exact `ReferenceKind::Call` resolution for file impact.
+
+**Acceptance:** leaf-only, prefix-line-shift, overload, same-name sibling, added-file, deleted-file, and watcher-race cases. A comment-only shift must yield zero changed symbols; unrelated `run` definitions must never enter the blast.
+
+### P0-03 — watcher and reconcile can remain stale forever after cold reload
+
+**Measured:** in independent tracked TypeScript and Zod controls, an added symbol never appeared. On Zod, stale-generation rejections rose from 0 to 4 after the event. After more than 30 seconds, health reported 487 reconcile repairs, but rejections rose to 492 and the symbol was still absent.
+
+**Root cause:** `run_watcher_with_stop` captures `expected_gen` before asynchronous cold reload around `src/watcher/mod.rs:721-724`. Reload advances the project generation, so all later watcher and reconcile mutations use a permanently stale generation. The repair counter counts attempted files rather than successful repairs.
+
+**Change:** acquire/current-check generation at each committed watcher batch and reconcile transaction, or subscribe the watcher to generation changes after reload. Count only accepted repairs; surface rejected attempts separately. Do not report Ready while the watcher is permanently stale.
+
+**Acceptance:** start a cold indexed repository, wait for explicit nonempty Ready, add/modify/delete a tracked source, and require the symbol/index change within the debounce bound. Force reload between watcher startup and event. After reconcile, stale rejections must not increase and `repairs` must equal successful applied files.
+
+### P0-04 — meta advertises one tool that cannot run
+
+**Measured:** meta lists only `symforge`; an ordinary call fails and recommends legacy tools hidden by meta. `symforge_facade_tool` accepts only `SurfaceProfile::Compact` at `src/protocol/tools.rs:9566-9625`.
+
+**Change:** make meta a real deferred-discovery router or withdraw it from documented/supported surfaces.
+
+**Acceptance:** meta's only advertised tool succeeds and can discover/execute a route without hidden tools, or meta is no longer selectable/advertised.
+
+### P1-03 — full is the costly default
+
+**Measured:** full schema is 17,894 cl100k tokens; compact is 1,163. `surface_profile_from_env` defaults unknown/unset to Full at `src/protocol/surface_probe.rs:39`; several installers explicitly write full.
+
+**Change:** make compact the default for fresh installations and unset environments; preserve explicit existing full choices. Reduce descriptions and expose verbose schema help through a resource/catalog.
+
+**Acceptance:** unset and fresh init list exactly compact's three tools; explicit full remains 36; schema budget regressions stay enforced.
+
+### P1-04 — local selector, import, and call identity are inconsistent
+
+**Measured:** matching local `project` selectors fail in `search_symbols`, `search_text`, and `find_references`; no-selector controls work. Python `from .protocol import ...` is lost, so `find_dependents` misses the importer while stem matching invents a Flask consumer. `get_symbol_context` promotes unresolved `to_owned` to an ordinary callee.
+
+**Root cause:** three tools still call `local_cross_project_refusal` (`src/protocol/tools.rs:4985`, `:5148`, `:7940`) rather than the newer `foreign_project_refusal`. `PYTHON_XREF_QUERY` at `src/parsing/xref.rs:83` does not retain the `relative_import` module. Several graph/context paths use simple name or stem matching.
+
+**Change:** centralize selector validation; preserve Python relative-module levels; resolve against importer package; carry typed symbol/reference identity end to end. Separate resolved project callees from unresolved/external calls.
+
+**Acceptance:** matching project name/key/root succeeds locally; foreign/multi-project requests fail with typed invalid request. Cover `.protocol`, `..protocol`, aliases, same-stem packages, and exact resolved versus unresolved call headings.
+
+### P1-05 — syntax validation accepts malformed JSON
+
+**Measured:** trailing-comma JSON was reported `Status: ok` in all three repetitions. A valid UTF-8-BOM/CRLF/Unicode JSON control was reported invalid at line 1, column 1. `estimate=true` returned the same actual response.
+
+**Root cause:** `validate_file_syntax` at `src/protocol/tools.rs:7838` relies on permissive tree-sitter parse status for JSON semantics and does not consume the estimate flag. `normalize_jsonc` leaves an initial BOM for `serde_json` in `src/parsing/config_extractors/json.rs`.
+
+**Change:** use authoritative parsers for JSON/TOML/YAML and reserve tree-sitter for languages where its error nodes are the advertised criterion. Return structured line/column diagnostics. Implement or remove estimate.
+
+**Acceptance:** reject the frozen malformed JSON at its oracle location; accept plain and BOM/CRLF/Unicode valid controls without changing original byte/span accounting; estimate response must be tagged and independently within declared tolerance.
+
+### P1-06 — mutation replay and insertion contracts are incomplete
+
+**Measured:** `symforge_edit` preview and apply were exact, but identical same-key replay failed 3/3 because stale `if_match` validation ran before replay lookup. `insert_symbol` and `batch_insert` produced byte-different output with no blank separator before the existing top-level item.
+
+**Root cause:** facade preflight calls the STEL concurrency gate before the planner/idempotency replay path. `build_insert_before` at `src/protocol/edit.rs:836` examines the blank before the splice but emits the wrong separator after inserted code.
+
+**Change:** perform a non-reserving exact replay probe before concurrency validation. Reuse one insertion layout function for single and batch operations, preserving LF/CRLF and exactly one project-style separator.
+
+**Acceptance:** same-key/same-hash replay returns stored result and writes zero bytes; changed-hash reuse conflicts; a new stale key still fails concurrency. Test insert-before at BOF, after an existing blank, with doc comments, LF, and CRLF.
+
+### P1-07 — snapshot and status views lose or hide state
+
+**Measured:** cold health reported 140 indexed + 78 metadata-only files; snapshot-warm health reported 140/0/0. `status` omits tool count, runtime schema hash, and model-visible load source. Broad controls showed compact health could say Ready while failed files existed. In daemon mode, `reset_calibration=true` left durable state byte-identical at `accumulating (3/24)`; the equivalent local control cleared to deferred.
+
+**Root cause:** `snapshot_to_live_index` restores `skipped_files: Vec::new()` in `src/live_index/persist.rs`. `status_stel_tool` proxies before applying reset at `src/protocol/tools.rs:10218-10277`; the storeless worker resets nothing, then proxy overlay restores the unchanged durable lines. Status formatting spends tokens on static phase hashes and deferred labels while omitting runtime identity fields.
+
+**Change:** persist/restore admission tiers or recompute them deterministically before Ready. Apply calibration reset to the proxy-owned store before proxying/rendering. Define Ready/Degraded/Failed semantics across full and compact health. Replace static status prose with tool count, schema identity, load source, project identity, and actionable mismatch counts.
+
+**Acceptance:** snapshot round trip preserves `(140,78,0)` and metadata-only behavior. Daemon and local calibration reset both clear samples/constants to deferred without changing index state. Compact/full/status agree on state, version, 36-tool manifest identity, schema hash, load source, project, and counts.
+
+### P1-08 — mutation receipts consume more tokens than the edits
+
+**Measured:** correct structural-edit scenarios cost 1.38×–2.90× their equivalent baselines before schema. Responses repeat the full safety envelope, absolute working directory, target path, indexed path, tee path, and often the original arguments on preview and apply. Zero-write replay repeats hundreds of tokens.
+
+**Change:** preview returns a source-bound `plan_handle` containing canonical request hash and source hash. Apply sends handle + idempotency key + guard. Default result is a relative target, compact change summary, write count, and replay marker. Move absolute routing, tee, and safety detail to `_meta` or explicit verbose mode; show it only when rerouted or degraded.
+
+**Acceptance:** one apply response ≤100 tokens, batch ≤150, replay ≤60 and visibly marked; no loss of source authority, safety, or trust facts. Reroute diagnostics remain available on demand.
+
+### P1-09 — compact facade ignores the complete response budget
+
+**Measured:** `SF-symforge-002` passed `max_tokens:63` but received 823 direct-payload tokens and an irrelevant two-step route. The requested definition intent should have used exact symbol search.
+
+**Root cause:** `StelDecision.effective_max_tokens` is populated at `src/stel/controller.rs:188-197`, but the final serve envelope is not capped. `apply_compact_serve_caps` constrains selected primitive arguments, not the composed facade response.
+
+**Change:** validate too-small budgets, enforce accepted budgets on the complete rendered envelope, and route exact definition language directly to `search_symbols`. Preserve a structured truncation/completeness marker.
+
+**Acceptance:** below-minimum budgets reject specifically; every accepted budget bounds final request + response within declared tolerance; “where is X defined?” returns the exact definition route, not co-change plus broad OR search.
+
+### P2-09 — CCR defers output but exact retrieval is not a saving
+
+**Measured:** stored payload hash and repeated retrieval are exact. The 333-token summary saves 698 tokens when sufficient, but retrieving the capped first 100 results makes the workflow 3.26× an information-matched first-100 baseline. Trigger + mandatory retrieval is necessarily more expensive than returning the same payload once.
+
+**Change:** disclose `stored 100 of 1,400`, support offset/max-token retrieval windows, and make summary sufficient for common decisions. Measure CCR success by avoided retrieval rate, not compressed first response alone.
+
+**Acceptance:** exact byte/hash replay remains; range retrieval is stable; mandatory-full-detail control reports negative savings; summary-only control reports actual avoided tokens.
+
+### P2-10 — worktree, inventory, guidance, and estimate formatters need contract tightening
+
+**Measured:** `what_changed` returns paths but drops staged/unstaged/add/delete/rename status and rename mapping. `context_inventory` can record a failed lookup as fetched. `investigation_suggest` treats `focus="call graph"` as a lexical substring, filters out the real dependency, then says no gaps. `get_repo_map` silently accepts unknown detail. `search_symbols` and `find_references` estimate modes returned full results; `get_file_context` estimate was intercepted by the ordinary repeat-read cache. Invalid structural pattern `def $$$(` scanned broadly and returned 50 Python functions instead of rejecting. Clear collision, invalid-handle, and isolated-add refusals from `checkpoint_now`, `symforge_retrieve`, and `index_folder` all carried `isError:false`. Local `search_files(projects=["*"])` returned local results instead of refusing or using daemon scope.
+
+**Change:** retain typed status and success state internally; route all failures through `OutcomeClass`; validate singular/plural project selectors and every enum; reject structural patterns containing parse error/missing nodes before scanning; route focus by relation category; run estimate before cache short-circuit; keep estimates tagged and empirically calibrated.
+
+**Acceptance:** map each behavior to its existing adverse/control case and require typed invalid requests rather than successful fallback prose.
+
+## Enhancement backlog
+
+### Symbol and graph identity
+
+- Introduce `SymbolId { project, path, language, kind, qualified_owner, name, duplicate_ordinal }`.
+- Resolve references to `SymbolId` with confidence and provenance.
+- Reuse one `SymbolDelta` engine in `diff_symbols`, `detect_impact`, and file impact.
+- Preserve path/kind/owner in every context, caller, dependent, and blast formatter.
+
+### Surface and schema
+
+- Fresh default: compact.
+- Keep explicit full backward-compatible.
+- Repair/withdraw meta.
+- Shorten schemas; move examples and extended guidance to `symforge://tools/catalog`.
+- Add an eager-schema budget regression: compact ≤1,250 cl100k; full descriptions separately measured.
+
+### Mutation protocol
+
+- Fail closed on unresolved rename references.
+- Replay probe before concurrency gate.
+- Source-bound preview handles.
+- Shared insertion whitespace/newline policy.
+- Compact apply/replay receipts and opt-in diagnostics.
+
+### Parsing, recovery, and status
+
+- Authoritative config parsers.
+- Python relative-import resolution.
+- Persist admission-tier metadata.
+- Rebind watcher/reconcile generation after reload and count only accepted repairs.
+- Apply daemon calibration reset at the proxy-owned durable store.
+- Typed Ready/Degraded/Failed state shared by health/status.
+
+### Search and formatter economics
+
+- Terse default trust envelope; structured `_meta` for repeated diagnostics.
+- Ranking explanation only when requested.
+- Validate detail/rank/filter enums.
+- Estimate final rendered response, including footer, and suppress marginal savings claims.
+- Make facade framing proportional to the answer rather than 86–220 fixed tokens.
+
+### Benchmark protocol follow-up
+
+- Fix readiness to reject Empty/empty-bootstrap.
+- Set `core.longpaths=true` before Windows checkout.
+- Give every variant an information-matched baseline.
+- Move batch patch hashes into the canonical oracle or explicitly route the case key to `baseline-patches.json`.
+- Version the protocol before changing any frozen case or baseline.
+
+## Acceptance-test checklist
+
+- [ ] `SF-batch_rename-002`: common-name rename rejects before staging and changes zero source hashes.
+- [ ] `SF-detect_impact-001`: exactly one changed leaf and one hop-one caller.
+- [ ] `SF-analyze_file_impact-001`: same-file `sfbench_mid` is present and typed as a call.
+- [ ] `SF-search_symbols-001`, `SF-search_text-001`, `SF-find_references-001`: matching local project key succeeds.
+- [ ] `SF-find_dependents-001`, `SF-get_file_context-001`: Python relative importer exact; unrelated Flask stem excluded.
+- [ ] `SF-get_symbol_context-001`: zero resolved project callees; `to_owned` omitted or labeled unresolved/external.
+- [ ] `SF-validate_file_syntax-001`: malformed JSON rejected at oracle location; estimate tagged.
+- [ ] `SF-validate_file_syntax-003`: BOM/CRLF/Unicode JSON accepted with byte-exact offsets.
+- [ ] `SF-symforge_edit-001`: replay before `if_match`; changed-key conflict preserved.
+- [ ] `SF-insert_symbol-001`, `SF-batch_insert-001`: exact frozen hashes and one blank separator.
+- [ ] `SF-health-001`: admission tiers survive snapshot restore.
+- [ ] Corrected `SF-health-003`: tracked edit is indexed after cold reload; reconcile applies rather than increasing stale rejections.
+- [ ] `SF-status-001`: surface/version/tool count/schema hash/load source/project/count parity.
+- [ ] `SF-status-003`: daemon and local durable reset both clear to deferred while preserving index state.
+- [ ] `SF-what_changed-001`: all Git status classes and rename mapping retained.
+- [ ] `SF-investigation_suggest-001`: call-graph focus returns real unloaded dependencies.
+- [ ] `SF-symforge_retrieve-001`: completeness disclosure and ranged retrieval; mandatory retrieval stays token-negative.
+- [ ] `SF-symforge-002`: accepted `max_tokens` constrains the full facade envelope; exact definition intent routes directly.
+- [ ] `SF-search_text-002`: malformed structural pattern rejects before repository scan.
+- [ ] Collision/invalid-handle/isolated-add controls: failure text carries typed error outcome and `isError:true`.
+- [ ] Meta surface: its only advertised tool succeeds.
+- [ ] Mutation output caps: ≤100 single apply, ≤150 batch, ≤60 replay.
+
+Neighboring regressions to rerun after identity/edit changes: all `batch_rename`, `find_references`, `get_symbol_context`, `find_dependents`, `get_file_context`, `detect_impact`, `analyze_file_impact`, `insert_symbol`, `batch_insert`, `symforge_edit`, and worktree cases across Rust, Python, TypeScript, Go, Java, and C++.
+
+## Sanitized artifact index and reproduction
+
+| Artifact | Purpose | SHA-256 |
+|---|---|---|
+| `runs/formal-happy-v2-20260712.jsonl` | Strict happy evidence | `4f3418ce3b949c9e504a936fd34a56a3c527571323f57753998ddbaac919dee1` |
+| `artifacts/happy-v2-adjudicated.json` | Correctness-adjusted summary | `b4c07a5daeca81edb0dde76eada780f6669805f8759f8a57a9d698f39850de36` |
+| `artifacts/happy-v2-adjudicated.md` | Human summary | `cef213c025840eee07b5a04e247dc51c3f9daaf908896a01591d99eacca36123` |
+| `artifacts/surface-final-full.jsonl` | 36-tool manifest (schema identity `9df1bccc…`) | `e3001ece78387243e7c3cc03a5705b2632315dc0a7ceceb128a47dbfb46ad460` |
+| `artifacts/surface-final-compact.jsonl` | 3-tool manifest (schema identity `8579e88c…`) | `211de6f161d5aa21af304566d54377a748856c3404031c7d015b032b8d467775` |
+| `artifacts/surface-final-meta.jsonl` | 1-tool manifest (schema identity `c356237a…`) | `4e93c50f4602bc5617f32b905523826c50a52138fe99548522d86416e473a34e` |
+| `artifacts/meta-symforge-call-final.jsonl` | Broken meta call | `432afff4ae1dd747f9b94f50377755a3460d27336c0844f8a60883e97b7987f9` |
+| `artifacts/compact-symforge-call-final.jsonl` | Compact control | `447b68f8bbf171e96c3c5b346c32d2eb2ea4d176bf0f1d14546833422b0239e1` |
+| `artifacts/pmap-non-tool-surface-smoke-v2.jsonl` | Resources/templates/prompts | `85255da703cfee186bfea2701f9a8c123b93b19564765e075761b9cd73c109a2` |
+| `runs/formal-broad-v1-20260712.jsonl` | 187-window broad diagnostic | `c57c615990332882b2f4c95c4e4093927d4dab75ddfe298ab005658471352f84` |
+| `gap-artifacts/20260712T152853Z/gap-diagnostics.jsonl` | All seven setup states | `293b7ae2b7560ebb624615612c1b94a43397e825fb7160ec94df6affc28fbf98` |
+| `gap-artifacts/20260712T153923Z/gap-diagnostics.jsonl` | Corrected nonempty readiness snapshot/recovery | `96b1441850e09b71787233bf9428bc836213b93f4b7138954e96128d29d9f609` |
+| `gap-artifacts/20260712T154612Z/gap-diagnostics.jsonl` | Tracked TypeScript watcher control | `d75216299132ea988dd7bd71f92e32cca127b75a348554955c7f6a8e516bde0e` |
+| `gap-artifacts/20260712T155246Z/gap-diagnostics.jsonl` | Local calibration reset control | `7649ac4bb9602fe55d1f9da07670fba6ca5f97c489fc02786a7a128bddf20818` |
+| `gap-artifacts/20260712T155444Z/gap-diagnostics.jsonl` | Zod watcher/reconcile control | `3b6e741a84ccb8c4e9150eb9af1a904302f6a69cf9e3a611d779aaf6882b20e2` |
+
+All external artifacts live under:
+
+```text
+C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface
+```
+
+The executable protocol, exact commands, expected unsupported inventory, and safety gates are in [the runbook](../../research/full-surface-benchmark/README.md). The derived human decisions are in [happy-v2-evaluator.json](../../research/full-surface-benchmark/happy-v2-evaluator.json). The adjudicator deliberately refuses to infer correctness from `case_complete`.
+
+Minimal validation and summary commands:
+
+```powershell
+uv run --script research/full-surface-benchmark/direct_case_runner.py validate `
+  --benchmark-root C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface `
+  --fixture-root C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface\fixtures\control-v1 `
+  --cases research/full-surface-benchmark/cases.json `
+  --campaign research/full-surface-benchmark/campaign.config.json `
+  --corpus-lock research/full-surface-benchmark/corpus.lock.json `
+  --asset-lock research/full-surface-benchmark/assets.lock.json `
+  --baseline-patches research/full-surface-benchmark/baseline-patches.json `
+  --server symforge --require-asset-lock
+
+uv run --script research/full-surface-benchmark/adjudicate_results.py validate `
+  --artifact C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface\runs\formal-happy-v2-20260712.jsonl `
+  --manifest C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface\artifacts\surface-final-full.jsonl `
+  --manifest C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface\artifacts\surface-final-compact.jsonl `
+  --manifest C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface\artifacts\surface-final-meta.jsonl `
+  --cases research/full-surface-benchmark/cases.json `
+  --asset-lock research/full-surface-benchmark/assets.lock.json `
+  --evaluator research/full-surface-benchmark/happy-v2-evaluator.json
+```
+
+## Limitations
+
+- No paid paired Claude/provider campaign was run, so provider input, cache-read, cache-write, output, reasoning, and billing totals are unavailable. Direct recipes are non-headline sensitivity evidence.
+- Thirty-nine primary HTTP cases were exercised only through declared stdio parity shadows. This is not HTTP transport evidence.
+- The broad diagnostic exposed a readiness bug in the benchmark harness: Empty/empty-bootstrap could be accepted as ready. Happy evidence contains zero Empty/zero-file preflights and is unaffected; affected cold/stress broad cases are invalidated.
+- Some Windows stress materializations failed because `core.longpaths=true` was not set before checkout. Those are harness failures, not SymForge failures.
+- Broad “process-warm” windows used independent fresh work directories, so they do not establish true same-process warmth; only explicit same-session gap controls support warm-state claims.
+- Seven frozen cases originally lacked deterministic setup machinery. All seven states were exercised in separate isolated diagnostics. The active-tuned-constants half of calibration was not publicly seedable, but accumulating-state daemon reset and an equivalent local control were measured.
+- Several frozen baselines were discovered to be non-equivalent or incompetent: raw `conventions` dump, uncapped retrieval baseline, ranking-free `search_files`, mixed `get_file_content` variants, and a Windows path regex. They are excluded from correctness-adjusted savings.
+- Several negative-test baselines treated expected nonzero exits as runner failures, and some broad cases contained unresolved refs/placeholders or nonexistent fixture paths. All such cases remain benchmark-invalid rather than product failures.
+- Two Rust batch cases name oracle keys absent from `oracle.json`; their exact hashes are in `baseline-patches.json`. That is executable by the runner but not fully self-contained for an arbitrary LLM reading only the declared oracle key.
+- Some broad adverse cases contain oracle/schema mismatches: exact-path `insert_symbol` is not ambiguous, legacy `replace_symbol_body.if_match` is presence-triggered rather than caller-value equality, and one investigation case failed to load the dependency it claimed was already loaded. They are not counted as product defects.
+- The protocol document remained marked draft and was not itself included in `assets.lock.json`. Cases, campaign config, corpus, oracle, runners, patches, tokenizer identities, and SUT were hash-locked before the final happy run; the protocol-status omission should be corrected in a versioned successor, not retroactively rewritten.
+- Results are Windows-local and repository-scale specific. They do not establish Linux/macOS path behavior, HTTP parity, peak memory, or very-large-monorepo resource ceilings.
+
+The net conclusion is intentionally conservative: SymForge's in-process architecture and several exact retrieval/edit primitives are promising and fast, but 8.14.0 does not yet work as advertised across the whole surface, and the default surface usually costs more tokens than competent traditional tools. Safety and symbol identity come first; compact schemas and compact receipts are the highest-leverage economics work after correctness.

--- a/research/full-surface-benchmark/README.md
+++ b/research/full-surface-benchmark/README.md
@@ -1,0 +1,690 @@
+# SFBENCH-1.0 execution runbook
+
+This runbook executes the frozen SymForge 8.14.0 benchmark without modifying
+the SymForge checkout, source mirrors, fixtures, frozen inputs, or prior
+artifacts. Run every PowerShell block with PowerShell 7 from the repository
+root. Never add cleanup commands. A path collision is a reason to choose a new
+campaign ID, not to delete evidence.
+
+Sources of truth:
+
+- [benchmark protocol](../../docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md)
+- [cases](./cases.json), [campaign config](./campaign.config.json), and
+  [corpus lock](./corpus.lock.json)
+- [asset lock](./assets.lock.json) and
+  [frozen baseline patches](./baseline-patches.json)
+- [adjudication specification](./adjudication.md),
+  [executable adjudicator](./adjudicate_results.py), and
+  [happy-v2 human decisions](./happy-v2-evaluator.json)
+
+`case_complete` means capture completed. It does not mean the result is
+correct or economical. Only adjudicated, correctness-valid evidence may enter
+token-savings totals.
+
+## 0. Establish paths and safety policy
+
+Prerequisites are PowerShell 7, Git, `uv`, the asset-locked `symforge`
+executable on `PATH`, and enough disk for independent clones. Network is
+allowed only while resuming the corpus. Disable it for measured runs. Do not
+print environment variables, auth state, credentials, raw secrets, or
+unsanitized model output.
+
+```powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+$ProjectRoot = [IO.Path]::GetFullPath((git rev-parse --show-toplevel).Trim())
+$BenchRoot = [IO.Path]::GetFullPath('C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface')
+$ProjectPrefix = $ProjectRoot.TrimEnd('\') + [IO.Path]::DirectorySeparatorChar
+if ($BenchRoot.Equals($ProjectRoot, [StringComparison]::OrdinalIgnoreCase) -or
+    $BenchRoot.StartsWith($ProjectPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Benchmark root must be outside the SymForge checkout.'
+}
+Set-Location -LiteralPath $ProjectRoot
+
+$BenchDir = Join-Path $ProjectRoot 'research/full-surface-benchmark'
+$SetupCorpus = Join-Path $BenchDir 'setup_corpus.ps1'
+$FixtureGenerator = Join-Path $BenchDir 'fixture_generator.py'
+$DirectRunner = Join-Path $BenchDir 'direct_case_runner.py'
+$NonToolRunner = Join-Path $BenchDir 'non_tool_surface_smoke.py'
+$ClaudeRunner = Join-Path $BenchDir 'claude_task_runner.py'
+$Harness = Join-Path $BenchDir 'mcp_harness.py'
+$Cases = Join-Path $BenchDir 'cases.json'
+$Campaign = Join-Path $BenchDir 'campaign.config.json'
+$CorpusLock = Join-Path $BenchDir 'corpus.lock.json'
+$AssetLock = Join-Path $BenchDir 'assets.lock.json'
+$BaselinePatches = Join-Path $BenchDir 'baseline-patches.json'
+$FixtureRoot = Join-Path $BenchRoot 'fixtures/control-v1'
+$RunRoot = Join-Path $BenchRoot 'runs'
+$WorkRoot = Join-Path $BenchRoot 'work'
+$ArtifactRoot = Join-Path $BenchRoot 'artifacts'
+$CampaignId = 'sfbench-' + (Get-Date -Format 'yyyyMMddTHHmmss')
+
+$FrozenInputs = @(
+    '--benchmark-root'
+    $BenchRoot
+    '--fixture-root'
+    $FixtureRoot
+    '--cases'
+    $Cases
+    '--campaign'
+    $Campaign
+    '--corpus-lock'
+    $CorpusLock
+    '--asset-lock'
+    $AssetLock
+    '--baseline-patches'
+    $BaselinePatches
+    '--server'
+    'symforge'
+)
+```
+
+## 1. Resume or create the frozen corpus
+
+The same command is safe after an interruption. `-Resume` verifies every
+existing mirror's origin, commit, clean state, tracked blobs, and Git object
+connectivity, then clones only missing mirrors. It fails closed on a partial or
+drifted mirror.
+
+```powershell
+pwsh -NoProfile -File $SetupCorpus `
+    -BenchRoot $BenchRoot `
+    -ProjectRoot $ProjectRoot `
+    -Resume
+
+$env:GIT_CONFIG_NOSYSTEM = '1'
+$env:GIT_CONFIG_GLOBAL = Join-Path $BenchRoot 'gitconfig.empty'
+$env:GIT_TEMPLATE_DIR = Join-Path $BenchRoot 'git-template.empty'
+$env:GIT_LFS_SKIP_SMUDGE = '1'
+```
+
+After this command succeeds, disable network access for the measurement
+processes.
+
+## 2. Generate and verify the controlled fixture
+
+The generator accepts only a new directory. The wrapper below generates once
+and otherwise leaves the existing fixture untouched. `validate` independently
+checks the fixture repositories, dirty worktree, oracle hashes, corpus pins,
+tokenizer locks, and SUT identity.
+
+```powershell
+if (-not (Test-Path -LiteralPath $FixtureRoot)) {
+    uv run $FixtureGenerator $FixtureRoot
+}
+
+uv run $DirectRunner validate @FrozenInputs --require-asset-lock
+```
+
+Do not regenerate a fixture after measured runs begin. A validation failure
+stops the campaign.
+
+## 3. Reproduce the baseline patch freeze
+
+Generate a fresh external candidate, scratch-apply every patch, and compare it
+with the frozen file. Keep the candidate as evidence. Never overwrite a frozen
+asset in place.
+
+```powershell
+$PatchCandidate = Join-Path $ArtifactRoot "$CampaignId-baseline-patches.candidate.json"
+if (Test-Path -LiteralPath $PatchCandidate) {
+    throw "Candidate already exists: $PatchCandidate"
+}
+
+uv run $DirectRunner freeze-baseline-patches @FrozenInputs `
+    --require-asset-lock `
+    --output $PatchCandidate
+
+$FrozenPatchHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $BaselinePatches).Hash
+$CandidatePatchHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $PatchCandidate).Hash
+if ($CandidatePatchHash -cne $FrozenPatchHash) {
+    throw 'Reproduced baseline patches differ from the frozen asset. Stop.'
+}
+```
+
+## 4. Validate every asset lock entry
+
+The first block checks all core and auxiliary assets plus the SUT. The runner
+command then performs semantic validation. Neither command prints asset
+contents.
+
+```powershell
+$Lock = Get-Content -Raw -LiteralPath $AssetLock | ConvertFrom-Json
+$Entries = @($Lock.core_assets) + @($Lock.auxiliary_assets)
+foreach ($Entry in $Entries) {
+    $Path = switch -CaseSensitive ([string] $Entry.path) {
+        'corpus-manifest.json' { Join-Path $BenchRoot 'corpus-manifest.json'; break }
+        'oracle.json' { Join-Path $FixtureRoot 'oracle.json'; break }
+        default { Join-Path $ProjectRoot ([string] $Entry.path) }
+    }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Locked asset is missing: $($Entry.path)"
+    }
+    $Actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+    if ($Actual -cne ([string] $Entry.sha256).ToLowerInvariant()) {
+        throw "Locked asset hash mismatch: $($Entry.path)"
+    }
+}
+
+$Sut = (Get-Command ([string] $Lock.system_under_test.path) `
+    -CommandType Application -ErrorAction Stop).Source
+$SutHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $Sut).Hash.ToLowerInvariant()
+if ($SutHash -cne ([string] $Lock.system_under_test.sha256).ToLowerInvariant()) {
+    throw 'System-under-test hash differs from assets.lock.json.'
+}
+Write-Host "assets.lock: PASS ($($Entries.Count) files plus SUT)"
+
+uv run $Harness self-test
+uv run $DirectRunner self-test
+uv run $NonToolRunner self-test
+uv run $ClaudeRunner self-test
+uv run $DirectRunner validate @FrozenInputs --require-asset-lock
+```
+
+## 5. Resolve the dry-run plan
+
+The frozen manifest has 115 cases: 37 happy, 38 adverse, 36 control, and 4
+stateful. The current direct runner can execute 108 through stdio or a declared
+stdio parity shadow. Seven require setup machinery that is not implemented.
+
+```powershell
+$PlanPath = Join-Path $ArtifactRoot "$CampaignId-dry-run.json"
+if (Test-Path -LiteralPath $PlanPath) {
+    throw "Dry-run artifact already exists: $PlanPath"
+}
+$PlanText = & uv run $DirectRunner dry-run @FrozenInputs `
+    --require-asset-lock `
+    --all `
+    --allow-stdio-shadow
+$PlanText | Set-Content -LiteralPath $PlanPath -Encoding utf8NoBOM
+$Plan = ($PlanText -join [Environment]::NewLine) | ConvertFrom-Json
+
+$ExpectedBlocked = @(
+    'SF-checkpoint_now-002'
+    'SF-checkpoint_now-003'
+    'SF-health-003'
+    'SF-index_folder-003'
+    'SF-search_files-003'
+    'SF-status-003'
+    'SF-symforge_retrieve-002'
+)
+$ActualBlocked = @(
+    $Plan.selected_cases |
+        Where-Object { -not $_.executable } |
+        ForEach-Object { [string] $_.id } |
+        Sort-Object
+)
+if ($Plan.executable_count -ne 108 -or
+    $Plan.unsupported_count -ne 7 -or
+    (Compare-Object ($ExpectedBlocked | Sort-Object) $ActualBlocked)) {
+    throw 'Dry-run support inventory differs from the frozen expectation.'
+}
+```
+
+The seven unsupported setup actions are:
+
+| Case | Missing setup action |
+|---|---|
+| `SF-checkpoint_now-002` | `runtime.snapshot.prepare_path_collision` |
+| `SF-checkpoint_now-003` | `runtime.snapshot.prepare_corrupt_copy` |
+| `SF-health-003` | `runtime.health.mutate_between_requests` |
+| `SF-index_folder-003` | `runtime.daemon.start_with_home_project` |
+| `SF-search_files-003` | `runtime.frecency.seed_fixture_paths` |
+| `SF-status-003` | `runtime.calibration.seed_durable_samples` |
+| `SF-symforge_retrieve-002` | `runtime.ccr.create_foreign_session_handle` |
+
+HTTP is also blocked. `campaign.config.json` requires an official-SDK parity
+runner, while `direct_case_runner.py` and `mcp_harness.py` implement stdio only.
+There are 39 primary HTTP cases. `--allow-stdio-shadow` executes their declared
+stdio shadows; it is not HTTP evidence and must not be reported as such. Without
+that flag, the primary HTTP cases remain unsupported.
+
+## 6. Run direct happy, adverse, control, and stateful cohorts
+
+The helper selects only cases marked executable by the dry-run plan. This keeps
+the seven setup blockers explicit without manufacturing `case_error` rows. It
+uses the frozen per-case repetitions and the competent recipe baseline.
+
+```powershell
+function Invoke-DirectCohort {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('happy', 'adverse', 'control', 'stateful')]
+        [string] $Kind
+    )
+
+    $CohortPlanText = & uv run $DirectRunner dry-run @FrozenInputs `
+        --require-asset-lock `
+        --case-kind $Kind `
+        --allow-stdio-shadow
+    $CohortPlan = ($CohortPlanText -join [Environment]::NewLine) | ConvertFrom-Json
+    $Selectors = @(
+        foreach ($Case in $CohortPlan.selected_cases) {
+            if ($Case.executable) {
+                '--case-id'
+                [string] $Case.id
+            }
+        }
+    )
+    if ($Selectors.Count -eq 0) {
+        throw "No executable $Kind cases."
+    }
+
+    $RunId = "$CampaignId-direct-$Kind"
+    $Output = Join-Path $RunRoot "$RunId.jsonl"
+    $WorkParent = Join-Path $WorkRoot $RunId
+    if ((Test-Path -LiteralPath $Output) -or
+        (Test-Path -LiteralPath $WorkParent)) {
+        throw "Choose a new campaign ID; $Kind output already exists."
+    }
+    $RunArguments = @('run') + $FrozenInputs + @(
+        '--require-asset-lock'
+        '--allow-stdio-shadow'
+        '--run-id'
+        $RunId
+        '--output'
+        $Output
+        '--work-parent'
+        $WorkParent
+        '--with-baseline'
+    ) + $Selectors
+    & uv run $DirectRunner @RunArguments
+
+    $Terminal = @(
+        Get-Content -LiteralPath $Output |
+            ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.record_type -eq 'campaign_complete' }
+    )
+    if ($Terminal.Count -ne 1 -or
+        ($Terminal[0].completed_trials + $Terminal[0].failed) -ne
+            $Terminal[0].scheduled_trials) {
+        throw "$Kind cohort has an incomplete terminal count. Preserve evidence and stop."
+    }
+    if ($Terminal[0].failed -gt 0) {
+        Write-Warning (
+            "$Kind captured $($Terminal[0].failed) failed trial(s). " +
+            'These are evidence, not permission to relabel the campaign incomplete.'
+        )
+    }
+}
+
+Invoke-DirectCohort -Kind happy
+Invoke-DirectCohort -Kind adverse
+Invoke-DirectCohort -Kind control
+Invoke-DirectCohort -Kind stateful
+```
+
+The first three calls are the requested happy, adverse, and control cohorts.
+The stateful call runs the one currently executable stateful case so the paired
+gate can distinguish completed evidence from the three stateful setup blockers.
+
+## 7. Smoke-test resources, templates, and prompts
+
+Use a fresh independent fixture clone because starting SymForge may create
+`.symforge/` state. Never point the smoke runner at the immutable fixture.
+
+```powershell
+function New-IndependentClone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Source,
+        [Parameter(Mandatory)] [string] $Destination,
+        [Parameter(Mandatory)] [string] $Commit
+    )
+    if (Test-Path -LiteralPath $Destination) {
+        throw "Clone destination already exists: $Destination"
+    }
+    git clone --local --no-hardlinks --no-checkout $Source $Destination
+    git -C $Destination config core.autocrlf false
+    git -C $Destination config core.eol lf
+    git -C $Destination checkout --detach $Commit
+    if (git -C $Destination status --porcelain=v1) {
+        throw "Fresh clone is dirty: $Destination"
+    }
+}
+
+$OraclePath = Join-Path $FixtureRoot 'oracle.json'
+$Oracle = Get-Content -Raw -LiteralPath $OraclePath | ConvertFrom-Json
+$SmokeSource = Join-Path $FixtureRoot ([string] $Oracle.paths.clean_repository)
+$SmokeCommit = [string] $Oracle.repositories.clean.head
+$SmokeSymbol = @($Oracle.symbols.Rust | Where-Object { $_.name -eq 'sfbench_leaf' })[0]
+$SmokeRunId = "$CampaignId-non-tool-smoke"
+$SmokeRepo = Join-Path $WorkRoot $SmokeRunId
+$SmokeOutput = Join-Path $RunRoot "$SmokeRunId.jsonl"
+if (Test-Path -LiteralPath $SmokeOutput) {
+    throw "Smoke output already exists: $SmokeOutput"
+}
+New-IndependentClone -Source $SmokeSource -Destination $SmokeRepo -Commit $SmokeCommit
+
+uv run $NonToolRunner run `
+    --repo $SmokeRepo `
+    --output $SmokeOutput `
+    --fixture-path ([string] $SmokeSymbol.path) `
+    --fixture-symbol ([string] $SmokeSymbol.name) `
+    --fixture-kind ([string] $SmokeSymbol.kind) `
+    --server symforge `
+    --run-id $SmokeRunId `
+    --case-id 'SF-non-tool-surface-001'
+```
+
+This covers all six static resources, four resource templates, and seven
+prompts in one isolated stdio session. Keep it separate from tool economics.
+
+## 8. Gate neutral and forced Claude trials
+
+Paid paired trials are disabled during the direct phase. Run them only after:
+
+1. all executable direct cohorts and the non-tool smoke complete;
+2. the seven setup blockers and HTTP limitation are accepted as explicit
+   limitations, not silently dropped;
+3. an operator records the maximum approved campaign cost;
+4. Claude Code reports exactly version `2.1.207`.
+
+The natural baseline and natural SymForge arms use the same derived neutral
+prompt and fresh independent clones. The forced prompt is SymForge-only and is
+reported separately. Never pool forced results with the natural paired
+headline.
+
+```powershell
+$MaxBudgetUsd = Read-Host 'Enter the approved maximum USD per Claude trial'
+if ($MaxBudgetUsd -notmatch '^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$' -or
+    [decimal]::Parse(
+        $MaxBudgetUsd,
+        [Globalization.CultureInfo]::InvariantCulture
+    ) -le 0) {
+    throw 'The approved maximum must be a positive decimal.'
+}
+
+$DirectRunFiles = @(
+    'happy', 'adverse', 'control', 'stateful' |
+        ForEach-Object { Join-Path $RunRoot "$CampaignId-direct-$_.jsonl" }
+)
+foreach ($Path in $DirectRunFiles) {
+    $Complete = @(
+        Get-Content -LiteralPath $Path |
+            ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.record_type -eq 'campaign_complete' }
+    )
+    if ($Complete.Count -ne 1 -or $Complete[0].failed -ne 0) {
+        throw "Direct gate failed: $Path"
+    }
+}
+if (-not (Test-Path -LiteralPath $SmokeOutput -PathType Leaf)) {
+    throw 'Non-tool smoke evidence is missing.'
+}
+if ((claude --version) -notmatch '2\.1\.207') {
+    throw 'Claude Code version must be 2.1.207.'
+}
+
+$CaseId = 'SF-get_repo_map-001'
+$Case = @(
+    (Get-Content -Raw -LiteralPath $Cases | ConvertFrom-Json).cases |
+        Where-Object { $_.id -eq $CaseId }
+)[0]
+$PairId = "$CampaignId-paired-get-repo-map"
+$PairSource = Join-Path (Join-Path $BenchRoot 'sources') ([string] $Case.repo)
+$BaselineRepo = Join-Path $WorkRoot "$PairId-neutral-baseline"
+$SymForgeRepo = Join-Path $WorkRoot "$PairId-neutral-symforge"
+$ForcedRepo = Join-Path $WorkRoot "$PairId-forced-symforge"
+New-IndependentClone -Source $PairSource -Destination $BaselineRepo -Commit ([string] $Case.commit)
+New-IndependentClone -Source $PairSource -Destination $SymForgeRepo -Commit ([string] $Case.commit)
+New-IndependentClone -Source $PairSource -Destination $ForcedRepo -Commit ([string] $Case.commit)
+
+$BaselineOutput = Join-Path $RunRoot "$PairId-neutral-baseline.jsonl"
+$SymForgeOutput = Join-Path $RunRoot "$PairId-neutral-symforge.jsonl"
+$ForcedOutput = Join-Path $RunRoot "$PairId-forced-symforge.jsonl"
+$ClaudeCommon = @(
+    'run'
+    '--case'
+    $Cases
+    '--case-id'
+    $CaseId
+    '--campaign'
+    $Campaign
+    '--corpus-manifest'
+    (Join-Path $BenchRoot 'corpus-manifest.json')
+    '--benchmark-root'
+    $BenchRoot
+    '--claude'
+    'claude'
+    '--symforge'
+    'symforge'
+    '--max-budget-usd'
+    $MaxBudgetUsd
+)
+
+# These three commands make no paid call and write no artifact.
+uv run $ClaudeRunner @ClaudeCommon --arm baseline --prompt-mode neutral `
+    --repo $BaselineRepo --output $BaselineOutput --dry-run
+uv run $ClaudeRunner @ClaudeCommon --arm symforge --prompt-mode neutral `
+    --repo $SymForgeRepo --output $SymForgeOutput --dry-run
+uv run $ClaudeRunner @ClaudeCommon --arm symforge --prompt-mode forced `
+    --repo $ForcedRepo --output $ForcedOutput --dry-run
+```
+
+Stop here until an operator approves the recorded cap. In the same PowerShell
+session, use the explicit confirmation gate below. These are the only paid
+commands in this runbook.
+
+```powershell
+$PaidApproval = Read-Host 'Type RUN PAID PAIRED TRIALS to approve the recorded cap'
+if ($PaidApproval -cne 'RUN PAID PAIRED TRIALS') {
+    throw 'Paid paired gate remains closed.'
+}
+
+# Paid calls begin here. Existing auth is inherited privately; never put it in arguments.
+uv run $ClaudeRunner @ClaudeCommon --arm baseline --prompt-mode neutral `
+    --repo $BaselineRepo --output $BaselineOutput
+uv run $ClaudeRunner @ClaudeCommon --arm symforge --prompt-mode neutral `
+    --repo $SymForgeRepo --output $SymForgeOutput
+uv run $ClaudeRunner @ClaudeCommon --arm symforge --prompt-mode forced `
+    --repo $ForcedRepo --output $ForcedOutput
+
+function Get-ClaudeTrial {
+    param([Parameter(Mandatory)] [string] $Path)
+    $Trial = @(
+        Get-Content -LiteralPath $Path |
+            ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.record_type -eq 'claude_task_trial' }
+    )
+    if ($Trial.Count -ne 1) {
+        throw "Expected one Claude trial: $Path"
+    }
+    return $Trial[0]
+}
+
+$BaselineTrial = Get-ClaudeTrial $BaselineOutput
+$SymForgeTrial = Get-ClaudeTrial $SymForgeOutput
+$ForcedTrial = Get-ClaudeTrial $ForcedOutput
+if ($BaselineTrial.prompt_mode -ne 'neutral' -or
+    $SymForgeTrial.prompt_mode -ne 'neutral' -or
+    $BaselineTrial.policy.task_prompt_sha256 -cne
+        $SymForgeTrial.policy.task_prompt_sha256 -or
+    $BaselineTrial.policy.model -cne $SymForgeTrial.policy.model) {
+    throw 'Natural paired-arm prompt/model parity failed.'
+}
+if ($ForcedTrial.prompt_mode -ne 'forced' -or
+    $ForcedTrial.policy.task_prompt_sha256 -ceq
+        $SymForgeTrial.policy.task_prompt_sha256) {
+    throw 'Forced workflow was not recorded separately.'
+}
+```
+
+Expand paired cases and seeds only after the representative gate passes and the
+campaign-wide cost cap is recorded.
+
+## 9. Build the adjudication packet and coding-agent report
+
+`adjudicate_results.py` validates artifact identity and structure, associates
+ordered repeated trial windows, computes token/latency views, and joins explicit
+human decisions. It deliberately never treats `case_complete` as correctness.
+The evaluator decision file is a JSON object using schema
+`SFBENCH-adjudication-decisions-1`; every pass or fail needs evidenced checks.
+
+The executed happy campaign uses `happy-v2-evaluator.json`. Reproduce its
+correctness-adjusted summary with new external output paths:
+
+```powershell
+$HappyArtifact = Join-Path $RunRoot 'formal-happy-v2-20260712.jsonl'
+$Evaluator = Join-Path $BenchDir 'happy-v2-evaluator.json'
+$SummaryJson = Join-Path $ArtifactRoot "$CampaignId-adjudicated.json"
+$SummaryMarkdown = Join-Path $ArtifactRoot "$CampaignId-adjudicated.md"
+foreach ($Path in @($SummaryJson, $SummaryMarkdown)) {
+    if (Test-Path -LiteralPath $Path) {
+        throw "Choose a new summary path: $Path"
+    }
+}
+
+uv run --script (Join-Path $BenchDir 'adjudicate_results.py') summarize `
+    --artifact $HappyArtifact `
+    --manifest (Join-Path $ArtifactRoot 'surface-final-full.jsonl') `
+    --manifest (Join-Path $ArtifactRoot 'surface-final-compact.jsonl') `
+    --manifest (Join-Path $ArtifactRoot 'surface-final-meta.jsonl') `
+    --cases $Cases `
+    --asset-lock $AssetLock `
+    --evaluator $Evaluator `
+    --output-json $SummaryJson `
+    --output-markdown $SummaryMarkdown
+```
+
+The optional manual handoff below remains useful for a new campaign or an
+independent evaluator. Its output shape is evaluator-owned and must not be
+confused with the executable summary schema.
+
+Create a hash-only evidence index and an exact evaluator handoff:
+
+```powershell
+$EvidenceIndexPath = Join-Path $ArtifactRoot "$CampaignId-evidence-index.json"
+$HandoffPath = Join-Path $ArtifactRoot "$CampaignId-adjudication-request.md"
+$AdjudicationOutput = Join-Path $ArtifactRoot "$CampaignId-adjudication.jsonl"
+$ReportOutput = Join-Path $ArtifactRoot "$CampaignId-report.md"
+foreach ($Path in @($EvidenceIndexPath, $HandoffPath, $AdjudicationOutput, $ReportOutput)) {
+    if (Test-Path -LiteralPath $Path) {
+        throw "Choose a new output path; evidence already exists: $Path"
+    }
+}
+
+$RunFiles = @(Get-ChildItem -LiteralPath $RunRoot -Filter "$CampaignId*.jsonl" -File)
+if ($RunFiles.Count -eq 0) {
+    throw 'No campaign JSONL files found.'
+}
+$IndexRows = @(
+    foreach ($File in ($RunFiles | Sort-Object FullName)) {
+        $RowCount = 0
+        foreach ($Line in Get-Content -LiteralPath $File.FullName) {
+            if ([string]::IsNullOrWhiteSpace($Line)) { continue }
+            $Record = $Line | ConvertFrom-Json
+            if ($Record.protocol -ne 'SFBENCH-1.0') {
+                throw "Protocol mismatch in $($File.Name)."
+            }
+            $RowCount += 1
+        }
+        [ordered]@{
+            path = $File.FullName
+            sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $File.FullName).Hash.ToLowerInvariant()
+            utf8_bytes = $File.Length
+            jsonl_rows = $RowCount
+        }
+    }
+)
+[ordered]@{
+    protocol = 'SFBENCH-1.0'
+    campaign_id = $CampaignId
+    files = $IndexRows
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $EvidenceIndexPath -Encoding utf8NoBOM
+
+@"
+# SFBENCH adjudication request
+
+Read these sources before judging any result:
+
+- Protocol: $ProjectRoot\docs\dogfood\2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md
+- Adjudication contract: $ProjectRoot\research\full-surface-benchmark\adjudication.md
+- Frozen cases: $Cases
+- Asset lock: $AssetLock
+- Fixture oracle: $OraclePath
+- Evidence index: $EvidenceIndexPath
+
+Write normalized adjudication JSONL to: $AdjudicationOutput
+Write the coding-agent report to: $ReportOutput
+
+Fail closed on frozen identity, ordering, parser, oracle, mutation, determinism,
+or accounting gaps. An efficient wrong answer is INVALID_INCORRECT. Keep
+capability-only baselines N/A. Report negative token deltas with a minus sign.
+Include explicit blocked entries for the seven unsupported setup cases and the
+39 unmeasured primary HTTP cases. Do not treat stdio shadows as HTTP evidence.
+
+The report must contain these exact sections:
+## Executive verdict
+## Environment and frozen methodology
+## Portfolio economics
+## Per-tool scorecard
+## Findings
+## Enhancement backlog
+## Acceptance-test checklist
+## Sanitized artifact index and reproduction
+## Limitations
+
+Score all 36 full-surface tools plus the compact/meta-only symforge facade.
+For every token-negative, failed, partial, slow, or noisy case, include the
+measured cost breakdown, read-only formatter counterfactual, concrete change,
+acceptance case, neighboring reruns, priority, and facts that must remain.
+Use NO CHANGE RECOMMENDED where no measured improvement survives correctness.
+Never include raw secrets or unsanitized output.
+"@ | Set-Content -LiteralPath $HandoffPath -Encoding utf8NoBOM
+```
+
+After the evaluator writes both outputs, run this fail-closed shape check:
+
+```powershell
+if (-not (Test-Path -LiteralPath $AdjudicationOutput -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $ReportOutput -PathType Leaf)) {
+    throw 'Adjudication JSONL and report are both required.'
+}
+$AdjudicationRows = @(
+    Get-Content -LiteralPath $AdjudicationOutput |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_ | ConvertFrom-Json }
+)
+if ($AdjudicationRows.Count -eq 0) {
+    throw 'Adjudication output is empty.'
+}
+$RequiredRecordFields = @(
+    'identity', 'artifact', 'steps', 'checks', 'correctness', 'determinism',
+    'mutation', 'latency', 'tokens', 'baseline', 'economics'
+)
+foreach ($Row in $AdjudicationRows) {
+    foreach ($Field in $RequiredRecordFields) {
+        if ($Field -notin $Row.PSObject.Properties.Name) {
+            throw "Adjudication row is missing $Field."
+        }
+    }
+}
+
+$Report = Get-Content -Raw -LiteralPath $ReportOutput
+$RequiredSections = @(
+    '## Executive verdict'
+    '## Environment and frozen methodology'
+    '## Portfolio economics'
+    '## Per-tool scorecard'
+    '## Findings'
+    '## Enhancement backlog'
+    '## Acceptance-test checklist'
+    '## Sanitized artifact index and reproduction'
+    '## Limitations'
+)
+foreach ($Section in $RequiredSections) {
+    if (-not $Report.Contains($Section, [StringComparison]::Ordinal)) {
+        throw "Report is missing section: $Section"
+    }
+}
+Write-Host "Adjudication/report shape: PASS ($($AdjudicationRows.Count) rows)"
+```
+
+Preserve every artifact. If any source mirror drifts, a write escapes a
+disposable clone, a secret reaches output, frozen identity changes, or the same
+harness failure repeats three times, stop the affected campaign and report the
+blocker. Do not repair evidence in place.

--- a/research/full-surface-benchmark/adjudicate_results.py
+++ b/research/full-surface-benchmark/adjudicate_results.py
@@ -1,0 +1,2270 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "tiktoken==0.13.0",
+# ]
+# ///
+"""Validate and summarize sanitized SymForge benchmark evidence.
+
+This analyzer is intentionally correctness-first. A runner ``case_complete``
+record proves capture completion only. Correctness can pass only through a
+separate evaluator decision with evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import pathlib
+import statistics
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+import mcp_harness as harness
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+DEFAULT_CASES = SCRIPT_DIR / "cases.json"
+DEFAULT_ASSET_LOCK = SCRIPT_DIR / "assets.lock.json"
+EVALUATOR_SCHEMA = "SFBENCH-adjudication-decisions-1"
+SUMMARY_SCHEMA = "SFBENCH-adjudication-summary-1"
+ENCODINGS = ("cl100k", "o200k")
+
+VALID_ROLES = {
+    "task",
+    "required_prerequisite",
+    "comparison_variant",
+    "estimate_diagnostic",
+    "oracle_reference",
+    "replay_diagnostic",
+    "warmup",
+}
+
+WORKFLOW_CASES = {
+    "SF-batch_edit-001",
+    "SF-batch_insert-001",
+    "SF-batch_rename-001",
+    "SF-delete_symbol-001",
+    "SF-edit_within_symbol-001",
+    "SF-insert_symbol-001",
+    "SF-replace_symbol_body-001",
+    "SF-symforge_edit-001",
+    "SF-investigation_suggest-001",
+}
+
+VARIANT_CASES = {
+    "SF-find_references-001",
+    "SF-get_file_content-001",
+    "SF-get_symbol-001",
+    "SF-get_symbol_context-001",
+    "SF-health-001",
+    "SF-search_files-001",
+    "SF-status-001",
+    "SF-validate_file_syntax-001",
+    "SF-symforge-001",
+}
+
+
+class AdjudicationError(RuntimeError):
+    """Expected failure with a message safe to display."""
+
+
+@dataclass
+class Issue:
+    severity: str
+    code: str
+    message: str
+    artifact: str | None = None
+    case_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "artifact": self.artifact,
+            "case_id": self.case_id,
+        }
+
+
+@dataclass
+class Artifact:
+    path: pathlib.Path
+    sha256: str
+    records: list[dict[str, Any]]
+
+
+@dataclass
+class Trial:
+    artifact: Artifact
+    run_id: str
+    case: dict[str, Any]
+    records: list[dict[str, Any]]
+    direct_trials: list[dict[str, Any]]
+    baseline_total: dict[str, Any] | None
+    terminal: str
+    automatic_failure_codes: list[str] = field(default_factory=list)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json_object(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise AdjudicationError(f"could not read {label}: {path.name}") from exc
+    except json.JSONDecodeError as exc:
+        raise AdjudicationError(
+            f"invalid {label} JSON at {path.name}:{exc.lineno}:{exc.colno}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise AdjudicationError(f"{label} must be one JSON object")
+    return value
+
+
+def load_records(path: pathlib.Path) -> Artifact:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise AdjudicationError(f"could not read artifact: {path.name}") from exc
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise AdjudicationError(f"artifact is not UTF-8: {path.name}") from exc
+    stripped = text.strip()
+    if not stripped:
+        raise AdjudicationError(f"artifact is empty: {path.name}")
+
+    records: list[dict[str, Any]] = []
+    try:
+        whole = json.loads(stripped)
+    except json.JSONDecodeError:
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise AdjudicationError(
+                    f"invalid artifact JSON at {path.name}:{line_number}:{exc.colno}"
+                ) from exc
+            if not isinstance(value, dict):
+                raise AdjudicationError(
+                    f"artifact row is not an object: {path.name}:{line_number}"
+                )
+            records.append(value)
+    else:
+        if isinstance(whole, dict):
+            records = [whole]
+        elif isinstance(whole, list) and all(isinstance(row, dict) for row in whole):
+            records = list(whole)
+        else:
+            raise AdjudicationError(
+                f"artifact must be JSONL, an object, or an object array: {path.name}"
+            )
+    return Artifact(path=path, sha256=sha256_bytes(raw), records=records)
+
+
+def flatten_asset_hashes(value: Any, result: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        path = value.get("path")
+        digest = value.get("sha256") or value.get("sha256_hex")
+        if isinstance(path, str) and is_sha256(digest):
+            result[path.replace("\\", "/")] = str(digest).lower()
+        for key, child in value.items():
+            if is_sha256(child) and looks_like_path(str(key)):
+                result[str(key).replace("\\", "/")] = str(child).lower()
+            elif isinstance(child, dict):
+                nested = child.get("sha256") or child.get("sha256_hex")
+                if is_sha256(nested):
+                    result[str(key).replace("\\", "/")] = str(nested).lower()
+            flatten_asset_hashes(child, result)
+    elif isinstance(value, list):
+        for child in value:
+            flatten_asset_hashes(child, result)
+
+
+def is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdefABCDEF" for character in value
+    )
+
+
+def looks_like_path(value: str) -> bool:
+    return "/" in value or "\\" in value or "." in pathlib.PurePosixPath(value).name
+
+
+def unique_asset_digest(path: pathlib.Path, hashes: dict[str, str]) -> str | None:
+    normalized = path.resolve().as_posix()
+    matches = {
+        digest
+        for name, digest in hashes.items()
+        if normalized.endswith(name.replace("\\", "/"))
+        or path.name == pathlib.PurePosixPath(name.replace("\\", "/")).name
+    }
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
+def nonnegative_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value >= 0
+
+
+def integer_field(record: dict[str, Any], key: str) -> int | None:
+    value = record.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def numeric_field(record: dict[str, Any], key: str) -> float | None:
+    value = record.get(key)
+    return float(value) if nonnegative_number(value) else None
+
+
+def percentile(values: Sequence[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * fraction
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def median(values: Sequence[float]) -> float | None:
+    return float(statistics.median(values)) if values else None
+
+
+def sanitize_output(value: dict[str, Any]) -> dict[str, Any]:
+    sanitizer = harness.Sanitizer()
+    safe = sanitizer.sanitize_obj(value, "adjudication_output")
+    final = harness.Sanitizer()
+    rescanned = final.sanitize_obj(safe, "adjudication_output.final")
+    if rescanned != safe or final.event_count():
+        raise AdjudicationError("final summary secret scan failed")
+    if sanitizer.event_count():
+        safe["sanitizer_redactions"] = sanitizer.event_count()
+    return safe
+
+
+def write_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_cases(path: pathlib.Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    manifest = load_json_object(path, "cases manifest")
+    if manifest.get("protocol") != harness.PROTOCOL_ID:
+        raise AdjudicationError("cases protocol does not match the harness")
+    rows = manifest.get("cases")
+    if not isinstance(rows, list) or not rows:
+        raise AdjudicationError("cases manifest has no cases")
+    by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("id"), str):
+            raise AdjudicationError("cases manifest contains a malformed case")
+        if row["id"] in by_id:
+            raise AdjudicationError("cases manifest contains duplicate case IDs")
+        by_id[row["id"]] = row
+    return manifest, by_id
+
+
+def expected_surfaces(cases: dict[str, Any]) -> dict[str, set[str]]:
+    inventory = cases.get("inventory", {})
+    result = {
+        "full": set(inventory.get("full_surface_tools", [])),
+        "compact": set(inventory.get("compact_surface_tools", [])),
+        "meta": set(inventory.get("meta_surface_tools", [])),
+    }
+    if any(not tools for tools in result.values()):
+        raise AdjudicationError("cases inventory omits a surface")
+    return result
+
+
+def manifest_schema_views(
+    artifacts: Sequence[Artifact],
+    cases: dict[str, Any],
+    counter: harness.TokenCounter,
+    issues: list[Issue],
+) -> dict[str, dict[str, Any]]:
+    expected = expected_surfaces(cases)
+    views: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        for record in artifact.records:
+            if record.get("record_type") not in {"manifest", "session_manifest"}:
+                continue
+            surface = record.get("surface")
+            manifest = record.get("manifest")
+            tools = manifest.get("tools") if isinstance(manifest, dict) else None
+            if surface not in expected or not isinstance(tools, list):
+                issues.append(
+                    Issue(
+                        "error",
+                        "MANIFEST_MALFORMED",
+                        "live manifest record lacks a known surface or tools list",
+                        artifact.path.name,
+                    )
+                )
+                continue
+            names = {
+                tool.get("name")
+                for tool in tools
+                if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+            }
+            if names != expected[surface]:
+                issues.append(
+                    Issue(
+                        "error",
+                        "MANIFEST_TOOL_SET_MISMATCH",
+                        f"{surface} tool set differs from cases inventory",
+                        artifact.path.name,
+                    )
+                )
+                continue
+            serialized = canonical_json(tools)
+            counts = counter.metrics(serialized)
+            individual: dict[str, dict[str, int]] = {}
+            for tool in tools:
+                if not isinstance(tool, dict) or not isinstance(tool.get("name"), str):
+                    continue
+                metrics = counter.metrics(canonical_json(tool))
+                individual[tool["name"]] = {
+                    "cl100k": metrics["cl100k"],
+                    "o200k": metrics["o200k"],
+                    "utf8_bytes": metrics["utf8_bytes"],
+                }
+            view = {
+                "manifest_sha256": sha256_bytes(canonical_json(manifest).encode()),
+                "tool_count": len(names),
+                "tokens": {
+                    "cl100k": counts["cl100k"],
+                    "o200k": counts["o200k"],
+                    "utf8_bytes": counts["utf8_bytes"],
+                },
+                "individual": individual,
+            }
+            previous = views.get(surface)
+            if previous is not None and previous != view:
+                issues.append(
+                    Issue(
+                        "error",
+                        "MANIFEST_NONDETERMINISTIC",
+                        f"multiple {surface} manifests disagree",
+                        artifact.path.name,
+                    )
+                )
+            else:
+                views[surface] = view
+    for surface in expected:
+        if surface not in views:
+            issues.append(
+                Issue(
+                    "error",
+                    "MANIFEST_SURFACE_MISSING",
+                    f"no live {surface} manifest was supplied",
+                )
+            )
+    return views
+
+
+def load_evaluator(path: pathlib.Path | None) -> dict[str, Any]:
+    if path is None:
+        return {"schema_version": EVALUATOR_SCHEMA, "cases": {}}
+    value = load_json_object(path, "evaluator decisions")
+    if value.get("schema_version") != EVALUATOR_SCHEMA:
+        raise AdjudicationError("evaluator decision schema is unsupported")
+    if not isinstance(value.get("cases"), dict):
+        raise AdjudicationError("evaluator decisions must contain cases{}")
+    return value
+
+
+def validate_decisions(
+    evaluator: dict[str, Any], case_ids: Iterable[str], issues: list[Issue]
+) -> None:
+    known = set(case_ids)
+    for case_id, decision in evaluator.get("cases", {}).items():
+        if case_id not in known or not isinstance(decision, dict):
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_CASE_INVALID",
+                    "evaluator names an unknown or malformed case",
+                    case_id=case_id,
+                )
+            )
+            continue
+        status = str(decision.get("status", "manual_pending")).lower()
+        if status not in {"pass", "fail", "manual_pending"}:
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_STATUS_INVALID",
+                    "evaluator status must be pass, fail, or manual_pending",
+                    case_id=case_id,
+                )
+            )
+        checks = decision.get("checks")
+        if not isinstance(checks, list) or not checks:
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_CHECKS_MISSING",
+                    "evaluator decision must include evidenced checks",
+                    case_id=case_id,
+                )
+            )
+            continue
+        check_statuses: list[str] = []
+        for check in checks:
+            if not isinstance(check, dict) or not isinstance(check.get("id"), str):
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_CHECK_INVALID",
+                        "evaluator check must have an ID",
+                        case_id=case_id,
+                    )
+                )
+                continue
+            check_status = str(check.get("status", "manual_pending")).lower()
+            evidence = check.get("evidence")
+            if check_status not in {"pass", "fail", "manual_pending"}:
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_CHECK_STATUS_INVALID",
+                        "evaluator check has an invalid status",
+                        case_id=case_id,
+                    )
+                )
+            if not isinstance(evidence, list) or not evidence:
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_EVIDENCE_MISSING",
+                        "every evaluator check needs evidence references",
+                        case_id=case_id,
+                    )
+                )
+            check_statuses.append(check_status)
+        if status == "pass" and any(item != "pass" for item in check_statuses):
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_PASS_INCONSISTENT",
+                    "case pass conflicts with unresolved or failed checks",
+                    case_id=case_id,
+                )
+            )
+        if status == "fail" and "fail" not in check_statuses:
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_FAIL_INCONSISTENT",
+                    "case fail has no failed check",
+                    case_id=case_id,
+                )
+            )
+
+        paired_arms = decision.get("paired_arms")
+        if paired_arms is None:
+            continue
+        if not isinstance(paired_arms, dict):
+            issues.append(
+                Issue(
+                    "error",
+                    "EVALUATOR_PAIRED_ARMS_INVALID",
+                    "paired_arms must be an object when supplied",
+                    case_id=case_id,
+                )
+            )
+            continue
+        for arm_name in ("baseline", "symforge"):
+            arm = paired_arms.get(arm_name)
+            if not isinstance(arm, dict):
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_PAIRED_ARM_MISSING",
+                        f"paired evaluator decision is missing the {arm_name} arm",
+                        case_id=case_id,
+                    )
+                )
+                continue
+            arm_status = str(arm.get("status", "manual_pending")).lower()
+            if arm_status not in {"pass", "fail", "manual_pending"}:
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_PAIRED_ARM_STATUS_INVALID",
+                        f"paired {arm_name} status is invalid",
+                        case_id=case_id,
+                    )
+                )
+            evidence = arm.get("evidence")
+            if not isinstance(evidence, list) or not evidence:
+                issues.append(
+                    Issue(
+                        "error",
+                        "EVALUATOR_PAIRED_ARM_EVIDENCE_MISSING",
+                        f"paired {arm_name} decision needs evidence references",
+                        case_id=case_id,
+                    )
+                )
+
+
+def evaluator_summary(decision: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(decision, dict):
+        return {
+            "status": "UNEVALUATED",
+            "check_counts": {"pass": 0, "fail": 0, "manual_pending": 0},
+            "evidence_sha256": None,
+        }
+    counts = {"pass": 0, "fail": 0, "manual_pending": 0}
+    evidence_basis: list[dict[str, Any]] = []
+    for check in decision.get("checks", []):
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status", "manual_pending")).lower()
+        if status in counts:
+            counts[status] += 1
+        evidence_basis.append(
+            {
+                "id": check.get("id"),
+                "status": status,
+                "evidence": check.get("evidence", []),
+            }
+        )
+    status = str(decision.get("status", "manual_pending")).lower()
+    normalized = {
+        "pass": "PASS",
+        "fail": "FAIL",
+        "manual_pending": "UNEVALUATED",
+    }.get(status, "UNEVALUATED")
+    return {
+        "status": normalized,
+        "check_counts": counts,
+        "evidence_sha256": sha256_bytes(canonical_json(evidence_basis).encode()),
+    }
+
+
+def validate_asset_identity(
+    cases_path: pathlib.Path,
+    asset_lock: dict[str, Any],
+    artifacts: Sequence[Artifact],
+    issues: list[Issue],
+) -> dict[str, Any]:
+    flattened: dict[str, str] = {}
+    flatten_asset_hashes(asset_lock, flattened)
+    locked_digests = set(flattened.values())
+    cases_digest = file_sha256(cases_path)
+    expected_cases = unique_asset_digest(cases_path, flattened)
+    if expected_cases != cases_digest:
+        issues.append(
+            Issue(
+                "error",
+                "CASES_ASSET_MISMATCH",
+                "cases.json is absent from the asset lock or has the wrong hash",
+            )
+        )
+    checked_input_hashes: set[str] = set()
+    for artifact in artifacts:
+        for record in artifact.records:
+            if record.get("record_type") != "campaign_start":
+                continue
+            input_hashes = record.get("input_hashes")
+            if not isinstance(input_hashes, dict):
+                issues.append(
+                    Issue(
+                        "error",
+                        "CAMPAIGN_INPUT_HASHES_MISSING",
+                        "campaign_start lacks input_hashes",
+                        artifact.path.name,
+                    )
+                )
+                continue
+            if input_hashes.get("cases") != cases_digest:
+                issues.append(
+                    Issue(
+                        "error",
+                        "CAMPAIGN_CASES_HASH_MISMATCH",
+                        "campaign cases hash differs from supplied cases.json",
+                        artifact.path.name,
+                    )
+                )
+            for digest in input_hashes.values():
+                if not is_sha256(digest):
+                    issues.append(
+                        Issue(
+                            "error",
+                            "CAMPAIGN_INPUT_HASH_INVALID",
+                            "campaign input hash is malformed",
+                            artifact.path.name,
+                        )
+                    )
+                    continue
+                normalized = str(digest).lower()
+                checked_input_hashes.add(normalized)
+                if normalized not in locked_digests:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "CAMPAIGN_INPUT_NOT_ASSET_LOCKED",
+                            "campaign input hash is absent from the asset lock",
+                            artifact.path.name,
+                        )
+                    )
+    return {
+        "asset_count": len(flattened),
+        "cases_sha256": cases_digest,
+        "checked_campaign_input_hashes": len(checked_input_hashes),
+    }
+
+
+def campaign_groups(
+    artifact: Artifact,
+) -> list[tuple[str, dict[str, Any], dict[str, Any], list[dict[str, Any]]]]:
+    starts = [
+        row for row in artifact.records if row.get("record_type") == "campaign_start"
+    ]
+    result: list[tuple[str, dict[str, Any], dict[str, Any], list[dict[str, Any]]]] = []
+    for start in starts:
+        run_id = start.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            continue
+        rows = [row for row in artifact.records if row.get("run_id") == run_id]
+        completes = [
+            row for row in rows if row.get("record_type") == "campaign_complete"
+        ]
+        complete = completes[0] if len(completes) == 1 else {}
+        result.append((run_id, start, complete, rows))
+    return result
+
+
+def trial_automatic_failures(
+    case: dict[str, Any],
+    rows: Sequence[dict[str, Any]],
+    direct: Sequence[dict[str, Any]],
+    terminal: str,
+) -> list[str]:
+    failures: list[str] = []
+    if terminal == "case_error":
+        failures.append("case_error")
+    if case.get("case_kind") == "happy":
+        for record in direct:
+            if record.get("status") != "ok":
+                failures.append("happy_request_not_ok")
+                break
+    for record in rows:
+        if record.get("record_type") != "source_inventory_after":
+            continue
+        policy = record.get("mutation_policy")
+        if isinstance(policy, dict) and policy.get("safe") is False:
+            failures.append("mutation_policy_violation")
+        auxiliary = record.get("fixture_auxiliary_violations")
+        if isinstance(auxiliary, list) and auxiliary:
+            failures.append("fixture_auxiliary_violation")
+    return sorted(set(failures))
+
+
+def baseline_automatic_failures(rows: Sequence[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    for record in rows:
+        if record.get("record_type") != "baseline_source_inventory_after":
+            continue
+        policy = record.get("mutation_policy")
+        if isinstance(policy, dict) and policy.get("safe") is False:
+            failures.append("baseline_mutation_policy_violation")
+        auxiliary = record.get("fixture_auxiliary_violations")
+        if isinstance(auxiliary, list) and auxiliary:
+            failures.append("baseline_fixture_auxiliary_violation")
+    return sorted(set(failures))
+
+
+def split_trial_windows(
+    rows: Sequence[dict[str, Any]],
+    artifact_name: str,
+    issues: list[Issue],
+) -> list[tuple[str, int, list[dict[str, Any]]]]:
+    """Split ordered campaign rows into case_start-to-terminal trial windows."""
+    windows: list[tuple[str, int, list[dict[str, Any]]]] = []
+    active_case: str | None = None
+    active_ordinal = 0
+    active_rows: list[dict[str, Any]] = []
+
+    for row in rows:
+        record_type = row.get("record_type")
+        if record_type == "case_start":
+            if active_case is not None:
+                issues.append(
+                    Issue(
+                        "error",
+                        "CASE_WINDOW_OVERLAP",
+                        "a new case_start appeared before the prior trial terminated",
+                        artifact_name,
+                        active_case,
+                    )
+                )
+                windows.append((active_case, active_ordinal, active_rows))
+            case_id = row.get("case_id")
+            ordinal = row.get("trial_ordinal")
+            if not isinstance(case_id, str) or not case_id:
+                issues.append(
+                    Issue(
+                        "error",
+                        "CASE_WINDOW_ID_INVALID",
+                        "case_start has no valid case_id",
+                        artifact_name,
+                    )
+                )
+                case_id = "<invalid-case-id>"
+            if (
+                isinstance(ordinal, bool)
+                or not isinstance(ordinal, int)
+                or ordinal <= 0
+            ):
+                issues.append(
+                    Issue(
+                        "error",
+                        "TRIAL_ORDINAL_INVALID",
+                        "case_start has no positive integer trial_ordinal",
+                        artifact_name,
+                        case_id,
+                    )
+                )
+                ordinal = -(len(windows) + 1)
+            active_case = case_id
+            active_ordinal = ordinal
+            active_rows = [row]
+            continue
+
+        if active_case is None:
+            continue
+        active_rows.append(row)
+        if record_type not in {"case_complete", "case_error"}:
+            continue
+        if row.get("case_id") != active_case:
+            issues.append(
+                Issue(
+                    "error",
+                    "CASE_WINDOW_TERMINAL_MISMATCH",
+                    "trial terminal case_id differs from its case_start",
+                    artifact_name,
+                    active_case,
+                )
+            )
+        windows.append((active_case, active_ordinal, active_rows))
+        active_case = None
+        active_ordinal = 0
+        active_rows = []
+
+    if active_case is not None:
+        issues.append(
+            Issue(
+                "error",
+                "CASE_WINDOW_UNTERMINATED",
+                "case_start has no following case_complete or case_error",
+                artifact_name,
+                active_case,
+            )
+        )
+        windows.append((active_case, active_ordinal, active_rows))
+    return windows
+
+
+def collect_direct_trials(
+    artifacts: Sequence[Artifact],
+    cases_by_id: dict[str, dict[str, Any]],
+    issues: list[Issue],
+) -> list[Trial]:
+    trials: list[Trial] = []
+    seen: set[tuple[str, str, int]] = set()
+    for artifact in artifacts:
+        for run_id, start, complete, rows in campaign_groups(artifact):
+            selected = start.get("selected_case_ids")
+            if not isinstance(selected, list) or not selected:
+                issues.append(
+                    Issue(
+                        "error",
+                        "CAMPAIGN_SELECTION_MISSING",
+                        "campaign_start has no selected case IDs",
+                        artifact.path.name,
+                    )
+                )
+                continue
+            if not complete:
+                issues.append(
+                    Issue(
+                        "error",
+                        "CAMPAIGN_TERMINAL_MISSING",
+                        "campaign has no unique campaign_complete record",
+                        artifact.path.name,
+                    )
+                )
+
+            windows = split_trial_windows(rows, artifact.path.name, issues)
+            selected_ids = {
+                case_id for case_id in selected if isinstance(case_id, str)
+            }
+            for case_id, _, _ in windows:
+                if case_id not in selected_ids:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "CAMPAIGN_CASE_UNSELECTED",
+                            "campaign contains a trial absent from selected_case_ids",
+                            artifact.path.name,
+                            case_id,
+                        )
+                    )
+
+            for case_id in selected:
+                if case_id not in cases_by_id:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "CAMPAIGN_CASE_UNKNOWN",
+                            "campaign selected a case absent from cases.json",
+                            artifact.path.name,
+                        )
+                    )
+                    continue
+                case_windows = [
+                    (ordinal, case_rows)
+                    for window_case, ordinal, case_rows in windows
+                    if window_case == case_id
+                ]
+                if not case_windows:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "CASE_TRIAL_MISSING",
+                            "selected case has no trial window",
+                            artifact.path.name,
+                            case_id,
+                        )
+                    )
+                    continue
+
+                case = cases_by_id[case_id]
+                warmups_required = int(
+                    case.get("limits", {}).get("discarded_warmups", 0)
+                )
+                warmups_observed = sum(
+                    case_rows[0].get("discarded_warmup") is True
+                    for _, case_rows in case_windows
+                    if case_rows
+                )
+                if warmups_observed != warmups_required:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "WARMUPS_INCOMPLETE",
+                            (
+                                f"case has {warmups_observed} discarded warmups but "
+                                f"requires {warmups_required}"
+                            ),
+                            artifact.path.name,
+                            case_id,
+                        )
+                    )
+
+                for ordinal, case_rows in case_windows:
+                    identity = (run_id, case_id, ordinal)
+                    if identity in seen:
+                        issues.append(
+                            Issue(
+                                "error",
+                                "TRIAL_ID_DUPLICATE",
+                                "run_id, case_id, and trial_ordinal are duplicated",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                        continue
+                    seen.add(identity)
+
+                    starts = [
+                        row
+                        for row in case_rows
+                        if row.get("record_type") == "case_start"
+                    ]
+                    completed = [
+                        row
+                        for row in case_rows
+                        if row.get("record_type") == "case_complete"
+                    ]
+                    errors = [
+                        row
+                        for row in case_rows
+                        if row.get("record_type") == "case_error"
+                    ]
+                    if len(starts) != 1:
+                        issues.append(
+                            Issue(
+                                "error",
+                                "CASE_START_COUNT",
+                                "trial does not have exactly one case_start",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                    if len(completed) + len(errors) != 1:
+                        issues.append(
+                            Issue(
+                                "error",
+                                "CASE_TERMINAL_COUNT",
+                                "trial does not have exactly one terminal case record",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                    terminal = "case_complete" if completed else "case_error"
+                    direct = sorted(
+                        [
+                            row
+                            for row in case_rows
+                            if row.get("record_type") == "direct_trial"
+                        ],
+                        key=lambda row: int(row.get("case_step", 0)),
+                    )
+                    requests = case.get("requests", [])
+                    if completed and len(direct) != len(requests):
+                        issues.append(
+                            Issue(
+                                "error",
+                                "REQUEST_COUNT_MISMATCH",
+                                "completed trial measured request count differs from case",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                    if completed:
+                        for expected, observed in zip(
+                            requests, direct, strict=False
+                        ):
+                            if (
+                                observed.get("case_step") != expected.get("step")
+                                or observed.get("request_label")
+                                != expected.get("label")
+                                or observed.get("tool") != expected.get("tool")
+                            ):
+                                issues.append(
+                                    Issue(
+                                        "error",
+                                        "REQUEST_IDENTITY_MISMATCH",
+                                        "measured request does not match the frozen step",
+                                        artifact.path.name,
+                                        case_id,
+                                    )
+                                )
+
+                    discarded_warmup = bool(
+                        starts and starts[0].get("discarded_warmup") is True
+                    )
+                    discard_flags = {
+                        row.get("discarded_warmup")
+                        for row in case_rows
+                        if row.get("record_type")
+                        in {"case_start", "direct_trial", "case_complete", "case_error"}
+                    }
+                    if len(discard_flags) != 1:
+                        issues.append(
+                            Issue(
+                                "error",
+                                "WARMUP_FLAG_MISMATCH",
+                                "trial rows disagree on discarded_warmup",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                    if discarded_warmup:
+                        if errors:
+                            issues.append(
+                                Issue(
+                                    "error",
+                                    "WARMUP_TRIAL_FAILED",
+                                    "discarded warmup terminated with case_error",
+                                    artifact.path.name,
+                                    case_id,
+                                )
+                            )
+                        continue
+
+                    if completed:
+                        before_count = sum(
+                            row.get("record_type") == "source_inventory_before"
+                            for row in case_rows
+                        )
+                        after_count = sum(
+                            row.get("record_type") == "source_inventory_after"
+                            for row in case_rows
+                        )
+                        if before_count != 1 or after_count != 1:
+                            issues.append(
+                                Issue(
+                                    "error",
+                                    "SOURCE_INVENTORY_INCOMPLETE",
+                                    "completed trial lacks before/after source inventory",
+                                    artifact.path.name,
+                                    case_id,
+                                )
+                            )
+                    baseline_rows = [
+                        row
+                        for row in case_rows
+                        if row.get("record_type") == "baseline_total"
+                    ]
+                    formal = start.get("formal_economics") is True
+                    if formal and len(baseline_rows) != 1:
+                        issues.append(
+                            Issue(
+                                "error",
+                                "BASELINE_TOTAL_MISSING",
+                                "formal trial lacks one recipe baseline_total",
+                                artifact.path.name,
+                                case_id,
+                            )
+                        )
+                    baseline = (
+                        baseline_rows[0] if len(baseline_rows) == 1 else None
+                    )
+                    trial = Trial(
+                        artifact=artifact,
+                        run_id=run_id,
+                        case=case,
+                        records=case_rows,
+                        direct_trials=direct,
+                        baseline_total=baseline,
+                        terminal=terminal,
+                    )
+                    trial.automatic_failure_codes = trial_automatic_failures(
+                        case, case_rows, direct, terminal
+                    )
+                    trials.append(trial)
+    return trials
+
+
+def validate_repetitions(trials: Sequence[Trial], issues: list[Issue]) -> None:
+    grouped: dict[str, list[Trial]] = {}
+    for trial in trials:
+        grouped.setdefault(trial.case["id"], []).append(trial)
+    for case_id, case_trials in grouped.items():
+        required = int(case_trials[0].case.get("limits", {}).get("repetitions", 0))
+        if required <= 0:
+            issues.append(
+                Issue(
+                    "error",
+                    "REPETITION_POLICY_INVALID",
+                    "case has no positive repetition count",
+                    case_id=case_id,
+                )
+            )
+        elif len(case_trials) != required:
+            issues.append(
+                Issue(
+                    "error",
+                    "REPETITIONS_INCOMPLETE",
+                    f"case has {len(case_trials)} trials but requires {required}",
+                    case_id=case_id,
+                )
+            )
+
+
+def tokenizer_status(issues: list[Issue]) -> dict[str, Any]:
+    version = importlib.metadata.version("tiktoken")
+    if version != "0.13.0":
+        issues.append(
+            Issue(
+                "error",
+                "TOKENIZER_VERSION_MISMATCH",
+                "adjudicator requires tiktoken 0.13.0",
+            )
+        )
+    return harness.TokenCounter().metadata()
+
+
+def request_role(case: dict[str, Any], request: dict[str, Any]) -> tuple[str, str]:
+    explicit = request.get("economics_role")
+    if explicit is not None:
+        if explicit not in VALID_ROLES:
+            raise AdjudicationError(
+                f"case {case['id']} has an invalid economics_role"
+            )
+        unit = str(request.get("economics_unit") or request.get("label") or "task")
+        return str(explicit), unit
+
+    label = str(request.get("label", "task"))
+    args = request.get("args", {})
+    if isinstance(args, dict) and args.get("estimate") is True:
+        return "estimate_diagnostic", label
+    if label == "full_reference":
+        return "oracle_reference", label
+    if label in {"replay", "repeat", "restart_probe"}:
+        return "replay_diagnostic", label
+    case_id = case["id"]
+    if case_id == "SF-investigation_suggest-001":
+        role = "required_prerequisite" if label == "step_1" else "task"
+        return role, "workflow"
+    if case_id in WORKFLOW_CASES:
+        return "task", "workflow"
+    if case_id == "SF-health_compact-001" and label == "full_reference":
+        return "oracle_reference", label
+    if case_id in VARIANT_CASES:
+        first_label = str(case.get("requests", [{}])[0].get("label", "task"))
+        role = "task" if label == first_label else "comparison_variant"
+        return role, label
+    return "task", "task"
+
+
+def request_by_step(case: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    return {
+        int(request["step"]): request
+        for request in case.get("requests", [])
+        if isinstance(request, dict) and isinstance(request.get("step"), int)
+    }
+
+
+def unit_rows(trial: Trial) -> list[dict[str, Any]]:
+    requests = request_by_step(trial.case)
+    observed = {
+        int(row["case_step"]): row
+        for row in trial.direct_trials
+        if isinstance(row.get("case_step"), int)
+    }
+    case_id = trial.case["id"]
+    if case_id == "SF-symforge_retrieve-001":
+        labels = {
+            request.get("label"): observed.get(step)
+            for step, request in requests.items()
+        }
+        result: list[dict[str, Any]] = []
+        if labels.get("trigger") is not None:
+            result.append(
+                {
+                    "name": "summary",
+                    "kind": "task",
+                    "rows": [labels["trigger"]],
+                }
+            )
+        if labels.get("trigger") is not None and labels.get("retrieve") is not None:
+            result.append(
+                {
+                    "name": "exact_detail",
+                    "kind": "task",
+                    "rows": [labels["trigger"], labels["retrieve"]],
+                }
+            )
+        return result
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for step, request in requests.items():
+        row = observed.get(step)
+        if row is None:
+            continue
+        role, unit = request_role(trial.case, request)
+        if role in {
+            "estimate_diagnostic",
+            "oracle_reference",
+            "replay_diagnostic",
+            "warmup",
+        }:
+            continue
+        entry = grouped.setdefault(
+            unit,
+            {
+                "name": unit,
+                "kind": "comparison_variant"
+                if role == "comparison_variant"
+                else "task",
+                "rows": [],
+            },
+        )
+        entry["rows"].append(row)
+    return list(grouped.values())
+
+
+def scenario_rows(trial: Trial) -> list[dict[str, Any]]:
+    requests = request_by_step(trial.case)
+    included: list[dict[str, Any]] = []
+    seen_steps: set[int] = set()
+    for row in trial.direct_trials:
+        step = row.get("case_step")
+        if not isinstance(step, int) or step in seen_steps or step not in requests:
+            continue
+        role, _ = request_role(trial.case, requests[step])
+        if role not in {
+            "estimate_diagnostic",
+            "oracle_reference",
+            "replay_diagnostic",
+            "warmup",
+        }:
+            included.append(row)
+            seen_steps.add(step)
+    return included
+
+
+def rows_metrics(
+    rows: Sequence[dict[str, Any]],
+    surface: str,
+    schema_views: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not rows or surface not in schema_views:
+        return None
+    latency_values = [numeric_field(row, "rpc_ms") for row in rows]
+    if any(value is None for value in latency_values):
+        return None
+    result: dict[str, Any] = {
+        "call_count": len(rows),
+        "call_tools": sorted(
+            {row.get("tool") for row in rows if isinstance(row.get("tool"), str)}
+        ),
+        "latency_ms": sum(float(value) for value in latency_values if value is not None),
+        "encodings": {},
+    }
+    for encoding in ENCODINGS:
+        request_key = f"schema_free_tool_request_{encoding}"
+        response_key = f"schema_free_tool_response_{encoding}"
+        direct_key = f"schema_free_direct_payload_{encoding}"
+        request_values = [integer_field(row, request_key) for row in rows]
+        response_values = [integer_field(row, response_key) for row in rows]
+        direct_values = [integer_field(row, direct_key) for row in rows]
+        if any(value is None for value in request_values + response_values + direct_values):
+            return None
+        request_total = sum(int(value) for value in request_values)
+        response_total = sum(int(value) for value in response_values)
+        direct_total = sum(int(value) for value in direct_values)
+        schema = int(schema_views[surface]["tokens"][encoding])
+        individual = schema_views[surface]["individual"]
+        lazy = sum(
+            int(individual[name][encoding])
+            for name in result["call_tools"]
+            if name in individual
+        )
+        result["encodings"][encoding] = {
+            "request": request_total,
+            "response": response_total,
+            "direct_payload": direct_total,
+            "cold_eager_surface": direct_total + schema,
+            "lazy_unique": direct_total + lazy,
+            "theoretical_amortized_5": direct_total + schema / 5,
+            "theoretical_amortized_20": direct_total + schema / 20,
+            "surface_schema": schema,
+            "lazy_schema_unique": lazy,
+        }
+    return result
+
+
+def final_correctness(
+    trials: Sequence[Trial], decision: dict[str, Any] | None
+) -> tuple[str, dict[str, Any]]:
+    summary = evaluator_summary(decision)
+    if any(trial.automatic_failure_codes for trial in trials):
+        return "FAIL", summary
+    return str(summary["status"]), summary
+
+
+def baseline_policy(decision: dict[str, Any] | None) -> tuple[str, str]:
+    if not isinstance(decision, dict):
+        return "unreviewed", "manual_pending"
+    equivalence = str(decision.get("baseline_equivalence", "unreviewed")).lower()
+    correctness = str(decision.get("baseline_correctness", "manual_pending")).lower()
+    if equivalence not in {
+        "valid",
+        "capability_only",
+        "lower_bound",
+        "invalid",
+        "unreviewed",
+    }:
+        equivalence = "invalid"
+    if correctness not in {"pass", "fail", "manual_pending"}:
+        correctness = "manual_pending"
+    return equivalence, correctness
+
+
+def numeric_verdict(
+    baseline: float, symforge: float
+) -> tuple[str, float, float | None, float | None]:
+    saved = baseline - symforge
+    if saved > 0:
+        verdict = "POSITIVE"
+    elif saved < 0:
+        verdict = "TOKEN_NEGATIVE"
+    else:
+        verdict = "NEUTRAL"
+    percent = 100 * saved / baseline if baseline else None
+    multiplier = symforge / baseline if baseline else None
+    return verdict, saved, percent, multiplier
+
+
+def recipe_economics(
+    trial: Trial,
+    correctness: str,
+    decision: dict[str, Any] | None,
+    schema_views: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    equivalence, baseline_correctness = baseline_policy(decision)
+    result: dict[str, Any] = {
+        "arm": "direct_recipe_sensitivity",
+        "headline": False,
+        "equivalence": equivalence,
+        "baseline_correctness": baseline_correctness,
+        "views": {},
+        "break_even_tasks": None,
+    }
+    if correctness == "FAIL":
+        result["verdict"] = "INVALID_INCORRECT"
+        result["reason"] = "symforge_correctness_failed"
+        return result
+    if correctness != "PASS":
+        result["verdict"] = "NOT_SCORED"
+        result["reason"] = "correctness_unevaluated"
+        return result
+    baseline_failures = baseline_automatic_failures(trial.records)
+    if baseline_failures:
+        result["verdict"] = "N/A_NO_EQUIVALENT_BASELINE"
+        result["reason"] = "baseline_automatic_failure"
+        result["baseline_automatic_failures"] = baseline_failures
+        return result
+    if equivalence != "valid" or baseline_correctness != "pass":
+        result["verdict"] = "N/A_NO_EQUIVALENT_BASELINE"
+        result["reason"] = (
+            "capability_gain"
+            if equivalence == "capability_only"
+            else "baseline_not_equivalent_or_correct"
+        )
+        return result
+    if trial.baseline_total is None:
+        result["verdict"] = "NOT_SCORED"
+        result["reason"] = "baseline_tokens_missing"
+        return result
+    metrics = rows_metrics(scenario_rows(trial), trial.case["surface"], schema_views)
+    if metrics is None:
+        result["verdict"] = "NOT_SCORED"
+        result["reason"] = "direct_tokens_missing"
+        return result
+
+    verdicts: list[str] = []
+    for encoding in ENCODINGS:
+        baseline_value = integer_field(
+            trial.baseline_total, f"direct_payload_{encoding}"
+        )
+        if baseline_value is None:
+            continue
+        symforge = float(metrics["encodings"][encoding]["direct_payload"])
+        verdict, saved, percent, multiplier = numeric_verdict(
+            float(baseline_value), symforge
+        )
+        verdicts.append(verdict)
+        result["views"][encoding] = {
+            "baseline_tokens": baseline_value,
+            "symforge_tokens": symforge,
+            "saved_tokens": saved,
+            "savings_percent": percent,
+            "cost_multiplier": multiplier,
+            "verdict": verdict,
+        }
+    if not result["views"]:
+        result["verdict"] = "NOT_SCORED"
+        result["reason"] = "baseline_tokens_missing"
+        return result
+    result["verdict"] = verdicts[0] if len(set(verdicts)) == 1 else "MIXED"
+    result["reason"] = "valid_direct_recipe_sensitivity"
+
+    setup = decision.get("setup_tokens") if isinstance(decision, dict) else None
+    if isinstance(setup, dict):
+        primary_setup = setup.get("cl100k")
+        view = result["views"].get("cl100k")
+        if isinstance(primary_setup, dict) and isinstance(view, dict):
+            sym_setup = primary_setup.get("symforge")
+            baseline_setup = primary_setup.get("baseline")
+            denominator = view["baseline_tokens"] - view["symforge_tokens"]
+            if nonnegative_number(sym_setup) and nonnegative_number(baseline_setup):
+                if denominator > 0:
+                    result["break_even_tasks"] = max(
+                        0,
+                        math.ceil((float(sym_setup) - float(baseline_setup)) / denominator),
+                    )
+                else:
+                    result["break_even_tasks"] = "no break-even observed"
+    return result
+
+
+def provider_total_tokens(record: dict[str, Any]) -> tuple[int | None, str | None]:
+    explicit = record.get("provider_total_tokens")
+    if isinstance(explicit, int) and not isinstance(explicit, bool) and explicit >= 0:
+        return explicit, "explicit_provider_total_tokens"
+    def usage_total(usage: object) -> tuple[int, str] | None:
+        if not isinstance(usage, dict):
+            return None
+        for total_key in ("total_tokens", "totalTokens"):
+            value = usage.get(total_key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                return value, total_key
+        snake = (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+        camel = (
+            "inputTokens",
+            "outputTokens",
+            "cacheCreationInputTokens",
+            "cacheReadInputTokens",
+        )
+        if any(key in usage for key in snake):
+            keys = snake
+        elif any(key in usage for key in camel):
+            keys = camel
+        else:
+            return None
+        values = [usage.get(key, 0) for key in keys]
+        if not all(
+            isinstance(value, int) and not isinstance(value, bool) and value >= 0
+            for value in values
+        ):
+            return None
+        return sum(int(value) for value in values), "documented_disjoint_usage_fields"
+
+    aggregate = usage_total(record.get("usage"))
+    if aggregate is not None:
+        return aggregate[0], f"usage.{aggregate[1]}"
+
+    model_usage = record.get("modelUsage")
+    if not isinstance(model_usage, dict) or not model_usage:
+        return None, None
+    model_totals: list[int] = []
+    bases: set[str] = set()
+    for usage in model_usage.values():
+        parsed = usage_total(usage)
+        if parsed is None:
+            return None, None
+        model_totals.append(parsed[0])
+        bases.add(parsed[1])
+    return sum(model_totals), "modelUsage." + "+".join(sorted(bases))
+
+
+def paired_provider_summary(
+    artifacts: Sequence[Artifact],
+    cases_by_id: dict[str, dict[str, Any]],
+    evaluator: dict[str, Any],
+) -> dict[str, Any]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for artifact in artifacts:
+        for record in artifact.records:
+            if record.get("record_type") != "claude_task_trial":
+                continue
+            case_id = record.get("case_id")
+            arm = record.get("arm")
+            if case_id in cases_by_id and arm in {"baseline", "symforge"}:
+                grouped.setdefault((str(case_id), str(arm)), []).append(record)
+    by_tool: dict[str, dict[str, Any]] = {}
+    for case_id, case in cases_by_id.items():
+        baseline_rows = grouped.get((case_id, "baseline"), [])
+        symforge_rows = grouped.get((case_id, "symforge"), [])
+        if not baseline_rows and not symforge_rows:
+            continue
+        decision = evaluator.get("cases", {}).get(case_id, {})
+        paired_decision = decision.get("paired_arms", {}) if isinstance(decision, dict) else {}
+        baseline_decision = paired_decision.get("baseline", {})
+        symforge_decision = paired_decision.get("symforge", {})
+        baseline_ok = isinstance(baseline_decision, dict) and str(
+            baseline_decision.get("status", "manual_pending")
+        ).lower() == "pass"
+        symforge_ok = isinstance(symforge_decision, dict) and str(
+            symforge_decision.get("status", "manual_pending")
+        ).lower() == "pass"
+        baseline_tokens: list[int] = []
+        symforge_tokens: list[int] = []
+        bases: set[str] = set()
+        for row in baseline_rows:
+            value, basis = provider_total_tokens(row)
+            if value is not None:
+                baseline_tokens.append(value)
+            if basis:
+                bases.add(basis)
+        for row in symforge_rows:
+            value, basis = provider_total_tokens(row)
+            if value is not None:
+                symforge_tokens.append(value)
+            if basis:
+                bases.add(basis)
+        if not baseline_ok or not symforge_ok:
+            verdict = "INVALID_INCORRECT" if (
+                (isinstance(baseline_decision, dict) and baseline_decision.get("status") == "fail")
+                or (isinstance(symforge_decision, dict) and symforge_decision.get("status") == "fail")
+            ) else "NOT_SCORED"
+            result = {
+                "case_id": case_id,
+                "verdict": verdict,
+                "reason": "paired_correctness_not_passed",
+                "baseline_samples": len(baseline_tokens),
+                "symforge_samples": len(symforge_tokens),
+            }
+        elif not baseline_tokens or not symforge_tokens:
+            result = {
+                "case_id": case_id,
+                "verdict": "NOT_SCORED",
+                "reason": "provider_total_missing",
+                "baseline_samples": len(baseline_tokens),
+                "symforge_samples": len(symforge_tokens),
+            }
+        else:
+            baseline_total = sum(baseline_tokens)
+            symforge_total = sum(symforge_tokens)
+            verdict, saved, percent, multiplier = numeric_verdict(
+                float(baseline_total), float(symforge_total)
+            )
+            result = {
+                "case_id": case_id,
+                "verdict": verdict,
+                "reason": "paired_provider_total",
+                "baseline_samples": len(baseline_tokens),
+                "symforge_samples": len(symforge_tokens),
+                "baseline_tokens": baseline_total,
+                "symforge_tokens": symforge_total,
+                "saved_tokens": saved,
+                "savings_percent": percent,
+                "cost_multiplier": multiplier,
+                "usage_basis": sorted(bases),
+                "negative_trial_rate": None,
+            }
+        tool = case["primary_tool"]
+        by_tool.setdefault(tool, {"headline": True, "cases": []})["cases"].append(
+            result
+        )
+    return by_tool
+
+
+def aggregate_units(
+    trials: Sequence[Trial],
+    schema_views: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    samples: dict[str, list[dict[str, Any]]] = {}
+    for trial in trials:
+        for unit in unit_rows(trial):
+            metrics = rows_metrics(unit["rows"], trial.case["surface"], schema_views)
+            if metrics is None:
+                continue
+            samples.setdefault(trial.case["primary_tool"], []).append(
+                {
+                    "case_id": trial.case["id"],
+                    "run_id_sha256": sha256_bytes(trial.run_id.encode()),
+                    "unit": unit["name"],
+                    "kind": unit["kind"],
+                    "surface": trial.case["surface"],
+                    **metrics,
+                }
+            )
+    result: dict[str, dict[str, Any]] = {}
+    for tool, tool_samples in samples.items():
+        encodings: dict[str, Any] = {}
+        for encoding in ENCODINGS:
+            keys = (
+                "request",
+                "response",
+                "direct_payload",
+                "cold_eager_surface",
+                "lazy_unique",
+                "theoretical_amortized_5",
+                "theoretical_amortized_20",
+            )
+            encoding_summary: dict[str, Any] = {}
+            for key in keys:
+                values = [
+                    float(sample["encodings"][encoding][key])
+                    for sample in tool_samples
+                ]
+                encoding_summary[key] = {
+                    "total": sum(values),
+                    "median": median(values),
+                    "p95": percentile(values, 0.95),
+                }
+            encodings[encoding] = encoding_summary
+        latency = [float(sample["latency_ms"]) for sample in tool_samples]
+        result[tool] = {
+            "sample_count": len(tool_samples),
+            "units": tool_samples,
+            "encodings": encodings,
+            "latency_ms": {
+                "median": median(latency),
+                "p95": percentile(latency, 0.95),
+            },
+        }
+    return result
+
+
+def summarize_tools(
+    trials: Sequence[Trial],
+    schema_views: dict[str, dict[str, Any]],
+    evaluator: dict[str, Any],
+    paired: dict[str, Any],
+) -> list[dict[str, Any]]:
+    units = aggregate_units(trials, schema_views)
+    grouped: dict[str, list[Trial]] = {}
+    for trial in trials:
+        grouped.setdefault(trial.case["primary_tool"], []).append(trial)
+    rows: list[dict[str, Any]] = []
+    for tool in sorted(grouped):
+        tool_trials = grouped[tool]
+        by_case: dict[str, list[Trial]] = {}
+        for trial in tool_trials:
+            by_case.setdefault(trial.case["id"], []).append(trial)
+        case_results: list[dict[str, Any]] = []
+        numeric_recipe_verdicts: list[str] = []
+        for case_id, case_trials in sorted(by_case.items()):
+            decision = evaluator.get("cases", {}).get(case_id)
+            correctness, decision_summary = final_correctness(case_trials, decision)
+            economics = [
+                recipe_economics(
+                    trial,
+                    correctness,
+                    decision if isinstance(decision, dict) else None,
+                    schema_views,
+                )
+                for trial in case_trials
+            ]
+            numeric_recipe_verdicts.extend(
+                item["verdict"]
+                for item in economics
+                if item.get("verdict") in {"POSITIVE", "TOKEN_NEGATIVE", "NEUTRAL"}
+            )
+            case_results.append(
+                {
+                    "case_id": case_id,
+                    "correctness": correctness,
+                    "automatic_failure_codes": sorted(
+                        {
+                            code
+                            for trial in case_trials
+                            for code in trial.automatic_failure_codes
+                        }
+                    ),
+                    "evaluator": decision_summary,
+                    "repetitions": len(case_trials),
+                    "direct_recipe_sensitivity": economics,
+                }
+            )
+        statuses = {item["correctness"] for item in case_results}
+        if "FAIL" in statuses:
+            correctness = "FAIL"
+        elif statuses == {"PASS"}:
+            correctness = "PASS"
+        else:
+            correctness = "UNEVALUATED"
+        negative = sum(item == "TOKEN_NEGATIVE" for item in numeric_recipe_verdicts)
+        recipe_rate = (
+            negative / len(numeric_recipe_verdicts)
+            if numeric_recipe_verdicts
+            else None
+        )
+        rows.append(
+            {
+                "tool": tool,
+                "correctness": correctness,
+                "cases": case_results,
+                "direct_metrics": units.get(tool),
+                "direct_recipe_sensitivity": {
+                    "headline": False,
+                    "valid_numeric_trials": len(numeric_recipe_verdicts),
+                    "negative_trial_rate": recipe_rate,
+                },
+                "paired_provider": paired.get(
+                    tool,
+                    {
+                        "headline": True,
+                        "cases": [],
+                        "status": "not_run",
+                    },
+                ),
+            }
+        )
+    return rows
+
+
+def validation_result(
+    artifact_paths: Sequence[pathlib.Path],
+    manifest_paths: Sequence[pathlib.Path],
+    cases_path: pathlib.Path,
+    asset_lock_path: pathlib.Path,
+    evaluator_path: pathlib.Path | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    issues: list[Issue] = []
+    cases, cases_by_id = load_cases(cases_path)
+    asset_lock = load_json_object(asset_lock_path, "asset lock")
+    artifacts = [load_records(path) for path in artifact_paths]
+    manifest_artifacts = [load_records(path) for path in manifest_paths]
+    evaluator = load_evaluator(evaluator_path)
+    validate_decisions(evaluator, cases_by_id, issues)
+    tokenizer = tokenizer_status(issues)
+    counter = harness.TokenCounter()
+    schema_views = manifest_schema_views(manifest_artifacts, cases, counter, issues)
+    asset_identity = validate_asset_identity(
+        cases_path, asset_lock, artifacts, issues
+    )
+    direct_trials = collect_direct_trials(artifacts, cases_by_id, issues)
+    validate_repetitions(direct_trials, issues)
+    paired_records = sum(
+        row.get("record_type") == "claude_task_trial"
+        for artifact in artifacts
+        for row in artifact.records
+    )
+    if not direct_trials:
+        issues.append(
+            Issue(
+                "error",
+                "DIRECT_TRIALS_MISSING",
+                "no direct campaign trials were supplied",
+            )
+        )
+    report = {
+        "schema_version": SUMMARY_SCHEMA,
+        "status": "valid"
+        if not any(issue.severity == "error" for issue in issues)
+        else "invalid",
+        "protocol": harness.PROTOCOL_ID,
+        "artifact_count": len(artifacts),
+        "artifact_identities": [
+            {"name": artifact.path.name, "sha256": artifact.sha256}
+            for artifact in artifacts
+        ],
+        "manifest_artifact_count": len(manifest_artifacts),
+        "direct_trial_count": len(direct_trials),
+        "paired_record_count": paired_records,
+        "asset_identity": asset_identity,
+        "tokenizer": tokenizer,
+        "schema_views": {
+            surface: {
+                "manifest_sha256": view["manifest_sha256"],
+                "tool_count": view["tool_count"],
+                "tokens": view["tokens"],
+            }
+            for surface, view in schema_views.items()
+        },
+        "issues": [issue.as_dict() for issue in issues],
+    }
+    state = {
+        "cases": cases,
+        "cases_by_id": cases_by_id,
+        "artifacts": artifacts,
+        "manifest_artifacts": manifest_artifacts,
+        "evaluator": evaluator,
+        "schema_views": schema_views,
+        "trials": direct_trials,
+        "issues": issues,
+    }
+    return report, state
+
+
+def build_summary(validation: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    if validation["status"] != "valid":
+        raise AdjudicationError(
+            "artifacts are incomplete or invalid; run validate and fix every error"
+        )
+    paired = paired_provider_summary(
+        state["artifacts"], state["cases_by_id"], state["evaluator"]
+    )
+    tools = summarize_tools(
+        state["trials"], state["schema_views"], state["evaluator"], paired
+    )
+    return {
+        "schema_version": SUMMARY_SCHEMA,
+        "protocol": harness.PROTOCOL_ID,
+        "status": "summarized",
+        "correctness_rule": (
+            "case_complete is capture-only; PASS requires a separate evidenced "
+            "evaluator decision"
+        ),
+        "validation": validation,
+        "economics": {
+            "headline": "paired_provider",
+            "sensitivity": "direct_recipe",
+            "schema_views": {
+                surface: {
+                    "tool_count": view["tool_count"],
+                    "tokens": view["tokens"],
+                    "manifest_sha256": view["manifest_sha256"],
+                }
+                for surface, view in state["schema_views"].items()
+            },
+            "views": [
+                "content_only",
+                "direct_payload",
+                "cold_eager_surface",
+                "lazy_unique",
+                "theoretical_amortized_5",
+                "theoretical_amortized_20",
+                "paired_provider_total",
+            ],
+        },
+        "tools": tools,
+    }
+
+
+def markdown_number(value: Any, digits: int = 1) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def markdown_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        "# SymForge benchmark adjudication summary",
+        "",
+        "> `case_complete` is capture-only. Correctness requires a separate "
+        "evidenced evaluator decision.",
+        "",
+        "## Schema views",
+        "",
+        "| Surface | Tools | cl100k | o200k |",
+        "|---|---:|---:|---:|",
+    ]
+    for surface in ("full", "compact", "meta"):
+        view = summary["economics"]["schema_views"].get(surface)
+        if not isinstance(view, dict):
+            continue
+        lines.append(
+            f"| `{surface}` | {view['tool_count']} | "
+            f"{view['tokens']['cl100k']} | {view['tokens']['o200k']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Per-tool results",
+            "",
+            "Direct recipe results are sensitivity measurements. Paired provider "
+            "usage is the headline only after both arms pass the same oracle.",
+            "",
+            "| Tool | Correctness | Samples | Direct cl100k median | "
+            "Latency median / p95 ms | Recipe negative rate | Paired status |",
+            "|---|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for tool in summary["tools"]:
+        metrics = tool.get("direct_metrics") or {}
+        encoding = metrics.get("encodings", {}).get("cl100k", {})
+        payload = encoding.get("direct_payload", {}).get("median")
+        latency = metrics.get("latency_ms", {})
+        recipe_rate = tool["direct_recipe_sensitivity"].get("negative_trial_rate")
+        paired_cases = tool.get("paired_provider", {}).get("cases", [])
+        if paired_cases:
+            paired_verdicts = sorted({case.get("verdict") for case in paired_cases})
+            paired_status = ", ".join(str(value) for value in paired_verdicts)
+        else:
+            paired_status = "not run"
+        lines.append(
+            f"| `{tool['tool']}` | {tool['correctness']} | "
+            f"{metrics.get('sample_count', 0)} | {markdown_number(payload)} | "
+            f"{markdown_number(latency.get('median'))} / "
+            f"{markdown_number(latency.get('p95'))} | "
+            f"{markdown_number(recipe_rate, 3)} | {paired_status} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "- `PASS` requires evidenced evaluator decisions; capture alone remains "
+            "`UNEVALUATED`.",
+            "- `INVALID_INCORRECT` takes precedence over token economics.",
+            "- Capability-only and lower-bound baselines are "
+            "`N/A_NO_EQUIVALENT_BASELINE`, never zero-token baselines.",
+            "- Cold eager and 5/20-task schema figures are theoretical unless exact "
+            "model-visible schemas were captured longitudinally.",
+            "- Provider totals already containing schema/cache/reasoning are never "
+            "augmented a second time.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--artifact", action="append", required=True)
+    parser.add_argument("--manifest", action="append", required=True)
+    parser.add_argument("--cases", default=str(DEFAULT_CASES))
+    parser.add_argument("--asset-lock", default=str(DEFAULT_ASSET_LOCK))
+    parser.add_argument("--evaluator")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate and summarize sanitized SymForge benchmark JSONL without "
+            "inferring correctness from runner completion."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser(
+        "validate", help="Validate identity, manifests, records, warmups, and repetitions."
+    )
+    common_arguments(validate)
+    summarize = subparsers.add_parser(
+        "summarize", help="Validate, then write sanitized JSON and Markdown summaries."
+    )
+    common_arguments(summarize)
+    summarize.add_argument("--output-json", required=True)
+    summarize.add_argument("--output-markdown", required=True)
+    subparsers.add_parser("self-test", help="Run synthetic sanitized evidence tests.")
+    return parser
+
+
+def paths(values: Sequence[str]) -> list[pathlib.Path]:
+    return [pathlib.Path(value).resolve() for value in values]
+
+
+def run_cli(args: argparse.Namespace) -> int:
+    validation, state = validation_result(
+        paths(args.artifact),
+        paths(args.manifest),
+        pathlib.Path(args.cases).resolve(),
+        pathlib.Path(args.asset_lock).resolve(),
+        pathlib.Path(args.evaluator).resolve() if args.evaluator else None,
+    )
+    safe_validation = sanitize_output(validation)
+    if args.command == "validate":
+        print(json.dumps(safe_validation, indent=2, sort_keys=True))
+        return 0 if validation["status"] == "valid" else 1
+    summary = sanitize_output(build_summary(validation, state))
+    output_json = pathlib.Path(args.output_json).resolve()
+    output_markdown = pathlib.Path(args.output_markdown).resolve()
+    if output_json == output_markdown:
+        raise AdjudicationError("JSON and Markdown outputs must be different paths")
+    write_json(output_json, summary)
+    output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    output_markdown.write_text(markdown_summary(summary), encoding="utf-8")
+    receipt = sanitize_output(
+        {
+            "status": "summarized",
+            "tools": len(summary["tools"]),
+            "output_json": str(output_json),
+            "output_markdown": str(output_markdown),
+        }
+    )
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+def temp_write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def temp_write_jsonl(path: pathlib.Path, rows: Sequence[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(canonical_json(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+
+def synthetic_manifest(surface: str, names: Sequence[str]) -> dict[str, Any]:
+    tools = [
+        {
+            "name": name,
+            "description": "Synthetic read-only benchmark tool.",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+        for name in names
+    ]
+    return {
+        "protocol": harness.PROTOCOL_ID,
+        "record_type": "manifest",
+        "surface": surface,
+        "manifest": {
+            "tools": tools,
+            "resources": [],
+            "resourceTemplates": [],
+            "prompts": [],
+        },
+    }
+
+
+def synthetic_campaign_rows(
+    run_id: str,
+    cases_hash: str,
+    campaign_hash: str,
+) -> list[dict[str, Any]]:
+    case_id = "SELF-get_repo_map-001"
+    return [
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "campaign_start",
+            "run_id": run_id,
+            "input_hashes": {"cases": cases_hash, "campaign": campaign_hash},
+            "selected_case_ids": [case_id],
+            "formal_economics": True,
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "case_start",
+            "run_id": run_id,
+            "case_id": case_id,
+            "surface": "full",
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "source_inventory_before",
+            "run_id": run_id,
+            "case_id": case_id,
+            "inventory": {"tree_sha256": "0" * 64},
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "direct_trial",
+            "run_id": run_id,
+            "case_id": case_id,
+            "case_step": 1,
+            "request_label": "actual",
+            "tool": "get_repo_map",
+            "status": "ok",
+            "rpc_ms": 5.0,
+            "schema_free_tool_request_cl100k": 10,
+            "schema_free_tool_response_cl100k": 20,
+            "schema_free_direct_payload_cl100k": 30,
+            "schema_free_tool_request_o200k": 9,
+            "schema_free_tool_response_o200k": 19,
+            "schema_free_direct_payload_o200k": 28,
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "source_inventory_after",
+            "run_id": run_id,
+            "case_id": case_id,
+            "inventory": {"tree_sha256": "0" * 64},
+            "changes": [],
+            "mutation_policy": {"safe": True, "violations": []},
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "baseline_total",
+            "run_id": run_id,
+            "case_id": case_id,
+            "direct_payload_cl100k": 50,
+            "direct_payload_o200k": 45,
+            "baseline_equivalence": "equivalent",
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "case_complete",
+            "run_id": run_id,
+            "case_id": case_id,
+            "status": "completed",
+        },
+        {
+            "protocol": harness.PROTOCOL_ID,
+            "record_type": "campaign_complete",
+            "run_id": run_id,
+            "selected": 1,
+            "completed": 1,
+            "failed": 0,
+        },
+    ]
+
+
+def synthetic_repeated_campaign_rows(
+    run_id: str,
+    cases_hash: str,
+    campaign_hash: str,
+) -> list[dict[str, Any]]:
+    """Mirror production: one selection with two ordered trial windows."""
+    base = synthetic_campaign_rows(run_id, cases_hash, campaign_hash)
+    rows = [dict(base[0])]
+    repeated_types = {"case_start", "direct_trial", "case_complete", "case_error"}
+    for ordinal in (1, 2):
+        for source in base[1:-1]:
+            record = dict(source)
+            if record.get("record_type") in repeated_types:
+                record["trial_ordinal"] = ordinal
+                record["measured_repetition"] = ordinal
+                record["discarded_warmup"] = False
+            rows.append(record)
+    campaign_complete = dict(base[-1])
+    campaign_complete["completed"] = 2
+    rows.append(campaign_complete)
+    return rows
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory(prefix="sfbench-adjudicator-") as root_text:
+        root = pathlib.Path(root_text)
+        cases_path = root / "cases.json"
+        campaign_path = root / "campaign.json"
+        asset_lock_path = root / "assets.lock.json"
+        evaluator_path = root / "evaluator.json"
+        manifest_path = root / "manifest.jsonl"
+        case = {
+            "id": "SELF-get_repo_map-001",
+            "primary_tool": "get_repo_map",
+            "case_kind": "happy",
+            "repo": "synthetic",
+            "language": "Python",
+            "surface": "full",
+            "requests": [
+                {
+                    "step": 1,
+                    "label": "actual",
+                    "tool": "get_repo_map",
+                    "args": {},
+                }
+            ],
+            "baseline_recipe": [{"executor": "shell"}],
+            "baseline_equivalence": "equivalent",
+            "limits": {
+                "call_limit": 1,
+                "timeout_seconds": 10,
+                "repetitions": 2,
+                "discarded_warmups": 0,
+            },
+            "mutation_allowlist": [],
+            "source_hash_policy": "no_source_bytes_may_change",
+        }
+        cases = {
+            "protocol": harness.PROTOCOL_ID,
+            "inventory": {
+                "full_surface_tools": ["get_repo_map"],
+                "full_surface_count": 1,
+                "compact_surface_tools": ["status", "symforge", "symforge_edit"],
+                "meta_surface_tools": ["symforge"],
+                "unique_tool_names": 4,
+            },
+            "cases": [case],
+        }
+        temp_write_json(cases_path, cases)
+        campaign = {"protocol": harness.PROTOCOL_ID, "name": "synthetic"}
+        temp_write_json(campaign_path, campaign)
+        cases_hash = file_sha256(cases_path)
+        campaign_hash = file_sha256(campaign_path)
+        asset_lock = {
+            "assets": [
+                {"path": "cases.json", "sha256": cases_hash},
+                {"path": "campaign.json", "sha256": campaign_hash},
+            ]
+        }
+        temp_write_json(asset_lock_path, asset_lock)
+        evaluator = {
+            "schema_version": EVALUATOR_SCHEMA,
+            "cases": {
+                case["id"]: {
+                    "status": "pass",
+                    "checks": [
+                        {
+                            "id": "inventory",
+                            "status": "pass",
+                            "evidence": ["synthetic-oracle:inventory"],
+                        }
+                    ],
+                    "baseline_equivalence": "valid",
+                    "baseline_correctness": "pass",
+                }
+            },
+        }
+        temp_write_json(evaluator_path, evaluator)
+        temp_write_jsonl(
+            manifest_path,
+            [
+                synthetic_manifest("full", ["get_repo_map"]),
+                synthetic_manifest("compact", ["status", "symforge", "symforge_edit"]),
+                synthetic_manifest("meta", ["symforge"]),
+            ],
+        )
+        repeated_path = root / "repeated-trials.jsonl"
+        temp_write_jsonl(
+            repeated_path,
+            synthetic_repeated_campaign_rows(
+                "self-test-repeated", cases_hash, campaign_hash
+            ),
+        )
+        artifact_paths = [repeated_path]
+
+        validation, state = validation_result(
+            artifact_paths,
+            [manifest_path],
+            cases_path,
+            asset_lock_path,
+            evaluator_path,
+        )
+        if validation["status"] != "valid":
+            raise AdjudicationError("self-test validation did not pass")
+        if validation["direct_trial_count"] != 2 or len(state["trials"]) != 2:
+            raise AdjudicationError("self-test repeated trial windows were collapsed")
+        summary = sanitize_output(build_summary(validation, state))
+        tool = summary["tools"][0]
+        if tool["tool"] != "get_repo_map" or tool["correctness"] != "PASS":
+            raise AdjudicationError("self-test correctness summary failed")
+        if tool["direct_metrics"]["sample_count"] != 2:
+            raise AdjudicationError("self-test repeated samples were not aggregated")
+        economics = tool["cases"][0]["direct_recipe_sensitivity"]
+        if not economics or any(item["verdict"] != "POSITIVE" for item in economics):
+            raise AdjudicationError("self-test recipe economics failed")
+        without_evaluator, state_without = validation_result(
+            artifact_paths,
+            [manifest_path],
+            cases_path,
+            asset_lock_path,
+            None,
+        )
+        if without_evaluator["status"] != "valid":
+            raise AdjudicationError("self-test unevaluated validation failed")
+        unevaluated = build_summary(without_evaluator, state_without)
+        if unevaluated["tools"][0]["correctness"] != "UNEVALUATED":
+            raise AdjudicationError("self-test inferred correctness without decisions")
+        if any(
+            item["verdict"] != "NOT_SCORED"
+            for item in unevaluated["tools"][0]["cases"][0][
+                "direct_recipe_sensitivity"
+            ]
+        ):
+            raise AdjudicationError("self-test scored unevaluated economics")
+        rendered = markdown_summary(summary)
+        if "case_complete` is capture-only" not in rendered:
+            raise AdjudicationError("self-test Markdown warning is absent")
+    print("adjudicate-results self-test: PASS")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "self-test":
+            return self_test()
+        return run_cli(args)
+    except AdjudicationError as exc:
+        print(f"adjudication error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/full-surface-benchmark/adjudication.md
+++ b/research/full-surface-benchmark/adjudication.md
@@ -1,0 +1,355 @@
+# SymForge benchmark adjudication specification
+
+This document defines how to turn benchmark JSONL evidence into correctness and
+token-economics results. It is subordinate to the
+[benchmark protocol](../../docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md)
+and the [frozen case manifest](./cases.json). The campaign identity, tokenizer
+locks, and safety settings come from [campaign.config.json](./campaign.config.json).
+
+The core rule is:
+
+> `case_complete` means that capture finished. It is not evidence that the tool
+> was correct, complete, deterministic, or economical.
+
+An efficient wrong answer is `INVALID_INCORRECT`. It never counts as a token
+saving.
+
+## 1. Inputs and fail-closed ingestion
+
+The adjudicator consumes:
+
+- one or more sanitized campaign JSONL files;
+- the exact `cases.json`, campaign config, corpus lock, corpus manifest, and
+  fixture `oracle.json` named by the campaign;
+- the executable, runner, harness, parser, and asset hashes recorded at capture;
+- paired-agent provider usage when the paired phase is enabled.
+
+Before evaluating a case, perform these checks in order:
+
+1. Verify every frozen input and executable hash.
+2. Verify the SUT version, surface, transport, repository commit, fixture hash,
+   tokenizer version, and tokenizer vocabulary hashes.
+3. Group records by `run_id`, `case_id`, repetition, cohort, and request step.
+4. Require exactly one `case_start`, the declared measured requests in order,
+   required per-step state records, and one terminal record.
+5. Reject unresolved placeholders, duplicate steps, unexpected measured calls,
+   missing token fields, or sanitizer redactions that obscure a mandatory fact.
+6. Parse tool output with a versioned parser. Store the parser version and hash.
+   A parse failure is `UNEVALUATED`, never a pass.
+7. Normalize only fields allowed by `parity-normalization.json`. Never normalize
+   paths, counts, source text, symbol identity, result ordering where ordering is
+   contractual, or Git state.
+
+Raw response text must never be persisted when it could contain a secret. Exact
+byte checks use an in-memory SHA-256 computed before sanitization plus sanitized
+semantic facts. If that fingerprint is absent, an exact-byte claim is not
+adjudicable.
+
+## 2. Correctness-first status model
+
+Artifact status and correctness status are separate.
+
+| Status | Meaning |
+|---|---|
+| `CAPTURED` | The runner reached `case_complete`; no correctness is implied. |
+| `ARTIFACT_INVALID` | Frozen identity, ordering, schema, or required evidence is missing or inconsistent. |
+| `UNEVALUATED` | Evidence exists, but a mandatory parser, oracle, or independent review is unresolved. |
+| `PASS` | Every mandatory automatic check and required independent review passed. |
+| `FAIL` | At least one mandatory correctness, determinism, or mutation check failed. |
+
+A happy case reaches `PASS` only when:
+
+1. every declared request completed in order with its expected status;
+2. every mandatory oracle check below passed;
+3. source and runtime mutation policies passed after every relevant step;
+4. required fresh repetitions completed with deterministic normalized facts;
+5. every fixed-rubric review is resolved;
+6. the case-specific stop condition, interpreted as all requests completed and
+   the objective oracle evaluated, is satisfied.
+
+All happy-path RPCs expect `ok`. A malformed source/config case still expects an
+`ok` tool response whose semantic result says invalid. It does not expect a
+JSON-RPC failure.
+
+## 3. Normalized result record
+
+Produce one adjudication record per case, repetition, and economics unit with
+these fields:
+
+```text
+identity:
+  run_id, case_id, primary_tool, repo, language, surface, transport
+  repetition, cohort, cache_state, sut_hash, input_hashes
+artifact:
+  status, parser_version, parser_hash, missing_records, redaction_conflicts
+steps[]:
+  step, label, economics_role, expected_status, actual_status, rpc_ms
+  raw_content_sha256, normalized_facts_sha256, evidence_record_ids
+checks[]:
+  check_id, oracle_source, expected_digest, observed_digest
+  status, evidence_record_ids, review_rubric
+correctness:
+  automatic_status, independent_review_status, final_status
+determinism:
+  required_repetitions, completed_repetitions, normalized_hashes, mismatches
+mutation:
+  policy, changed_paths, allowed_paths, violations
+latency:
+  samples, median_ms, iqr_ms, p95_ms, failures, timeouts
+tokens:
+  cl100k, o200k, provider_usage
+baseline:
+  arm, equivalence_status, correctness_status, token_totals, concerns
+economics[]:
+  view, workload_size, baseline_tokens, symforge_tokens, saved_tokens
+  savings_percent, cost_multiplier, verdict, reason
+```
+
+`checks[].status` is one of `pass`, `fail`, `manual_pending`, or
+`not_observable`. Any mandatory `manual_pending` or `not_observable` keeps the
+case `UNEVALUATED`.
+
+## 4. Mandatory happy-case checks
+
+The oracle notation below refers to independently generated fixture facts, Git
+plumbing, frozen native rubrics, or an economics-excluded evaluator call. An
+evaluator call may confirm state after measured calls, but its tokens and latency
+must not enter the task economics.
+
+### 4.1 Mutation, runtime, and state tools
+
+| Case/tool | Mandatory checks | Economics unit and pre-freeze requirements |
+|---|---|---|
+| `SF-analyze_file_impact-001` / `analyze_file_impact` | Modified symbols are exactly `sfbench_leaf`; added/removed sets are empty; affected dependents equal the graph-derived contract set; an excluded follow-up symbol read matches the mutated source hash. | One measured call. **Pre-freeze:** add the follow-up evidence needed to prove refreshed indexed bytes. |
+| `SF-batch_edit-001` / `batch_edit` | Dry run leaves both target hashes unchanged; apply produces independently frozen hashes for both files; replay changes no bytes and identifies stored replay; Rust syntax is valid. | Preview+apply is the normal workflow; replay is a diagnostic. **Pre-freeze:** freeze combined per-file output hashes and per-step state fingerprints. |
+| `SF-batch_insert-001` / `batch_insert` | Preview changes zero bytes; apply inserts exactly twice before the two anchors with correct indentation; final hash matches an independently generated oracle; Rust syntax is valid. | Preview+apply. **Pre-freeze:** the claim says replay-safe but has no replay request; add one or remove that claim. |
+| `SF-batch_rename-001` / `batch_rename` | Preview changes zero bytes; apply changes exactly the definition and four code references; two comment/string mentions remain; final hash and Rust syntax match the oracle. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-checkpoint_now-001` / `checkpoint_now` | Snapshot exists and is nonempty; verify-after-write succeeded; no partial temp remains; an excluded restart loads the snapshot and reproduces project identity and counts. | One task call; restart is evaluator evidence. Baseline is capability-only. **Pre-freeze:** add restart/load evidence. |
+| `SF-context_inventory-001` / `context_inventory` | Fetched-file count, fetched-symbol count, and associated content tokens are zero; no prior commitment retrieval occurred. | One call. Automatic, but the recipe baseline is only a narrow fresh-session control. |
+| `SF-delete_symbol-001` / `delete_symbol` | Preview changes zero bytes; apply equals the oracle final hash; target symbol is absent; adjacent blank lines are normalized; Rust syntax is valid. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-detect_impact-001` / `detect_impact` | Impact marker is present; payload is valid JSON with the documented schema; changed file/symbol equal the dirty leaf; depth-1 blast radius equals the direct caller set with correct hop/risk; data files are absent. | One call. Fully automatable. |
+| `SF-edit_within_symbol-001` / `edit_within_symbol` | Preview changes zero bytes; final hash equals the oracle; both in-symbol literals change; the one outside literal remains; Rust syntax is valid. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-health-001` / `health` | Loading response is bounded and honest; project identity and counts agree with independent admitted-file/symbol evidence; reported load source agrees with lifecycle and snapshot evidence. | Cold, snapshot-warm, and process-warm are separate cohorts. **Pre-freeze:** the current two requests do not deterministically cover all three claimed states. |
+| `SF-health_compact-001` / `health_compact` | Shared state, project, count, issue, and snapshot fields equal the full-health reference; compact response content tokens are lower. | Compact is the task; full health is an excluded reference call. |
+| `SF-index_folder-001` / `index_folder` | First call targets the expected project identity and produces expected index anchors/counts; replay is identified as replay, performs no rebuild, and duplicates no watcher/project state. | First call is the task; replay is diagnostic. Baseline is capability-only. **Pre-freeze:** define admitted count/anchor oracles. |
+| `SF-insert_symbol-001` / `insert_symbol` | Preview changes zero bytes; apply matches an independently frozen final hash; placement before the anchor, indentation, and Rust syntax are exact. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-replace_symbol_body-001` / `replace_symbol_body` | Preview changes zero bytes; apply equals oracle file and diff hashes; unrelated Unicode/newline bytes remain exact; Rust syntax is valid; guard use is reported. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-status-001` / `status` | Version, surface, and wiring agree with the live manifest; project identity and index fields agree with excluded health evidence; projects detail contains exactly one home project in isolated mode. | Compact/full/projects are separate variants. Baseline is capability-only. **Pre-freeze:** capture excluded manifest/health parity evidence. |
+| `SF-symforge_edit-001` / `symforge_edit` | Preview changes zero bytes; apply equals the replacement oracle hash; indentation is not doubled; exact-body guard is accepted; Rust syntax is valid. | Preview+apply. **Pre-freeze:** add the claimed replay request or narrow the claim. |
+| `SF-what_changed-001` / `what_changed` | Normalize the exact six staged/unstaged/untracked/rename/add/delete states; file set equals Git plumbing; fused symbol delta equals an independent before/after parser oracle. | One call. **Pre-freeze:** freeze the fused symbol-delta oracle. |
+
+### 4.2 Read, search, guidance, and facade tools
+
+| Case/tool | Mandatory checks | Economics unit and pre-freeze requirements |
+|---|---|---|
+| `SF-ask-001` / `ask` | Route category is definition lookup; path, name, kind, and start line equal the unique Python leaf oracle. | One call. Allow a frozen equivalent-route set; explanation quality uses a rubric. |
+| `SF-conventions-001` / `conventions` | Extract naming, error handling, imports, tests, and layout facts; compare them with independent stratified counts and sampled native files; reject contradictions. | One call. **Pre-freeze:** freeze the ripgrep convention rubric and thresholds. Qualitative synthesis requires fixed-rubric review. |
+| `SF-diff_symbols-001` / `diff_symbols` | Per-file added/removed/modified symbol sets equal an independently parsed Git ref diff. | One call. **Pre-freeze blocker:** current `sfbench-v1` maps to final replay `HEAD`, and the Rust path does not change. Choose a real differing ref/path or make the expected empty result explicit. |
+| `SF-edit_plan-001` / `edit_plan` | Exact target identity and reference count match the oracle; suggested sequence includes impact/discovery, the correct structural edit family, and post-edit impact without irrelevant operations. | One call. Count checks are automatic; “minimal” ordering uses a frozen allowed-sequence rubric. |
+| `SF-explore-001` / `explore` | Required native ripgrep anchors and paths are present; signatures are present; reported first-hop edges resolve to real symbols; no invented anchor appears. | One call. **Pre-freeze:** freeze the native command-parsing anchors. Relevance/coverage requires rubric review. |
+| `SF-find_dependents-001` / `find_dependents` | Dependent set for Python protocol is exactly `core.py`; edge kind is import; no unrelated cycle/test file appears. | One call. Fully automatable. |
+| `SF-find_references-001` / `find_references` | Full set equals the leaf call from `sfbench_mid`, classified as a call with exact location; compact normalized set equals full. | Full and compact are separate variants, not a summed task. |
+| `SF-get_file_content-001` / `get_file_content` | Strip documented framing, reconstruct returned source, and compare line-range, offset/limit, and full-file bytes/lines with the oracle; verify headers and line numbers independently. | Three separate variants. Exact checks require pre-sanitization fingerprints. |
+| `SF-get_file_context-001` / `get_file_context` | Outline equals symbols in Python core; imports equal import oracle; consumers equal dependent-file oracle; references equal call graph; Git anchors equal frozen history. | One call. Set checks are automatic. |
+| `SF-get_repo_map-001` / `get_repo_map` | File, language, and top-directory counts equal pre-session native inventory under documented admission rules; required native anchors are present; estimate error is recorded against actual content tokens. | Actual is the task; estimate is diagnostic. **Pre-freeze:** distinguish indexed/admitted counts from raw tracked counts. |
+| `SF-get_symbol-001` / `get_symbol` | Source-body hash, byte span, line span, kind, and path equal the oracle; force-refresh normalized facts equal actual; estimate error is recorded. | Actual and refresh are separate cache cohorts; estimate is excluded. |
+| `SF-get_symbol_context-001` / `get_symbol_context` | Definition identity is exact; callers equal `{sfbench_mid}`; callees are empty; every real verbosity preserves its required identity/edge facts. | Each verbosity is separate. **Pre-freeze:** the current summary request is estimate-only, so add an actual summary call before scoring summary parity or estimate accuracy. |
+| `SF-inspect_match-001` / `inspect_match` | Enclosing symbol, span, parent chain, sibling set, and excerpt equal independently derived structure around the requested line. | One call. **Pre-freeze:** the target leaf is top-level while the claim says nested; fix the claim or select a nested symbol. |
+| `SF-investigation_suggest-001` / `investigation_suggest` | Initial step loads only entry; suggestions include real unloaded `sfbench_mid`/worker dependencies; loaded entry is not repeated; every suggestion resolves to a real path/symbol. | `get_symbol` plus suggestion is one required workflow. Membership is automatic; ranking usefulness uses a rubric. |
+| `SF-search_files-001` / `search_files` | Fuzzy results include both duplicate paths; resolve returns the exact `a/` path; ranking explanation cites real current-file/path-prefix evidence. | Fuzzy and resolve are separate variants. Set checks are automatic; ranking explanation uses a rubric. |
+| `SF-search_symbols-001` / `search_symbols` | Result set contains exactly the Rust leaf with oracle path/kind/start line; no test/generated/vendor/personal result appears; precision and recall are both one. | One call. Fully automatable. |
+| `SF-search_text-001` / `search_text` | Exact Rust source-marker hit set, enclosing symbol, and caller enrichment match the oracle; no test/generated/vendor/personal noise appears. | One call. Fully automatable. |
+| `SF-symforge_retrieve-001` / `symforge_retrieve` | Trigger yields exactly one handle; retrieved raw payload contains the expected generated symbols/count and equals the captured uncompressed payload fingerprint; repeat bytes are identical. | Summary task is trigger only; exact-detail task is trigger+retrieve; repeated retrieve is diagnostic. |
+| `SF-validate_file_syntax-001` / `validate_file_syntax` | Valid JSON is accepted; malformed JSON is semantically rejected while RPC remains successful; diagnostic line agrees with the authoritative parser where promised; estimate error is recorded. | Valid and malformed are separate tasks; estimate is diagnostic. |
+| `SF-symforge-001` / `symforge` | For each intent, extract route identity and facts; compare with economics-excluded granular evidence for definition, callers, source body, graph orientation, impact, exact file resolution, and next-context suggestion. | Seven separate intent tasks, never one summed task. Fact parity is automatic; route optimality/explanation quality uses a rubric. |
+
+## 5. Economics roles
+
+Every request must have one role:
+
+| Role | Included in ordinary task economics? |
+|---|---|
+| `task` | Yes. |
+| `required_prerequisite` | Yes, when the task cannot be completed without it. |
+| `comparison_variant` | No; report as a separate task variant. |
+| `estimate_diagnostic` | No, unless the user task explicitly asks for an estimate. |
+| `oracle_reference` | No. |
+| `replay_diagnostic` | No; report idempotency/replay overhead separately. |
+| `warmup` | No. |
+
+Apply these case rules:
+
+- edit preview+apply is one normal workflow;
+- replay calls are diagnostics;
+- estimate calls are diagnostics;
+- full health in compact/full parity is an oracle reference;
+- reference/verbosity/read/detail modes are separate variants unless the user
+  task explicitly requires more than one;
+- `investigation_suggest` includes the initial symbol load as a required
+  prerequisite;
+- CCR summary-only is trigger-only, exact-detail is trigger+retrieve, and repeat
+  is diagnostic;
+- each of the seven `symforge` intents is a separate task.
+
+## 6. Token accounting
+
+Calculate every independent view for both `cl100k_base` and `o200k_base`.
+Provider-reported totals are primary for paired tasks.
+
+For encoding `e`, over task-role measured calls:
+
+```text
+Q_e = sum(schema_free_tool_request_e)
+C_e = sum(schema_free_tool_response_e)
+P_e = sum(schema_free_direct_payload_e)
+```
+
+Validate all three recorded fields independently. Do **not** require
+`P_e == Q_e + C_e`: BPE tokenization is not additive across a serialization
+boundary, so tokenizing the canonical combined direct payload can legitimately
+differ from tokenizing its request and response components separately. `P_e` is
+the primary task-cost measurement; `Q_e` and `C_e` are diagnostic decompositions.
+
+### 6.1 Content-only and direct payload
+
+```text
+content_only_symforge_e = C_e
+content_only_baseline_e = sum(baseline output tokens)
+
+direct_payload_symforge_e = P_e
+direct_payload_recipe_baseline_e = baseline_total.direct_payload_e
+```
+
+Content-only is diagnostic. Direct payload is the direct-RPC comparison. Neither
+is interchangeable with the complete paired-agent task total.
+
+### 6.2 Cold eager schema
+
+```text
+cold_eager_symforge_e = P_e + S_surface_e
+cold_eager_baseline_e = B_payload_e + S_baseline_surface_e
+```
+
+`S_surface_e` is the exact model-visible surface when captured. Serialized
+`tools/list` is a theoretical fallback, not proof that a client sent every
+schema. Full tools use the full-36 surface; compact/meta tools use their actual
+3/1-tool surfaces. Do not calculate schema-inclusive savings when the baseline
+schema is absent.
+
+### 6.3 Tool-specific lazy schema
+
+```text
+S_lazy_unique_e =
+  sum(individual schema tokens for distinct top-level tools exposed for task)
+
+lazy_unique_symforge_e = P_e + S_lazy_unique_e
+
+S_lazy_per_turn_e =
+  sum(exact model-visible schema definitions on each actual model turn)
+```
+
+For facades such as `ask` and `symforge`, internal server routing does not add
+routed-tool schema. Only top-level model-visible definitions count.
+
+### 6.4 Five- and twenty-task amortization
+
+The one-time-schema calculation is a labeled counterfactual only:
+
+```text
+amortized_e(N) =
+  (sum(P_e for N tasks) + S_surface_e + one_time_visible_setup_e) / N
+```
+
+For identical tasks:
+
+```text
+amortized_e(N) = P_e + (S_surface_e + one_time_visible_setup_e) / N
+```
+
+Report `N=5` and `N=20`, plus `N=1`. Label these
+`theoretical_one_time_schema`. Clients may resend schema every turn.
+
+The actual longitudinal result is:
+
+```text
+actual_session_per_task_e(N) = provider_session_total_tokens_e / N
+```
+
+Provider totals already containing schema, cached input, reasoning, or transcript
+replay must not receive those components a second time.
+
+### 6.5 Savings and break-even
+
+```text
+saved_tokens = baseline_total_tokens - symforge_total_tokens
+savings_percent = 100 * saved_tokens / baseline_total_tokens
+cost_multiplier = symforge_total_tokens / baseline_total_tokens
+negative_trial_rate = token_negative_trials / valid_paired_trials
+```
+
+If baseline tokens are zero, keep the absolute delta but set percentage and
+multiplier to null.
+
+```text
+break_even_tasks = ceil(
+  (symforge_setup_cost - baseline_setup_cost) /
+  (baseline_query_cost - symforge_query_cost)
+)
+```
+
+If the denominator is zero or negative, report `no break-even observed`.
+
+Aggregate tokens before calculating percentages:
+
+- micro: pool valid tokens for the declared workload;
+- macro: pool within each task/repository stratum, then equal-weight strata;
+- report median, IQR, p95, all failures/timeouts, negative-trial rate, and the
+  paired bootstrap confidence interval.
+
+## 7. Economics verdict precedence
+
+Reject `ARTIFACT_INVALID` and incomplete-accounting records before economics.
+Then apply exactly this order:
+
+1. `INVALID_INCORRECT` if either arm fails the same correctness oracle.
+2. `N/A_NO_EQUIVALENT_BASELINE` when the baseline is capability-only,
+   materially partial, or incorrect. Record a reason such as `capability_gain`.
+3. `TOKEN_NEGATIVE`, `POSITIVE`, or `NEUTRAL` for each valid view/trial.
+4. `MIXED` only for an aggregate containing both positive and token-negative
+   valid trials.
+
+Never turn a failed, partial, or capability-only baseline into zero tokens or
+infinite savings.
+
+## 8. Baseline-equivalence caveats
+
+- Happy edit recipes for `batch_edit`, `batch_insert`, `batch_rename`,
+  `delete_symbol`, `edit_within_symbol`, `insert_symbol`,
+  `replace_symbol_body`, and `symforge_edit` reference patches that are not
+  present in the frozen oracle. Recipe economics are unavailable until exact
+  patches and expected hashes are asset-locked.
+- `checkpoint_now`, `index_folder`, and `status` are capability-only.
+- `health` and `health_compact` shell recipes observe file/snapshot existence,
+  not parser, watcher, load-source, or trust state. Split observable subclaims or
+  use `N/A_NO_EQUIVALENT_BASELINE` for the full claim.
+- `context_inventory` uses a synthetic empty list rather than an independent
+  observation. Treat it as a narrow control, not general equivalence.
+- The `get_file_content` PowerShell recipe is not byte exact. Replace it with raw
+  byte reading and a deterministic representation or hash.
+- `conventions`, `explore`, `edit_plan`, `investigation_suggest`, and `symforge`
+  recipes are retrieval lower bounds, not completed equivalent answers. Their
+  paired free-agent baseline is the headline.
+- `detect_impact`, `diff_symbols`, `get_file_context`,
+  `get_symbol_context`, and `inspect_match` recipes expose raw evidence but do
+  not independently perform the claimed classification. Keep recipe totals as
+  sensitivity lower bounds.
+- Mutation recipes verify `git diff --check`, not Rust syntax. Add an
+  authoritative parser/compiler check.
+- `symforge_retrieve` has an equivalent ordinary path for exact content, but no
+  ordinary equivalent for CCR handle/session semantics. Split task-outcome and
+  capability economics.
+- A baseline arm that does not pass the same objective oracle is not a SymForge
+  win; it is an invalid comparison.
+
+The paired free-agent LLM arm remains the headline comparison. Recipe results
+are stable lower-bound sensitivity measurements and must be labeled as such.

--- a/research/full-surface-benchmark/assets.lock.json
+++ b/research/full-surface-benchmark/assets.lock.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "1.0",
+  "protocol": "SFBENCH-1.0",
+  "frozen_at": "2026-07-12",
+  "core_assets": [
+    {
+      "path": "research/full-surface-benchmark/cases.json",
+      "sha256": "7bbf41fa3b6a827cd0aa50e37fde993447be7703645174005129aef2f2a8db58"
+    },
+    {
+      "path": "research/full-surface-benchmark/campaign.config.json",
+      "sha256": "85b60a9fafd763e03aa97563807d135b2995dcaf7da207fcc0723e8b3ae27662"
+    },
+    {
+      "path": "research/full-surface-benchmark/corpus.lock.json",
+      "sha256": "1376e2fb33963d142409cbdccc7fa75593f85ebfa8ae607a90a797dac588f316"
+    },
+    {
+      "path": "corpus-manifest.json",
+      "sha256": "a8d154c61f2ff228e9b254851e06cd7d236766d4bf191abbd094b7934f041158"
+    },
+    {
+      "path": "oracle.json",
+      "sha256": "eb1fd3d075a1a29626a25d4b65faa7124c83db9c0ed1109e2cb9dcc90b12fadd"
+    },
+    {
+      "path": "research/full-surface-benchmark/direct_case_runner.py",
+      "sha256": "90b92b450375fec071cc23ae4a522ebcfb73b2efe8574ea7a86a9ef37f3edd15"
+    },
+    {
+      "path": "research/full-surface-benchmark/mcp_harness.py",
+      "sha256": "1f2696eb0ef32636c52171606863a7a5beaf1003bb29477d7fc11aebf60fe2b4"
+    },
+    {
+      "path": "research/full-surface-benchmark/fixture_generator.py",
+      "sha256": "99275c0c7143b940f4acb35c4624f6e971f87e33763eefc32f45c23886340b8e"
+    },
+    {
+      "path": "research/full-surface-benchmark/parity-normalization.json",
+      "sha256": "f1a50e26c2fc89da5c4073c7e152678078bc956971d61bc509040920c4cd28b3"
+    },
+    {
+      "path": "research/full-surface-benchmark/baseline-patches.json",
+      "sha256": "c4116e246edac2aee8f32ce933e3a05bc169c3378da15ff4bfd3fac2cff9d935"
+    }
+  ],
+  "auxiliary_assets": [
+    {
+      "path": "research/full-surface-benchmark/claude_task_runner.py",
+      "sha256": "837489f3953de0fea54fb2135dcd3fd66ff7df30553bc605d20e1b56bd6cd675"
+    },
+    {
+      "path": "research/full-surface-benchmark/non_tool_surface_smoke.py",
+      "sha256": "44d5b4fcac134d466d2a2995fabeadcfa6e51b31fa94e7d7d23be8b3e99bce81"
+    },
+    {
+      "path": "research/full-surface-benchmark/setup_corpus.ps1",
+      "sha256": "849d25159d9e2c42ae0399eeef7ddd5400ce9da58828ef3b71303960d897924a"
+    },
+    {
+      "path": "research/full-surface-benchmark/adjudication.md",
+      "sha256": "79fe6948b1e050af78c0868a2e983a7016e9c006018aad48fe6c174726c4702d"
+    }
+  ],
+  "system_under_test": {
+    "path": "symforge.exe",
+    "version": "8.14.0",
+    "sha256": "294ad9fae560ac217b10d685aa06c2a8fbaa63794d6f70bb92c2f5f61f9947fe"
+  },
+  "notes": [
+    "Core assets are fail-closed inputs verified by direct_case_runner.py.",
+    "Auxiliary assets are frozen for audit reproducibility.",
+    "The fixture tree, Git worktree state, corpus commits, tokenizer vocabulary, and SUT identity are independently verified by the runner."
+  ]
+}

--- a/research/full-surface-benchmark/baseline-patches.json
+++ b/research/full-surface-benchmark/baseline-patches.json
@@ -1,0 +1,257 @@
+{
+  "patch_count": 16,
+  "patches": {
+    "SF-batch_edit-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "e7bb0c6d27f867eb0a3382ed0f21c6faa7449930e6614997253ee72045e6b1ff",
+        "sfbench_fixture/rust/src/protocol.rs": "82d27d23b846aa2b2f9f536e36b4e186296e68e1bef035c80ca6825eb568b149"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e",
+        "sfbench_fixture/rust/src/protocol.rs": "1a5a025915918e483143f71b276dfa78f3c3923961368ecf1cd2ded936891771"
+      },
+      "case_id": "SF-batch_edit-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -45,7 +45,7 @@\n }\n \n pub fn sfbench_mutable() -> (&'static str, &'static str, &'static str) {\n-    let first = \"SF_BENCH_EDIT_OLD_9F31\";\n+    let first = \"SF_BENCH_EDIT_NEW_9F31\";\n     let unicode_inside = \"\u017earek \u03bb\";\n     let second = \"SF_BENCH_EDIT_OLD_9F31\";\n     (first, unicode_inside, second)\n--- a/sfbench_fixture/rust/src/protocol.rs\n+++ b/sfbench_fixture/rust/src/protocol.rs\n@@ -1,3 +1,7 @@\n pub trait SfBenchProtocol {\n     fn run(&self) -> String;\n }\n+\n+pub fn sfbench_inserted() -> &'static str {\n+    \"inserted\"\n+}\n",
+      "patch_sha256": "84025fa53397f846dc9d1fc7720d98e1155781586bcf272b2bb6b810620cedbd",
+      "patch_utf8_bytes": 611,
+      "placeholder": "${fixture.oracle.mutations.Rust.batch_edit.patch}",
+      "recipe_step": 2
+    },
+    "SF-batch_edit-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "0e9ae23dc97a000f928e9a3c10a5993855239f42ed910a5c10ee2e7ae6e97107"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-batch_edit-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -43,7 +43,7 @@\n }\n \n export function sfbench_mutable(): [string, string, string] {\n-  const first = \"SF_BENCH_EDIT_OLD_9F31\";\n+  const first = \"SF_BENCH_EDIT_NEW_9F31\";\n   const unicodeInside = \"\u017earek \u03bb\";\n   const second = \"SF_BENCH_EDIT_OLD_9F31\";\n   return [first, unicodeInside, second];\n@@ -51,10 +51,6 @@\n \n export function sfbench_outside_literal(): string {\n   return \"SF_BENCH_EDIT_OLD_9F31\";\n-}\n-\n-export function sfbench_delete_me(): string {\n-  return \"delete\";\n }\n \n export namespace SfBenchOuter {\n",
+      "patch_sha256": "4452fcbf88219d73d881b58159ab842de89689cc28b02eac8f2338a1d36763eb",
+      "patch_utf8_bytes": 606,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.batch_edit.patch}",
+      "recipe_step": 2
+    },
+    "SF-batch_insert-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "f59268ae1b3661551501b9c88753d4bb8bbd0a9fd537469283427114fedb43f1",
+        "sfbench_fixture/rust/src/protocol.rs": "63e8a586ebef39bd2a1a466d25bcbf9e265d21123c8305d276167b3553c7dbd3"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e",
+        "sfbench_fixture/rust/src/protocol.rs": "1a5a025915918e483143f71b276dfa78f3c3923961368ecf1cd2ded936891771"
+      },
+      "case_id": "SF-batch_insert-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -21,6 +21,10 @@\n     fn run(&self) -> String {\n         sfbench_rename_me()\n     }\n+}\n+\n+pub fn sfbench_inserted() -> &'static str {\n+    \"inserted\"\n }\n \n pub fn sfbench_entry() -> String {\n--- a/sfbench_fixture/rust/src/protocol.rs\n+++ b/sfbench_fixture/rust/src/protocol.rs\n@@ -1,3 +1,7 @@\n+pub fn sfbench_inserted() -> &'static str {\n+    \"inserted\"\n+}\n+\n pub trait SfBenchProtocol {\n     fn run(&self) -> String;\n }\n",
+      "patch_sha256": "cee82d8236eac299a7ba9cf778a19c406b75df197f4192de305bc3531be80752",
+      "patch_utf8_bytes": 501,
+      "placeholder": "${fixture.oracle.mutations.Rust.batch_insert_before.patch}",
+      "recipe_step": 2
+    },
+    "SF-batch_insert-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "3ac90f755c72d868a1a8d8a671230086f00056af6b967ea1e9029c4141b9042c"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-batch_insert-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -26,8 +26,16 @@\n   return `${sfbench_mid()}:${worker.run()}`;\n }\n \n+export function sfbench_inserted(): string {\n+  return \"inserted\";\n+}\n+\n export function sfbench_unused(): string {\n   return \"unused\";\n+}\n+\n+export function sfbench_inserted(): string {\n+  return \"inserted\";\n }\n \n export function sfbench_rename_user_one(): string {\n",
+      "patch_sha256": "1bce7e96fd3d4dc89c87a18bf0123a194d292bc74f1f6c6c62ed2b884f590ce5",
+      "patch_utf8_bytes": 428,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.batch_insert_after.patch}",
+      "recipe_step": 2
+    },
+    "SF-batch_rename-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "3454c8a8a7f055b7c69030570402d1f742e915c49c69d6a5b616aa9d890a2944"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-batch_rename-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -11,7 +11,7 @@\n     sfbench_leaf()\n }\n \n-pub fn sfbench_rename_me() -> String {\n+pub fn sfbench_renamed() -> String {\n     \"rename\".to_owned()\n }\n \n@@ -19,7 +19,7 @@\n \n impl SfBenchProtocol for SfBenchWorker {\n     fn run(&self) -> String {\n-        sfbench_rename_me()\n+        sfbench_renamed()\n     }\n }\n \n@@ -33,15 +33,15 @@\n }\n \n pub fn sfbench_rename_user_one() -> String {\n-    sfbench_rename_me()\n+    sfbench_renamed()\n }\n \n pub fn sfbench_rename_user_two() -> String {\n-    sfbench_rename_me()\n+    sfbench_renamed()\n }\n \n pub fn sfbench_rename_user_three() -> String {\n-    sfbench_rename_me()\n+    sfbench_renamed()\n }\n \n pub fn sfbench_mutable() -> (&'static str, &'static str, &'static str) {\n",
+      "patch_sha256": "45c7278038fda5e466033ac144e2675a031878745f0ce4a15ac40fe8b302c8be",
+      "patch_utf8_bytes": 788,
+      "placeholder": "${fixture.oracle.mutations.Rust.rename_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-delete_symbol-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "964d6f536b0f80c0a8231f43cf29e4853044e26e4d595aa5e248016537c76a33"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-delete_symbol-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -55,10 +55,6 @@\n     \"SF_BENCH_EDIT_OLD_9F31\"\n }\n \n-pub fn sfbench_delete_me() -> &'static str {\n-    \"delete\"\n-}\n-\n pub mod sfbench_outer {\n     pub mod inner {\n         pub fn sfbench_nested() -> &'static str {\n",
+      "patch_sha256": "bbdf6a35f2fdcfdc06c6cef67cbd465bc0c6ab8e0e158ae5b39e93ae4fb4e6e9",
+      "patch_utf8_bytes": 294,
+      "placeholder": "${fixture.oracle.mutations.Rust.delete_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-delete_symbol-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "b15888c08e6ead482949204e606b8809fae5a7e51b2197bae89569af2bb82878"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-delete_symbol-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -53,10 +53,6 @@\n   return \"SF_BENCH_EDIT_OLD_9F31\";\n }\n \n-export function sfbench_delete_me(): string {\n-  return \"delete\";\n-}\n-\n export namespace SfBenchOuter {\n   export class Inner {\n     sfbench_nested(): string {\n",
+      "patch_sha256": "3a3bb6e39fc6a3b3c27711dbd4900e513d53b087d94714235c910c0c7962c557",
+      "patch_utf8_bytes": 311,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.delete_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-edit_within_symbol-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "e4682227ea279fdae8c3acba284b763f46c3316b96bd9fb7f60e7cca35448672"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-edit_within_symbol-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -45,9 +45,9 @@\n }\n \n pub fn sfbench_mutable() -> (&'static str, &'static str, &'static str) {\n-    let first = \"SF_BENCH_EDIT_OLD_9F31\";\n+    let first = \"SF_BENCH_EDIT_NEW_9F31\";\n     let unicode_inside = \"\u017earek \u03bb\";\n-    let second = \"SF_BENCH_EDIT_OLD_9F31\";\n+    let second = \"SF_BENCH_EDIT_NEW_9F31\";\n     (first, unicode_inside, second)\n }\n \n",
+      "patch_sha256": "6ba7609d0953309b4cde5b4e040e92e07c4d1d872bef6e0909f86803bd69a1ed",
+      "patch_utf8_bytes": 430,
+      "placeholder": "${fixture.oracle.mutations.Rust.edit_within.patch}",
+      "recipe_step": 2
+    },
+    "SF-edit_within_symbol-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "5eacb3b2f86cb2c17f967aec14d17270f0ecfb9687f42386ebdd8d9a7015d332"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-edit_within_symbol-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -43,9 +43,9 @@\n }\n \n export function sfbench_mutable(): [string, string, string] {\n-  const first = \"SF_BENCH_EDIT_OLD_9F31\";\n+  const first = \"SF_BENCH_EDIT_NEW_9F31\";\n   const unicodeInside = \"\u017earek \u03bb\";\n-  const second = \"SF_BENCH_EDIT_OLD_9F31\";\n+  const second = \"SF_BENCH_EDIT_NEW_9F31\";\n   return [first, unicodeInside, second];\n }\n \n",
+      "patch_sha256": "cf5f4429958af253927636e2a43c22f9f38e1486f31974f737c453c366428ba0",
+      "patch_utf8_bytes": 435,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.edit_within.patch}",
+      "recipe_step": 2
+    },
+    "SF-insert_symbol-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "f59268ae1b3661551501b9c88753d4bb8bbd0a9fd537469283427114fedb43f1"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-insert_symbol-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -21,6 +21,10 @@\n     fn run(&self) -> String {\n         sfbench_rename_me()\n     }\n+}\n+\n+pub fn sfbench_inserted() -> &'static str {\n+    \"inserted\"\n }\n \n pub fn sfbench_entry() -> String {\n",
+      "patch_sha256": "f57c27f285e08e7bb7a459f12aca615015f27ff054fb38993f066e0dbc6e7bd1",
+      "patch_utf8_bytes": 271,
+      "placeholder": "${fixture.oracle.mutations.Rust.insert_symbol.before_patch}",
+      "recipe_step": 2
+    },
+    "SF-insert_symbol-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "32e703873ad87e7b0b4501c2ece5b1a474b4611c9f9586fca60e7ff50080a89d"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-insert_symbol-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -24,6 +24,10 @@\n export function sfbench_entry(): string {\n   const worker = new SfBenchWorker();\n   return `${sfbench_mid()}:${worker.run()}`;\n+}\n+\n+export function sfbench_inserted(): string {\n+  return \"inserted\";\n }\n \n export function sfbench_unused(): string {\n",
+      "patch_sha256": "d60746ee7862e59d110a5071d8da9afb57b52a47a852618687897d89ffb95a36",
+      "patch_utf8_bytes": 359,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.insert_symbol.after_patch}",
+      "recipe_step": 2
+    },
+    "SF-replace_symbol_body-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "44d8269f12e936e6b3999f4fb62f35c9a13f702d9521a068d11c2329303df9cb"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-replace_symbol_body-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -4,7 +4,7 @@\n pub const SF_BENCH_UNICODE_BEFORE: &str = \"na\u00efve \u03bb\";\n \n pub fn sfbench_leaf() -> String {\n-    \"leaf\".to_owned()\n+    \"leaf-v2\".to_owned()\n }\n \n pub fn sfbench_mid() -> String {\n",
+      "patch_sha256": "44a0fd676849bc0af45e8efda57075a68e2039107bc9ecfecb84a8fa9aae8a18",
+      "patch_utf8_bytes": 275,
+      "placeholder": "${fixture.oracle.mutations.Rust.replace_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-replace_symbol_body-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "b3b76f6602750047943561a258b8d404112fec36fd9a6180f96d891577c07d42"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-replace_symbol_body-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -4,7 +4,7 @@\n export const SF_BENCH_UNICODE_BEFORE = \"na\u00efve \u03bb\";\n \n export function sfbench_leaf(): string {\n-  return \"leaf\";\n+  return \"leaf-v2\";\n }\n \n export function sfbench_mid(): string {\n",
+      "patch_sha256": "0d3bcf3747c251ba1b98e8c9e49f332366b2d1be76d2f564cab027c1ad5f20fe",
+      "patch_utf8_bytes": 288,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.replace_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-symforge_edit-001": {
+      "after_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "44d8269f12e936e6b3999f4fb62f35c9a13f702d9521a068d11c2329303df9cb"
+      },
+      "apply_during_baseline": true,
+      "before_sha256": {
+        "sfbench_fixture/rust/src/core.rs": "9df53742dfcb0876e5ca0a949d2fc79a3a3fac7ad7e244ea48400a53f121627e"
+      },
+      "case_id": "SF-symforge_edit-001",
+      "patch": "--- a/sfbench_fixture/rust/src/core.rs\n+++ b/sfbench_fixture/rust/src/core.rs\n@@ -4,7 +4,7 @@\n pub const SF_BENCH_UNICODE_BEFORE: &str = \"na\u00efve \u03bb\";\n \n pub fn sfbench_leaf() -> String {\n-    \"leaf\".to_owned()\n+    \"leaf-v2\".to_owned()\n }\n \n pub fn sfbench_mid() -> String {\n",
+      "patch_sha256": "44a0fd676849bc0af45e8efda57075a68e2039107bc9ecfecb84a8fa9aae8a18",
+      "patch_utf8_bytes": 275,
+      "placeholder": "${fixture.oracle.mutations.Rust.replace_symbol.patch}",
+      "recipe_step": 2
+    },
+    "SF-symforge_edit-003": {
+      "after_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "61f4f420880493b3dfd94241aa32ac96f18e84df753401831a602091257cfe51"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/typescript/src/core.ts": "8b688c92e5adebeb2fa3bd6cf5bfe59ecc5d963e2f0857578275daf008b33c9a"
+      },
+      "case_id": "SF-symforge_edit-003",
+      "patch": "--- a/sfbench_fixture/typescript/src/core.ts\n+++ b/sfbench_fixture/typescript/src/core.ts\n@@ -19,6 +19,10 @@\n   run(): string {\n     return sfbench_rename_me();\n   }\n+}\n+\n+export function sfbench_inserted(): string {\n+  return \"inserted\";\n }\n \n export function sfbench_entry(): string {\n@@ -43,9 +47,9 @@\n }\n \n export function sfbench_mutable(): [string, string, string] {\n-  const first = \"SF_BENCH_EDIT_OLD_9F31\";\n+  const first = \"SF_BENCH_EDIT_NEW_9F31\";\n   const unicodeInside = \"\u017earek \u03bb\";\n-  const second = \"SF_BENCH_EDIT_OLD_9F31\";\n+  const second = \"SF_BENCH_EDIT_NEW_9F31\";\n   return [first, unicodeInside, second];\n }\n \n",
+      "patch_sha256": "cbd76db473a504ab3161448293301770ef5f3f1718faa9e074badaa54b8bf656",
+      "patch_utf8_bytes": 632,
+      "placeholder": "${fixture.oracle.mutations.TypeScript.facade_control.patch}",
+      "recipe_step": 2
+    },
+    "SF-symforge_edit-004": {
+      "after_sha256": {
+        "sfbench_fixture/java/src/SfBenchCore.java": "fb9a6107f03339d0694c9e13ae1e4c3ee9f3c70392d324bcc0d8987af921075b"
+      },
+      "apply_during_baseline": false,
+      "before_sha256": {
+        "sfbench_fixture/java/src/SfBenchCore.java": "8336d957eb2b4166b586daffeaa7caa50c3ef2980f23b983ef78a6aaa8e9db6e"
+      },
+      "case_id": "SF-symforge_edit-004",
+      "patch": "--- a/sfbench_fixture/java/src/SfBenchCore.java\n+++ b/sfbench_fixture/java/src/SfBenchCore.java\n@@ -3,7 +3,7 @@\n     static final String SF_BENCH_UNICODE_BEFORE = \"na\u00efve \u03bb\";\n \n     static String sfbench_leaf() {\n-        return \"leaf\";\n+        return \"leaf-v2\";\n     }\n \n     static String sfbench_mid() {\n",
+      "patch_sha256": "ad5655fc5e1802c2c51514ba3b81151b5c54d65c5981f63ec2cb78286ec119d7",
+      "patch_utf8_bytes": 309,
+      "placeholder": "${fixture.oracle.mutations.Java.replace_symbol.patch}",
+      "recipe_step": 2
+    }
+  },
+  "protocol": "SFBENCH-1.0",
+  "schema_version": "SFBENCH-BASELINE-PATCHES-1",
+  "source_hashes": {
+    "cases": "7bbf41fa3b6a827cd0aa50e37fde993447be7703645174005129aef2f2a8db58",
+    "fixture_clean_tree": "0460fad2ce33aa359c9266546b4d0614a800361de3c4b16b592ee1eb07bb0b13",
+    "oracle": "eb1fd3d075a1a29626a25d4b65faa7124c83db9c0ed1109e2cb9dcc90b12fadd"
+  },
+  "visibility": "evaluator-only; never expose to paired LLM arms"
+}

--- a/research/full-surface-benchmark/campaign.config.json
+++ b/research/full-surface-benchmark/campaign.config.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "protocol_id": "SFBENCH-1.0",
+  "system_under_test": {
+    "version": "8.14.0",
+    "binary_sha256": "294ad9fae560ac217b10d685aa06c2a8fbaa63794d6f70bb92c2f5f61f9947fe",
+    "surface_modes": [
+      "full",
+      "compact",
+      "meta"
+    ],
+    "daemon_policy": "isolated_no_daemon_except_explicit_daemon_cases"
+  },
+  "mcp": {
+    "protocol_version": "2025-06-18",
+    "primary_transport": "stdio",
+    "http_status": "blocked_until_official_sdk_parity_runner",
+    "manifest_identity": "surface+tool_name+schema_sha256"
+  },
+  "tokenization": {
+    "package": "tiktoken",
+    "version": "0.13.0",
+    "primary": {
+      "encoding": "cl100k_base",
+      "vocabulary_sha256": "83d6504082a038c7aa769af6e2808471f94bf303ac150db2060cfc2a57020aa4"
+    },
+    "sensitivity": {
+      "encoding": "o200k_base",
+      "vocabulary_sha256": "5d2372a38d68a4f7d6b65369719645d2aad38694af99b2a5274f5649ca47f591"
+    },
+    "provider_usage_is_primary_when_available": true
+  },
+  "repetitions": {
+    "direct_correctness_fresh_sessions": 3,
+    "cold_build_independent_starts": 5,
+    "warm_calls_per_cohort": 20,
+    "discarded_warmups": 2,
+    "paired_llm_seeds": 5
+  },
+  "paired_llm": {
+    "enabled_during_direct_phase": false,
+    "runner": "claude_task_runner.py",
+    "client": "Claude Code",
+    "client_version": "2.1.207",
+    "model_alias": "sonnet",
+    "resolved_model_must_be_recorded_per_trial": true,
+    "effort": "medium",
+    "seed_control": null,
+    "temperature_control": null,
+    "natural_and_forced_workflows_reported_separately": true,
+    "activation_gate": "direct suite complete and maximum campaign cost recorded"
+  },
+  "statistics": {
+    "confidence_level": 0.95,
+    "bootstrap_resamples": 10000,
+    "report_micro_and_macro_aggregates": true,
+    "strata": [
+      "tiny",
+      "normal",
+      "symbol-poor",
+      "stress"
+    ]
+  },
+  "safety": {
+    "persist_unsanitized_output": false,
+    "source_mirrors_are_immutable": true,
+    "ordinary_cases_use_independent_clones": true,
+    "oracle_visible_to_llm": false,
+    "network_during_measurement": false
+  }
+}

--- a/research/full-surface-benchmark/cases.json
+++ b/research/full-surface-benchmark/cases.json
@@ -1,0 +1,16544 @@
+{
+  "schema_version": "sfbench-cases-1.0",
+  "protocol": "SFBENCH-1.0",
+  "frozen_at": "2026-07-12",
+  "system_under_test": "SymForge MCP 8.14.0",
+  "source_protocol": "docs/dogfood/2026-07-12-symforge-8.14.0-full-surface-benchmark-protocol.md",
+  "oracle_contract": {
+    "generator": "research/full-surface-benchmark/fixture_generator.py",
+    "expected_oracle_sha256": "eb1fd3d075a1a29626a25d4b65faa7124c83db9c0ed1109e2cb9dcc90b12fadd",
+    "expected_clean_head": "eb809dbd6391dbd7068f4d8a0e08d9f4c378b783",
+    "expected_clean_tree_sha256": "0460fad2ce33aa359c9266546b4d0614a800361de3c4b16b592ee1eb07bb0b13",
+    "forbid_symforge_derived_oracles": true
+  },
+  "placeholders": {
+    "syntax": "${namespace.path}",
+    "substitute_recursively": true,
+    "preserve_native_json_type_when_entire_value_is_one_placeholder": true,
+    "interpolate_as_string_when_embedded": true,
+    "reject_unresolved": true,
+    "namespaces": {
+      "fixture.root": {
+        "type": "absolute_path",
+        "required": true,
+        "source": "fixture generator output root"
+      },
+      "fixture.oracle.*": {
+        "type": "oracle_json_value",
+        "required": "when referenced",
+        "source": "fixture.root/oracle.json"
+      },
+      "repo.<alias>.root": {
+        "type": "absolute_path",
+        "required": true,
+        "source": "corpus.lock.json materialization"
+      },
+      "repo.<alias>.commit": {
+        "type": "full_git_sha",
+        "required": true,
+        "source": "corpus.lock.json"
+      },
+      "case.work_root": {
+        "type": "absolute_path",
+        "required": true,
+        "source": "fresh disposable case clone"
+      },
+      "case.idempotency_key": {
+        "type": "string",
+        "required": "for mutation/replay cases",
+        "format": "SFBENCH-1.0/<run-id>/<case-id>"
+      },
+      "session.project_id": {
+        "type": "string",
+        "required": "when referenced",
+        "source": "MCP project evidence"
+      },
+      "session.model": {
+        "type": "string",
+        "required": true,
+        "source": "campaign lock"
+      },
+      "session.seed": {
+        "type": "integer_or_null",
+        "required": true,
+        "source": "paired-run schedule"
+      },
+      "prior.<case_id>.<field>": {
+        "type": "stateful_json_value",
+        "required": "when referenced",
+        "source": "earlier setup/request record_as in the same declared workflow"
+      }
+    },
+    "derived_oracle_bindings": {
+      "fixture.oracle.symbol_index.<Language>.<symbol>": {
+        "source": "fixture.oracle.symbols.<Language>",
+        "select": "exactly one array element whose name equals <symbol>",
+        "fail_on_zero_or_many": true
+      },
+      "fixture.oracle.paths.exact_lf_source": {
+        "value": "sfbench_fixture/exact/lf_source.py"
+      },
+      "fixture.oracle.paths.exact_crlf_source": {
+        "value": "sfbench_fixture/exact/crlf_source.py"
+      },
+      "fixture.oracle.paths.exact_no_final_newline": {
+        "value": "sfbench_fixture/exact/no_final_newline.py"
+      },
+      "fixture.oracle.paths.exact_binary": {
+        "value": "sfbench_fixture/exact/deterministic.bin"
+      },
+      "fixture.oracle.repositories.<alias>.*": {
+        "source": "campaign native-anchor oracle",
+        "note": "runner must populate native anchors independently before measured trials"
+      },
+      "fixture.oracle.history.refs.sfbench-v1": {
+        "value": "refs/tags/sfbench-v1",
+        "preflight": "fixture.oracle.history.refs must contain refs/tags/sfbench-v1 and the selected materialization profile must map that ref to the corresponding replay commit"
+      },
+      "fixture.oracle.history.refs.initial": {
+        "value": "refs/bench/initial",
+        "preflight": "fixture.oracle.history.refs must contain refs/bench/initial and the selected materialization profile must map that ref to the corresponding first replay commit"
+      },
+      "fixture.oracle.large_file.middle_chunk_100": {
+        "source": "fixture.oracle.large_file.path",
+        "derive": "ceil(total_lines / 200), clamped to at least 1 after reading the frozen fixture bytes",
+        "type": "integer"
+      },
+      "fixture.oracle.large_file.final_chunk_100": {
+        "source": "fixture.oracle.large_file.path",
+        "derive": "ceil(total_lines / 100) after reading the frozen fixture bytes",
+        "type": "integer"
+      },
+      "fixture.oracle.mutations.TypeScript.new_file": {
+        "value": {
+          "path": "sfbench_fixture/typescript/src/new_probe.ts",
+          "symbol": "sfbench_new_file_probe",
+          "utf8": "export function sfbench_new_file_probe(): string { return 'SF_BENCH_SOURCE_9F31'; }\n"
+        }
+      },
+      "fixture.oracle.mutations.<Language>.*.patch": {
+        "type": "unified_diff_text",
+        "source": "the named frozen mutation record plus fixture templates",
+        "derive": "materialize the declared case operation in a scratch copy, capture one canonical git diff with core.autocrlf=false, hash and lock it before either measured arm",
+        "must_not_be_visible_to_llm": true
+      },
+      "fixture.oracle.mutations.<Language>.insert_symbol.<position>_patch": {
+        "type": "unified_diff_text",
+        "source": "the frozen insert_symbol body plus the requested before/after anchor position",
+        "derive": "materialize the insertion in a scratch copy, capture one canonical git diff with core.autocrlf=false, hash and lock it before either measured arm",
+        "must_not_be_visible_to_llm": true
+      },
+      "fixture.oracle.runtime.quarantine.<offset>": {
+        "type": "integer",
+        "source": "runtime.quarantine.populate_malformed_configs oracle_action output",
+        "derive": "middle_offset=floor(count/2), final_offset=max(count-1,0), out_of_range_offset=count+1"
+      }
+    },
+    "runner_requirement": "Resolve and type-check every placeholder before launching a process. A remaining ${...} substring is a fatal harness error."
+  },
+  "inventory": {
+    "full_surface_tools": [
+      "analyze_file_impact",
+      "ask",
+      "batch_edit",
+      "batch_insert",
+      "batch_rename",
+      "checkpoint_now",
+      "context_inventory",
+      "conventions",
+      "delete_symbol",
+      "detect_impact",
+      "diff_symbols",
+      "edit_plan",
+      "edit_within_symbol",
+      "explore",
+      "find_dependents",
+      "find_references",
+      "get_file_content",
+      "get_file_context",
+      "get_repo_map",
+      "get_symbol",
+      "get_symbol_context",
+      "health",
+      "health_compact",
+      "index_folder",
+      "insert_symbol",
+      "inspect_match",
+      "investigation_suggest",
+      "replace_symbol_body",
+      "search_files",
+      "search_symbols",
+      "search_text",
+      "status",
+      "symforge_edit",
+      "symforge_retrieve",
+      "validate_file_syntax",
+      "what_changed"
+    ],
+    "full_surface_count": 36,
+    "compact_surface_tools": [
+      "symforge",
+      "symforge_edit",
+      "status"
+    ],
+    "meta_surface_tools": [
+      "symforge"
+    ],
+    "unique_tool_names": 37,
+    "case_identity": [
+      "surface",
+      "primary_tool",
+      "runtime_schema_sha256",
+      "id"
+    ]
+  },
+  "materialization_profiles": {
+    "commit_semantics": "Each case commit is the frozen public-repository base commit before the controlled overlay is replayed.",
+    "default_profile": "public_repo_with_deterministic_fixture_history_overlay",
+    "native_only_case_ids": [
+      "SF-ask-003",
+      "SF-checkpoint_now-001",
+      "SF-checkpoint_now-002",
+      "SF-checkpoint_now-003",
+      "SF-context_inventory-001",
+      "SF-conventions-001",
+      "SF-conventions-002",
+      "SF-conventions-003",
+      "SF-explore-001",
+      "SF-explore-002",
+      "SF-explore-003",
+      "SF-get_file_content-003",
+      "SF-get_repo_map-001",
+      "SF-get_repo_map-002",
+      "SF-get_repo_map-003",
+      "SF-get_symbol-003",
+      "SF-health-001",
+      "SF-health-003",
+      "SF-health_compact-001",
+      "SF-health_compact-003",
+      "SF-index_folder-001",
+      "SF-index_folder-002",
+      "SF-index_folder-003",
+      "SF-status-001",
+      "SF-status-002",
+      "SF-status-003",
+      "SF-status-004"
+    ],
+    "public_repo_native_only": {
+      "steps": [
+        "git clone --local --no-hardlinks --no-checkout ${repo.<alias>.root} ${case.work_root}",
+        "git -C ${case.work_root} config core.autocrlf false",
+        "git -C ${case.work_root} config core.eol lf",
+        "git -C ${case.work_root} checkout --detach ${repo.<alias>.commit}",
+        "verify HEAD equals the case commit and git status --porcelain=v1 is empty"
+      ],
+      "fixture_rule": "No control-repo bytes are copied. Case-specific setup may still create only its declared allowlisted adverse file."
+    },
+    "public_repo_with_deterministic_fixture_history_overlay": {
+      "source_repository": "${fixture.root}/${fixture.oracle.paths.clean_repository}",
+      "destination_repository": "${case.work_root}",
+      "base_steps": [
+        "materialize public_repo_native_only first",
+        "enumerate the seven source fixture commits oldest to newest",
+        "for the case language select sfbench_fixture/<language-root>/** plus sfbench_fixture/history/** plus sfbench_fixture/filter_cases/**, configs/**, exact/**, generated/**, worktree/**, ignored/** and .claude/gsd-tools/**",
+        "for every source commit, byte-copy that commit's selected tree and deletions, git add only selected paths, and create one allow-empty overlay commit using the source commit's author, committer, timestamps, and message prefixed SFBENCH-OVERLAY",
+        "write sfbench_fixture/.gitattributes with exact/** -text, generated/large_generated.py -text, and configs/bom_crlf_unicode.json -text before the first overlay commit; never overwrite the public repository's root .gitattributes, .gitignore, README, or module manifests",
+        "map each fixture refs/bench/* and refs/tags/sfbench-v1 ref to the replay commit corresponding to the same source-commit ordinal",
+        "verify every selected final file hash against oracle.json, verify every pre-existing public tracked file hash against the base commit, and require an empty worktree"
+      ],
+      "language_root_map": {
+        "Rust": "sfbench_fixture/rust",
+        "Python": "sfbench_fixture/python",
+        "TypeScript": "sfbench_fixture/typescript",
+        "Go": "sfbench_fixture/go",
+        "Java": "sfbench_fixture/java",
+        "C++": "sfbench_fixture/cpp",
+        "Perl": "sfbench_fixture/perl",
+        "JSON": null,
+        "JavaScript": null
+      },
+      "result_contract": "The case remains the named public repository plus a deterministic, committed, language-appropriate oracle overlay; it is never silently replaced by control-repo."
+    },
+    "public_repo_with_fixture_history_and_dirty_state": {
+      "inherits": "public_repo_with_deterministic_fixture_history_overlay",
+      "extra_steps": [
+        "apply only the selected dirty paths from ${fixture.root}/${fixture.oracle.paths.mutation_repository} as raw bytes/deletions/rename",
+        "reproduce the staged versus unstaged versus untracked index state exactly from fixture.oracle.worktree.status_porcelain_v1",
+        "verify status porcelain equals the oracle before launching SymForge"
+      ]
+    },
+    "selection_rule": "A case in native_only_case_ids uses public_repo_native_only. A case whose preconditions.fixture_repository is mutation-repo uses public_repo_with_fixture_history_and_dirty_state. Every other case uses the default profile. Empty preconditions.setup does not disable the selected materialization profile."
+  },
+  "setup_action_catalog": {
+    "execution_boundary": "Setup actions run before source_sha256_before is captured unless an action explicitly declares a between-request hook. They are evaluator/harness actions, are hidden from both LLM arms, and must emit a sanitized action record and output hash.",
+    "oracle_lookup": "Select exactly one object from the named oracle array using the declared equality predicate and bind it under save_as; zero or multiple matches are fatal.",
+    "write_fixture_file": "Write exactly the declared UTF-8 bytes beneath case.work_root, reject path escape, and verify the resulting SHA-256 before indexing.",
+    "mutations.Rust.replace_symbol.apply_to_work_root": "Using the Rust replace_symbol oracle span and new_body, splice the clean indexed file once, verify after_sha256, and leave it unstaged for analyze_file_impact.",
+    "mutations.TypeScript.new_file.create": "Write fixture.oracle.mutations.TypeScript.new_file.utf8 to its declared relative path as an untracked file and verify the expected symbol occurs exactly once.",
+    "impact.Rust.leaf_dirty.apply": "Apply the Rust replace_symbol mutation as one unstaged worktree edit after the initial index is ready.",
+    "impact.Python.leaf_dirty.apply": "Apply the Python replace_symbol mutation as one unstaged worktree edit after the initial index is ready.",
+    "impact.TypeScript.leaf_dirty_and_data.apply": "Apply the TypeScript replace_symbol mutation unstaged and add one deterministic untracked JSON file containing SF_BENCH_DATA_9F31 so include_data false/true has an exact delta.",
+    "mutations.Python.concurrent_divergence.prepare": "Index and resolve the clean Python target, then immediately before the measured replace call write one deterministic comment outside the target span; bind the post-write hash and require the guarded apply to preserve it.",
+    "mutations.stale_index.prepare": "Index the clean stale_target.py bytes, then install a hook after request label repeat that writes mutations.stale_index.after_bytes_utf8 atomically and verifies after_sha256 before the refresh request.",
+    "runtime.snapshot.prepare_path_collision": "Create and verify a valid prior checkpoint, preserve its hash, then create a directory at the next atomic temporary-snapshot destination so the measured write fails before replacing index.bin; bind prior_hash and enumerate temp artifacts.",
+    "runtime.snapshot.prepare_corrupt_copy": "Start from a valid snapshot and install a hook after request label export that copies index.bin, flips one fixed byte in the disposable active copy, preserves the valid exported artifact, and records both hashes before restart_probe.",
+    "runtime.quarantine.populate_malformed_configs": "Before indexing, create 23 deterministic malformed JSON files under sfbench_fixture/configs/quarantine/page_000.json through page_022.json, then bind count=23, middle_offset=11, final_offset=22, and out_of_range_offset=24.",
+    "runtime.health.mutate_between_requests": "Install a hook after request label before that writes exactly `export const SF_BENCH_WATCHER_PROBE = 31;\n` to sfbench_fixture/runtime/health_watcher_probe.ts, poll until the watcher generation advances, and then run after_mutation.",
+    "runtime.daemon.start_with_home_project": "Materialize a separate locked ripgrep native-only home clone, start one daemon/session on it, verify status(detail=projects) has exactly one home row, and expose the current case work root only as the add=true target.",
+    "runtime.frecency.seed_fixture_paths": "Perform the fixed commitment-read sequence core path, protocol path, core path in the same session; record ranking diagnostics before and after and prove discovery-only searches do not create bumps.",
+    "runtime.calibration.seed_durable_samples": "Start a daemon with a fresh durable store, execute the frozen estimator/actual sample sequence until status reports non-Deferred calibration with at least the campaign minimum sample rows, and bind the pre-reset status hash.",
+    "runtime.ccr.create_foreign_session_handle": "In a separate isolated MCP session on the same immutable bytes, trigger CCR with the large-file query, extract and validate the 12-hex handle, close that session, and bind only the handle and source payload hash under save_as.",
+    "session_context.start_empty": "Start a new MCP process/session and assert context_inventory is empty before the first measured request.",
+    "symbols.Rust.sfbench_leaf.read_exact_body": "Select the unique Rust sfbench_leaf oracle span, read those exact current worktree bytes without newline conversion, decode UTF-8, and bind body plus SHA-256 under save_as."
+  },
+  "runner_contract": {
+    "requests_are_sequential_within_case": true,
+    "record_as_semantics": "Store the sanitized structured response under prior.<case_id>.<record_as>. For CCR-producing responses additionally parse exactly one 12-hex footer handle into .hash and retain the pre-compression payload SHA-256; zero or multiple handles are fatal when a later placeholder requires .hash.",
+    "fresh_process_before_semantics": "Gracefully close the prior MCP process, preserve ${case.work_root} and all .symforge snapshot bytes, then start a new process with the same resolved surface and transport. A cold_build-to-fresh-process sequence must verify shutdown persistence before classifying the next request as snapshot_warm.",
+    "fresh_case_clone_per_repetition": true,
+    "parity_shadow_uses_identical_resolved_args": true,
+    "direct_rpc_is_primary": true,
+    "paired_modes": [
+      "natural",
+      "forced_workflow",
+      "recipe"
+    ],
+    "baseline_recipe_scope": "baseline_recipe is the pre-registered secondary recipe arm only. Never expose resolved oracle values, derived patches, setup-action records, or evaluator outputs to the natural or forced-workflow LLM sessions; those sessions receive only task_prompt, the disposable repository, and their allowed tools.",
+    "economics_role_contract": {
+      "allowed": [
+        "task",
+        "required_prerequisite",
+        "comparison_variant",
+        "estimate_diagnostic",
+        "oracle_reference",
+        "replay_diagnostic"
+      ],
+      "mandatory_per_request": true,
+      "headline_roles": [
+        "task",
+        "required_prerequisite"
+      ],
+      "excluded_from_headline": [
+        "comparison_variant",
+        "estimate_diagnostic",
+        "oracle_reference",
+        "replay_diagnostic"
+      ],
+      "rules": [
+        "Preview plus apply are both task work when both are required for the advertised mutation workflow.",
+        "A trigger needed to obtain a CCR handle and context-loading reads needed by a guidance tool are required_prerequisite.",
+        "Parameter or formatting alternatives are comparison_variant and are reported separately, never summed into a task headline.",
+        "Estimate-only, independent oracle/reference, and replay/cache/idempotency diagnostics are excluded from headline economics."
+      ]
+    },
+    "recipe_economics_policy": "Only baseline_equivalence=equivalent recipe arms may appear in recipe headline economics. lower_bound, partial, capability_only, conformance_only, and mixed recipes are diagnostics; paired natural and forced-workflow LLM results remain the campaign headline.",
+    "exact_final_answer_shape": {
+      "answer": "...",
+      "evidence": [
+        {
+          "path": "...",
+          "line": 1
+        }
+      ]
+    },
+    "unresolved_placeholder_is_fatal": true,
+    "source_writes_outside_mutation_allowlist_are_unsafe": true,
+    "runtime_artifact_allowlist": [
+      "${case.work_root}/.symforge/**"
+    ],
+    "sanitize_before_persist": true,
+    "never_persist_secret_values": true
+  },
+  "cases": [
+    {
+      "id": "SF-analyze_file_impact-001",
+      "primary_tool": "analyze_file_impact",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A readable externally modified Rust file is re-indexed and reports the exact symbol delta and dependents.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "oracle_mutation:Rust.replace_symbol",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "mutations.Rust.replace_symbol.apply_to_work_root"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use analyze_file_impact to test this claim: A readable externally modified Rust file is re-indexed and reports the exact symbol delta and dependents. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "analyze_file_impact",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "include_co_changes": false,
+            "new_file": false,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "refreshed_symbol_reference",
+          "economics_role": "oracle_reference",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf",
+            "kind": "fn",
+            "force_refresh": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "refreshed_symbol"
+        },
+        {
+          "step": 3,
+          "label": "refreshed_file_reference",
+          "economics_role": "oracle_reference",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "mode": "symbol",
+            "around_symbol": "sfbench_leaf",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_leaf.start_line}",
+            "context_lines": 0,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "refreshed_file"
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 -- \"${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.replace_symbol",
+        "expected_outcome": "exact modified-symbol delta and reverse dependents; excluded symbol/file reference probes both match the mutation after_sha256 bytes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "include_co_changes=false",
+        "new_file=false",
+        "estimate=false",
+        "project",
+        "excluded refreshed symbol/file byte references"
+      ]
+    },
+    {
+      "id": "SF-analyze_file_impact-002",
+      "primary_tool": "analyze_file_impact",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A deleted or missing path fails honestly and leaves the live index uncorrupted.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "missing_path",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use analyze_file_impact to test this claim: A deleted or missing path fails honestly and leaves the live index uncorrupted. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "analyze_file_impact",
+          "args": {
+            "path": "sfbench_fixture/python/src/does_not_exist.py",
+            "include_co_changes": true,
+            "co_changes_limit": 0,
+            "new_file": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/sfbench_fixture/python/src/does_not_exist.py\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.missing_path",
+        "expected_outcome": "not-found error, no fabricated delta, no source or index corruption",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "co_changes_limit=0",
+        "include_co_changes=true",
+        "missing path"
+      ]
+    },
+    {
+      "id": "SF-analyze_file_impact-003",
+      "primary_tool": "analyze_file_impact",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A newly added TypeScript source is admitted, and estimate mode is checked against the actual response without hiding setup or envelope cost.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "oracle_mutation:TypeScript.new_file",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "mutations.TypeScript.new_file.create"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use analyze_file_impact to test this claim: A newly added TypeScript source is admitted, and estimate mode is checked against the actual response without hiding setup or envelope cost. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "analyze_file_impact",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.new_file.path}",
+            "new_file": true,
+            "include_co_changes": true,
+            "co_changes_limit": 10,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "analyze_file_impact",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.new_file.path}",
+            "new_file": true,
+            "include_co_changes": true,
+            "co_changes_limit": 10,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 -- \"${fixture.oracle.mutations.TypeScript.new_file.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"${fixture.oracle.mutations.TypeScript.new_file.symbol}\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.new_file",
+        "expected_outcome": "exact added-symbol delta; estimate error recorded against independent tokenization",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "new_file=true",
+        "co_changes_limit=10",
+        "estimate=true",
+        "estimate=false"
+      ]
+    },
+    {
+      "id": "SF-analyze_file_impact-004",
+      "primary_tool": "analyze_file_impact",
+      "case_kind": "adverse",
+      "claim_type": "desired",
+      "claim_under_test": "An existing unsupported PowerShell file passed with new_file=true must return an honest unsupported/admission error, not the misleading claim that the file is absent on disk.",
+      "advertised_boundary": "Source indexing is advertised; PowerShell parsing is not. The desired contract is an honest unsupported-language/admission diagnostic for an existing file.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "existing_unsupported_source",
+        "setup": [
+          {
+            "executor": "write_fixture_file",
+            "path": "sfbench_fixture/unsupported/existing_probe.ps1",
+            "utf8": "function SfBench-Probe { return 31 }\n"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use analyze_file_impact to test this claim: An existing unsupported PowerShell file passed with new_file=true must return an honest unsupported/admission error, not the misleading claim that the file is absent on disk. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "analyze_file_impact",
+          "args": {
+            "path": "sfbench_fixture/unsupported/existing_probe.ps1",
+            "new_file": true,
+            "include_co_changes": false,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/sfbench_fixture/unsupported/existing_probe.ps1\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/sfbench_fixture/unsupported/existing_probe.ps1\" -TotalCount 5",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "desired_errors.unsupported_existing_source",
+        "expected_outcome": "unsupported-language or not-admitted error explicitly acknowledging that the file exists; never 'File not found on disk'",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "new_file=true",
+        "unsupported extension",
+        "existing disk file",
+        "desired honest error"
+      ]
+    },
+    {
+      "id": "SF-ask-001",
+      "primary_tool": "ask",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "The natural-language definition query routes to symbol lookup and returns the exact Python leaf definition.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use ask to test this claim: The natural-language definition query routes to symbol lookup and returns the exact Python leaf definition. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "ask",
+          "args": {
+            "query": "where is sfbench_leaf defined",
+            "max_tokens": 512,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.py\" -- \"^(async[ ]+)?def[ ]+sfbench_leaf\\b\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "symbols.Python.sfbench_leaf",
+        "expected_outcome": "route identifies a definition lookup and returns the exact path and start line",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "query definition",
+        "max_tokens=512",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-ask-002",
+      "primary_tool": "ask",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A blank question is rejected with a specific actionable invalid-request response.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use ask to test this claim: A blank question is rejected with a specific actionable invalid-request response. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "ask",
+          "args": {
+            "query": "",
+            "max_tokens": 64
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Input-validation conformance has no token-equivalent shell task."
+        }
+      ],
+      "baseline_equivalence": "conformance_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.blank_query",
+        "expected_outcome": "invalid request naming query as required",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "blank query",
+        "max_tokens=64"
+      ]
+    },
+    {
+      "id": "SF-ask-003",
+      "primary_tool": "ask",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "For an exact filename query, routing overhead is measured against both the direct file-search route and rg --files.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use ask to test this claim: For an exact filename query, routing overhead is measured against both the direct file-search route and rg --files. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "ask",
+          "args": {
+            "query": "find file index.js",
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | rg \"(^|/)index\\.js$\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "repositories.p-map.native_anchor_file",
+        "expected_outcome": "correct exact file and routed-tool identity; combined tokens compared with direct search_files",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "file intent",
+        "routing overhead",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-batch_edit-001",
+      "primary_tool": "batch_edit",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A mixed two-file structured batch previews without writes, applies atomically, and replays the same idempotency key.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean_mutation_copy",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_edit to test this claim: A mixed two-file structured batch previews without writes, applies atomically, and replays the same idempotency key. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "batch_edit",
+          "args": {
+            "dry_run": true,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}",
+            "edits": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_mutable",
+                "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_mutable.start_line}",
+                "operation": {
+                  "type": "edit_within",
+                  "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+                  "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}"
+                }
+              },
+              {
+                "path": "${fixture.oracle.languages.Rust.root}/src/protocol.rs",
+                "name": "SfBenchProtocol",
+                "operation": {
+                  "type": "insert_after",
+                  "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}"
+                }
+              }
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "batch_edit",
+          "args": {
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}",
+            "edits": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_mutable",
+                "operation": {
+                  "type": "edit_within",
+                  "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+                  "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}"
+                }
+              },
+              {
+                "path": "${fixture.oracle.languages.Rust.root}/src/protocol.rs",
+                "name": "SfBenchProtocol",
+                "operation": {
+                  "type": "insert_after",
+                  "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}"
+                }
+              }
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "batch_edit",
+          "args": {
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}",
+            "edits": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_mutable",
+                "operation": {
+                  "type": "edit_within",
+                  "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+                  "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}"
+                }
+              },
+              {
+                "path": "${fixture.oracle.languages.Rust.root}/src/protocol.rs",
+                "name": "SfBenchProtocol",
+                "operation": {
+                  "type": "insert_after",
+                  "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}"
+                }
+              }
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_mutable|SfBenchProtocol\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.batch_edit.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.batch_edit",
+        "expected_outcome": "dry run changes zero bytes; apply exact two-file diff; replay returns stored result without a second edit",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}",
+        "${fixture.oracle.languages.Rust.root}/src/protocol.rs"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "structured edits",
+        "edit_within",
+        "insert_after",
+        "dry_run=true",
+        "dry_run=false",
+        "idempotency replay",
+        "working_directory",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-batch_edit-002",
+      "primary_tool": "batch_edit",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "One invalid selector in a live batch causes total rollback and reserves no partial source state.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_edit to test this claim: One invalid selector in a live batch causes total rollback and reserves no partial source state. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "batch_edit",
+          "args": {
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "edits": [
+              {
+                "path": "${fixture.oracle.mutations.Python.path}",
+                "name": "sfbench_mutable",
+                "operation": {
+                  "type": "edit_within",
+                  "old_text": "${fixture.oracle.mutations.Python.edit_within.old_text}",
+                  "new_text": "${fixture.oracle.mutations.Python.edit_within.new_text}"
+                }
+              },
+              {
+                "path": "${fixture.oracle.mutations.Python.path}",
+                "name": "missing_symbol_9F31",
+                "operation": {
+                  "type": "delete"
+                }
+              }
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_mutable|missing_symbol_9F31\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.atomic_rollback",
+        "expected_outcome": "invalid selector error and byte-identical repository",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "delete operation",
+        "invalid selector",
+        "atomic rollback"
+      ]
+    },
+    {
+      "id": "SF-batch_edit-003",
+      "primary_tool": "batch_edit",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Shorthand dry-run economics are compared with one competent atomic patch for the same small edits.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_edit to test this claim: Shorthand dry-run economics are compared with one competent atomic patch for the same small edits. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "batch_edit",
+          "args": {
+            "dry_run": true,
+            "edits": [
+              "${fixture.oracle.mutations.TypeScript.path}::sfbench_mutable => edit_within SF_BENCH_EDIT_OLD_9F31 >>> SF_BENCH_EDIT_NEW_9F31",
+              "${fixture.oracle.mutations.TypeScript.path}::sfbench_delete_me => delete"
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_mutable|sfbench_delete_me\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.batch_edit.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.batch_edit_preview",
+        "expected_outcome": "preview resolves both targets and changes zero bytes; direct and task token deltas recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "shorthand edits",
+        "edit_within",
+        "delete",
+        "token-negative control"
+      ]
+    },
+    {
+      "id": "SF-batch_insert-001",
+      "primary_tool": "batch_insert",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "The same Rust item is inserted before two valid targets transactionally with correct indentation and replay safety.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_insert to test this claim: The same Rust item is inserted before two valid targets transactionally with correct indentation and replay safety. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "batch_insert",
+          "args": {
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "targets": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_entry",
+                "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_entry.start_line}"
+              },
+              {
+                "path": "sfbench_fixture/rust/src/protocol.rs",
+                "name": "SfBenchProtocol",
+                "symbol_line": "${fixture.oracle.symbol_index.Rust.SfBenchProtocol.start_line}"
+              }
+            ],
+            "dry_run": true,
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "batch_insert",
+          "args": {
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "targets": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_entry"
+              },
+              {
+                "path": "sfbench_fixture/rust/src/protocol.rs",
+                "name": "SfBenchProtocol"
+              }
+            ],
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "batch_insert",
+          "args": {
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "targets": [
+              {
+                "path": "${fixture.oracle.mutations.Rust.path}",
+                "name": "sfbench_entry"
+              },
+              {
+                "path": "sfbench_fixture/rust/src/protocol.rs",
+                "name": "SfBenchProtocol"
+              }
+            ],
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry|sfbench_unused\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.batch_insert_before.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.batch_insert_before",
+        "expected_outcome": "zero-byte preview then exact two insertions with valid Rust syntax; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}",
+        "sfbench_fixture/rust/src/protocol.rs"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "position=before",
+        "targets structured",
+        "dry_run",
+        "apply",
+        "working_directory",
+        "project",
+        "idempotency_key",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-batch_insert-002",
+      "primary_tool": "batch_insert",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "One missing Python target causes total rollback across all batch targets.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_insert to test this claim: One missing Python target causes total rollback across all batch targets. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "batch_insert",
+          "args": {
+            "content": "${fixture.oracle.mutations.Python.insert_symbol.body}",
+            "position": "after",
+            "targets": [
+              {
+                "path": "${fixture.oracle.mutations.Python.path}",
+                "name": "sfbench_entry"
+              },
+              {
+                "path": "${fixture.oracle.mutations.Python.path}",
+                "name": "missing_target_9F31"
+              }
+            ],
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry|missing_target_9F31\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.atomic_rollback",
+        "expected_outcome": "invalid target error and no source byte changes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "position=after",
+        "invalid target",
+        "rollback"
+      ]
+    },
+    {
+      "id": "SF-batch_insert-003",
+      "primary_tool": "batch_insert",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A two-target TypeScript preview is measured against bounded anchor discovery plus one patch.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_insert to test this claim: A two-target TypeScript preview is measured against bounded anchor discovery plus one patch. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "batch_insert",
+          "args": {
+            "content": "${fixture.oracle.mutations.TypeScript.insert_symbol.body}",
+            "position": "after",
+            "targets": [
+              "${fixture.oracle.mutations.TypeScript.path}::sfbench_entry",
+              "${fixture.oracle.mutations.TypeScript.path}::sfbench_unused"
+            ],
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry|sfbench_unused\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.batch_insert_after.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.batch_insert_after",
+        "expected_outcome": "correct preview, no writes, and token delta versus competent patch workflow",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "shorthand targets",
+        "position=after",
+        "token-negative control"
+      ]
+    },
+    {
+      "id": "SF-batch_rename-001",
+      "primary_tool": "batch_rename",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A Rust rename updates exactly the definition plus four code references, preserves two comment/string mentions in code-only mode, and replays safely.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_rename to test this claim: A Rust rename updates exactly the definition plus four code references, preserves two comment/string mentions in code-only mode, and replays safely. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.rename_symbol.name}",
+            "new_name": "${fixture.oracle.mutations.Rust.rename_symbol.new_name}",
+            "kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_rename_me.start_line}",
+            "code_only": true,
+            "dry_run": true,
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.rename_symbol.name}",
+            "new_name": "${fixture.oracle.mutations.Rust.rename_symbol.new_name}",
+            "kind": "fn",
+            "code_only": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.rename_symbol.name}",
+            "new_name": "${fixture.oracle.mutations.Rust.rename_symbol.new_name}",
+            "kind": "fn",
+            "code_only": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_rename_me\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.rename_symbol.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.rename_symbol",
+        "expected_outcome": "five code occurrences changed, two comment/string mentions untouched, syntax valid; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "code_only=true",
+        "kind",
+        "dry_run",
+        "apply",
+        "idempotency_key",
+        "working_directory",
+        "project",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-batch_rename-002",
+      "primary_tool": "batch_rename",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "An ambiguous common Python symbol is rejected or uncertain matches are reported without speculative writes.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_rename to test this claim: An ambiguous common Python symbol is rejected or uncertain matches are reported without speculative writes. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "run",
+            "new_name": "run_bench",
+            "code_only": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"run\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.ambiguous_common_symbol",
+        "expected_outcome": "honest ambiguity/uncertainty and byte-identical source",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "common name",
+        "ambiguity",
+        "uncertain matches"
+      ]
+    },
+    {
+      "id": "SF-batch_rename-003",
+      "primary_tool": "batch_rename",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "code_only=false preview exposes whether comment/string matches add noise and tokens versus rg classification.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use batch_rename to test this claim: code_only=false preview exposes whether comment/string matches add noise and tokens versus rg classification. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "all_files_preview",
+          "economics_role": "task",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "${fixture.oracle.mutations.TypeScript.rename_symbol.name}",
+            "new_name": "${fixture.oracle.mutations.TypeScript.rename_symbol.new_name}",
+            "code_only": false,
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "code_only_preview",
+          "economics_role": "comparison_variant",
+          "tool": "batch_rename",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "${fixture.oracle.mutations.TypeScript.rename_symbol.name}",
+            "new_name": "${fixture.oracle.mutations.TypeScript.rename_symbol.new_name}",
+            "code_only": true,
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_rename_me\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "references.TypeScript.sfbench_rename_me",
+        "expected_outcome": "both previews classify five code and two non-code mentions honestly; token difference recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "code_only=false",
+        "code_only=true",
+        "preview comparison"
+      ]
+    },
+    {
+      "id": "SF-checkpoint_now-001",
+      "primary_tool": "checkpoint_now",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "An explicit verified checkpoint writes an atomically readable snapshot that restores in a fresh process and serves the same indexed bytes.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use checkpoint_now to test this claim: An explicit verified checkpoint writes an atomically readable snapshot and preserves exact index identity. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "checkpoint",
+          "economics_role": "task",
+          "tool": "checkpoint_now",
+          "args": {
+            "verify_after_write": true,
+            "export_artifact": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "checkpoint"
+        },
+        {
+          "step": 2,
+          "label": "restart_health",
+          "economics_role": "oracle_reference",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": true,
+          "fresh_session_before": false,
+          "record_as": "restart_health"
+        },
+        {
+          "step": 3,
+          "label": "post_restart_read",
+          "economics_role": "oracle_reference",
+          "tool": "get_file_content",
+          "args": {
+            "path": "Cargo.toml",
+            "start_line": 1,
+            "end_line": 5,
+            "header": false,
+            "show_line_numbers": false,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "post_restart_read"
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "No ordinary tool creates an equivalent SymForge index snapshot."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.snapshot.verified_restart_restore",
+        "expected_outcome": "index.bin exists and verifies; a fresh process reports SnapshotRestore and an indexed Cargo.toml read matches the independent Git byte prefix",
+        "expected_evidence": {
+          "snapshot_path": ".symforge/index.bin",
+          "restart_health_load_source": "SnapshotRestore",
+          "post_restart_read": "Cargo.toml lines 1-5 must byte-match git show HEAD:Cargo.toml without force refresh"
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 5,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/index.bin"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "verify_after_write=true",
+        "export_artifact=false",
+        "fresh-process SnapshotRestore health",
+        "post-restart indexed read"
+      ]
+    },
+    {
+      "id": "SF-checkpoint_now-002",
+      "primary_tool": "checkpoint_now",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A path collision or non-writable snapshot destination fails explicitly without destroying the prior valid snapshot or leaving temp files.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "snapshot_path_collision",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.snapshot.prepare_path_collision"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use checkpoint_now to test this claim: A path collision or non-writable snapshot destination fails explicitly without destroying the prior valid snapshot or leaving temp files. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "checkpoint_now",
+          "args": {
+            "verify_after_write": true,
+            "export_artifact": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Item -Force -LiteralPath \"${case.work_root}/.symforge/index.bin\" | Select-Object FullName,Attributes,Length",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.snapshot.write_failure",
+        "expected_outcome": "explicit failure, prior valid bytes preserved, no partial temp file",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/index.bin"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "write failure",
+        "prior snapshot preservation"
+      ]
+    },
+    {
+      "id": "SF-checkpoint_now-003",
+      "primary_tool": "checkpoint_now",
+      "case_kind": "stateful",
+      "claim_type": "advertised",
+      "claim_under_test": "Artifact export, restart restore, corrupted disposable-copy quarantine, and source recovery are deterministic.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.snapshot.prepare_corrupt_copy"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use checkpoint_now to test this claim: Artifact export, restart restore, corrupted disposable-copy quarantine, and source recovery are deterministic. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "export",
+          "economics_role": "task",
+          "tool": "checkpoint_now",
+          "args": {
+            "verify_after_write": true,
+            "export_artifact": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "restart_probe",
+          "economics_role": "oracle_reference",
+          "tool": "health_compact",
+          "args": {},
+          "fresh_process_before": true,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Artifact export is capability-only; restart savings compare source re-scan timing with snapshot load timing."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.snapshot.export_restart_quarantine",
+        "expected_outcome": "valid zstd artifact and manifest, clean restart restore, corrupted copy quarantined and never served",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 600,
+        "repetitions": 5,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/index.bin",
+        ".symforge/index.bin.zst",
+        ".symforge/artifact.json",
+        ".gitattributes",
+        ".symforge/quarantine/index-snapshots/**"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "export_artifact=true",
+        "restart",
+        "corrupt-copy quarantine",
+        "source recovery",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-context_inventory-001",
+      "primary_tool": "context_inventory",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A fresh session inventory is empty and accurately labeled.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use context_inventory to test this claim: A fresh session inventory is empty and accurately labeled. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "context_inventory",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$inventory = @(); $inventory.Count",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "session_context.empty",
+        "expected_outcome": "zero fetched files and zero fetched symbols",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "empty object schema",
+        "empty session"
+      ]
+    },
+    {
+      "id": "SF-context_inventory-002",
+      "primary_tool": "context_inventory",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Failed and no-match reads do not become falsely loaded context entries.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "session_context.start_empty"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use context_inventory to test this claim: Failed and no-match reads do not become falsely loaded context entries. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "missing_symbol_9F31"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "step_2",
+          "economics_role": "task",
+          "tool": "context_inventory",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$loaded = [System.Collections.Generic.HashSet[string]]::new(); $loaded.Count",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "session_context.failed_fetch_not_recorded",
+        "expected_outcome": "missing symbol absent from inventory; no fabricated file/symbol fetch",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "after failed fetch",
+        "honest ledger"
+      ]
+    },
+    {
+      "id": "SF-context_inventory-003",
+      "primary_tool": "context_inventory",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A tiny known fetch sequence is represented exactly and inventory envelope cost is compared with a client-side two-entry ledger.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use context_inventory to test this claim: A tiny known fetch sequence is represented exactly and inventory envelope cost is compared with a client-side two-entry ledger. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "step_2",
+          "economics_role": "required_prerequisite",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "start_line": 1,
+            "end_line": 3
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "step_3",
+          "economics_role": "task",
+          "tool": "context_inventory",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "repeat",
+          "economics_role": "replay_diagnostic",
+          "tool": "context_inventory",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$loaded = @(\"${fixture.oracle.mutations.Rust.path}::sfbench_leaf\",\"${fixture.oracle.mutations.Rust.path}:1-3\"); $loaded",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "session_context.known_sequence",
+        "expected_outcome": "exact fetched file/symbol set; token estimates carry approximate labeling; repeat is state-stable",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "known fetch sequence",
+        "repeat",
+        "token-negative small inventory"
+      ]
+    },
+    {
+      "id": "SF-conventions-001",
+      "primary_tool": "conventions",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Detected Rust naming, error-handling, imports, tests, and layout agree with independent stratified counts.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use conventions to test this claim: Detected Rust naming, error-handling, imports, tests, and layout agree with independent stratified counts. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "conventions",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | rg \"\\.rs$\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.rs\" -- \"Result<|unwrap\\(|#\\[test\\]|use \" \"${case.work_root}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "conventions.ripgrep",
+        "expected_outcome": "frozen fact-rubric thresholds and sampled native files pass",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "empty object schema",
+        "Rust normal repo"
+      ]
+    },
+    {
+      "id": "SF-conventions-002",
+      "primary_tool": "conventions",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A symbol-poor JSON corpus produces an honest sparse/unsupported conventions result rather than invented coding patterns.",
+      "repo": "json-schema-suite",
+      "repo_stratum": "symbol-poor",
+      "commit": "${repo.json-schema-suite.commit}",
+      "language": "JSON",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use conventions to test this claim: A symbol-poor JSON corpus produces an honest sparse/unsupported conventions result rather than invented coding patterns. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "conventions",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Group-Object { [IO.Path]::GetExtension($_) } | Sort-Object Count -Descending",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "conventions.symbol_poor",
+        "expected_outcome": "sparse evidence disclosed; no fabricated naming or error-handling style",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "symbol-poor repo",
+        "adverse sparse evidence"
+      ]
+    },
+    {
+      "id": "SF-conventions-003",
+      "primary_tool": "conventions",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "On a tiny JavaScript repo, conventions usefulness and response cost are compared with a bounded manifest-and-source sample.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use conventions to test this claim: On a tiny JavaScript repo, conventions usefulness and response cost are compared with a bounded manifest-and-source sample. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "conventions",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/package.json\" -TotalCount 120",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/index.js\" -TotalCount 160",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "conventions.p-map",
+        "expected_outcome": "all rubric facts supported by sampled files; token delta recorded",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "tiny repo",
+        "token-negative control"
+      ]
+    },
+    {
+      "id": "SF-delete_symbol-001",
+      "primary_tool": "delete_symbol",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "An isolated Rust symbol is previewed then deleted with exact blank-line cleanup and replay safety.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use delete_symbol to test this claim: An isolated Rust symbol is previewed then deleted with exact blank-line cleanup and replay safety. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "delete_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.delete_symbol.symbol}",
+            "kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_delete_me.start_line}",
+            "dry_run": true,
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "delete_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.delete_symbol.symbol}",
+            "kind": "fn",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "delete_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.delete_symbol.symbol}",
+            "kind": "fn",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_delete_me\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.delete_symbol.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.delete_symbol",
+        "expected_outcome": "dry run zero writes; exact deletion hash; valid Rust and normalized adjacent blank lines; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "kind",
+        "dry_run",
+        "apply",
+        "idempotency_key",
+        "working_directory",
+        "project",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-delete_symbol-002",
+      "primary_tool": "delete_symbol",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A missing symbol selector is rejected without touching the Python file.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use delete_symbol to test this claim: A missing symbol selector is rejected without touching the Python file. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "delete_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "missing_symbol_9F31",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"missing_symbol_9F31\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0,
+            1
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.missing_symbol",
+        "expected_outcome": "not-found error and byte-identical file",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "missing selector",
+        "rejected write"
+      ]
+    },
+    {
+      "id": "SF-delete_symbol-003",
+      "primary_tool": "delete_symbol",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A small TypeScript delete preview is compared with declaration discovery plus one bounded patch.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use delete_symbol to test this claim: A small TypeScript delete preview is compared with declaration discovery plus one bounded patch. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "delete_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "${fixture.oracle.mutations.TypeScript.delete_symbol.symbol}",
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_delete_me\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.delete_symbol.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.delete_symbol",
+        "expected_outcome": "exact preview and zero writes; direct/full-task token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "dry-run token control"
+      ]
+    },
+    {
+      "id": "SF-detect_impact-001",
+      "primary_tool": "detect_impact",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "WORKTREE impact at depth 1 returns the exact changed Rust symbol and first-hop reverse callers in the documented JSON payload.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "oracle_mutation:Rust.leaf_dirty",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "impact.Rust.leaf_dirty.apply"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use detect_impact to test this claim: WORKTREE impact at depth 1 returns the exact changed Rust symbol and first-hop reverse callers in the documented JSON payload. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "detect_impact",
+          "args": {
+            "since": "WORKTREE",
+            "depth": 1,
+            "scope": "symbols",
+            "include_untracked": true,
+            "include_data": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --name-only HEAD",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Rust.impact.depth1",
+        "expected_outcome": "payload marker, valid JSON schema, exact changed symbol and hop-1 blast radius",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "since=WORKTREE",
+        "depth=1",
+        "scope=symbols",
+        "include_untracked=true",
+        "include_data=false"
+      ]
+    },
+    {
+      "id": "SF-detect_impact-002",
+      "primary_tool": "detect_impact",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Invalid refs fail explicitly, while depth above five is clamped with a warning on a valid comparison.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "oracle_mutation:Python.leaf_dirty",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "impact.Python.leaf_dirty.apply"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use detect_impact to test this claim: Invalid refs fail explicitly, while depth above five is clamped with a warning on a valid comparison. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "invalid_ref",
+          "economics_role": "task",
+          "tool": "detect_impact",
+          "args": {
+            "base_branch": "missing-ref-9F31",
+            "depth": 2,
+            "scope": "symbols",
+            "include_untracked": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "clamped",
+          "economics_role": "comparison_variant",
+          "tool": "detect_impact",
+          "args": {
+            "since": "WORKTREE",
+            "depth": 6,
+            "scope": "files",
+            "include_untracked": true,
+            "include_data": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" rev-parse --verify \"missing-ref-9F31\"",
+          "expected_exit_codes": [
+            128
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --name-only HEAD",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Python.impact.validation",
+        "expected_outcome": "first request invalid-ref error; second uses depth 5 and includes a clamp warning",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "base_branch",
+        "invalid ref",
+        "depth=2",
+        "depth=6 over-cap",
+        "scope=files",
+        "include_untracked=false",
+        "include_data=true"
+      ]
+    },
+    {
+      "id": "SF-detect_impact-003",
+      "primary_tool": "detect_impact",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "since takes precedence over base_branch, and depth-2 file aggregation is compared with Git plus a scoped reference walk.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "oracle_mutation:TypeScript.leaf_dirty",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "impact.TypeScript.leaf_dirty_and_data.apply"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use detect_impact to test this claim: since takes precedence over base_branch, and depth-2 file aggregation is compared with Git plus a scoped reference walk. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "without_data",
+          "economics_role": "task",
+          "tool": "detect_impact",
+          "args": {
+            "base_branch": "missing-ref-ignored-9F31",
+            "since": "WORKTREE",
+            "depth": 2,
+            "scope": "files",
+            "include_untracked": true,
+            "include_data": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "with_data",
+          "economics_role": "comparison_variant",
+          "tool": "detect_impact",
+          "args": {
+            "base_branch": "missing-ref-ignored-9F31",
+            "since": "WORKTREE",
+            "depth": 5,
+            "scope": "symbols",
+            "include_untracked": true,
+            "include_data": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --name-status HEAD",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf|sfbench_mid|sfbench_entry\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.TypeScript.impact.depths",
+        "expected_outcome": "WORKTREE comparison succeeds despite invalid base_branch; exact file/symbol radii and data inclusion delta",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "since precedence",
+        "base_branch ignored",
+        "depth=2",
+        "depth=5",
+        "scope files/symbols",
+        "data filter"
+      ]
+    },
+    {
+      "id": "SF-diff_symbols-001",
+      "primary_tool": "diff_symbols",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "An initial-to-HEAD Python history comparison returns the exact added, removed, and modified symbol sets.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use diff_symbols to test this claim: A Rust ref comparison returns the exact added, removed, and modified symbol sets. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "diff_symbols",
+          "args": {
+            "base": "refs/bench/initial",
+            "target": "HEAD",
+            "language": "Python",
+            "path_prefix": "sfbench_fixture/history",
+            "code_only": true,
+            "compact": false,
+            "summary_only": false,
+            "estimate": false,
+            "max_tokens": 2048,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 \"refs/bench/initial\" HEAD -- \"sfbench_fixture/history/source.py\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "history.initial_to_head.symbol_diff",
+        "expected_outcome": "exact Python added, removed, and modified symbol sets from the first fixture commit to HEAD",
+        "expected_evidence": {
+          "path": "sfbench_fixture/history/source.py",
+          "added": [
+            {
+              "name": "sfbench_history_added",
+              "kind": "fn"
+            }
+          ],
+          "modified": [
+            {
+              "name": "sfbench_history_modified",
+              "kind": "fn"
+            }
+          ],
+          "removed": [
+            {
+              "name": "sfbench_history_removed",
+              "kind": "fn"
+            }
+          ]
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "base",
+        "target",
+        "language",
+        "path_prefix",
+        "code_only=true",
+        "compact=false",
+        "summary_only=false",
+        "estimate=false",
+        "max_tokens",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-diff_symbols-002",
+      "primary_tool": "diff_symbols",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "An invalid base ref is rejected without returning a misleading empty diff.",
+      "repo": "gson",
+      "repo_stratum": "normal",
+      "commit": "${repo.gson.commit}",
+      "language": "Java",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use diff_symbols to test this claim: An invalid base ref is rejected without returning a misleading empty diff. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "diff_symbols",
+          "args": {
+            "base": "missing-ref-9F31",
+            "target": "HEAD",
+            "language": "Java"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" rev-parse --verify \"missing-ref-9F31\"",
+          "expected_exit_codes": [
+            128
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.invalid_git_ref",
+        "expected_outcome": "invalid-ref error",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid base"
+      ]
+    },
+    {
+      "id": "SF-diff_symbols-003",
+      "primary_tool": "diff_symbols",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Compact, summary-only, and estimate modes preserve exact aggregate counts while exposing formatter economics.",
+      "repo": "fmt",
+      "repo_stratum": "normal",
+      "commit": "${repo.fmt.commit}",
+      "language": "C++",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use diff_symbols to test this claim: Compact, summary-only, and estimate modes preserve exact aggregate counts while exposing formatter economics. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "compact",
+          "economics_role": "task",
+          "tool": "diff_symbols",
+          "args": {
+            "base": "${fixture.oracle.history.refs.sfbench-v1}",
+            "target": "HEAD",
+            "language": "C++",
+            "path_prefix": "sfbench_fixture/cpp",
+            "code_only": false,
+            "compact": true,
+            "summary_only": false,
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "summary",
+          "economics_role": "comparison_variant",
+          "tool": "diff_symbols",
+          "args": {
+            "base": "${fixture.oracle.history.refs.sfbench-v1}",
+            "target": "HEAD",
+            "language": "C++",
+            "code_only": true,
+            "compact": false,
+            "summary_only": true,
+            "max_tokens": 64
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "diff_symbols",
+          "args": {
+            "base": "${fixture.oracle.history.refs.sfbench-v1}",
+            "target": "HEAD",
+            "language": "C++",
+            "code_only": true,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --stat \"${fixture.oracle.history.refs.sfbench-v1}\" HEAD -- \"sfbench_fixture/cpp\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 \"${fixture.oracle.history.refs.sfbench-v1}\" HEAD -- \"sfbench_fixture/cpp\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "history.symbol_diff.C++",
+        "expected_outcome": "all modes agree on aggregate counts; estimate error and token deltas recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "compact=true",
+        "summary_only=true",
+        "code_only=false",
+        "estimate=true",
+        "max_tokens=64"
+      ]
+    },
+    {
+      "id": "SF-edit_plan-001",
+      "primary_tool": "edit_plan",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "An exact Rust selector yields the correct reference count and minimal structural edit sequence.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_plan to test this claim: An exact Rust selector yields the correct reference count and minimal structural edit sequence. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "edit_plan",
+          "args": {
+            "target": "${fixture.oracle.mutations.Rust.path}::sfbench_leaf",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" log --oneline -- \"${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "edit_plans.Rust.sfbench_leaf",
+        "expected_outcome": "correct target, reference impact, and minimal suggested tool order",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "exact selector",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-edit_plan-002",
+      "primary_tool": "edit_plan",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A missing edit target produces an actionable not-found result without invented impact.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_plan to test this claim: A missing edit target produces an actionable not-found result without invented impact. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "edit_plan",
+          "args": {
+            "target": "missing_symbol_9F31"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"missing_symbol_9F31\" \"${case.work_root}\"",
+          "expected_exit_codes": [
+            0,
+            1
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.missing_edit_target",
+        "expected_outcome": "not-found result with no fabricated references",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "missing target"
+      ]
+    },
+    {
+      "id": "SF-edit_plan-003",
+      "primary_tool": "edit_plan",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A bare duplicate symbol and a file-path target expose ambiguity resolution and planning overhead versus rg plus Git context.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_plan to test this claim: A bare duplicate symbol and a file-path target expose ambiguity resolution and planning overhead versus rg plus Git context. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "ambiguous_symbol",
+          "economics_role": "task",
+          "tool": "edit_plan",
+          "args": {
+            "target": "sfbench_duplicate"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "file_target",
+          "economics_role": "comparison_variant",
+          "tool": "edit_plan",
+          "args": {
+            "target": "${fixture.oracle.mutations.TypeScript.path}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_duplicate\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" log --oneline -- \"${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "edit_plans.TypeScript.ambiguity_and_file",
+        "expected_outcome": "honest duplicate ambiguity and correct file-level plan; token delta recorded",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "bare symbol",
+        "file path",
+        "ambiguity",
+        "token control"
+      ]
+    },
+    {
+      "id": "SF-edit_within_symbol-001",
+      "primary_tool": "edit_within_symbol",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Replacing all two identical literals inside the Rust symbol leaves the identical outside literal untouched and replays safely.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_within_symbol to test this claim: Replacing all two identical literals inside the Rust symbol leaves the identical outside literal untouched and replays safely. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.edit_within.symbol}",
+            "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}",
+            "replace_all": true,
+            "dry_run": true,
+            "kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_mutable.start_line}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.edit_within.symbol}",
+            "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}",
+            "replace_all": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "kind": "fn",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.edit_within.symbol}",
+            "old_text": "${fixture.oracle.mutations.Rust.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.Rust.edit_within.new_text}",
+            "replace_all": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "kind": "fn",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --fixed-strings -- \"SF_BENCH_EDIT_OLD_9F31\" \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.edit_within.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.edit_within",
+        "expected_outcome": "two in-symbol replacements, one outside occurrence unchanged, syntax valid; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "replace_all=true",
+        "dry_run",
+        "apply",
+        "kind",
+        "working_directory",
+        "project",
+        "idempotency_key",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-edit_within_symbol-002",
+      "primary_tool": "edit_within_symbol",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Mutually exclusive occurrence, near_line, and replace_all selectors are rejected before any write.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_within_symbol to test this claim: Mutually exclusive occurrence, near_line, and replace_all selectors are rejected before any write. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "${fixture.oracle.mutations.Python.edit_within.symbol}",
+            "old_text": "${fixture.oracle.mutations.Python.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.Python.edit_within.new_text}",
+            "occurrence": 2,
+            "near_line": 1,
+            "replace_all": true,
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --fixed-strings -- \"SF_BENCH_EDIT_OLD_9F31\" \"${case.work_root}/${fixture.oracle.mutations.Python.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.conflicting_occurrence_selectors",
+        "expected_outcome": "invalid-request error naming the conflict and zero writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "occurrence",
+        "near_line",
+        "replace_all conflict"
+      ]
+    },
+    {
+      "id": "SF-edit_within_symbol-003",
+      "primary_tool": "edit_within_symbol",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "First, second-occurrence, near-line, and replace-all previews are compared with a one-patch baseline for a tiny scoped edit.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_lookup",
+            "key": "symbols.TypeScript",
+            "where": {
+              "name": "sfbench_mutable"
+            },
+            "save_as": "prior.SF-edit_within_symbol-003.mutable"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use edit_within_symbol to test this claim: First, second-occurrence, near-line, and replace-all previews are compared with a one-patch baseline for a tiny scoped edit. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "first",
+          "economics_role": "task",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "sfbench_mutable",
+            "old_text": "${fixture.oracle.mutations.TypeScript.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.TypeScript.edit_within.new_text}",
+            "replace_all": false,
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "second",
+          "economics_role": "comparison_variant",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "sfbench_mutable",
+            "old_text": "${fixture.oracle.mutations.TypeScript.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.TypeScript.edit_within.new_text}",
+            "occurrence": 2,
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "near",
+          "economics_role": "comparison_variant",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "sfbench_mutable",
+            "old_text": "${fixture.oracle.mutations.TypeScript.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.TypeScript.edit_within.new_text}",
+            "near_line": "${prior.SF-edit_within_symbol-003.mutable.start_line}",
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "all",
+          "economics_role": "comparison_variant",
+          "tool": "edit_within_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "sfbench_mutable",
+            "old_text": "${fixture.oracle.mutations.TypeScript.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.TypeScript.edit_within.new_text}",
+            "replace_all": true,
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --fixed-strings -- \"SF_BENCH_EDIT_OLD_9F31\" \"${case.work_root}/${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.edit_within.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.edit_within.selector_modes",
+        "expected_outcome": "each preview selects the documented occurrences and writes zero bytes; full-task token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "replace_all=false",
+        "occurrence=2",
+        "near_line",
+        "selector modes",
+        "token-negative control"
+      ]
+    },
+    {
+      "id": "SF-explore-001",
+      "primary_tool": "explore",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Depth-2 exploration of command parsing returns independently verified native anchors plus signatures and first-hop dependents.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use explore to test this claim: Depth-2 exploration of command parsing returns independently verified native anchors plus signatures and first-hop dependents. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "explore",
+          "args": {
+            "query": "command parsing",
+            "depth": 2,
+            "language": "Rust",
+            "path_prefix": "crates/",
+            "limit": 10,
+            "max_tokens": 1500,
+            "include_noise": false,
+            "include_vendor": false,
+            "include_personal_tooling": false,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -i -- \"command|parse|parser\" \"${case.work_root}/crates\" | Select-Object -First 40",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}/crates\" | rg \"command|args|cli\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "native_rubrics.ripgrep.command_parsing",
+        "expected_outcome": "required native fact anchors, relevant paths, signatures, and one-hop dependents",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "depth=2",
+        "language",
+        "path_prefix",
+        "limit",
+        "max_tokens",
+        "include_noise=false",
+        "include_vendor=false",
+        "include_personal_tooling=false",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-explore-002",
+      "primary_tool": "explore",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A nonexistent concept in a symbol-poor corpus returns an honest no-hit result without unrelated filler.",
+      "repo": "json-schema-suite",
+      "repo_stratum": "symbol-poor",
+      "commit": "${repo.json-schema-suite.commit}",
+      "language": "JSON",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use explore to test this claim: A nonexistent concept in a symbol-poor corpus returns an honest no-hit result without unrelated filler. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "explore",
+          "args": {
+            "query": "sfbench concept that cannot exist 9F31",
+            "depth": 3,
+            "limit": 1,
+            "include_noise": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -i -- \"sfbench concept that cannot exist 9F31\" \"${case.work_root}\"",
+          "expected_exit_codes": [
+            0,
+            1
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "search.no_hit",
+        "expected_outcome": "no-hit outcome with no fabricated symbols or files",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "depth=3",
+        "limit=1",
+        "no-hit"
+      ]
+    },
+    {
+      "id": "SF-explore-003",
+      "primary_tool": "explore",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Depth 1 versus 3, noise filters, estimates, and tight budgets reveal completed-workflow token economics on the stress repo.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use explore to test this claim: Depth 1 versus 3, noise filters, estimates, and tight budgets reveal completed-workflow token economics on the stress repo. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "depth1",
+          "economics_role": "task",
+          "tool": "explore",
+          "args": {
+            "query": "serialization",
+            "depth": 1,
+            "language": "TypeScript",
+            "limit": 10,
+            "max_tokens": 256,
+            "include_noise": false,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "depth3_noise",
+          "economics_role": "comparison_variant",
+          "tool": "explore",
+          "args": {
+            "query": "serialization",
+            "depth": 3,
+            "language": "TypeScript",
+            "limit": 10,
+            "max_tokens": 3000,
+            "include_noise": true,
+            "include_vendor": true,
+            "include_personal_tooling": true,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "explore",
+          "args": {
+            "query": "serialization",
+            "depth": 3,
+            "language": "TypeScript",
+            "limit": 10,
+            "max_tokens": 3000,
+            "include_noise": true,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -i --glob \"*.ts\" -- \"serializ(e|ation)\" \"${case.work_root}/src\" | Select-Object -First 50",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}/src\" | rg -i \"serial\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "native_rubrics.typescript.serialization",
+        "expected_outcome": "required anchors at both depths; noise admission disclosed; estimate error and token deltas recorded",
+        "expected_evidence": null,
+        "scoring_status": "manual_pending"
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "depth=1",
+        "depth=3",
+        "include_noise=true",
+        "include_vendor=true",
+        "include_personal_tooling=true",
+        "estimate=true",
+        "max_tokens tight"
+      ]
+    },
+    {
+      "id": "SF-find_dependents-001",
+      "primary_tool": "find_dependents",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "File-level Python dependents return the exact importing files and edge kinds in text mode.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_dependents to test this claim: File-level Python dependents return the exact importing files and edge kinds in text mode. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "find_dependents",
+          "args": {
+            "path": "${fixture.oracle.languages.Python.root}/src/protocol.py",
+            "format": "text",
+            "compact": false,
+            "limit": 20,
+            "max_per_file": 5,
+            "max_tokens": 1024,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.py\" -- \"from .*protocol|import .*protocol\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "dependent_files.Python",
+        "expected_outcome": "exact dependent-file set and import edge kinds",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "format=text",
+        "compact=false",
+        "limit",
+        "max_per_file",
+        "max_tokens",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-find_dependents-002",
+      "primary_tool": "find_dependents",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Passing a symbol-shaped name to the file-level tool returns the advertised redirect to find_references.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_dependents to test this claim: Passing a symbol-shaped name to the file-level tool returns the advertised redirect to find_references. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "find_dependents",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf",
+            "format": "text",
+            "compact": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.find_dependents_symbol_misuse",
+        "expected_outcome": "explicit redirect to find_references, not a fabricated file graph",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "name misuse",
+        "compact=true",
+        "redirect"
+      ]
+    },
+    {
+      "id": "SF-find_dependents-003",
+      "primary_tool": "find_dependents",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Mermaid, DOT, and compact text outputs encode the same cyclic TypeScript dependency graph and expose formatter token cost.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_dependents to test this claim: Mermaid, DOT, and compact text outputs encode the same cyclic TypeScript dependency graph and expose formatter token cost. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "mermaid",
+          "economics_role": "task",
+          "tool": "find_dependents",
+          "args": {
+            "path": "${fixture.oracle.languages.TypeScript.root}/src/cycle_a.ts",
+            "format": "mermaid",
+            "compact": false,
+            "limit": 100,
+            "max_per_file": 50
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "dot",
+          "economics_role": "comparison_variant",
+          "tool": "find_dependents",
+          "args": {
+            "path": "${fixture.oracle.languages.TypeScript.root}/src/cycle_a.ts",
+            "format": "dot",
+            "compact": false,
+            "limit": 101,
+            "max_per_file": 51
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "compact",
+          "economics_role": "estimate_diagnostic",
+          "tool": "find_dependents",
+          "args": {
+            "path": "${fixture.oracle.languages.TypeScript.root}/src/cycle_a.ts",
+            "format": "text",
+            "compact": true,
+            "estimate": true,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.ts\" -- \"cycle_a|cycle_b\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.import_cycles.TypeScript",
+        "expected_outcome": "all formats encode exact edges without recursion loops; caps and estimate behavior disclosed",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "format=mermaid",
+        "format=dot",
+        "compact=true",
+        "limit=100",
+        "limit over-cap",
+        "max_per_file=50",
+        "estimate=true"
+      ]
+    },
+    {
+      "id": "SF-find_references-001",
+      "primary_tool": "find_references",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Rust leaf references are classified exactly as calls in compact and full modes.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_references to test this claim: Rust leaf references are classified exactly as calls in compact and full modes. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "full",
+          "economics_role": "task",
+          "tool": "find_references",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol_kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_leaf.start_line}",
+            "kind": "call",
+            "mode": "references",
+            "compact": false,
+            "limit": 20,
+            "max_per_file": 10,
+            "max_tokens": 1024,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "compact",
+          "economics_role": "comparison_variant",
+          "tool": "find_references",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "kind": "all",
+            "mode": "references",
+            "compact": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "references.Rust.sfbench_leaf",
+        "expected_outcome": "exact reference set and call classification; compact/full facts agree",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "symbol_kind",
+        "kind=call",
+        "kind=all",
+        "mode=references",
+        "compact false/true",
+        "limit",
+        "max_per_file",
+        "max_tokens",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-find_references-002",
+      "primary_tool": "find_references",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A no-reference symbol is honestly empty, and mutually exclusive project selectors are rejected.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_references to test this claim: A no-reference symbol is honestly empty, and mutually exclusive project selectors are rejected. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "no_refs",
+          "economics_role": "task",
+          "tool": "find_references",
+          "args": {
+            "name": "sfbench_unused",
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "kind": "all",
+            "mode": "references"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "selector_conflict",
+          "economics_role": "comparison_variant",
+          "tool": "find_references",
+          "args": {
+            "name": "sfbench_leaf",
+            "project": "${session.project_id}",
+            "projects": [
+              "${session.project_id}"
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_unused\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "references.Python.no_refs_and_selector_validation",
+        "expected_outcome": "exact zero reference sites for unused symbol; selector conflict invalid request",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "no refs",
+        "project+projects conflict"
+      ]
+    },
+    {
+      "id": "SF-find_references-003",
+      "primary_tool": "find_references",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Implementation mode in trait, type, and auto directions returns the exact Java interface/implementor relation with bounded output.",
+      "repo": "gson",
+      "repo_stratum": "normal",
+      "commit": "${repo.gson.commit}",
+      "language": "Java",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use find_references to test this claim: Implementation mode in trait, type, and auto directions returns the exact Java interface/implementor relation with bounded output. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "trait",
+          "economics_role": "task",
+          "tool": "find_references",
+          "args": {
+            "name": "SfBenchProtocol",
+            "mode": "implementations",
+            "direction": "trait",
+            "limit": 200
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "type",
+          "economics_role": "comparison_variant",
+          "tool": "find_references",
+          "args": {
+            "name": "SfBenchWorker",
+            "mode": "implementations",
+            "direction": "type",
+            "limit": 500
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "auto_estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "find_references",
+          "args": {
+            "name": "SfBenchProtocol",
+            "mode": "implementations",
+            "direction": "auto",
+            "limit": 501,
+            "estimate": true,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.java\" -- \"interface SfBenchProtocol|implements SfBenchProtocol|class SfBenchWorker\" \"${case.work_root}/sfbench_fixture/java\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "implementors.Java",
+        "expected_outcome": "exact bidirectional implementation relation; limit cap and estimate disclosed",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "mode=implementations",
+        "direction=trait",
+        "direction=type",
+        "direction=auto",
+        "limit=200",
+        "limit=500",
+        "over-cap",
+        "estimate=true"
+      ]
+    },
+    {
+      "id": "SF-get_file_content-001",
+      "primary_tool": "get_file_content",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Full, explicit line-range, and offset/limit reads preserve exact Rust bytes and documented headers.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_content to test this claim: Full, explicit line-range, and offset/limit reads preserve exact Rust bytes and documented headers. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "range",
+          "economics_role": "task",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "mode": "lines",
+            "start_line": 1,
+            "end_line": 12,
+            "header": true,
+            "show_line_numbers": true,
+            "max_tokens": 1024,
+            "force_refresh": false,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "offset_limit",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "offset": 0,
+            "limit": 12,
+            "header": false,
+            "show_line_numbers": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "full",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.paths.exact_lf_source}",
+            "header": true,
+            "show_line_numbers": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"; $b=[System.IO.File]::ReadAllBytes($p); $end=$b.Length; $n=0; for($i=0;$i -lt $b.Length;$i++){ if($b[$i] -eq 10){ $n++; if($n -eq 12){ $end=$i+1; break } } }; [Console]::OpenStandardOutput().Write($b,0,$end)",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/${fixture.oracle.paths.exact_lf_source}\"; $b=[System.IO.File]::ReadAllBytes($p); [Console]::OpenStandardOutput().Write($b,0,$b.Length)",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "files.byte_exact_reads",
+        "expected_outcome": "selected content hashes and line numbering exactly match oracle bytes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "mode=lines",
+        "start_line",
+        "end_line",
+        "offset",
+        "limit",
+        "header true/false",
+        "show_line_numbers true/false",
+        "max_tokens",
+        "force_refresh=false",
+        "estimate=false",
+        "project",
+        "full read"
+      ]
+    },
+    {
+      "id": "SF-get_file_content-002",
+      "primary_tool": "get_file_content",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Conflicting selection fields and missing files return parameter-specific errors without fallback content.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_content to test this claim: Conflicting selection fields and missing files return parameter-specific errors without fallback content. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "offset_conflict",
+          "economics_role": "task",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "offset": 0,
+            "start_line": 1,
+            "limit": 5
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "mode_conflict",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "mode": "symbol",
+            "around_match": "sfbench_leaf"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "missing",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "sfbench_fixture/python/src/missing_9F31.py",
+            "start_line": 1,
+            "end_line": 2
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/sfbench_fixture/python/src/missing_9F31.py\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.file_content_conflicts",
+        "expected_outcome": "each request names the conflicting/missing input and returns no unrelated content",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "offset+start conflict",
+        "mode mismatch",
+        "missing path"
+      ]
+    },
+    {
+      "id": "SF-get_file_content-003",
+      "primary_tool": "get_file_content",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A known tiny line range exposes any token-negative response-envelope cost versus a bounded raw read.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_content to test this claim: A known tiny line range exposes any token-negative response-envelope cost versus a bounded raw read. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+            "start_line": 1,
+            "end_line": 5,
+            "header": false,
+            "show_line_numbers": false,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "repeat",
+          "economics_role": "replay_diagnostic",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+            "start_line": 1,
+            "end_line": 5,
+            "header": false,
+            "show_line_numbers": false,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "refresh",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+            "start_line": 1,
+            "end_line": 5,
+            "header": false,
+            "show_line_numbers": false,
+            "force_refresh": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+            "start_line": 1,
+            "end_line": 5,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/${fixture.oracle.repositories.p-map.native_anchor_file}\"; $b=[System.IO.File]::ReadAllBytes($p); $end=$b.Length; $n=0; for($i=0;$i -lt $b.Length;$i++){ if($b[$i] -eq 10){ $n++; if($n -eq 5){ $end=$i+1; break } } }; [Console]::OpenStandardOutput().Write($b,0,$end)",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "repositories.p-map.native_anchor_range",
+        "expected_outcome": "exact same five lines for actual/repeat/refresh; estimate error and negative token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "cache repeat",
+        "force_refresh=true",
+        "estimate=true",
+        "tiny range token-negative control"
+      ]
+    },
+    {
+      "id": "SF-get_file_content-004",
+      "primary_tool": "get_file_content",
+      "case_kind": "stateful",
+      "claim_type": "advertised",
+      "claim_under_test": "Match, occurrence, symbol, around-line, and chunk modes reconstruct anchors from a large generated file while preserving CRLF, Unicode, and no-final-newline controls.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_content to test this claim: Match, occurrence, symbol, around-line, and chunk modes reconstruct anchors from a large generated file while preserving CRLF, Unicode, and no-final-newline controls. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "match",
+          "economics_role": "task",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.large_file.path}",
+            "mode": "match",
+            "around_match": "SF_BENCH_LARGE_MIDDLE_9F31",
+            "match_occurrence": 1,
+            "context_lines": 2,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "symbol",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "mode": "symbol",
+            "around_symbol": "sfbench_leaf",
+            "symbol_line": "${fixture.oracle.symbol_index.TypeScript.sfbench_leaf.start_line}",
+            "context_lines": 1
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "around_line",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.paths.exact_crlf_source}",
+            "around_line": 2,
+            "context_lines": 1
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "chunk_first",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.large_file.path}",
+            "mode": "chunk",
+            "chunk_index": 1,
+            "max_lines": 100
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "chunk_middle",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.large_file.path}",
+            "mode": "chunk",
+            "chunk_index": "${fixture.oracle.large_file.middle_chunk_100}",
+            "max_lines": 100
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 6,
+          "label": "chunk_final",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.large_file.path}",
+            "mode": "chunk",
+            "chunk_index": "${fixture.oracle.large_file.final_chunk_100}",
+            "max_lines": 100
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -C 2 --fixed-strings -- \"SF_BENCH_LARGE_MIDDLE_9F31\" \"${case.work_root}/${fixture.oracle.large_file.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/${fixture.oracle.large_file.path}\"; $b=[System.IO.File]::ReadAllBytes($p); $end=$b.Length; $n=0; for($i=0;$i -lt $b.Length;$i++){ if($b[$i] -eq 10){ $n++; if($n -eq 100){ $end=$i+1; break } } }; [Console]::OpenStandardOutput().Write($b,0,$end)",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "large_file.chunk_and_anchor_reads",
+        "expected_outcome": "exact anchor hashes; all chunks bounded and collectively address start/middle/end; byte-style controls preserved",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 7,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "mode=match",
+        "around_match",
+        "match_occurrence",
+        "context_lines",
+        "mode=symbol",
+        "around_symbol",
+        "around_line",
+        "mode=chunk",
+        "chunk_index",
+        "max_lines",
+        "large file"
+      ]
+    },
+    {
+      "id": "SF-get_file_context-001",
+      "primary_tool": "get_file_context",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Selected Python outline, imports, consumers, references, and Git sections match the independent oracle including tests.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_context to test this claim: Selected Python outline, imports, consumers, references, and Git sections match the independent oracle including tests. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "sections": [
+              "outline",
+              "imports",
+              "consumers",
+              "references",
+              "git"
+            ],
+            "include_tests": true,
+            "max_tokens": 2048,
+            "force_refresh": false,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.py\" -- \"^(from|import|def|class) \" \"${case.work_root}/${fixture.oracle.languages.Python.root}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" log --oneline -- \"${fixture.oracle.mutations.Python.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "file_context.Python.core",
+        "expected_outcome": "exact outline/import/consumer/reference sets and Git anchors",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "sections all",
+        "include_tests=true",
+        "max_tokens",
+        "force_refresh=false",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-get_file_context-002",
+      "primary_tool": "get_file_context",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "An invalid section name and missing path fail explicitly rather than silently dropping requested evidence.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_context to test this claim: An invalid section name and missing path fail explicitly rather than silently dropping requested evidence. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "bad_section",
+          "economics_role": "task",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "sections": [
+              "outline",
+              "not_a_section_9F31"
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "missing_path",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_context",
+          "args": {
+            "path": "sfbench_fixture/rust/src/missing_9F31.rs"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/sfbench_fixture/rust/src/missing_9F31.rs\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.file_context_validation",
+        "expected_outcome": "invalid-section and missing-path errors are distinct and actionable",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid sections",
+        "missing path"
+      ]
+    },
+    {
+      "id": "SF-get_file_context-003",
+      "primary_tool": "get_file_context",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "First fetch, cache repeat, forced refresh after controlled disk mutation, and estimate mode are fresh and economically transparent.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "mutations.stale_index.prepare"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_file_context to test this claim: First fetch, cache repeat, forced refresh after controlled disk mutation, and estimate mode are fresh and economically transparent. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "first",
+          "economics_role": "task",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.stale_index.path}",
+            "sections": [
+              "outline"
+            ],
+            "include_tests": false,
+            "max_tokens": 64,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "repeat",
+          "economics_role": "replay_diagnostic",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.stale_index.path}",
+            "sections": [
+              "outline"
+            ],
+            "include_tests": false,
+            "max_tokens": 64,
+            "force_refresh": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "external_mutation",
+          "economics_role": "oracle_reference",
+          "tool": "get_file_content",
+          "args": {
+            "path": "${fixture.oracle.mutations.stale_index.path}",
+            "start_line": 1,
+            "end_line": 1
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "stale_before"
+        },
+        {
+          "step": 4,
+          "label": "refresh",
+          "economics_role": "comparison_variant",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.stale_index.path}",
+            "sections": [
+              "outline"
+            ],
+            "force_refresh": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_file_context",
+          "args": {
+            "path": "${fixture.oracle.mutations.stale_index.path}",
+            "sections": [
+              "outline"
+            ],
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/${fixture.oracle.mutations.stale_index.path}\" -TotalCount 80",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.stale_index",
+        "expected_outcome": "cache behavior labeled; force_refresh observes new bytes; estimate independently scored",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 6,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.stale_index.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "sections subset",
+        "include_tests=false",
+        "max_tokens=64",
+        "cache repeat",
+        "force_refresh=true",
+        "estimate=true",
+        "dirty state"
+      ]
+    },
+    {
+      "id": "SF-get_repo_map-001",
+      "primary_tool": "get_repo_map",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Compact overview of the tiny JavaScript repository has exact file, language, and top-directory counts.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_repo_map to test this claim: Compact overview of the tiny JavaScript repository has exact file, language, and top-directory counts. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "compact",
+            "max_tokens": 1024,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "compact",
+            "max_tokens": 1024,
+            "estimate": true,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Group-Object { [IO.Path]::GetExtension($_) } | Sort-Object Count -Descending",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "repositories.p-map.inventory",
+        "expected_outcome": "exact inventory counts and required manifest anchors; estimate error recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "detail=compact",
+        "max_tokens",
+        "estimate false/true",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-get_repo_map-002",
+      "primary_tool": "get_repo_map",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Invalid detail and nonexistent subtree are rejected or honestly empty without presenting a complete repository claim.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_repo_map to test this claim: Invalid detail and nonexistent subtree are rejected or honestly empty without presenting a complete repository claim. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "bad_detail",
+          "economics_role": "task",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "not-a-detail"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "missing_subtree",
+          "economics_role": "comparison_variant",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "tree",
+            "path": "missing/subtree/9F31",
+            "depth": 6
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/missing/subtree/9F31\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.repo_map_validation",
+        "expected_outcome": "specific invalid-detail result; missing subtree disclosed; depth cap behavior explicit",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid detail",
+        "detail=tree",
+        "path",
+        "depth over-cap"
+      ]
+    },
+    {
+      "id": "SF-get_repo_map-003",
+      "primary_tool": "get_repo_map",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Tree and full modes on the stress repo respect depth, file, and token budgets, with CCR economics measured when full output compresses.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_repo_map to test this claim: Tree and full modes on the stress repo respect depth, file, and token budgets, with CCR economics measured when full output compresses. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "tree",
+          "economics_role": "task",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "tree",
+            "path": "src",
+            "depth": 5,
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "full",
+          "economics_role": "comparison_variant",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "full",
+            "max_files": 200,
+            "max_tokens": 1024,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "full_over",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_repo_map",
+          "args": {
+            "detail": "full",
+            "max_files": 201,
+            "max_tokens": 256,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}/src\" | Select-Object -First 200",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Group-Object { Split-Path $_ -Parent } | Sort-Object Count -Descending | Select-Object -First 50",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "repositories.typescript.inventory",
+        "expected_outcome": "exact bounded counts/anchors, honest truncation or CCR footer, estimate error and token delta",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "detail=tree",
+        "depth=5",
+        "path",
+        "detail=full",
+        "max_files=200",
+        "max_files over boundary",
+        "max_tokens",
+        "estimate=true"
+      ]
+    },
+    {
+      "id": "SF-get_symbol-001",
+      "primary_tool": "get_symbol",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Exact Rust symbol retrieval returns the oracle body and span; estimate and forced refresh are independently checked.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_lookup",
+            "key": "symbols.Rust",
+            "where": {
+              "name": "sfbench_leaf"
+            },
+            "save_as": "prior.SF-get_symbol-001.leaf"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol to test this claim: Exact Rust symbol retrieval returns the oracle body and span; estimate and forced refresh are independently checked. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf",
+            "kind": "fn",
+            "symbol_line": "${prior.SF-get_symbol-001.leaf.start_line}",
+            "max_tokens": 1000,
+            "estimate": false,
+            "force_refresh": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf",
+            "kind": "fn",
+            "symbol_line": "${prior.SF-get_symbol-001.leaf.start_line}",
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "refresh",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_leaf",
+            "kind": "fn",
+            "symbol_line": "${prior.SF-get_symbol-001.leaf.start_line}",
+            "force_refresh": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.rs\" -- \"^(pub[ ]+)?fn[ ]+sfbench_leaf\\b\" \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\" -TotalCount 120",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "symbols.Rust.sfbench_leaf",
+        "expected_outcome": "exact UTF-8 body hash, start/end line and byte span; estimate error and refresh parity",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "name",
+        "kind",
+        "symbol_line",
+        "max_tokens",
+        "estimate true/false",
+        "force_refresh true/false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-get_symbol-002",
+      "primary_tool": "get_symbol",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Omitted-path duplicate lookup is honestly ambiguous, and an empty selector is rejected.",
+      "repo": "gson",
+      "repo_stratum": "normal",
+      "commit": "${repo.gson.commit}",
+      "language": "Java",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol to test this claim: Omitted-path duplicate lookup is honestly ambiguous, and an empty selector is rejected. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "ambiguous",
+          "economics_role": "task",
+          "tool": "get_symbol",
+          "args": {
+            "name": "sfbench_duplicate",
+            "kind": "method"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "empty",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.java\" -- \"sfbench_duplicate\" \"${case.work_root}/sfbench_fixture/java\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "duplicate_basenames.Java",
+        "expected_outcome": "ambiguity lists both candidates; empty selector invalid request",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "omitted path",
+        "duplicate ambiguity",
+        "empty args"
+      ]
+    },
+    {
+      "id": "SF-get_symbol-003",
+      "primary_tool": "get_symbol",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A tiny known native symbol plus batch symbol/range targets are compared with declaration rg and bounded reads.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol to test this claim: A tiny known native symbol plus batch symbol/range targets are compared with declaration rg and bounded reads. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "single",
+          "economics_role": "task",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+            "name": "${fixture.oracle.repositories.p-map.native_anchor_symbol}",
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "batch",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol",
+          "args": {
+            "targets": [
+              {
+                "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+                "name": "${fixture.oracle.repositories.p-map.native_anchor_symbol}"
+              },
+              {
+                "path": "${fixture.oracle.repositories.p-map.native_anchor_file}",
+                "start_byte": "${fixture.oracle.repositories.p-map.native_slice.start_byte}",
+                "end_byte": "${fixture.oracle.repositories.p-map.native_slice.end_byte}"
+              }
+            ],
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -- \"${fixture.oracle.repositories.p-map.native_anchor_symbol}\" \"${case.work_root}/${fixture.oracle.repositories.p-map.native_anchor_file}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/${fixture.oracle.repositories.p-map.native_anchor_file}\" -TotalCount 80",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "repositories.p-map.native_symbol_and_slice",
+        "expected_outcome": "exact single body and batch slice bytes; completed workflow token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "single without kind",
+        "targets batch",
+        "target name",
+        "target byte range",
+        "tiny symbol control"
+      ]
+    },
+    {
+      "id": "SF-get_symbol_context-001",
+      "primary_tool": "get_symbol_context",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Rust leaf context returns exact callers/callees and definition facts across full, compact, signature, and summary verbosity.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol_context to test this claim: Rust leaf context returns exact callers/callees and definition facts across full, compact, signature, and summary verbosity. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "full",
+          "economics_role": "task",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol_kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_leaf.start_line}",
+            "verbosity": "full",
+            "include_tests": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "compact",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "verbosity": "compact"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "signature",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "verbosity": "signature"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "summary_actual",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "verbosity": "summary",
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "summary_estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_leaf",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "verbosity": "summary",
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Content -LiteralPath \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\" -TotalCount 140",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Rust.sfbench_leaf_context",
+        "expected_outcome": "all four actual verbosity modes preserve required identity/edge facts; the separate summary estimate is independently scored",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 6,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "default mode",
+        "verbosity full/compact/signature/summary actual",
+        "symbol_kind",
+        "include_tests=false",
+        "estimate=true",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-get_symbol_context-002",
+      "primary_tool": "get_symbol_context",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Recursive TypeScript custom-type cycles in bundle mode terminate without duplicates and obey a tight token budget.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol_context to test this claim: Recursive TypeScript custom-type cycles in bundle mode terminate without duplicates and obey a tight token budget. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "bundle",
+          "economics_role": "task",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "CycleA",
+            "path": "${fixture.oracle.languages.TypeScript.root}/src/cycle_a.ts",
+            "bundle": true,
+            "max_tokens": 64,
+            "verbosity": "full"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "bad_section",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "sfbench_entry",
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "sections": [
+              "not_a_section_9F31"
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.ts\" -- \"CycleA|CycleB\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.recursive_custom_type_cycles.TypeScript",
+        "expected_outcome": "cycle terminates with no duplicate closure entry and honest budget truncation; invalid section rejected",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "bundle=true",
+        "max_tokens=64",
+        "recursive cycle",
+        "invalid sections"
+      ]
+    },
+    {
+      "id": "SF-get_symbol_context-003",
+      "primary_tool": "get_symbol_context",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Trace mode with all sections and explicit subsets returns exact Java implementations, siblings/dependents, and Git facts versus multiple scoped searches.",
+      "repo": "gson",
+      "repo_stratum": "normal",
+      "commit": "${repo.gson.commit}",
+      "language": "Java",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use get_symbol_context to test this claim: Trace mode with all sections and explicit subsets returns exact Java implementations, siblings/dependents, and Git facts versus multiple scoped searches. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "all_sections",
+          "economics_role": "task",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "SfBenchProtocol",
+            "path": "${fixture.oracle.languages.Java.root}/src/protocol.java",
+            "sections": [],
+            "verbosity": "signature",
+            "include_tests": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "subset",
+          "economics_role": "comparison_variant",
+          "tool": "get_symbol_context",
+          "args": {
+            "name": "SfBenchWorker",
+            "path": "${fixture.oracle.mutations.Java.path}",
+            "sections": [
+              "dependents",
+              "siblings",
+              "implementations",
+              "git"
+            ],
+            "verbosity": "compact",
+            "file": "${fixture.oracle.mutations.Java.path}",
+            "max_tokens": 2048
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.java\" -- \"SfBenchProtocol|SfBenchWorker|implements\" \"${case.work_root}/sfbench_fixture/java\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" log --oneline -- \"sfbench_fixture/java\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Java.trace_context",
+        "expected_outcome": "exact trace sections without loops/duplicates; task token delta versus multi-search baseline",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "sections empty=all",
+        "dependents",
+        "siblings",
+        "implementations",
+        "git",
+        "include_tests=true",
+        "file",
+        "verbosity variants"
+      ]
+    },
+    {
+      "id": "SF-health-001",
+      "primary_tool": "health",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Cold-build and snapshot-warm health states report exact project counts and load source.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "cold_build",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health to test this claim: Cold-build, snapshot-warm, and process-warm health states report exact project counts and load source while remaining callable during loading. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "cold_build",
+          "economics_role": "task",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "snapshot_warm",
+          "economics_role": "comparison_variant",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": true,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/.symforge/index.bin\"; if(Test-Path -LiteralPath $p){ Get-Item -Force -LiteralPath $p | Select-Object Length,LastWriteTimeUtc } else { 'snapshot absent in non-SymForge baseline' }",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.health.states",
+        "expected_outcome": "cold-build and snapshot-warm state/load-source/counts agree with the independent process and inventory oracle",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 5,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "quarantine_limit=10",
+        "quarantine_offset=0",
+        "cold build",
+        "snapshot warm"
+      ]
+    },
+    {
+      "id": "SF-health-002",
+      "primary_tool": "health",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Quarantine pagination at zero, cap, over-cap, middle, final, and out-of-range offsets has no gaps or duplicates and discloses clamping.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "parse_issue_registry",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.quarantine.populate_malformed_configs"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health to test this claim: Quarantine pagination at zero, cap, over-cap, middle, final, and out-of-range offsets has no gaps or duplicates and discloses clamping. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "zero",
+          "economics_role": "task",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 0,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "middle",
+          "economics_role": "comparison_variant",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": "${fixture.oracle.runtime.quarantine.middle_offset}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "cap",
+          "economics_role": "comparison_variant",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 1000,
+            "quarantine_offset": "${fixture.oracle.runtime.quarantine.final_offset}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "over_cap",
+          "economics_role": "comparison_variant",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 1001,
+            "quarantine_offset": "${fixture.oracle.runtime.quarantine.out_of_range_offset}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-ChildItem -Recurse -File -LiteralPath \"${case.work_root}/.symforge/quarantine\" -ErrorAction SilentlyContinue | Sort-Object FullName | Select-Object FullName",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.quarantine.pagination",
+        "expected_outcome": "exact ordered registry slices, no gaps/duplicates, cap warning, honest out-of-range empty page",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "limit=0",
+        "limit=10",
+        "limit=1000",
+        "limit over-cap",
+        "offset middle/final/out-of-range"
+      ]
+    },
+    {
+      "id": "SF-health-003",
+      "primary_tool": "health",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Repeated process-warm health after one controlled mutation is deterministic apart from normalized runtime fields and economically compared with file aggregation.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.health.mutate_between_requests"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health to test this claim: Repeated process-warm health after one controlled mutation is deterministic apart from normalized runtime fields and economically compared with file aggregation. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "before",
+          "economics_role": "task",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "after_mutation",
+          "economics_role": "comparison_variant",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" status --porcelain=v1",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.health.process_warm_transition",
+        "expected_outcome": "only oracle-authorized state/count fields change; normalized parity and token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [
+        "sfbench_fixture/runtime/health_watcher_probe.ts"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "process warm repeat",
+        "post-mutation",
+        "determinism",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-health_compact-001",
+      "primary_tool": "health_compact",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Compact health required fields exactly agree with full health while using fewer direct payload tokens.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health_compact to test this claim: Compact health required fields exactly agree with full health while using fewer direct payload tokens. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "compact",
+          "economics_role": "task",
+          "tool": "health_compact",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "full_reference",
+          "economics_role": "oracle_reference",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 10,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/.symforge/index.bin\"; if(Test-Path -LiteralPath $p){ Get-Item -Force -LiteralPath $p | Select-Object Length } else { 'snapshot absent in non-SymForge baseline' }",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.health.compact_full_parity",
+        "expected_outcome": "shared state, project identity, counts, and snapshot fields agree",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "empty object schema",
+        "full comparison"
+      ]
+    },
+    {
+      "id": "SF-health_compact-002",
+      "primary_tool": "health_compact",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Compact health surfaces parse-issue state honestly rather than remaining falsely healthy.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "parse_issue_registry",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.quarantine.populate_malformed_configs"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health_compact to test this claim: Compact health surfaces parse-issue state honestly rather than remaining falsely healthy. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "health_compact",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-ChildItem -Recurse -File -LiteralPath \"${case.work_root}/.symforge/quarantine\" -ErrorAction SilentlyContinue | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.health.parse_issue_compact",
+        "expected_outcome": "non-healthy/partial state and issue count agree with full health",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "parse issue state"
+      ]
+    },
+    {
+      "id": "SF-health_compact-003",
+      "primary_tool": "health_compact",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "On a tiny repo, compact health envelope cost is compared with plain observable snapshot and file-count facts.",
+      "repo": "p-map",
+      "repo_stratum": "tiny",
+      "commit": "${repo.p-map.commit}",
+      "language": "JavaScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use health_compact to test this claim: On a tiny repo, compact health envelope cost is compared with plain observable snapshot and file-count facts. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "health_compact",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "repeat",
+          "economics_role": "replay_diagnostic",
+          "tool": "health_compact",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/.symforge/index.bin\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.health.tiny",
+        "expected_outcome": "correct stable fields; token-negative direct/session economics recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "repeat",
+        "tiny repo control",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-index_folder-001",
+      "primary_tool": "index_folder",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Cold retarget indexes the disposable repository, and same-key/same-request replay returns the stored result without rebuilding.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "cold_build",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use index_folder to test this claim: Cold retarget indexes the disposable repository, and same-key/same-request replay returns the stored result without rebuilding. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "first",
+          "economics_role": "task",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}",
+            "add": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}",
+            "add": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Ordinary tools have no equivalent persistent code index; setup cost is compared with zero baseline setup and later per-task shell costs."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.index_folder.retarget_replay",
+        "expected_outcome": "project identity and counts match oracle; replay does not rebuild or duplicate watcher state",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 600,
+        "repetitions": 5,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/**"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "add=false",
+        "idempotency replay",
+        "cold build"
+      ]
+    },
+    {
+      "id": "SF-index_folder-002",
+      "primary_tool": "index_folder",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Missing paths fail honestly, and same idempotency key with changed arguments is rejected deterministically.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use index_folder to test this claim: Missing paths fail honestly, and same idempotency key with changed arguments is rejected deterministically. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "missing",
+          "economics_role": "task",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}/missing-folder-9F31",
+            "add": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "seed",
+          "economics_role": "comparison_variant",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}",
+            "add": false,
+            "idempotency_key": "${case.idempotency_key}-conflict"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "conflict",
+          "economics_role": "comparison_variant",
+          "tool": "index_folder",
+          "args": {
+            "path": "${fixture.root}/${fixture.oracle.paths.non_git_directory}",
+            "add": false,
+            "idempotency_key": "${case.idempotency_key}-conflict"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/missing-folder-9F31\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-ChildItem -Recurse -File -LiteralPath \"${fixture.root}/${fixture.oracle.paths.non_git_directory}\" | Measure-Object",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.index_folder.validation_and_conflict",
+        "expected_outcome": "missing-path error; same-key/different-hash conflict; original active project retained after rejection",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/**"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "missing path",
+        "same key different args",
+        "non-Git path argument"
+      ]
+    },
+    {
+      "id": "SF-index_folder-003",
+      "primary_tool": "index_folder",
+      "case_kind": "stateful",
+      "claim_type": "advertised",
+      "claim_under_test": "A daemon add=true opens a second project without retargeting the home project, while isolated stdio honestly refuses additive mode.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.daemon.start_with_home_project"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use index_folder to test this claim: A daemon add=true opens a second project without retargeting the home project, while isolated stdio honestly refuses additive mode. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "daemon_add",
+          "economics_role": "task",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}",
+            "add": true,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "added"
+        },
+        {
+          "step": 2,
+          "label": "status_projects",
+          "economics_role": "oracle_reference",
+          "tool": "status",
+          "args": {
+            "detail": "projects"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "isolated_refusal",
+          "economics_role": "comparison_variant",
+          "tool": "index_folder",
+          "args": {
+            "path": "${case.work_root}",
+            "add": true,
+            "idempotency_key": "${case.idempotency_key}-isolated"
+          },
+          "fresh_process_before": true,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Multi-project live index routing is capability-only; shell can inspect each directory separately but has no equivalent session state."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.multi_project.add_and_refusal",
+        "expected_outcome": "daemon inventory contains home plus added project exactly once; isolated call refuses add=true with corrective guidance",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 300,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/**"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "add=true",
+        "daemon multi-project",
+        "isolated refusal",
+        "status projects"
+      ]
+    },
+    {
+      "id": "SF-insert_symbol-001",
+      "primary_tool": "insert_symbol",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A Rust symbol inserted before an exact anchor is correctly indented, previewed, applied, and replay-safe.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use insert_symbol to test this claim: A Rust symbol inserted before an exact anchor is correctly indented, previewed, applied, and replay-safe. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.insert_symbol.anchor}",
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_entry.start_line}",
+            "dry_run": true,
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.insert_symbol.anchor}",
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "kind": "fn",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.insert_symbol.anchor}",
+            "content": "${fixture.oracle.mutations.Rust.insert_symbol.body}",
+            "position": "before",
+            "kind": "fn",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry\" \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.insert_symbol.before_patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.insert_symbol.before",
+        "expected_outcome": "zero-byte preview then exact placement/indentation and valid Rust; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "position=before",
+        "content",
+        "kind",
+        "dry/apply",
+        "idempotency",
+        "working_directory",
+        "project",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-insert_symbol-002",
+      "primary_tool": "insert_symbol",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "An invalid position or ambiguous anchor is rejected before a Python write.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use insert_symbol to test this claim: An invalid position or ambiguous anchor is rejected before a Python write. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "bad_position",
+          "economics_role": "task",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "sfbench_entry",
+            "content": "${fixture.oracle.mutations.Python.insert_symbol.body}",
+            "position": "sideways",
+            "dry_run": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "ambiguous",
+          "economics_role": "comparison_variant",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.languages.Python.root}/duplicates/a/duplicate.py",
+            "name": "sfbench_duplicate",
+            "content": "${fixture.oracle.mutations.Python.insert_symbol.body}",
+            "position": "after",
+            "dry_run": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry|sfbench_duplicate\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.insert_validation",
+        "expected_outcome": "invalid-position and ambiguity errors; byte-identical source",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid position",
+        "ambiguous anchor"
+      ]
+    },
+    {
+      "id": "SF-insert_symbol-003",
+      "primary_tool": "insert_symbol",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A TypeScript insert-after preview is compared with bounded anchor discovery and one patch.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use insert_symbol to test this claim: A TypeScript insert-after preview is compared with bounded anchor discovery and one patch. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "insert_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "${fixture.oracle.mutations.TypeScript.insert_symbol.anchor}",
+            "content": "${fixture.oracle.mutations.TypeScript.insert_symbol.body}",
+            "position": "after",
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_entry\" \"${case.work_root}/${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.insert_symbol.after_patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.insert_symbol",
+        "expected_outcome": "exact preview, zero writes, token delta versus competent patch workflow",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "position=after",
+        "dry-run token control"
+      ]
+    },
+    {
+      "id": "SF-inspect_match-001",
+      "primary_tool": "inspect_match",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A line inside a nested Python symbol returns the exact enclosing symbol, parent chain, siblings, and excerpt.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_lookup",
+            "key": "symbols.Python",
+            "where": {
+              "name": "sfbench_nested"
+            },
+            "save_as": "prior.SF-inspect_match-001.nested"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use inspect_match to test this claim: A line inside a nested Python symbol returns the exact enclosing symbol, parent chain, siblings, and excerpt. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.symbol_index.Python.sfbench_nested.path}",
+            "line": "${prior.SF-inspect_match-001.nested.start_line}",
+            "context": 3,
+            "sibling_limit": 10,
+            "max_tokens": 1024,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$p=\"${case.work_root}/${fixture.oracle.symbol_index.Python.sfbench_nested.path}\"; $b=[System.IO.File]::ReadAllBytes($p); $s=[System.Text.UTF8Encoding]::new($false,$true).GetString($b); $l=$s -split \"(?<=\\n)\"; $n=${prior.SF-inspect_match-001.nested.start_line}; $l[([Math]::Max(0,$n-4))..([Math]::Min($l.Count-1,$n+2))]",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "symbols.Python.sfbench_nested.enclosure",
+        "expected_outcome": "exact nested method enclosure, parent chain, siblings, and excerpt lines",
+        "expected_evidence": {
+          "path": "sfbench_fixture/python/src/core.py",
+          "line": 49,
+          "enclosing_symbol": "sfbench_nested",
+          "parents": [
+            "SfBenchOuter",
+            "Inner"
+          ]
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "line",
+        "context=3",
+        "sibling_limit=10",
+        "max_tokens",
+        "estimate=false"
+      ]
+    },
+    {
+      "id": "SF-inspect_match-002",
+      "primary_tool": "inspect_match",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Line zero and a line beyond EOF are rejected, while sibling_limit zero suppresses siblings on a valid line.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_lookup",
+            "key": "symbols.Rust",
+            "where": {
+              "name": "sfbench_entry"
+            },
+            "save_as": "prior.SF-inspect_match-002.entry"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use inspect_match to test this claim: Line zero and a line beyond EOF are rejected, while sibling_limit zero suppresses siblings on a valid line. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "line_zero",
+          "economics_role": "task",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "line": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "past_eof",
+          "economics_role": "comparison_variant",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "line": 999999
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "no_siblings",
+          "economics_role": "comparison_variant",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "line": "${prior.SF-inspect_match-002.entry.start_line}",
+            "context": 0,
+            "sibling_limit": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "(Get-Content -LiteralPath \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\").Count",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.inspect_line_bounds",
+        "expected_outcome": "two bound errors and valid enclosure with no sibling list",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "line=0",
+        "line past EOF",
+        "context=0",
+        "sibling_limit=0"
+      ]
+    },
+    {
+      "id": "SF-inspect_match-003",
+      "primary_tool": "inspect_match",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A known top-level C++ line in actual and estimate modes is compared with one bounded source read.",
+      "repo": "fmt",
+      "repo_stratum": "normal",
+      "commit": "${repo.fmt.commit}",
+      "language": "C++",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_lookup",
+            "key": "symbols.C++",
+            "where": {
+              "name": "sfbench_entry"
+            },
+            "save_as": "prior.SF-inspect_match-003.entry"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use inspect_match to test this claim: A known top-level C++ line in actual and estimate modes is compared with one bounded source read. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.mutations.C++.path}",
+            "line": "${prior.SF-inspect_match-003.entry.start_line}",
+            "context": 1,
+            "sibling_limit": 3,
+            "max_tokens": 64
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "inspect_match",
+          "args": {
+            "path": "${fixture.oracle.mutations.C++.path}",
+            "line": "${prior.SF-inspect_match-003.entry.start_line}",
+            "context": 1,
+            "sibling_limit": 3,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -C 1 --word-regexp -- \"sfbench_entry\" \"${case.work_root}/sfbench_fixture/cpp\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "symbols.C++.sfbench_entry.enclosure",
+        "expected_outcome": "exact top-level enclosure; estimate error and token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "top-level line",
+        "estimate=true",
+        "max_tokens=64",
+        "token control"
+      ]
+    },
+    {
+      "id": "SF-investigation_suggest-001",
+      "primary_tool": "investigation_suggest",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "After loading only Rust entry, suggestions include real not-yet-loaded dependencies and honor focus.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use investigation_suggest to test this claim: After loading only Rust entry, suggestions include real not-yet-loaded dependencies and honor focus. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "sfbench_entry"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "step_2",
+          "economics_role": "task",
+          "tool": "investigation_suggest",
+          "args": {
+            "focus": "call graph",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$loaded=@(\"sfbench_entry\"); rg -n --word-regexp -- \"sfbench_mid|SfBenchWorker\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Rust.investigation_after_entry",
+        "expected_outcome": "suggests sfbench_mid/SfBenchWorker or equivalent real unloaded dependencies with no loaded-item repetition",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "focus",
+        "project",
+        "partial context"
+      ]
+    },
+    {
+      "id": "SF-investigation_suggest-002",
+      "primary_tool": "investigation_suggest",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "After all Python dependencies are loaded, cyclic dependencies do not repeat loaded items or produce an infinite suggestion loop.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use investigation_suggest to test this claim: After all Python dependencies are loaded, cyclic dependencies do not repeat loaded items or produce an infinite suggestion loop. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "sfbench_entry"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "step_2",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "sfbench_mid"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "step_3",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "sfbench_leaf"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "step_4",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.languages.Python.root}/src/cycle_a.py",
+            "name": "CycleA"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "step_5",
+          "economics_role": "required_prerequisite",
+          "tool": "get_symbol",
+          "args": {
+            "path": "${fixture.oracle.languages.Python.root}/src/cycle_b.py",
+            "name": "CycleB"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 6,
+          "label": "step_6",
+          "economics_role": "task",
+          "tool": "investigation_suggest",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$loaded=@(\"sfbench_entry\",\"sfbench_mid\",\"sfbench_leaf\",\"CycleA\",\"CycleB\"); $loaded",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "graphs.Python.investigation_complete_cycle",
+        "expected_outcome": "no loaded dependency is recommended; finite response with honest no-next-step state",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 7,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "no focus",
+        "all dependencies loaded",
+        "cycle termination"
+      ]
+    },
+    {
+      "id": "SF-investigation_suggest-003",
+      "primary_tool": "investigation_suggest",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Empty-session suggestion cost and utility are compared with an empty client ledger.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use investigation_suggest to test this claim: Empty-session suggestion cost and utility are compared with an empty client ledger. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "investigation_suggest",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$loaded=@(); $loaded.Count",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "session_context.empty_investigation",
+        "expected_outcome": "honest orientation/no-context guidance and token-negative control measurement",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "empty session",
+        "token-negative control"
+      ]
+    },
+    {
+      "id": "SF-replace_symbol_body-001",
+      "primary_tool": "replace_symbol_body",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Rust full-body replacement previews, applies with a presence-triggered disk guard, preserves bytes/newlines, and replays safely.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use replace_symbol_body to test this claim: Rust full-body replacement previews, applies with a presence-triggered disk guard, preserves bytes/newlines, and replays safely. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "dry_run",
+          "economics_role": "task",
+          "tool": "replace_symbol_body",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "new_body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "kind": "fn",
+            "symbol_line": "${fixture.oracle.symbol_index.Rust.sfbench_leaf.start_line}",
+            "if_match": "guard-present",
+            "dry_run": true,
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "replace_symbol_body",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "new_body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "kind": "fn",
+            "if_match": "guard-present",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "replace_symbol_body",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "name": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "new_body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "kind": "fn",
+            "if_match": "guard-present",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}",
+            "working_directory": "${case.work_root}",
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.replace_symbol.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.replace_symbol",
+        "expected_outcome": "exact diff hash, newline/Unicode preservation, valid Rust, replay no-op; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "new_body",
+        "kind",
+        "if_match presence guard",
+        "dry/apply",
+        "idempotency",
+        "working_directory",
+        "project",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-replace_symbol_body-002",
+      "primary_tool": "replace_symbol_body",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A concurrent disk divergence after planning is rejected without clobbering either the external edit or unrelated bytes.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "stale_index",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "mutations.Python.concurrent_divergence.prepare"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use replace_symbol_body to test this claim: A concurrent disk divergence after planning is rejected without clobbering either the external edit or unrelated bytes. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "replace_symbol_body",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "name": "${fixture.oracle.mutations.Python.replace_symbol.symbol}",
+            "new_body": "${fixture.oracle.mutations.Python.replace_symbol.new_body}",
+            "if_match": "guard-present",
+            "dry_run": false,
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 -- \"${fixture.oracle.mutations.Python.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Python.concurrent_divergence",
+        "expected_outcome": "stale/concurrent-change rejection and exact externally changed bytes preserved",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "concurrent divergence",
+        "rejected guarded write"
+      ]
+    },
+    {
+      "id": "SF-replace_symbol_body-003",
+      "primary_tool": "replace_symbol_body",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "A TypeScript replacement preview is compared with one bounded read plus apply_patch to expose granular-tool overhead.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use replace_symbol_body to test this claim: A TypeScript replacement preview is compared with one bounded read plus apply_patch to expose granular-tool overhead. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "replace_symbol_body",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "name": "${fixture.oracle.mutations.TypeScript.replace_symbol.symbol}",
+            "new_body": "${fixture.oracle.mutations.TypeScript.replace_symbol.new_body}",
+            "dry_run": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.replace_symbol.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.replace_symbol",
+        "expected_outcome": "exact preview, zero writes, full-task token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "dry-run token control",
+        "if_match omitted"
+      ]
+    },
+    {
+      "id": "SF-search_files-001",
+      "primary_tool": "search_files",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Fuzzy and resolve modes find duplicate Python basenames, with current-file and path-prefix ranking grounded in the oracle.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_files to test this claim: Fuzzy and resolve modes find duplicate Python basenames, with current-file and path-prefix ranking grounded in the oracle. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "fuzzy",
+          "economics_role": "task",
+          "tool": "search_files",
+          "args": {
+            "query": "duplicate.py",
+            "current_file": "${fixture.oracle.mutations.Python.path}",
+            "path_prefix": "sfbench_fixture/python",
+            "limit": 20,
+            "max_tokens": 512,
+            "resolve": false,
+            "include_vendor": false,
+            "include_personal_tooling": false,
+            "debug_ranking": true,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "resolve",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "query": "duplicates/a/duplicate.py",
+            "path_prefix": "sfbench_fixture/python",
+            "resolve": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}/sfbench_fixture/python\" | rg \"duplicate\\.py$\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "duplicate_basenames.Python",
+        "expected_outcome": "both duplicate paths in fuzzy results and exact a/ path in resolve mode; ranking explanation truthful",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "query",
+        "current_file",
+        "path_prefix",
+        "limit",
+        "max_tokens",
+        "resolve false/true",
+        "include_vendor=false",
+        "include_personal_tooling=false",
+        "debug_ranking=true",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-search_files-002",
+      "primary_tool": "search_files",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Filesystem paths used as project IDs and mutually exclusive project selectors are rejected with corrective guidance.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_files to test this claim: Filesystem paths used as project IDs and mutually exclusive project selectors are rejected with corrective guidance. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "path_as_project",
+          "economics_role": "task",
+          "tool": "search_files",
+          "args": {
+            "query": "core.rs",
+            "project": "${case.work_root}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "selector_conflict",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "query": "core.rs",
+            "project": "${session.project_id}",
+            "projects": [
+              "${session.project_id}"
+            ]
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | rg \"core\\.rs$\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.project_selector_validation",
+        "expected_outcome": "both requests invalid; path error points to index_folder(add=true)",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid project path",
+        "project+projects conflict"
+      ]
+    },
+    {
+      "id": "SF-search_files-003",
+      "primary_tool": "search_files",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Default, frecency, legacy co-change, recommended path+cochange, vendor/personal filters, caps, and estimates expose ranking value versus rg and Git history.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.frecency.seed_fixture_paths"
+          }
+        ]
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_files to test this claim: Default, frecency, legacy co-change, recommended path+cochange, vendor/personal filters, caps, and estimates expose ranking value versus rg and Git history. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "default",
+          "economics_role": "task",
+          "tool": "search_files",
+          "args": {
+            "query": "marker.py",
+            "limit": 50,
+            "include_vendor": false,
+            "include_personal_tooling": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "frecency",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "query": "core",
+            "rank_by": "frecency",
+            "debug_ranking": true,
+            "current_file": "${fixture.oracle.mutations.TypeScript.path}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "legacy_cochange",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "changed_with": "${fixture.oracle.mutations.TypeScript.path}",
+            "limit": 20
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "path_cochange",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "query": "test",
+            "rank_by": "path+cochange",
+            "anchor_path": "${fixture.oracle.mutations.TypeScript.path}",
+            "include_vendor": true,
+            "include_personal_tooling": true,
+            "limit": 51,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "search_files",
+          "args": {
+            "query": "core",
+            "rank_by": "path+cochange",
+            "anchor_path": "${fixture.oracle.mutations.TypeScript.path}",
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 6,
+          "label": "multi_project",
+          "economics_role": "comparison_variant",
+          "tool": "search_files",
+          "args": {
+            "query": "core",
+            "projects": [
+              "*"
+            ],
+            "limit": 20
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | rg -i \"core|marker|test\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" log --name-only --format= -- \"${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "ranking.files.TypeScript",
+        "expected_outcome": "exact eligible sets, honest fallback/readiness evidence, known co-change order, cap behavior, estimate error",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 7,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "rank_by=frecency",
+        "changed_with",
+        "rank_by=path+cochange",
+        "anchor_path",
+        "include_vendor=true",
+        "include_personal_tooling=true",
+        "limit=50",
+        "limit over-cap",
+        "estimate=true",
+        "projects=*"
+      ]
+    },
+    {
+      "id": "SF-search_symbols-001",
+      "primary_tool": "search_symbols",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Exact Rust symbol search returns the oracle path, kind, and line while respecting source/test/noise filters.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_symbols to test this claim: Exact Rust symbol search returns the oracle path, kind, and line while respecting source/test/noise filters. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_leaf",
+            "kind": "fn",
+            "language": "Rust",
+            "path_prefix": "sfbench_fixture/rust",
+            "include_tests": false,
+            "include_generated": false,
+            "include_vendor": false,
+            "include_personal_tooling": false,
+            "limit": 50,
+            "max_tokens": 512,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.rs\" -- \"^(pub[ ]+)?fn[ ]+sfbench_leaf\\b\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "symbols.Rust.sfbench_leaf",
+        "expected_outcome": "precision=1, recall=1, exact path/kind/start line",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "query",
+        "kind",
+        "language",
+        "path_prefix",
+        "all filters false",
+        "limit",
+        "max_tokens",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-search_symbols-002",
+      "primary_tool": "search_symbols",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Missing all selectors, empty projects, and a path used as project ID are each rejected with distinct actionable guidance.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_symbols to test this claim: Missing all selectors, empty projects, and a path used as project ID are each rejected with distinct actionable guidance. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "no_selector",
+          "economics_role": "task",
+          "tool": "search_symbols",
+          "args": {},
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "empty_projects",
+          "economics_role": "comparison_variant",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_leaf",
+            "projects": []
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "path_project",
+          "economics_role": "comparison_variant",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_leaf",
+            "project": "${case.work_root}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Schema/selector validation is conformance-only."
+        }
+      ],
+      "baseline_equivalence": "conformance_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.search_symbols_validation",
+        "expected_outcome": "three invalid requests with no search side effects",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "no query/kind/path_prefix",
+        "projects empty",
+        "project path rejection"
+      ]
+    },
+    {
+      "id": "SF-search_symbols-003",
+      "primary_tool": "search_symbols",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Browse mode, inclusion filters, multi-project selection, cap/CCR behavior, and estimate accuracy are measured on the stress repository.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_symbols to test this claim: Browse mode, inclusion filters, multi-project selection, cap/CCR behavior, and estimate accuracy are measured on the stress repository. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "browse",
+          "economics_role": "task",
+          "tool": "search_symbols",
+          "args": {
+            "kind": "function",
+            "path_prefix": "src",
+            "language": "TypeScript",
+            "include_tests": true,
+            "include_generated": true,
+            "include_vendor": true,
+            "include_personal_tooling": true,
+            "limit": 100,
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "over_cap",
+          "economics_role": "comparison_variant",
+          "tool": "search_symbols",
+          "args": {
+            "query": "create",
+            "include_tests": true,
+            "include_generated": true,
+            "limit": 101,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "search_symbols",
+          "args": {
+            "query": "create",
+            "include_tests": true,
+            "include_generated": true,
+            "limit": 100,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "multi_project",
+          "economics_role": "comparison_variant",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_leaf",
+            "projects": [
+              "*"
+            ],
+            "limit": 20
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.ts\" -- \"(function|class|interface)[ ]+[A-Za-z0-9_]*create\" \"${case.work_root}/src\" | Select-Object -First 100",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "search_symbols.typescript_stress",
+        "expected_outcome": "deterministic browse representative ordering, honest cap/CCR, eligible filter set, estimate error",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "browse mode",
+        "include_tests/generated/vendor/personal=true",
+        "limit=100",
+        "limit over-cap",
+        "estimate=true",
+        "projects=*",
+        "CCR"
+      ]
+    },
+    {
+      "id": "SF-search_text-001",
+      "primary_tool": "search_text",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Source marker search grouped by symbol with caller enrichment returns the exact source hit and excludes test/generated/vendor/personal noise.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_text to test this claim: Source marker search grouped by symbol with caller enrichment returns the exact source hit and excludes test/generated/vendor/personal noise. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "search_text",
+          "args": {
+            "query": "${fixture.oracle.markers.source.value}",
+            "case_sensitive": true,
+            "context": 1,
+            "follow_refs": true,
+            "follow_refs_limit": 3,
+            "glob": "sfbench_fixture/**/*.rs",
+            "exclude_glob": "**/tests/**",
+            "group_by": "symbol",
+            "include_tests": false,
+            "include_generated": false,
+            "include_vendor": false,
+            "include_personal_tooling": false,
+            "language": "Rust",
+            "limit": 50,
+            "max_per_file": 5,
+            "max_tokens": 1024,
+            "path_prefix": "sfbench_fixture/rust",
+            "ranked": true,
+            "regex": false,
+            "structural": false,
+            "whole_word": true,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -C 1 --fixed-strings --glob \"*.rs\" --glob \"!**/tests/**\" -- \"${fixture.oracle.markers.source.value}\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "markers.source",
+        "expected_outcome": "exact source-only hit set, grouping, enclosing symbol, and caller enrichment",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "query",
+        "case_sensitive",
+        "context",
+        "follow_refs",
+        "follow_refs_limit",
+        "glob",
+        "exclude_glob",
+        "group_by=symbol",
+        "all filters false",
+        "language",
+        "limit",
+        "max_per_file",
+        "max_tokens",
+        "path_prefix",
+        "ranked",
+        "regex=false",
+        "structural=false",
+        "whole_word",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-search_text-002",
+      "primary_tool": "search_text",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Invalid regex, regex plus whole-word conflict, and invalid structural pattern fail specifically; default test-only search reports the suppressed-count hint.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_text to test this claim: Invalid regex, regex plus whole-word conflict, and invalid structural pattern fail specifically; default test-only search reports the suppressed-count hint. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "invalid_regex",
+          "economics_role": "task",
+          "tool": "search_text",
+          "args": {
+            "query": "(",
+            "regex": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "regex_word_conflict",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "sfbench",
+            "regex": true,
+            "whole_word": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "invalid_structural",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "def $$$(",
+            "structural": true,
+            "language": "Python"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "test_suppressed",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "${fixture.oracle.markers.test.value}",
+            "include_tests": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "test_included",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "${fixture.oracle.markers.test.value}",
+            "include_tests": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --fixed-strings -- \"${fixture.oracle.markers.test.value}\" \"${case.work_root}/sfbench_fixture/python\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "search_text.validation_and_test_suppression.Python",
+        "expected_outcome": "three specific invalid requests; zero source hits plus exact suppressed count; exact hits when tests included",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 6,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid regex",
+        "regex+whole_word conflict",
+        "invalid structural",
+        "include_tests false/true",
+        "suppressed hint"
+      ]
+    },
+    {
+      "id": "SF-search_text-003",
+      "primary_tool": "search_text",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "OR terms, regex/case, all grouping modes, structural search, filters, caps, CCR, estimates, and multi-project search are measured against scoped rg.",
+      "repo": "typescript",
+      "repo_stratum": "stress",
+      "commit": "${repo.typescript.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use search_text to test this claim: OR terms, regex/case, all grouping modes, structural search, filters, caps, CCR, estimates, and multi-project search are measured against scoped rg. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "terms_file",
+          "economics_role": "task",
+          "tool": "search_text",
+          "args": {
+            "terms": [
+              "sfbench_leaf",
+              "sfbench_mid"
+            ],
+            "group_by": "file",
+            "case_sensitive": false,
+            "limit": 50,
+            "max_per_file": 5
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "regex_usage",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "sfbench_(leaf|mid)",
+            "regex": true,
+            "case_sensitive": true,
+            "group_by": "usage",
+            "ranked": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "names_noise",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "SF_BENCH_",
+            "group_by": "names",
+            "include_tests": true,
+            "include_generated": true,
+            "include_vendor": true,
+            "include_personal_tooling": true,
+            "limit": 50,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "structural",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "function $NAME($$$) { $$$ }",
+            "structural": true,
+            "language": "TypeScript",
+            "group_by": "symbol"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "ccr",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "sfbench_bulk_result_",
+            "include_generated": true,
+            "group_by": "names",
+            "limit": 50,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "ccr_source"
+        },
+        {
+          "step": 6,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "search_text",
+          "args": {
+            "query": "sfbench_bulk_result_",
+            "include_generated": true,
+            "group_by": "names",
+            "limit": 50,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 7,
+          "label": "multi_project",
+          "economics_role": "comparison_variant",
+          "tool": "search_text",
+          "args": {
+            "query": "sfbench_leaf",
+            "projects": [
+              "*"
+            ],
+            "limit": 20
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.ts\" -- \"sfbench_(leaf|mid)|SF_BENCH_|sfbench_bulk_result_\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "search_text.TypeScript.portfolio_modes",
+        "expected_outcome": "exact TP/FP/FN sets and groupings, valid structural matches, honest CCR footer, estimate error, selector correctness",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 8,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "terms OR",
+        "group_by=file/usage/names/symbol",
+        "regex=true",
+        "case modes",
+        "ranked",
+        "all noise filters true",
+        "structural=true",
+        "CCR",
+        "estimate=true",
+        "projects=*"
+      ]
+    },
+    {
+      "id": "SF-status-001",
+      "primary_tool": "status",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Full-surface compact, full, and projects detail modes agree with health and manifest identity.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use status to test this claim: Full-surface compact, full, and projects detail modes agree with health and manifest identity. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "compact",
+          "economics_role": "task",
+          "tool": "status",
+          "args": {
+            "detail": "compact",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "full",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "projects",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "projects",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "health_reference",
+          "economics_role": "oracle_reference",
+          "tool": "health",
+          "args": {
+            "quarantine_limit": 0,
+            "quarantine_offset": 0
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "health_reference"
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "STEL trust/calibration state has no ordinary shell equivalent; observable index fields are cross-checked with files and process state."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.status.detail_modes",
+        "expected_outcome": "surface/version/wiring/index fields agree across modes and with health; one home project in isolated mode",
+        "expected_evidence": {
+          "health_parity": "project/index counts and load state agree with excluded health reference",
+          "manifest_parity": "surface, version, tool count, and runtime schema hash agree with the frozen campaign manifest"
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 5,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "detail=compact",
+        "detail=full",
+        "detail=projects",
+        "reset_calibration=false",
+        "full surface",
+        "excluded health reference",
+        "frozen manifest parity"
+      ]
+    },
+    {
+      "id": "SF-status-002",
+      "primary_tool": "status",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Invalid detail is rejected, and reset_calibration on an isolated no-durable-store build is an honest no-op affecting no index state.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use status to test this claim: Invalid detail is rejected, and reset_calibration on an isolated no-durable-store build is an honest no-op affecting no index state. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "invalid_detail",
+          "economics_role": "task",
+          "tool": "status",
+          "args": {
+            "detail": "verbose"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "reset_no_store",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "recheck",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Calibration reset is capability-only."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.status.validation_and_no_store_reset",
+        "expected_outcome": "invalid enum error; no-store reset disclosed/no-op; index identity/counts unchanged",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "invalid detail",
+        "reset_calibration=true",
+        "compact surface",
+        "no durable store"
+      ]
+    },
+    {
+      "id": "SF-status-003",
+      "primary_tool": "status",
+      "case_kind": "stateful",
+      "claim_type": "advertised",
+      "claim_under_test": "Daemon durable calibration reset clears tuned constants and samples to Deferred while preserving index state.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.calibration.seed_durable_samples"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use status to test this claim: Daemon durable calibration reset clears tuned constants and samples to Deferred while preserving index state. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "before",
+          "economics_role": "task",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "reset",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "after",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full",
+            "reset_calibration": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Durable calibration reset is capability-only."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.calibration.durable_reset",
+        "expected_outcome": "calibration becomes Deferred and sample rows clear; index/snapshot/project fields unchanged",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        ".symforge/**"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "durable reset",
+        "state transition",
+        "compact surface",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-status-004",
+      "primary_tool": "status",
+      "case_kind": "control",
+      "claim_type": "advertised",
+      "claim_under_test": "The compact-surface status schema accepts only its advertised compact/full detail values and reports the served compact surface honestly.",
+      "advertised_boundary": "The live compact schema does not advertise reset_calibration or projects detail; this case does not invent either field and records that surface gap separately.",
+      "repo": "fmt",
+      "repo_stratum": "normal",
+      "commit": "${repo.fmt.commit}",
+      "language": "C++",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "compact",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use status on the compact surface with compact and full detail. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "compact",
+          "economics_role": "task",
+          "tool": "status",
+          "args": {
+            "detail": "compact"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "full",
+          "economics_role": "comparison_variant",
+          "tool": "status",
+          "args": {
+            "detail": "full"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Compact STEL trust-envelope state has no equivalent ordinary shell command."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.status.compact_surface_identity",
+        "expected_outcome": "both advertised detail values succeed, report surface=compact, and agree on shared index/project fields",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "compact_surface_schema_and_idle_tax",
+      "covers": [
+        "compact (surface,tool) identity",
+        "detail=compact",
+        "detail=full",
+        "no hidden reset field",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-symforge_edit-001",
+      "primary_tool": "symforge_edit",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Facade replace previews by default, applies a flush-left full body with value-matched if_match, and replays safely.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "symbols.Rust.sfbench_leaf.read_exact_body",
+            "save_as": "prior.SF-symforge_edit-001.current"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_edit to test this claim: Facade replace previews by default, applies a flush-left full body with value-matched if_match, and replays safely. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "preview",
+          "economics_role": "task",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "intent": "edit",
+            "op": "replace",
+            "apply": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "apply",
+          "economics_role": "task",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "intent": "edit",
+            "op": "replace",
+            "apply": true,
+            "if_match": "${prior.SF-symforge_edit-001.current.body}",
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "same_key_replay",
+          "economics_role": "replay_diagnostic",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol": "${fixture.oracle.mutations.Rust.replace_symbol.symbol}",
+            "body": "${fixture.oracle.mutations.Rust.replace_symbol.new_body}",
+            "intent": "edit",
+            "op": "replace",
+            "apply": true,
+            "if_match": "${prior.SF-symforge_edit-001.current.body}",
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/${fixture.oracle.mutations.Rust.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Rust.replace_symbol.patch}"
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --check",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "$out=Join-Path ([System.IO.Path]::GetTempPath()) (\"sfbench-\"+[guid]::NewGuid().ToString(\"N\")+\".rmeta\"); & rustc --edition=2021 --crate-type lib --emit metadata -o $out \"${case.work_root}/sfbench_fixture/rust/src/mod.rs\"; $ec=$LASTEXITCODE; Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue; exit $ec",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Rust.replace_symbol",
+        "expected_outcome": "preview zero writes; exact replacement without doubled indentation; replay safe; same-key replay returns the stored result with zero additional source writes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [
+        "${fixture.oracle.mutations.Rust.path}"
+      ],
+      "source_hash_policy": "only_allowlisted_paths_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "symbol",
+        "body",
+        "intent=edit",
+        "op=replace",
+        "apply false/true",
+        "if_match value",
+        "idempotency_key",
+        "same-key replay"
+      ]
+    },
+    {
+      "id": "SF-symforge_edit-002",
+      "primary_tool": "symforge_edit",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "A stale value-matched if_match and missing op-specific fields are rejected before any Python write.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_edit to test this claim: A stale value-matched if_match and missing op-specific fields are rejected before any Python write. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "stale_match",
+          "economics_role": "task",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "symbol": "sfbench_leaf",
+            "body": "${fixture.oracle.mutations.Python.replace_symbol.new_body}",
+            "op": "replace",
+            "apply": true,
+            "if_match": "definitely-stale-9F31",
+            "idempotency_key": "${case.idempotency_key}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "missing_old_text",
+          "economics_role": "comparison_variant",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Python.path}",
+            "symbol": "sfbench_mutable",
+            "op": "edit_within",
+            "new_text": "x",
+            "apply": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff -- \"${fixture.oracle.mutations.Python.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.symforge_edit_preflight",
+        "expected_outcome": "both invalid requests and byte-identical source",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "stale if_match",
+        "op=edit_within missing old_text",
+        "rejected writes"
+      ]
+    },
+    {
+      "id": "SF-symforge_edit-003",
+      "primary_tool": "symforge_edit",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Compact facade edit_within and insert-before/after previews match granular-tool diffs while exposing facade routing/schema overhead.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_edit to test this claim: Compact facade edit_within and insert-before/after previews match granular-tool diffs while exposing facade routing/schema overhead. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "edit_within",
+          "economics_role": "task",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "symbol": "sfbench_mutable",
+            "op": "edit_within",
+            "old_text": "${fixture.oracle.mutations.TypeScript.edit_within.old_text}",
+            "new_text": "${fixture.oracle.mutations.TypeScript.edit_within.new_text}",
+            "replace_all": true,
+            "apply": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "insert_before",
+          "economics_role": "comparison_variant",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "symbol": "sfbench_entry",
+            "op": "insert_before",
+            "body": "${fixture.oracle.mutations.TypeScript.insert_symbol.body}",
+            "apply": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "insert_after",
+          "economics_role": "comparison_variant",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.TypeScript.path}",
+            "symbol": "sfbench_entry",
+            "op": "insert_after",
+            "body": "${fixture.oracle.mutations.TypeScript.insert_symbol.body}",
+            "apply": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_mutable|sfbench_entry\" \"${case.work_root}/${fixture.oracle.mutations.TypeScript.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.TypeScript.facade_control.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.TypeScript.symforge_edit_parity",
+        "expected_outcome": "each preview exact and byte-identical to granular equivalent; no writes; token deltas recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "op=edit_within",
+        "old_text",
+        "new_text",
+        "replace_all",
+        "op=insert_before",
+        "op=insert_after",
+        "compact surface",
+        "facade parity"
+      ]
+    },
+    {
+      "id": "SF-symforge_edit-004",
+      "primary_tool": "symforge_edit",
+      "case_kind": "control",
+      "claim_type": "advertised",
+      "claim_under_test": "The compact-surface schema-advertised path/symbol/body/intent request previews a replace without relying on hidden full-surface fields.",
+      "repo": "gson",
+      "repo_stratum": "normal",
+      "commit": "${repo.gson.commit}",
+      "language": "Java",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "compact",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_edit to preview replacing sfbench_leaf using only the compact surface schema fields. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "compact_preview",
+          "economics_role": "task",
+          "tool": "symforge_edit",
+          "args": {
+            "path": "${fixture.oracle.mutations.Java.path}",
+            "symbol": "${fixture.oracle.mutations.Java.replace_symbol.symbol}",
+            "body": "${fixture.oracle.mutations.Java.replace_symbol.new_body}",
+            "intent": "edit"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf\" \"${case.work_root}/${fixture.oracle.mutations.Java.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "apply_patch",
+          "patch": "${fixture.oracle.mutations.Java.replace_symbol.patch}"
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "mutations.Java.replace_symbol",
+        "expected_outcome": "default preview returns the exact Java replacement diff and changes zero source bytes",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "compact_surface_schema_and_token_control",
+      "covers": [
+        "compact (surface,tool) identity",
+        "schema-advertised path",
+        "symbol",
+        "body",
+        "intent=edit",
+        "default preview",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-symforge_retrieve-001",
+      "primary_tool": "symforge_retrieve",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "A valid same-session CCR handle retrieves the exact stored pre-compression payload and repeated retrieval is stable.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_retrieve to test this claim: A valid same-session CCR handle retrieves the exact stored pre-compression payload and repeated retrieval is stable. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "trigger",
+          "economics_role": "required_prerequisite",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_bulk_result_",
+            "include_generated": true,
+            "limit": 100,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "ccr"
+        },
+        {
+          "step": 2,
+          "label": "retrieve",
+          "economics_role": "task",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "${prior.SF-symforge_retrieve-001.ccr.hash}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "repeat",
+          "economics_role": "replay_diagnostic",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "${prior.SF-symforge_retrieve-001.ccr.hash}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -- \"sfbench_bulk_result_\" \"${case.work_root}/${fixture.oracle.large_file.path}\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "large_file.ccr_payload",
+        "expected_outcome": "retrieved payload hash equals stored uncompressed ranked output; repeat bytes identical",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "valid hash",
+        "same-session retrieval",
+        "repeat"
+      ]
+    },
+    {
+      "id": "SF-symforge_retrieve-002",
+      "primary_tool": "symforge_retrieve",
+      "case_kind": "adverse",
+      "claim_type": "desired",
+      "claim_under_test": "Malformed, unknown, and cross-session CCR handles fail specifically and never return another session's content.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": [
+          {
+            "executor": "oracle_action",
+            "key": "runtime.ccr.create_foreign_session_handle",
+            "save_as": "prior.SF-symforge_retrieve-002.foreign"
+          }
+        ]
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_retrieve to test this claim: Malformed, unknown, and cross-session CCR handles fail specifically and never return another session's content. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "malformed",
+          "economics_role": "task",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "not-a-hash"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "unknown",
+          "economics_role": "comparison_variant",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "000000000000"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "cross_session",
+          "economics_role": "comparison_variant",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "${prior.SF-symforge_retrieve-002.foreign.hash}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": true,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "CCR handle validation/isolation is capability-only."
+        }
+      ],
+      "baseline_equivalence": "capability_only",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "runtime.ccr.validation_and_isolation",
+        "expected_outcome": "malformed/unknown invalid results; foreign-session handle rejected with no payload disclosure",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "malformed hash",
+        "unknown hash",
+        "cross-session desired isolation"
+      ]
+    },
+    {
+      "id": "SF-symforge_retrieve-003",
+      "primary_tool": "symforge_retrieve",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Summary-sufficient and exact-detail workflows measure CCR with and without mandatory retrieval, including the extra turn and transcript replay.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge_retrieve to test this claim: Summary-sufficient and exact-detail workflows measure CCR with and without mandatory retrieval, including the extra turn and transcript replay. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "summary_trigger",
+          "economics_role": "required_prerequisite",
+          "tool": "search_symbols",
+          "args": {
+            "query": "sfbench_bulk_result_",
+            "include_generated": true,
+            "limit": 100,
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": "summary_ccr"
+        },
+        {
+          "step": 2,
+          "label": "exact_retrieve",
+          "economics_role": "task",
+          "tool": "symforge_retrieve",
+          "args": {
+            "hash": "${prior.SF-symforge_retrieve-003.summary_ccr.hash}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n -- \"sfbench_bulk_result_\" \"${case.work_root}/${fixture.oracle.large_file.path}\" | Select-Object -First 100",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "large_file.ccr_workflow_economics",
+        "expected_outcome": "summary satisfies summary oracle; combined retrieval satisfies exact oracle; both token totals and replay cost recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "summary-only economics",
+        "mandatory retrieval economics",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-validate_file_syntax-001",
+      "primary_tool": "validate_file_syntax",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Valid and malformed JSON agree with the authoritative parser, including diagnostic location when available and estimate accuracy.",
+      "repo": "json-schema-suite",
+      "repo_stratum": "symbol-poor",
+      "commit": "${repo.json-schema-suite.commit}",
+      "language": "JSON",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use validate_file_syntax to test this claim: Valid and malformed JSON agree with the authoritative parser, including diagnostic location when available and estimate accuracy. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "valid",
+          "economics_role": "task",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/valid.json",
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "malformed",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/malformed.json",
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/malformed.json",
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -m json.tool \"${case.work_root}/sfbench_fixture/configs/valid.json\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -m json.tool \"${case.work_root}/sfbench_fixture/configs/malformed.json\"",
+          "expected_exit_codes": [
+            1
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "configs.json",
+        "expected_outcome": "valid accepted; malformed rejected at oracle diagnostic location; estimate error recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "path",
+        "estimate false/true",
+        "project",
+        "valid/malformed JSON"
+      ]
+    },
+    {
+      "id": "SF-validate_file_syntax-002",
+      "primary_tool": "validate_file_syntax",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Missing paths and unsupported extensions are distinguished from syntax errors.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use validate_file_syntax to test this claim: Missing paths and unsupported extensions are distinguished from syntax errors. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "missing",
+          "economics_role": "task",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/missing_9F31.json"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "unsupported",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/exact/deterministic.bin"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Test-Path -LiteralPath \"${case.work_root}/sfbench_fixture/configs/missing_9F31.json\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-Item -LiteralPath \"${case.work_root}/sfbench_fixture/exact/deterministic.bin\" | Select-Object Length",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "errors.syntax_missing_and_unsupported",
+        "expected_outcome": "specific not-found and unsupported-format outcomes; no fabricated parser diagnostic",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "missing path",
+        "unsupported extension"
+      ]
+    },
+    {
+      "id": "SF-validate_file_syntax-003",
+      "primary_tool": "validate_file_syntax",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "TOML, YAML, BOM/CRLF/Unicode, and unindexed config handling agree with authoritative parsers and expose response overhead.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use validate_file_syntax to test this claim: TOML, YAML, BOM/CRLF/Unicode, and unindexed config handling agree with authoritative parsers and expose response overhead. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "valid_toml",
+          "economics_role": "task",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/valid.toml"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "bad_toml",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/malformed.toml"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "valid_yaml",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/valid.yaml"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "bad_yaml",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/malformed.yaml"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "bom_crlf_unicode",
+          "economics_role": "comparison_variant",
+          "tool": "validate_file_syntax",
+          "args": {
+            "path": "sfbench_fixture/configs/bom_crlf_unicode.json"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path(r'${case.work_root}/sfbench_fixture/configs/valid.toml').read_text(encoding='utf-8'))\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path(r'${case.work_root}/sfbench_fixture/configs/malformed.toml').read_text(encoding='utf-8'))\"",
+          "expected_exit_codes": [
+            1
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -c \"import pathlib,yaml; yaml.safe_load(pathlib.Path(r'${case.work_root}/sfbench_fixture/configs/valid.yaml').read_text(encoding='utf-8'))\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "python -c \"import pathlib,yaml; yaml.safe_load(pathlib.Path(r'${case.work_root}/sfbench_fixture/configs/malformed.yaml').read_text(encoding='utf-8'))\"",
+          "expected_exit_codes": [
+            1
+          ]
+        }
+      ],
+      "baseline_equivalence": "equivalent",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "configs.toml_yaml_bom",
+        "expected_outcome": "all validity decisions and available diagnostic lines agree; token delta recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 6,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "TOML",
+        "YAML",
+        "BOM",
+        "CRLF",
+        "Unicode",
+        "unindexed fallback",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-what_changed-001",
+      "primary_tool": "what_changed",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Dirty Python state returns the exact staged, unstaged, untracked, rename, add, and delete file set with fused symbol diff.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "mutation-repo",
+        "state": "declared_dirty_worktree",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use what_changed to test this claim: Dirty Python state returns the exact staged, unstaged, untracked, rename, add, and delete file set with fused symbol diff. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "step_1",
+          "economics_role": "task",
+          "tool": "what_changed",
+          "args": {
+            "uncommitted": true,
+            "include_symbol_diff": true,
+            "code_only": false,
+            "language": "Python",
+            "path_prefix": "sfbench_fixture",
+            "max_tokens": 2048,
+            "estimate": false,
+            "project": "${session.project_id}"
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" status --porcelain=v1",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --name-status HEAD",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 HEAD",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "worktree.status_and_fused_symbol_diff",
+        "expected_outcome": "exact file statuses and exact fused symbol delta",
+        "expected_evidence": {
+          "file_statuses": "exact fixture.oracle.worktree.status_porcelain_v1 entries",
+          "fused_symbol_delta": {
+            "added": [],
+            "modified": [],
+            "removed": []
+          },
+          "note": "The controlled Python dirty files contain module assignments only; the exact function/class symbol delta is empty and must be reported honestly."
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "uncommitted=true",
+        "include_symbol_diff=true",
+        "code_only=false",
+        "language",
+        "path_prefix",
+        "max_tokens",
+        "estimate=false",
+        "project"
+      ]
+    },
+    {
+      "id": "SF-what_changed-002",
+      "primary_tool": "what_changed",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Invalid Git refs fail explicitly, while timestamp mode does not pretend to provide unsupported symbol-diff fusion.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use what_changed to test this claim: Invalid Git refs fail explicitly, while timestamp mode does not pretend to provide unsupported symbol-diff fusion. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "invalid_ref",
+          "economics_role": "task",
+          "tool": "what_changed",
+          "args": {
+            "git_ref": "missing-ref-9F31",
+            "include_symbol_diff": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "timestamp",
+          "economics_role": "comparison_variant",
+          "tool": "what_changed",
+          "args": {
+            "since": 0,
+            "include_symbol_diff": true,
+            "code_only": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" rev-parse --verify \"missing-ref-9F31\"",
+          "expected_exit_codes": [
+            128
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "Get-ChildItem -Recurse -File -LiteralPath \"${case.work_root}\" | Where-Object LastWriteTimeUtc -gt ([DateTimeOffset]::FromUnixTimeSeconds(0).UtcDateTime) | Select-Object FullName",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "changes.validation_and_timestamp",
+        "expected_outcome": "invalid-ref error; timestamp file set exact and symbol-diff limitation explicit",
+        "expected_evidence": {
+          "invalid_ref": "explicit Git-ref validation failure",
+          "timestamp_symbol_delta": "unsupported/not-applicable, never a fabricated fused symbol set"
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "git_ref invalid",
+        "since timestamp",
+        "include_symbol_diff in timestamp",
+        "code_only=true"
+      ]
+    },
+    {
+      "id": "SF-what_changed-003",
+      "primary_tool": "what_changed",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Initial-to-HEAD Python history comparison, symbol fusion, compact budget, and estimate accuracy are compared with Git plumbing.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "full",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use what_changed to test this claim: Ref comparison, code-only/path/language filters, compact budget, and estimate accuracy are compared with Git plumbing. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "actual",
+          "economics_role": "task",
+          "tool": "what_changed",
+          "args": {
+            "git_ref": "refs/bench/initial",
+            "include_symbol_diff": true,
+            "code_only": true,
+            "language": "Python",
+            "path_prefix": "sfbench_fixture/history",
+            "max_tokens": 256,
+            "estimate": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "estimate",
+          "economics_role": "estimate_diagnostic",
+          "tool": "what_changed",
+          "args": {
+            "git_ref": "refs/bench/initial",
+            "include_symbol_diff": true,
+            "code_only": true,
+            "language": "Python",
+            "path_prefix": "sfbench_fixture/history",
+            "max_tokens": 256,
+            "estimate": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --name-status \"refs/bench/initial\" HEAD -- \"sfbench_fixture/history/source.py\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "git -C \"${case.work_root}\" diff --unified=0 \"${fixture.oracle.history.refs.initial}\" HEAD -- \"sfbench_fixture/history/source.py\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "history.initial_to_head.what_changed",
+        "expected_outcome": "exact filtered history file and fused Python symbol sets; estimate error and token delta recorded",
+        "expected_evidence": {
+          "path": "sfbench_fixture/history/source.py",
+          "added": [
+            {
+              "name": "sfbench_history_added",
+              "kind": "fn"
+            }
+          ],
+          "modified": [
+            {
+              "name": "sfbench_history_modified",
+              "kind": "fn"
+            }
+          ],
+          "removed": [
+            {
+              "name": "sfbench_history_removed",
+              "kind": "fn"
+            }
+          ]
+        }
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "git_ref",
+        "symbol diff fusion",
+        "code_only=true",
+        "language",
+        "path_prefix",
+        "max_tokens",
+        "estimate=true",
+        "HTTP parity"
+      ]
+    },
+    {
+      "id": "SF-symforge-001",
+      "primary_tool": "symforge",
+      "case_kind": "happy",
+      "claim_type": "advertised",
+      "claim_under_test": "Compact facade definition, callers, explanation, file, exploration, and impact intents match the optimal granular routes and oracle facts.",
+      "repo": "ripgrep",
+      "repo_stratum": "normal",
+      "commit": "${repo.ripgrep.commit}",
+      "language": "Rust",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "compact",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge to test this claim: Compact facade definition, callers, explanation, file, exploration, and impact intents match the optimal granular routes and oracle facts. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "definition",
+          "economics_role": "task",
+          "tool": "symforge",
+          "args": {
+            "query": "where is sfbench_leaf defined",
+            "intent": "find",
+            "symbol": "sfbench_leaf",
+            "max_tokens": 512,
+            "preview": false
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "callers",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "who calls sfbench_leaf",
+            "intent": "trace",
+            "symbol": "sfbench_leaf",
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "read",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "show sfbench_leaf",
+            "intent": "read",
+            "path": "${fixture.oracle.mutations.Rust.path}",
+            "symbol": "sfbench_leaf",
+            "max_tokens": 512
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 4,
+          "label": "orient",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "explain the sfbench call graph",
+            "intent": "orient",
+            "max_tokens": 1024
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 5,
+          "label": "impact",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "what would changing sfbench_leaf affect",
+            "intent": "impact",
+            "symbol": "sfbench_leaf",
+            "max_tokens": 1024
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 6,
+          "label": "auto",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "find file core.rs",
+            "intent": "auto",
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 7,
+          "label": "meta",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "what context should I load next",
+            "intent": "meta",
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --word-regexp -- \"sfbench_leaf|sfbench_mid|sfbench_entry\" \"${case.work_root}/sfbench_fixture/rust\"",
+          "expected_exit_codes": [
+            0
+          ]
+        },
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg --files \"${case.work_root}\" | rg \"core\\.rs$\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "facade.compact.intent_routes.Rust",
+        "expected_outcome": "each answer and routed-tool identity matches the direct granular fact set",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 8,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "query",
+        "intent=find/trace/read/orient/impact/auto/meta",
+        "path",
+        "symbol",
+        "max_tokens",
+        "preview=false",
+        "compact surface"
+      ]
+    },
+    {
+      "id": "SF-symforge-002",
+      "primary_tool": "symforge",
+      "case_kind": "adverse",
+      "claim_type": "advertised",
+      "claim_under_test": "Blank query, below-minimum budget, and vague input fail or degrade honestly within the advertised compact schema.",
+      "repo": "flask",
+      "repo_stratum": "normal",
+      "commit": "${repo.flask.commit}",
+      "language": "Python",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "snapshot_warm",
+      "transport": "stdio",
+      "surface": "compact",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge to test this claim: Blank query, below-minimum budget, and vague input fail or degrade honestly within the advertised compact schema. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "blank",
+          "economics_role": "task",
+          "tool": "symforge",
+          "args": {
+            "query": ""
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "below_min",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "where is sfbench_leaf defined",
+            "max_tokens": 63
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 3,
+          "label": "vague",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {
+            "query": "thing",
+            "intent": "auto",
+            "preview": true
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "capability_only",
+          "reason": "Facade schema/input validation is conformance-only; vague-query utility is judged against a no-result ordinary search."
+        }
+      ],
+      "baseline_equivalence": "mixed_conformance_and_utility",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "facade.compact.validation",
+        "expected_outcome": "blank and below-min rejected specifically; vague result names uncertainty and does not fabricate facts",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 4,
+        "timeout_seconds": 120,
+        "repetitions": 3,
+        "discarded_warmups": 0
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "correctness_then_economics",
+      "covers": [
+        "blank query",
+        "max_tokens below 64",
+        "vague query",
+        "preview=true"
+      ]
+    },
+    {
+      "id": "SF-symforge-003",
+      "primary_tool": "symforge",
+      "case_kind": "control",
+      "claim_type": "desired",
+      "claim_under_test": "Meta surface is measured honestly: its advertised ordinary query cannot masquerade as a measurement relay when relay fields are absent from the live schema.",
+      "advertised_boundary": "The live meta schema advertises query/intent/path/symbol/max_tokens/preview only; harness-only relay fields are not schema-advertised and are intentionally not invented in this case.",
+      "repo": "zod",
+      "repo_stratum": "normal",
+      "commit": "${repo.zod.commit}",
+      "language": "TypeScript",
+      "preconditions": {
+        "materialization": "independent_local_clone_no_hardlinks",
+        "work_root": "${case.work_root}",
+        "fixture_root": "${fixture.root}",
+        "fixture_repository": "control-repo",
+        "state": "clean",
+        "setup": []
+      },
+      "cache_state": "process_warm",
+      "transport": "http",
+      "parity_shadow_transport": "stdio",
+      "surface": "meta",
+      "execution_mode": "direct_rpc",
+      "critical": true,
+      "task_prompt": "Use symforge to test this claim: Meta surface is measured honestly: its advertised ordinary query cannot masquerade as a measurement relay when relay fields are absent from the live schema. Return exactly {\"answer\":\"...\",\"evidence\":[{\"path\":\"...\",\"line\":1}]}.",
+      "model_policy": {
+        "model": "${session.model}",
+        "reasoning_effort": "medium",
+        "seed": "${session.seed}",
+        "context_limit_tokens": 128000,
+        "same_model_both_arms": true
+      },
+      "token_budget": {
+        "max_task_tokens": 4096,
+        "count_provider_usage": true,
+        "independent_tokenizers": [
+          "cl100k_base",
+          "o200k_base"
+        ],
+        "views": [
+          "direct_payload",
+          "paired_task_total",
+          "session_amortized"
+        ]
+      },
+      "requests": [
+        {
+          "step": 1,
+          "label": "ordinary_query",
+          "economics_role": "task",
+          "tool": "symforge",
+          "args": {
+            "query": "where is sfbench_leaf defined",
+            "intent": "find",
+            "symbol": "sfbench_leaf",
+            "max_tokens": 256
+          },
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        },
+        {
+          "step": 2,
+          "label": "missing_query",
+          "economics_role": "comparison_variant",
+          "tool": "symforge",
+          "args": {},
+          "intentional_schema_violation": "required query omitted to verify schema and handler error behavior",
+          "fresh_process_before": false,
+          "fresh_session_before": false,
+          "record_as": null
+        }
+      ],
+      "baseline_recipe": [
+        {
+          "executor": "shell",
+          "shell": "powershell",
+          "command": "rg -n --glob \"*.ts\" -- \"sfbench_leaf\" \"${case.work_root}/sfbench_fixture/typescript\"",
+          "expected_exit_codes": [
+            0
+          ]
+        }
+      ],
+      "baseline_equivalence": "lower_bound",
+      "allowed_helpers": [
+        "rg",
+        "bounded_read",
+        "git_read",
+        "native_parser",
+        "apply_patch"
+      ],
+      "allowed_builtin_tools": [
+        "shell_command",
+        "apply_patch"
+      ],
+      "forbidden_tools": [
+        "lsp",
+        "ctags",
+        "custom_index",
+        "internet",
+        "symforge_in_baseline"
+      ],
+      "correctness_oracle": {
+        "key": "facade.meta.schema_honesty",
+        "expected_outcome": "ordinary query returns documented compact-surface requirement rather than pretending to execute; missing query invalid; schema/description gap recorded",
+        "expected_evidence": null
+      },
+      "stop_condition": "all requests completed and objective oracle evaluated",
+      "limits": {
+        "call_limit": 3,
+        "timeout_seconds": 120,
+        "repetitions": 20,
+        "discarded_warmups": 2
+      },
+      "mutation_allowlist": [],
+      "source_hash_policy": "no_source_bytes_may_change",
+      "economics_focus": "token_negative_control",
+      "covers": [
+        "meta surface",
+        "advertised fields only",
+        "ordinary query failure",
+        "missing query",
+        "schema-tax control"
+      ]
+    }
+  ]
+}

--- a/research/full-surface-benchmark/claude_task_runner.py
+++ b/research/full-surface-benchmark/claude_task_runner.py
@@ -1,0 +1,1965 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "tiktoken>=0.7.0,<1",
+# ]
+# ///
+"""Run one resolved SFBENCH task through Claude Code 2.1.207.
+
+The runner persists one sanitized JSONL record.  It deliberately sends the task
+prompt over stdin and never serializes the process environment or auth state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fnmatch
+import hashlib
+import io
+import json
+import os
+import pathlib
+import queue
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from mcp_harness import (
+    REDACTED,
+    Sanitizer,
+    TokenCounter,
+    canonical_json,
+    is_within,
+    sha256_text,
+)
+
+
+PROTOCOL_ID = "SFBENCH-1.0"
+REQUIRED_CLAUDE_VERSION = "2.1.207"
+BUILTIN_TOOLS = ("Bash", "Read", "Grep", "Glob", "Edit", "Write")
+MCP_PERMISSION = "mcp__symforge__*"
+RUNTIME_PATH_PREFIXES = (".symforge/",)
+DOLLAR_PLACEHOLDER = re.compile(r"\$\{([^{}]+)\}")
+RUNTIME_CASE_FIELDS = (
+    "id",
+    "task_prompt",
+    "model_policy",
+    "token_budget",
+    "allowed_helpers",
+    "forbidden_tools",
+    "mutation_allowlist",
+    "limits",
+    "timeout_seconds",
+    "call_limit",
+    "transport",
+    "surface",
+    "cache_state",
+    "execution_mode",
+    "source_hash_policy",
+)
+ANSWER_EXAMPLE = {"answer": "...", "evidence": [{"path": "...", "line": 1}]}
+SAFE_ENV_NAMES = {
+    "APPDATA",
+    "COMSPEC",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOCALAPPDATA",
+    "PATH",
+    "PATHEXT",
+    "PROGRAMDATA",
+    "SystemRoot",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "USERPROFILE",
+    "WINDIR",
+}
+CREDENTIAL_ENV_PREFIXES = (
+    "ANTHROPIC_",
+    "AWS_",
+    "AZURE_",
+    "BEDROCK_",
+    "CLAUDE_API_",
+    "CLOUD_",
+    "FOUNDRY_",
+    "GCP_",
+    "GH_",
+    "GITHUB_",
+    "GOOGLE_",
+    "HF_",
+    "OPENAI_",
+    "VERTEX_",
+)
+ANSWER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["answer", "evidence"],
+    "properties": {
+        "answer": {"type": "string"},
+        "evidence": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["path", "line"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "line": {"type": "integer", "minimum": 1},
+                },
+            },
+        },
+    },
+}
+
+
+class RunnerError(RuntimeError):
+    """Expected failure whose message contains no child output or credentials."""
+
+
+@dataclass(frozen=True)
+class TrialConfig:
+    case: dict[str, Any]
+    arm: str
+    repo: pathlib.Path
+    benchmark_root: pathlib.Path
+    output: pathlib.Path
+    claude: pathlib.Path
+    claude_prefix_args: tuple[str, ...]
+    symforge: pathlib.Path | None
+    max_budget_usd: str
+    prompt_mode: str = "neutral"
+
+
+@dataclass(frozen=True)
+class GitState:
+    available: bool
+    status_sha256: str | None
+    status_count: int | None
+    diff_sha256: str | None
+    paths: tuple[str, ...]
+    path_hashes: dict[str, str]
+
+
+@dataclass
+class StreamCapture:
+    exit_code: int | None
+    elapsed_ms: float
+    timed_out: bool
+    call_limit_exceeded: bool
+    stdout_utf8_bytes: int
+    stderr_utf8_bytes: int
+    stderr_safe: str
+    events_safe: list[Any]
+    invalid_event_count: int
+    tool_uses: list[dict[str, Any]]
+    tool_results: list[dict[str, Any]]
+    assistant_turns: list[dict[str, Any]]
+    final_result_raw: dict[str, Any] | None
+    final_result_safe: dict[str, Any] | None
+
+
+def hash_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_executable(value: str) -> pathlib.Path:
+    candidate = pathlib.Path(value).expanduser()
+    if candidate.is_absolute() or candidate.parent != pathlib.Path("."):
+        resolved = candidate.resolve()
+        if not resolved.is_file():
+            raise RunnerError("a supplied executable does not exist")
+        return resolved
+    found = shutil.which(value)
+    if found is None:
+        raise RunnerError("a supplied executable was not found on PATH")
+    return pathlib.Path(found).resolve()
+
+
+def decimal_budget(value: str) -> str:
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise RunnerError("--max-budget-usd must be a positive decimal") from exc
+    if not parsed.is_finite() or parsed <= 0:
+        raise RunnerError("--max-budget-usd must be a positive decimal")
+    return format(parsed, "f")
+
+
+def find_placeholders(value: Any, path: str = "case") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key)
+            found.extend(find_placeholders(child, f"{path}.{key_text}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(find_placeholders(child, f"{path}[{index}]"))
+    elif isinstance(value, str):
+        stripped = value.strip()
+        unresolved = (
+            bool(re.fullmatch(r"<[^<>]+>", stripped))
+            or "${" in value
+            or "{{" in value
+            or bool(re.fullmatch(r"__[A-Za-z0-9_-]+__", stripped))
+            or stripped.lower()
+            in {"placeholder", "replace_me", "tbd", "todo", "unresolved"}
+        )
+        if unresolved:
+            found.append(path)
+    return found
+
+
+def neutral_prompt_names_tool(prompt: str, primary_tool: str | None) -> bool:
+    if re.search(r"(?i)\bsymforge\b|mcp__symforge__", prompt):
+        return True
+    if not primary_tool:
+        return False
+    escaped = re.escape(primary_tool)
+    if "_" in primary_tool and re.search(rf"(?i)(?<!\w){escaped}(?!\w)", prompt):
+        return True
+    return bool(
+        re.search(rf"(?i)`{escaped}`", prompt)
+        or re.search(
+            rf"(?i)\b(?:use|call|invoke)\s+(?:the\s+)?[`'\"]?{escaped}(?!\w)",
+            prompt,
+        )
+    )
+
+
+def select_task_prompt(case: dict[str, Any], prompt_mode: str) -> str:
+    if prompt_mode == "forced":
+        prompt = case.get("task_prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise RunnerError("forced prompt mode requires task_prompt")
+        return prompt
+    if prompt_mode != "neutral":
+        raise RunnerError("unsupported prompt mode")
+
+    explicit = case.get("neutral_task_prompt")
+    claim = case.get("claim_under_test")
+    if isinstance(explicit, str) and explicit.strip():
+        prompt = explicit
+    elif isinstance(claim, str) and claim.strip():
+        prompt = (
+            "Test this repository claim using any allowed local tools: "
+            f"{claim.strip()} Return exactly {canonical_json(ANSWER_EXAMPLE)}."
+        )
+    else:
+        # A single-case artifact may already contain a resolved neutral prompt.
+        prompt = case.get("task_prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise RunnerError(
+                "neutral prompt mode requires neutral_task_prompt or claim_under_test"
+            )
+    primary_tool = case.get("primary_tool")
+    primary_name = primary_tool if isinstance(primary_tool, str) else None
+    if neutral_prompt_names_tool(prompt, primary_name):
+        raise RunnerError("neutral task prompt names SymForge or the primary tool")
+    return prompt
+
+
+def load_json_object(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RunnerError(f"could not read the {label} JSON") from exc
+    except json.JSONDecodeError as exc:
+        raise RunnerError(
+            f"{label} JSON is invalid at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+    if not isinstance(document, dict):
+        raise RunnerError(f"{label} JSON must contain an object")
+    return document
+
+
+def tree_lookup(value: dict[str, Any], dotted: str) -> Any:
+    current: Any = value
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(dotted)
+        current = current[part]
+    return current
+
+
+def manifest_repository(corpus_manifest: dict[str, Any], alias: str) -> dict[str, Any]:
+    repositories = corpus_manifest.get("repositories")
+    if not isinstance(repositories, list):
+        raise RunnerError("corpus manifest repository list is malformed")
+    matches = [
+        item
+        for item in repositories
+        if isinstance(item, dict) and item.get("alias") == alias
+    ]
+    if len(matches) != 1:
+        raise RunnerError(f"corpus manifest has no unique repository alias {alias}")
+    return matches[0]
+
+
+def resolve_case_placeholder(
+    name: str,
+    field_path: str,
+    *,
+    campaign: dict[str, Any] | None,
+    fixture_oracle: dict[str, Any] | None,
+    corpus_manifest: dict[str, Any] | None,
+    corpus_manifest_path: pathlib.Path | None,
+) -> Any:
+    if name in {"session.model", "session.seed"}:
+        if not field_path.startswith("case.model_policy"):
+            raise RunnerError("session placeholders are allowed only in model_policy")
+        if campaign is None:
+            raise RunnerError(f"--campaign is required to resolve {name}")
+        if name == "session.seed":
+            return None
+        model = campaign.get("paired_llm", {}).get("model_alias")
+        if not isinstance(model, str) or not model.strip():
+            raise RunnerError("campaign paired_llm.model_alias is missing")
+        return model
+
+    if not field_path.startswith("case.mutation_allowlist"):
+        raise RunnerError(
+            "external placeholders are allowed only in mutation_allowlist"
+        )
+    if name.startswith("fixture.oracle."):
+        if fixture_oracle is None:
+            raise RunnerError(f"--fixture-oracle is required to resolve {name}")
+        try:
+            return tree_lookup(fixture_oracle, name.removeprefix("fixture.oracle."))
+        except KeyError as exc:
+            raise RunnerError(f"unknown fixture oracle placeholder: {name}") from exc
+    if name.startswith("repo."):
+        if corpus_manifest is None:
+            raise RunnerError(f"--corpus-manifest is required to resolve {name}")
+        parts = name.split(".", 2)
+        if len(parts) != 3 or parts[2] not in {"commit", "root"}:
+            raise RunnerError(f"unknown repository placeholder: {name}")
+        repository = manifest_repository(corpus_manifest, parts[1])
+        if parts[2] == "commit":
+            if not isinstance(repository.get("commit"), str):
+                raise RunnerError(f"repository commit is missing for alias {parts[1]}")
+            return repository["commit"]
+        if corpus_manifest_path is None:
+            raise RunnerError(f"--corpus-manifest is required to resolve {name}")
+        return str(corpus_manifest_path.resolve().parent / "sources" / parts[1])
+    if name.startswith("corpus."):
+        if corpus_manifest is None:
+            raise RunnerError(f"--corpus-manifest is required to resolve {name}")
+        try:
+            return tree_lookup(corpus_manifest, name.removeprefix("corpus."))
+        except KeyError as exc:
+            raise RunnerError(f"unknown corpus manifest placeholder: {name}") from exc
+    raise RunnerError(f"unknown placeholder: {name}")
+
+
+def resolve_case_value(
+    value: Any,
+    field_path: str,
+    *,
+    campaign: dict[str, Any] | None,
+    fixture_oracle: dict[str, Any] | None,
+    corpus_manifest: dict[str, Any] | None,
+    corpus_manifest_path: pathlib.Path | None,
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: resolve_case_value(
+                child,
+                f"{field_path}.{key}",
+                campaign=campaign,
+                fixture_oracle=fixture_oracle,
+                corpus_manifest=corpus_manifest,
+                corpus_manifest_path=corpus_manifest_path,
+            )
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            resolve_case_value(
+                child,
+                f"{field_path}[{index}]",
+                campaign=campaign,
+                fixture_oracle=fixture_oracle,
+                corpus_manifest=corpus_manifest,
+                corpus_manifest_path=corpus_manifest_path,
+            )
+            for index, child in enumerate(value)
+        ]
+    if not isinstance(value, str):
+        return value
+
+    def resolved(match: re.Match[str]) -> Any:
+        return resolve_case_placeholder(
+            match.group(1),
+            field_path,
+            campaign=campaign,
+            fixture_oracle=fixture_oracle,
+            corpus_manifest=corpus_manifest,
+            corpus_manifest_path=corpus_manifest_path,
+        )
+
+    exact = DOLLAR_PLACEHOLDER.fullmatch(value)
+    if exact:
+        return resolved(exact)
+    return DOLLAR_PLACEHOLDER.sub(lambda match: str(resolved(match)), value)
+
+
+def load_case(
+    path: pathlib.Path,
+    requested_id: str | None,
+    *,
+    campaign: dict[str, Any] | None = None,
+    fixture_oracle: dict[str, Any] | None = None,
+    corpus_manifest: dict[str, Any] | None = None,
+    corpus_manifest_path: pathlib.Path | None = None,
+    prompt_mode: str = "neutral",
+) -> dict[str, Any]:
+    document = load_json_object(path, "case")
+
+    if isinstance(document.get("cases"), list):
+        if not requested_id:
+            raise RunnerError("--case-id is required when the JSON contains cases[]")
+        matches = [
+            candidate
+            for candidate in document["cases"]
+            if isinstance(candidate, dict) and candidate.get("id") == requested_id
+        ]
+        if len(matches) != 1:
+            raise RunnerError("--case-id did not select exactly one case")
+        case = matches[0]
+    else:
+        case = document
+        if requested_id is not None and case.get("id") != requested_id:
+            raise RunnerError("--case-id does not match the single case object")
+
+    # The Claude runner never consumes direct-RPC requests, baseline recipes,
+    # preconditions, or oracle definitions. Excluding them here prevents both
+    # false placeholder failures and accidental persistence of unused inputs.
+    runtime_case = {key: case[key] for key in RUNTIME_CASE_FIELDS if key in case}
+    runtime_case["task_prompt"] = select_task_prompt(case, prompt_mode)
+    resolved_case = resolve_case_value(
+        runtime_case,
+        "case",
+        campaign=campaign,
+        fixture_oracle=fixture_oracle,
+        corpus_manifest=corpus_manifest,
+        corpus_manifest_path=corpus_manifest_path,
+    )
+    validate_case(resolved_case)
+    return resolved_case
+
+
+def require_nonempty_string(container: dict[str, Any], key: str) -> str:
+    value = container.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RunnerError(f"resolved case requires a non-empty {key} string")
+    return value
+
+
+def case_timeout(case: dict[str, Any]) -> float:
+    value: Any = case.get("timeout_seconds")
+    limits = case.get("limits")
+    if value is None and isinstance(limits, dict):
+        value = limits.get("timeout_seconds")
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise RunnerError("resolved case requires a positive timeout_seconds limit")
+    return float(value)
+
+
+def case_call_limit(case: dict[str, Any]) -> int:
+    value: Any = case.get("call_limit")
+    limits = case.get("limits")
+    if value is None and isinstance(limits, dict):
+        value = limits.get("call_limit")
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise RunnerError("resolved case requires a positive call_limit")
+    return value
+
+
+def case_max_task_tokens(case: dict[str, Any]) -> int:
+    value: Any = case.get("token_budget")
+    if isinstance(value, dict):
+        value = value.get("max_task_tokens")
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise RunnerError(
+            "resolved case requires token_budget.max_task_tokens as a positive integer"
+        )
+    return value
+
+
+def validate_case(case: dict[str, Any]) -> None:
+    require_nonempty_string(case, "id")
+    require_nonempty_string(case, "task_prompt")
+    model_policy = case.get("model_policy")
+    if not isinstance(model_policy, dict):
+        raise RunnerError("resolved case requires model_policy")
+    require_nonempty_string(model_policy, "model")
+    effort = require_nonempty_string(model_policy, "reasoning_effort")
+    if effort not in {"low", "medium", "high", "xhigh", "max"}:
+        raise RunnerError("model_policy.reasoning_effort is unsupported by Claude Code")
+    case_max_task_tokens(case)
+    if not isinstance(case.get("allowed_helpers"), list):
+        raise RunnerError("resolved case requires allowed_helpers[]")
+    if not isinstance(case.get("forbidden_tools"), list):
+        raise RunnerError("resolved case requires forbidden_tools[]")
+    if not isinstance(case.get("mutation_allowlist"), list):
+        raise RunnerError("resolved case requires mutation_allowlist[]")
+    if model_policy.get("same_model_both_arms") is False:
+        raise RunnerError("resolved case must use the same model in both paired arms")
+    case_timeout(case)
+    case_call_limit(case)
+    if case.get("transport", "stdio") != "stdio":
+        raise RunnerError("this Claude runner supports only stdio SymForge cases")
+    surface = case.get("surface", "full")
+    if surface not in {"full", "compact", "meta"}:
+        raise RunnerError("resolved case has an unsupported surface")
+    placeholders = find_placeholders(case)
+    if placeholders:
+        raise RunnerError(
+            "resolved case still contains placeholders at " + ", ".join(placeholders)
+        )
+
+
+def validate_paths(
+    repo: pathlib.Path,
+    benchmark_root: pathlib.Path,
+    output: pathlib.Path,
+) -> None:
+    project_root = pathlib.Path(__file__).resolve().parents[2]
+    if not benchmark_root.is_dir() or is_within(benchmark_root, project_root):
+        raise RunnerError(
+            "--benchmark-root must be an existing directory outside SymForge"
+        )
+    if not repo.is_dir() or not is_within(repo, benchmark_root):
+        raise RunnerError("--repo must be an existing directory under --benchmark-root")
+    if repo == benchmark_root:
+        raise RunnerError("--repo must be a disposable child of --benchmark-root")
+    if is_within(repo, project_root):
+        raise RunnerError(
+            "the SymForge checkout cannot be used as the disposable repository"
+        )
+    if not is_within(output, benchmark_root) or is_within(output, repo):
+        raise RunnerError("--output must be under --benchmark-root and outside --repo")
+    if output.exists():
+        raise RunnerError("--output already exists; each arm requires a fresh artifact")
+
+
+def system_prompt(case: dict[str, Any]) -> str:
+    policy = {
+        "case_id": case["id"],
+        "allowed_helpers": case["allowed_helpers"],
+        "forbidden_tools": case["forbidden_tools"],
+        "mutation_allowlist": case["mutation_allowlist"],
+        "call_limit": case_call_limit(case),
+        "token_budget": case_max_task_tokens(case),
+    }
+    return (
+        "You are executing one frozen SFBENCH-1.0 task in a disposable repository. "
+        "Work only inside the current repository. Never inspect, print, or transmit "
+        "environment variables, authentication material, credential stores, or secret "
+        "files. Do not use the network or internet. Do not use LSPs, ctags, custom "
+        "indexes, or tools forbidden by the policy below. Source mutations are allowed "
+        "only for paths in mutation_allowlist; an empty list means read-only. Stop when "
+        "the task oracle answer is established or the frozen call/token limit is reached. "
+        "Return only the object required by the supplied JSON schema, with concise "
+        "repo-relative evidence paths and 1-based lines. Frozen policy: "
+        + canonical_json(policy)
+    )
+
+
+def mcp_config(config: TrialConfig) -> dict[str, Any]:
+    if config.arm == "baseline":
+        return {"mcpServers": {}}
+    assert config.symforge is not None
+    surface = config.case.get("surface", "full")
+    return {
+        "mcpServers": {
+            "symforge": {
+                "type": "stdio",
+                "command": str(config.symforge),
+                "args": [],
+                "env": {
+                    "SYMFORGE_SURFACE": surface,
+                    "SYMFORGE_NO_DAEMON": "1",
+                    "SYMFORGE_AUTO_INDEX": "true",
+                    "NO_COLOR": "1",
+                },
+            }
+        }
+    }
+
+
+def common_fingerprint(config: TrialConfig) -> dict[str, Any]:
+    model_policy = config.case["model_policy"]
+    prompt = system_prompt(config.case)
+    return {
+        "model": model_policy["model"],
+        "effort": model_policy["reasoning_effort"],
+        "max_budget_usd": config.max_budget_usd,
+        "builtin_tools": list(BUILTIN_TOOLS),
+        "task_prompt_sha256": sha256_text(config.case["task_prompt"]),
+        "system_prompt_sha256": sha256_text(prompt),
+        "answer_schema_sha256": sha256_text(canonical_json(ANSWER_SCHEMA)),
+    }
+
+
+def build_command(config: TrialConfig, mcp_path: pathlib.Path) -> list[str]:
+    model_policy = config.case["model_policy"]
+    allowed = list(BUILTIN_TOOLS)
+    if config.arm == "symforge":
+        allowed.append(MCP_PERMISSION)
+    return [
+        str(config.claude),
+        *config.claude_prefix_args,
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--safe-mode",
+        "--no-session-persistence",
+        "--strict-mcp-config",
+        "--mcp-config",
+        str(mcp_path),
+        "--no-chrome",
+        "--disable-slash-commands",
+        "--prompt-suggestions",
+        "false",
+        "--permission-mode",
+        "dontAsk",
+        "--tools",
+        ",".join(BUILTIN_TOOLS),
+        "--allowedTools",
+        ",".join(allowed),
+        "--disallowedTools",
+        "WebFetch,WebSearch",
+        "--system-prompt",
+        system_prompt(config.case),
+        "--json-schema",
+        canonical_json(ANSWER_SCHEMA),
+        "--model",
+        model_policy["model"],
+        "--effort",
+        model_policy["reasoning_effort"],
+        "--max-budget-usd",
+        config.max_budget_usd,
+    ]
+
+
+def command_shape(config: TrialConfig) -> dict[str, Any]:
+    model_policy = config.case["model_policy"]
+    allowed = list(BUILTIN_TOOLS)
+    if config.arm == "symforge":
+        allowed.append(MCP_PERMISSION)
+    return {
+        "executable": config.claude.name,
+        "cwd": str(config.repo),
+        "flags": {
+            "print": True,
+            "output_format": "stream-json",
+            "verbose": True,
+            "partial_messages": False,
+            "safe_mode": True,
+            "no_session_persistence": True,
+            "strict_mcp_config": True,
+            "mcp_config": (
+                "<generated-empty-mcp-config>"
+                if config.arm == "baseline"
+                else "<generated-symforge-stdio-mcp-config>"
+            ),
+            "permission_mode": "dontAsk",
+            "builtin_tools": list(BUILTIN_TOOLS),
+            "allowed_tools": allowed,
+            "system_prompt": "<frozen-system-prompt>",
+            "json_schema": "<frozen-answer-schema>",
+            "model": model_policy["model"],
+            "effort": model_policy["reasoning_effort"],
+            "max_budget_usd": config.max_budget_usd,
+        },
+        "stdin": "<task-prompt>",
+        "task_prompt_sha256": sha256_text(config.case["task_prompt"]),
+    }
+
+
+def is_credential_env_name(name: str) -> bool:
+    upper = name.upper()
+    return upper.endswith(
+        ("_KEY", "_TOKEN", "_SECRET", "_PASSWORD")
+    ) or upper.startswith(CREDENTIAL_ENV_PREFIXES)
+
+
+def claude_environment() -> dict[str, str]:
+    """Pass only OS/path essentials; key-only auth may intentionally fail."""
+    allowed_upper = {name.upper() for name in SAFE_ENV_NAMES}
+    env = {
+        name: value
+        for name, value in os.environ.items()
+        if name.upper() in allowed_upper and not is_credential_env_name(name)
+    }
+    env.update(
+        {
+            "CLAUDE_CODE_SAFE_MODE": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_LFS_SKIP_SMUDGE": "1",
+            "NO_COLOR": "1",
+        }
+    )
+    return env
+
+
+def verify_claude_version(config: TrialConfig) -> None:
+    try:
+        result = subprocess.run(
+            [str(config.claude), *config.claude_prefix_args, "--version"],
+            cwd=config.repo,
+            env=claude_environment(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RunnerError("Claude Code version verification failed") from exc
+    version_text = result.stdout.decode("utf-8", errors="replace").strip()
+    if result.returncode != 0 or not re.match(
+        rf"^{re.escape(REQUIRED_CLAUDE_VERSION)}\b", version_text
+    ):
+        raise RunnerError(
+            f"Claude Code {REQUIRED_CLAUDE_VERSION} is required for this campaign"
+        )
+
+
+def terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def run_git(repo: pathlib.Path, arguments: list[str]) -> tuple[int, bytes]:
+    git = shutil.which("git", path=claude_environment().get("PATH"))
+    if git is None:
+        return 127, b""
+    try:
+        result = subprocess.run(
+            [git, "-C", str(repo), *arguments],
+            cwd=repo,
+            env=claude_environment(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 126, b""
+    return result.returncode, result.stdout
+
+
+def parse_status_paths(status: bytes) -> tuple[int, tuple[str, ...]]:
+    fields = status.split(b"\0")
+    paths: set[str] = set()
+    count = 0
+    index = 0
+    while index < len(fields) and fields[index]:
+        entry = fields[index]
+        index += 1
+        if len(entry) < 4:
+            continue
+        code = entry[:2]
+        paths.add(
+            entry[3:].decode("utf-8", errors="surrogateescape").replace("\\", "/")
+        )
+        count += 1
+        if (b"R" in code or b"C" in code) and index < len(fields) and fields[index]:
+            paths.add(
+                fields[index]
+                .decode("utf-8", errors="surrogateescape")
+                .replace("\\", "/")
+            )
+            index += 1
+    return count, tuple(sorted(paths))
+
+
+def repo_path_hash(repo: pathlib.Path, relative: str) -> str:
+    target = repo.joinpath(*pathlib.PurePosixPath(relative).parts)
+    try:
+        if target.is_symlink():
+            return sha256_text("symlink:" + os.readlink(target))
+        if not target.exists():
+            return sha256_text("missing")
+        if not target.is_file():
+            return sha256_text("non-file")
+        digest = hashlib.sha256()
+        with target.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return sha256_text("unreadable")
+
+
+def capture_git_state(repo: pathlib.Path) -> GitState:
+    status_code, status = run_git(
+        repo, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
+    )
+    if status_code != 0:
+        return GitState(False, None, None, None, (), {})
+    count, paths = parse_status_paths(status)
+    diff_code, diff = run_git(repo, ["diff", "--binary", "--no-ext-diff", "HEAD", "--"])
+    if diff_code != 0:
+        _, unstaged = run_git(repo, ["diff", "--binary", "--no-ext-diff", "--"])
+        _, staged = run_git(
+            repo, ["diff", "--cached", "--binary", "--no-ext-diff", "--"]
+        )
+        diff = unstaged + staged
+    path_hashes = {path: repo_path_hash(repo, path) for path in paths}
+    digest = hashlib.sha256()
+    digest.update(diff)
+    for path in paths:
+        digest.update(path.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        digest.update(path_hashes[path].encode("ascii"))
+        digest.update(b"\0")
+    return GitState(
+        True,
+        hashlib.sha256(status).hexdigest(),
+        count,
+        digest.hexdigest(),
+        paths,
+        path_hashes,
+    )
+
+
+def git_state_record(state: GitState) -> dict[str, Any]:
+    return {
+        "available": state.available,
+        "status_sha256": state.status_sha256,
+        "status_count": state.status_count,
+        "diff_sha256": state.diff_sha256,
+        "dirty_path_count": len(state.paths) if state.available else None,
+    }
+
+
+def changed_git_paths(before: GitState, after: GitState) -> list[str]:
+    if not before.available or not after.available:
+        return []
+    paths = set(before.paths) | set(after.paths)
+    changed = [
+        path
+        for path in paths
+        if before.path_hashes.get(path) != after.path_hashes.get(path)
+    ]
+    if before.diff_sha256 != after.diff_sha256 and not changed:
+        changed.append("<unresolved-git-change>")
+    return sorted(changed)
+
+
+def is_runtime_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return any(normalized.startswith(prefix) for prefix in RUNTIME_PATH_PREFIXES)
+
+
+def is_allowlisted_path(path: str, allowlist: list[Any]) -> bool:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if is_runtime_path(normalized):
+        return True
+    for candidate in allowlist:
+        if not isinstance(candidate, str):
+            continue
+        pattern = candidate.replace("\\", "/")
+        while pattern.startswith("./"):
+            pattern = pattern[2:]
+        if normalized == pattern or fnmatch.fnmatchcase(normalized, pattern):
+            return True
+    return False
+
+
+def mutation_policy(
+    case: dict[str, Any], before: GitState, after: GitState
+) -> dict[str, Any]:
+    changed = changed_git_paths(before, after)
+    policy = str(case.get("source_hash_policy", "no_source_bytes_may_change"))
+    allowlist = case.get("mutation_allowlist", [])
+    if not before.available or not after.available:
+        return {
+            "status": "unverifiable_non_git",
+            "violation": False,
+            "source_hash_policy": policy,
+            "changed_paths": [],
+            "violating_paths": [],
+        }
+    if "no_source" in policy:
+        violating = [path for path in changed if not is_runtime_path(path)]
+    else:
+        violating = [
+            path for path in changed if not is_allowlisted_path(path, allowlist)
+        ]
+    return {
+        "status": "violation" if violating else "compliant",
+        "violation": bool(violating),
+        "source_hash_policy": policy,
+        "changed_paths": changed,
+        "violating_paths": violating,
+    }
+
+
+def strip_session_ids(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: strip_session_ids(child)
+            for key, child in value.items()
+            if key != "session_id"
+        }
+    if isinstance(value, list):
+        return [strip_session_ids(child) for child in value]
+    return value
+
+
+def typed_blocks(value: Any, block_type: str) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        if value.get("type") == block_type:
+            found.append(value)
+        for child in value.values():
+            found.extend(typed_blocks(child, block_type))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(typed_blocks(child, block_type))
+    return found
+
+
+def stable_content_text(value: Any) -> str:
+    return value if isinstance(value, str) else canonical_json(value)
+
+
+def token_metrics(counter: TokenCounter, text: str) -> dict[str, int]:
+    return {
+        "utf8_bytes": len(text.encode("utf-8")),
+        "cl100k": len(counter.encodings["cl100k"].encode(text, disallowed_special=())),
+        "o200k": len(counter.encodings["o200k"].encode(text, disallowed_special=())),
+    }
+
+
+def run_process(
+    command: list[str],
+    config: TrialConfig,
+    sanitizer: Sanitizer,
+    counter: TokenCounter,
+) -> StreamCapture:
+    creationflags = 0
+    start_new_session = os.name != "nt"
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(
+            subprocess, "CREATE_NO_WINDOW", 0
+        )
+    started = time.perf_counter_ns()
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=config.repo,
+            env=claude_environment(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            creationflags=creationflags,
+            start_new_session=start_new_session,
+        )
+    except OSError as exc:
+        raise RunnerError("failed to start Claude Code") from exc
+
+    stdout_queue: queue.Queue[bytes | None] = queue.Queue()
+    stderr_parts: list[bytes] = []
+
+    def read_stdout() -> None:
+        assert process.stdout is not None
+        while line := process.stdout.readline():
+            stdout_queue.put(line)
+        stdout_queue.put(None)
+
+    def read_stderr() -> None:
+        assert process.stderr is not None
+        while chunk := process.stderr.read(65536):
+            stderr_parts.append(chunk)
+
+    stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+    stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+    stdout_thread.start()
+    stderr_thread.start()
+    assert process.stdin is not None
+    try:
+        process.stdin.write(config.case["task_prompt"].encode("utf-8"))
+        process.stdin.close()
+    except (BrokenPipeError, OSError):
+        pass
+
+    events_safe: list[Any] = []
+    tool_uses: list[dict[str, Any]] = []
+    tool_results: list[dict[str, Any]] = []
+    assistant_turns: list[dict[str, Any]] = []
+    seen_tool_uses: set[str] = set()
+    seen_tool_results: set[str] = set()
+    final_result_raw: dict[str, Any] | None = None
+    final_result_safe: dict[str, Any] | None = None
+    invalid_event_count = 0
+    stdout_bytes = 0
+    timed_out = False
+    call_limit_exceeded = False
+    deadline = time.monotonic() + case_timeout(config.case)
+    event_index = 0
+
+    while True:
+        if process.poll() is None and time.monotonic() >= deadline:
+            timed_out = True
+            terminate_process_tree(process)
+        try:
+            raw_line = stdout_queue.get(timeout=0.1)
+        except queue.Empty:
+            if process.poll() is not None and not stdout_thread.is_alive():
+                break
+            continue
+        if raw_line is None:
+            break
+        stdout_bytes += len(raw_line)
+        decoded = raw_line.decode("utf-8", errors="replace")
+        try:
+            event_raw = json.loads(decoded)
+        except json.JSONDecodeError:
+            invalid_event_count += 1
+            events_safe.append(
+                {
+                    "type": "invalid_stream_json",
+                    "text": sanitizer.sanitize_text(
+                        decoded, f"claude_stream[{event_index}]"
+                    ),
+                }
+            )
+            event_index += 1
+            continue
+        if not isinstance(event_raw, dict):
+            invalid_event_count += 1
+            events_safe.append(
+                sanitizer.sanitize_obj(event_raw, f"claude_stream[{event_index}]")
+            )
+            event_index += 1
+            continue
+
+        event_safe = sanitizer.sanitize_obj(
+            strip_session_ids(event_raw), f"claude_stream[{event_index}]"
+        )
+        events_safe.append(event_safe)
+
+        uses_in_event = typed_blocks(event_raw, "tool_use")
+        for block_index, block in enumerate(uses_in_event):
+            raw_id = str(block.get("id", f"event-{event_index}-{block_index}"))
+            if raw_id in seen_tool_uses:
+                continue
+            seen_tool_uses.add(raw_id)
+            safe_arguments = sanitizer.sanitize_obj(
+                block.get("input", {}),
+                f"tool_use[{len(tool_uses)}].arguments",
+            )
+            tool_uses.append(
+                {
+                    "event_index": event_index,
+                    "name": block.get("name"),
+                    "tool_use_id_sha256": sha256_text(raw_id),
+                    "sanitized_arguments_sha256": sha256_text(
+                        canonical_json(safe_arguments)
+                    ),
+                }
+            )
+
+        for block_index, block in enumerate(typed_blocks(event_raw, "tool_result")):
+            raw_id = str(block.get("tool_use_id", f"event-{event_index}-{block_index}"))
+            if raw_id in seen_tool_results:
+                continue
+            seen_tool_results.add(raw_id)
+            raw_content = stable_content_text(block.get("content", ""))
+            safe_content = sanitizer.sanitize_obj(
+                block.get("content", ""),
+                f"tool_result[{len(tool_results)}].content",
+            )
+            safe_content_text = stable_content_text(safe_content)
+            raw_counts = token_metrics(counter, raw_content)
+            safe_counts = token_metrics(counter, safe_content_text)
+            tool_results.append(
+                {
+                    "event_index": event_index,
+                    "tool_use_id_sha256": sha256_text(raw_id),
+                    "is_error": bool(block.get("is_error", False)),
+                    "content_utf8_bytes": raw_counts["utf8_bytes"],
+                    "content_cl100k": raw_counts["cl100k"],
+                    "content_o200k": raw_counts["o200k"],
+                    "sanitized_content_utf8_bytes": safe_counts["utf8_bytes"],
+                    "sanitized_content_cl100k": safe_counts["cl100k"],
+                    "sanitized_content_o200k": safe_counts["o200k"],
+                }
+            )
+
+        if event_raw.get("type") == "assistant":
+            message = event_raw.get("message", {})
+            content = message.get("content", []) if isinstance(message, dict) else []
+            text = "\n".join(
+                str(block.get("text", ""))
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+            assistant_turns.append(
+                {
+                    "event_index": event_index,
+                    "model": message.get("model")
+                    if isinstance(message, dict)
+                    else None,
+                    "content_types": [
+                        block.get("type")
+                        for block in content
+                        if isinstance(block, dict)
+                    ],
+                    "text_counts": token_metrics(counter, text),
+                    "tool_use_count": len(uses_in_event),
+                    "usage": sanitizer.sanitize_obj(
+                        message.get("usage") if isinstance(message, dict) else None,
+                        f"assistant_turn[{len(assistant_turns)}].usage",
+                    ),
+                }
+            )
+
+        if event_raw.get("type") == "result":
+            final_result_raw = event_raw
+            final_result_safe = event_safe
+
+        if len(tool_uses) > case_call_limit(config.case) and not call_limit_exceeded:
+            call_limit_exceeded = True
+            terminate_process_tree(process)
+        event_index += 1
+
+    if process.poll() is None:
+        terminate_process_tree(process)
+    stdout_thread.join(timeout=1)
+    stderr_thread.join(timeout=1)
+    stderr = b"".join(stderr_parts)
+    stderr_safe = sanitizer.sanitize_text(
+        stderr.decode("utf-8", errors="replace"), "claude_stderr"
+    )
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return StreamCapture(
+        exit_code=process.returncode,
+        elapsed_ms=elapsed_ms,
+        timed_out=timed_out,
+        call_limit_exceeded=call_limit_exceeded,
+        stdout_utf8_bytes=stdout_bytes,
+        stderr_utf8_bytes=len(stderr),
+        stderr_safe=stderr_safe,
+        events_safe=events_safe,
+        invalid_event_count=invalid_event_count,
+        tool_uses=tool_uses,
+        tool_results=tool_results,
+        assistant_turns=assistant_turns,
+        final_result_raw=final_result_raw,
+        final_result_safe=final_result_safe,
+    )
+
+
+def structured_answer(envelope: dict[str, Any]) -> Any:
+    candidate = envelope.get("structured_output")
+    if candidate is not None:
+        return candidate
+    result = envelope.get("result")
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def valid_answer(value: Any) -> bool:
+    if not isinstance(value, dict) or not isinstance(value.get("answer"), str):
+        return False
+    evidence = value.get("evidence")
+    if not isinstance(evidence, list):
+        return False
+    return all(
+        isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and bool(item["path"])
+        and isinstance(item.get("line"), int)
+        and not isinstance(item["line"], bool)
+        and item["line"] >= 1
+        for item in evidence
+    )
+
+
+def persist_record(
+    output: pathlib.Path,
+    record: dict[str, Any],
+    sanitizer: Sanitizer,
+) -> dict[str, Any]:
+    before = sanitizer.event_count()
+    safe_record = sanitizer.sanitize_obj(record, "claude_trial")
+    safe_record["sanitizer"] = {
+        "redaction_count": sanitizer.event_count(),
+        "events": sanitizer.events_since(0),
+        "final_record_events": sanitizer.events_since(before),
+    }
+    try:
+        with output.open("x", encoding="utf-8", newline="\n") as handle:
+            handle.write(canonical_json(safe_record) + "\n")
+    except FileExistsError as exc:
+        raise RunnerError(
+            "output already exists; each arm requires a fresh artifact"
+        ) from exc
+    except OSError as exc:
+        raise RunnerError("could not persist the sanitized trial artifact") from exc
+    return safe_record
+
+
+def run_trial(config: TrialConfig) -> tuple[dict[str, Any], int]:
+    try:
+        config.output.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RunnerError("could not prepare the trial artifact directory") from exc
+    git_before = capture_git_state(config.repo)
+    verify_claude_version(config)
+    sanitizer = Sanitizer()
+    counter = TokenCounter()
+    config_object = mcp_config(config)
+    config_redactions = sanitizer.event_count()
+    safe_config = sanitizer.sanitize_obj(config_object, "generated_mcp_config")
+    if sanitizer.event_count() != config_redactions:
+        raise RunnerError("generated MCP config contained secret-shaped data")
+
+    with tempfile.TemporaryDirectory(prefix="sfbench-claude-mcp-") as temp_text:
+        mcp_path = pathlib.Path(temp_text) / "mcp.json"
+        mcp_path.write_text(canonical_json(safe_config) + "\n", encoding="utf-8")
+        command = build_command(config, mcp_path)
+        capture = run_process(command, config, sanitizer, counter)
+
+    git_after = capture_git_state(config.repo)
+    mutation = mutation_policy(config.case, git_before, git_after)
+    result_raw = capture.final_result_raw
+    result_safe = capture.final_result_safe
+    answer_raw = structured_answer(result_raw) if result_raw is not None else None
+    answer_safe = sanitizer.sanitize_obj(answer_raw, "structured_answer")
+    answer_is_valid = valid_answer(answer_raw)
+
+    if capture.timed_out:
+        status = "timeout"
+    elif capture.call_limit_exceeded:
+        status = "tool_call_limit_exceeded"
+    elif capture.exit_code != 0:
+        status = "claude_error"
+    elif result_raw is None:
+        status = "missing_result_event"
+    elif capture.invalid_event_count:
+        status = "invalid_stream_json"
+    elif not answer_is_valid:
+        status = "invalid_structured_answer"
+    elif result_raw.get("is_error") is True:
+        status = "claude_error"
+    elif mutation["violation"]:
+        status = "policy_violation"
+    else:
+        status = "ok"
+
+    usage = result_safe.get("usage") if isinstance(result_safe, dict) else None
+    model_usage = (
+        result_safe.get("modelUsage") if isinstance(result_safe, dict) else None
+    )
+    policy_violation = bool(mutation["violation"] or capture.call_limit_exceeded)
+    record = {
+        "protocol": PROTOCOL_ID,
+        "record_type": "claude_task_trial",
+        "case_id": config.case["id"],
+        "arm": config.arm,
+        "repo": str(config.repo),
+        "status": status,
+        "claude_code_version": REQUIRED_CLAUDE_VERSION,
+        "claude_executable_sha256": hash_file(config.claude),
+        "symforge_executable_sha256": (
+            hash_file(config.symforge) if config.symforge is not None else None
+        ),
+        "mcp_mode": "empty" if config.arm == "baseline" else "symforge_stdio",
+        "surface": config.case.get("surface", "full"),
+        "cache_state": config.case.get("cache_state"),
+        "execution_mode": (
+            "paired_llm_natural"
+            if config.prompt_mode == "neutral"
+            else "paired_llm_forced"
+        ),
+        "prompt_mode": config.prompt_mode,
+        "policy": {
+            **common_fingerprint(config),
+            "seed": config.case["model_policy"].get("seed"),
+            "context_limit_tokens": config.case["model_policy"].get(
+                "context_limit_tokens"
+            ),
+            "token_budget": case_max_task_tokens(config.case),
+            "call_limit": case_call_limit(config.case),
+            "timeout_seconds": case_timeout(config.case),
+        },
+        "command_shape": command_shape(config),
+        "elapsed_ms": capture.elapsed_ms,
+        "exit_code": capture.exit_code,
+        "timed_out": capture.timed_out,
+        "stdout_utf8_bytes": capture.stdout_utf8_bytes,
+        "stderr_utf8_bytes": capture.stderr_utf8_bytes,
+        "sanitized_stdout_sha256": sha256_text(canonical_json(capture.events_safe)),
+        "sanitized_stderr_sha256": sha256_text(capture.stderr_safe),
+        "num_turns": (
+            result_safe.get("num_turns") if isinstance(result_safe, dict) else None
+        ),
+        "total_cost_usd": (
+            result_safe.get("total_cost_usd") if isinstance(result_safe, dict) else None
+        ),
+        "usage": usage,
+        "modelUsage": model_usage,
+        "stream_event_count": len(capture.events_safe),
+        "invalid_stream_event_count": capture.invalid_event_count,
+        "stream_events": capture.events_safe,
+        "tool_call_limit": case_call_limit(config.case),
+        "tool_call_count": len(capture.tool_uses),
+        "tool_call_limit_exceeded": capture.call_limit_exceeded,
+        "tool_uses": capture.tool_uses,
+        "tool_results": capture.tool_results,
+        "tool_result_count_basis": (
+            "exact UTF-8 for string content; canonical JSON for structured content"
+        ),
+        "assistant_turn_count": len(capture.assistant_turns),
+        "assistant_turns": capture.assistant_turns,
+        "policy_violation": policy_violation,
+        "git_before": git_state_record(git_before),
+        "git_after": git_state_record(git_after),
+        "git_diff_hash_basis": "tracked binary diff plus dirty-path content hashes",
+        "mutation_policy": mutation,
+        "tokenizer": counter.metadata(),
+        "structured_answer_valid": answer_is_valid,
+        "final_structured_answer": answer_safe,
+        "claude_envelope": result_safe,
+        "stderr": capture.stderr_safe,
+        "correct": None,
+        "oracle_result": None,
+    }
+    safe_record = persist_record(config.output, record, sanitizer)
+    return safe_record, 0 if status == "ok" else 1
+
+
+def make_config(args: argparse.Namespace) -> TrialConfig:
+    benchmark_root = pathlib.Path(args.benchmark_root).resolve()
+    repo = pathlib.Path(args.repo).resolve()
+    output = pathlib.Path(args.output).resolve()
+    validate_paths(repo, benchmark_root, output)
+    if args.prompt_mode == "forced" and args.arm != "symforge":
+        raise RunnerError("forced prompt mode is available only for the SymForge arm")
+    campaign = (
+        load_json_object(pathlib.Path(args.campaign), "campaign config")
+        if args.campaign is not None
+        else None
+    )
+    fixture_oracle = (
+        load_json_object(pathlib.Path(args.fixture_oracle), "fixture oracle")
+        if args.fixture_oracle is not None
+        else None
+    )
+    corpus_manifest_path = (
+        pathlib.Path(args.corpus_manifest) if args.corpus_manifest is not None else None
+    )
+    corpus_manifest = (
+        load_json_object(corpus_manifest_path, "corpus manifest")
+        if corpus_manifest_path is not None
+        else None
+    )
+    case = load_case(
+        pathlib.Path(args.case),
+        args.case_id,
+        campaign=campaign,
+        fixture_oracle=fixture_oracle,
+        corpus_manifest=corpus_manifest,
+        corpus_manifest_path=corpus_manifest_path,
+        prompt_mode=args.prompt_mode,
+    )
+    claude = resolve_executable(args.claude)
+    symforge = resolve_executable(args.symforge) if args.arm == "symforge" else None
+    return TrialConfig(
+        case=case,
+        arm=args.arm,
+        repo=repo,
+        benchmark_root=benchmark_root,
+        output=output,
+        claude=claude,
+        claude_prefix_args=(),
+        symforge=symforge,
+        max_budget_usd=decimal_budget(args.max_budget_usd),
+        prompt_mode=args.prompt_mode,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one resolved case or one selected cases.json entry with Claude Code "
+            "2.1.207. Only Claude-consumed case fields are resolved and retained. "
+            "Baseline loads an empty strict MCP config; SymForge loads one generated "
+            "stdio config."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    run = subparsers.add_parser("run", help="Execute and persist one sanitized trial.")
+    run.add_argument(
+        "--case",
+        required=True,
+        help=(
+            "Single resolved case JSON or cases manifest. Unused direct-RPC, baseline, "
+            "precondition, and oracle fields are ignored and never persisted."
+        ),
+    )
+    run.add_argument("--case-id", help="Required when --case contains cases[].")
+    run.add_argument(
+        "--campaign",
+        help=(
+            "Campaign config used only to resolve session.model/session.seed in "
+            "model_policy; required when those placeholders are present."
+        ),
+    )
+    run.add_argument(
+        "--fixture-oracle",
+        help=(
+            "Optional fixture oracle used only for fixture.oracle placeholders in "
+            "mutation_allowlist. Oracle content is not retained."
+        ),
+    )
+    run.add_argument(
+        "--corpus-manifest",
+        help=(
+            "Optional corpus manifest used only for repo/corpus placeholders in "
+            "mutation_allowlist. Manifest content is not retained."
+        ),
+    )
+    run.add_argument("--arm", choices=("baseline", "symforge"), required=True)
+    run.add_argument(
+        "--prompt-mode",
+        choices=("neutral", "forced"),
+        default="neutral",
+        help=(
+            "neutral (default) derives one tool-agnostic prompt for paired arms; "
+            "forced uses the original tool-directed prompt and is SymForge-only."
+        ),
+    )
+    run.add_argument("--repo", required=True, help="Disposable repository directory.")
+    run.add_argument("--benchmark-root", required=True)
+    run.add_argument("--output", required=True, help="Fresh JSONL artifact path.")
+    run.add_argument("--claude", default="claude")
+    run.add_argument("--symforge", default="symforge")
+    run.add_argument("--max-budget-usd", required=True)
+    run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print only a sanitized command shape; do not call Claude or write files.",
+    )
+    subparsers.add_parser(
+        "self-test", help="Exercise both arms with an internal fake Claude executable."
+    )
+    return parser
+
+
+def argument_after(arguments: list[str], flag: str) -> str | None:
+    try:
+        index = arguments.index(flag)
+    except ValueError:
+        return None
+    return arguments[index + 1] if index + 1 < len(arguments) else None
+
+
+def fake_claude(arguments: list[str]) -> int:
+    if arguments == ["--version"]:
+        print(f"{REQUIRED_CLAUDE_VERSION} (Claude Code)")
+        return 0
+    if any(is_credential_env_name(name) for name in os.environ):
+        return 5
+    required_flags = {
+        "--print",
+        "--safe-mode",
+        "--no-session-persistence",
+        "--strict-mcp-config",
+        "--mcp-config",
+        "--json-schema",
+        "--model",
+        "--effort",
+        "--max-budget-usd",
+        "--tools",
+        "--allowedTools",
+        "--system-prompt",
+        "--verbose",
+    }
+    if not required_flags.issubset(arguments):
+        return 3
+    if argument_after(arguments, "--output-format") != "stream-json":
+        return 3
+    if "--include-partial-messages" in arguments:
+        return 3
+    mcp_path = argument_after(arguments, "--mcp-config")
+    if mcp_path is None:
+        return 3
+    try:
+        config = json.loads(pathlib.Path(mcp_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 3
+    servers = config.get("mcpServers") if isinstance(config, dict) else None
+    if not isinstance(servers, dict) or set(servers) not in (set(), {"symforge"}):
+        return 3
+    prompt = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+    if "FAKE_MUTATE_ALLOWED" in prompt:
+        pathlib.Path("allowed.txt").write_text("allowed\n", encoding="utf-8")
+    elif "FAKE_MUTATE" in prompt:
+        pathlib.Path("violation.txt").write_text("violation\n", encoding="utf-8")
+    sensitive_stdout = "unit" + "-sensitive" + "-stdout"
+    sensitive_stderr = "unit" + "-sensitive" + "-stderr"
+    tool_name = "mcp__symforge__get_file_context" if servers else "Read"
+    events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "synthetic-session-id",
+            "tools": [tool_name],
+            "model": "claude-test-model",
+        },
+        {
+            "type": "assistant",
+            "session_id": "synthetic-session-id",
+            "message": {
+                "model": "claude-test-model",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Inspecting the fixture."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool-use-1",
+                        "name": tool_name,
+                        "input": {
+                            "path": "fixture.py",
+                            "password": sensitive_stdout,
+                        },
+                    },
+                ],
+                "usage": {"input_tokens": 100, "output_tokens": 12},
+            },
+        },
+        {
+            "type": "user",
+            "session_id": "synthetic-session-id",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-use-1",
+                        "content": (
+                            f"API_TOKEN={sensitive_stdout} special=<|endoftext|>"
+                        ),
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "session_id": "synthetic-session-id",
+            "message": {
+                "model": "claude-test-model",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "The fixture is present."}],
+                "usage": {"input_tokens": 20, "output_tokens": 8},
+            },
+        },
+    ]
+    if "FAKE_TWO_TOOLS" in prompt:
+        events[1]["message"]["content"].append(
+            {
+                "type": "tool_use",
+                "id": "tool-use-2",
+                "name": tool_name,
+                "input": {"path": "fixture.py"},
+            }
+        )
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "duration_ms": 12,
+        "duration_api_ms": 10,
+        "num_turns": 2,
+        "result": f"API_TOKEN={sensitive_stdout}",
+        "session_id": "synthetic-session-id",
+        "total_cost_usd": 0.0125,
+        "usage": {
+            "input_tokens": 100,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+            "output_tokens": 30,
+        },
+        "modelUsage": {
+            "claude-test-model": {
+                "inputTokens": 130,
+                "outputTokens": 30,
+                "costUSD": 0.0125,
+            }
+        },
+        "structured_output": {
+            "answer": "ok",
+            "evidence": [{"path": "fixture.py", "line": 1}],
+        },
+    }
+    events.append(result)
+    for event in events:
+        sys.stdout.write(canonical_json(event) + "\n")
+    sys.stdout.flush()
+    sys.stderr.write(f"PASSWORD={sensitive_stderr}\n")
+    return 0
+
+
+def initialize_test_repo(repo: pathlib.Path) -> None:
+    repo.mkdir(parents=True)
+    (repo / "fixture.py").write_text("VALUE = 1\n", encoding="utf-8")
+    git = shutil.which("git", path=claude_environment().get("PATH"))
+    if git is None:
+        raise RunnerError("git is required for the fake Claude self-test")
+    commands = (
+        [git, "init", "-q", str(repo)],
+        [git, "-C", str(repo), "add", "fixture.py"],
+        [
+            git,
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=SFBENCH",
+            "-c",
+            "user.email=sfbench.invalid@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+    )
+    for command in commands:
+        result = subprocess.run(
+            command,
+            env=claude_environment(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RunnerError("could not initialize the fake Claude Git repository")
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory(prefix="sfbench-claude-runner-test-") as root_text:
+        root = pathlib.Path(root_text)
+        repo = root / "work" / "repo"
+        artifacts = root / "artifacts"
+        initialize_test_repo(repo)
+        artifacts.mkdir()
+        case = {
+            "id": "SF-fake-001",
+            "task_prompt": "Find the fake fixture.",
+            "model_policy": {
+                "model": "claude-test-model",
+                "reasoning_effort": "low",
+                "seed": 1,
+                "context_limit_tokens": 200000,
+                "same_model_both_arms": True,
+            },
+            "token_budget": {
+                "max_task_tokens": 4000,
+                "count_provider_usage": True,
+            },
+            "allowed_helpers": ["rg", "bounded_read"],
+            "forbidden_tools": ["internet", "lsp"],
+            "transport": "stdio",
+            "surface": "full",
+            "cache_state": "cold_build",
+            "execution_mode": "natural",
+            "limits": {"timeout_seconds": 10, "call_limit": 4},
+            "mutation_allowlist": [],
+            "source_hash_policy": "no_source_bytes_may_change",
+        }
+        validate_case(case)
+        case_path = root / "resolved-case.json"
+        case_path.write_text(canonical_json(case) + "\n", encoding="utf-8")
+        if load_case(case_path, None) != case:
+            raise RunnerError("resolved case loading invariant failed")
+        script = pathlib.Path(__file__).resolve()
+
+        benchmark_assets = script.parent
+        real_cases_path = benchmark_assets / "cases.json"
+        real_campaign_path = benchmark_assets / "campaign.config.json"
+        real_campaign = load_json_object(real_campaign_path, "campaign config")
+        selected = load_case(
+            real_cases_path,
+            "SF-get_repo_map-001",
+            campaign=real_campaign,
+        )
+        forced_selected = load_case(
+            real_cases_path,
+            "SF-get_repo_map-001",
+            campaign=real_campaign,
+            prompt_mode="forced",
+        )
+        expected_model = real_campaign.get("paired_llm", {}).get("model_alias")
+        neutral_prompt = selected.get("task_prompt")
+        if (
+            selected.get("id") != "SF-get_repo_map-001"
+            or selected.get("model_policy", {}).get("model") != expected_model
+            or selected.get("model_policy", {}).get("seed") is not None
+            or not isinstance(neutral_prompt, str)
+            or neutral_prompt_names_tool(neutral_prompt, "get_repo_map")
+            or "get_repo_map" in neutral_prompt
+            or "symforge" in neutral_prompt.lower()
+            or forced_selected.get("task_prompt") == neutral_prompt
+            or "get_repo_map" not in forced_selected.get("task_prompt", "")
+            or find_placeholders(selected)
+            or any(key not in RUNTIME_CASE_FIELDS for key in selected)
+        ):
+            raise RunnerError("real cases.json projection invariant failed")
+
+        integration_repo = root / "work" / "manifest-dry-run"
+        initialize_test_repo(integration_repo)
+        integration_output = artifacts / "manifest-dry-run.jsonl"
+        dry_stdout = io.StringIO()
+        with contextlib.redirect_stdout(dry_stdout):
+            dry_exit = main(
+                [
+                    "run",
+                    "--case",
+                    str(real_cases_path),
+                    "--case-id",
+                    "SF-get_repo_map-001",
+                    "--campaign",
+                    str(real_campaign_path),
+                    "--arm",
+                    "baseline",
+                    "--repo",
+                    str(integration_repo),
+                    "--benchmark-root",
+                    str(root),
+                    "--output",
+                    str(integration_output),
+                    "--claude",
+                    sys.executable,
+                    "--max-budget-usd",
+                    "1.00",
+                    "--dry-run",
+                ]
+            )
+        dry_shape = json.loads(dry_stdout.getvalue())
+        if (
+            dry_exit != 0
+            or integration_output.exists()
+            or dry_shape.get("flags", {}).get("model") != expected_model
+            or dry_shape.get("task_prompt_sha256") != sha256_text(neutral_prompt)
+            or "${" in canonical_json(dry_shape)
+            or "requests" in dry_shape
+        ):
+            raise RunnerError("real cases.json dry-run integration invariant failed")
+
+        records: list[dict[str, Any]] = []
+        sensitive_env = {
+            "ANTHROPIC_API_KEY": "unit" + "-credential" + "-fixture",
+            "AWS_SECRET_ACCESS_KEY": "unit" + "-cloud" + "-fixture",
+            "BENCH_TOKEN": "unit" + "-token" + "-fixture",
+        }
+        previous_env = {name: os.environ.get(name) for name in sensitive_env}
+        os.environ.update(sensitive_env)
+
+        def fake_config(
+            trial_case: dict[str, Any],
+            trial_repo: pathlib.Path,
+            artifact_name: str,
+            arm: str = "baseline",
+        ) -> TrialConfig:
+            return TrialConfig(
+                case=trial_case,
+                arm=arm,
+                repo=trial_repo,
+                benchmark_root=root,
+                output=artifacts / f"{artifact_name}.jsonl",
+                claude=pathlib.Path(sys.executable).resolve(),
+                claude_prefix_args=(str(script), "--_fake-claude"),
+                symforge=(
+                    pathlib.Path(sys.executable).resolve()
+                    if arm == "symforge"
+                    else None
+                ),
+                max_budget_usd="1.00",
+            )
+
+        try:
+            for arm in ("baseline", "symforge"):
+                config = fake_config(case, repo, arm, arm)
+                record, exit_code = run_trial(config)
+                if exit_code != 0:
+                    raise RunnerError("fake Claude trial did not complete")
+                persisted = config.output.read_text(encoding="utf-8")
+                forbidden_values = {
+                    "unit" + "-sensitive" + "-stdout",
+                    "unit" + "-sensitive" + "-stderr",
+                    *sensitive_env.values(),
+                }
+                if any(value in persisted for value in forbidden_values):
+                    raise RunnerError("fake Claude sanitizer invariant failed")
+                if REDACTED not in persisted or "session_id" in persisted:
+                    raise RunnerError("fake Claude redaction evidence is missing")
+                if case["task_prompt"] in canonical_json(command_shape(config)):
+                    raise RunnerError("dry-run command shape exposed the task prompt")
+                if (
+                    record["tool_call_count"] != 1
+                    or len(record["tool_results"]) != 1
+                    or record["assistant_turn_count"] != 2
+                    or record["tool_results"][0]["content_cl100k"] <= 0
+                    or record["tool_results"][0]["content_o200k"] <= 0
+                    or record["mutation_policy"]["status"] != "compliant"
+                    or record["git_before"]["diff_sha256"]
+                    != record["git_after"]["diff_sha256"]
+                ):
+                    raise RunnerError("Claude stream trace invariant failed")
+                records.append(record)
+
+            if records[0]["policy"] != records[1]["policy"]:
+                raise RunnerError("paired-arm common policy invariant failed")
+            if not all(
+                record["num_turns"] == 2
+                and record["total_cost_usd"] == 0.0125
+                and record["structured_answer_valid"] is True
+                and isinstance(record["usage"], dict)
+                and isinstance(record["modelUsage"], dict)
+                for record in records
+            ):
+                raise RunnerError("Claude JSON capture invariant failed")
+
+            no_source_repo = root / "work" / "no-source-violation"
+            initialize_test_repo(no_source_repo)
+            no_source_case = {
+                **case,
+                "id": "SF-fake-no-source",
+                "task_prompt": "FAKE_MUTATE",
+            }
+            no_source_record, no_source_exit = run_trial(
+                fake_config(no_source_case, no_source_repo, "no-source-violation")
+            )
+            if (
+                no_source_exit == 0
+                or no_source_record["status"] != "policy_violation"
+                or "violation.txt"
+                not in no_source_record["mutation_policy"]["violating_paths"]
+            ):
+                raise RunnerError("read-only Git mutation invariant failed")
+
+            escape_repo = root / "work" / "allowlist-escape"
+            initialize_test_repo(escape_repo)
+            escape_case = {
+                **case,
+                "id": "SF-fake-allowlist-escape",
+                "task_prompt": "FAKE_MUTATE",
+                "source_hash_policy": "only_allowlisted_paths_may_change",
+                "mutation_allowlist": ["allowed.txt"],
+            }
+            escape_record, escape_exit = run_trial(
+                fake_config(escape_case, escape_repo, "allowlist-escape")
+            )
+            if (
+                escape_exit == 0
+                or escape_record["mutation_policy"]["status"] != "violation"
+                or "violation.txt"
+                not in escape_record["mutation_policy"]["violating_paths"]
+            ):
+                raise RunnerError("mutation allowlist escape invariant failed")
+
+            limit_repo = root / "work" / "call-limit"
+            initialize_test_repo(limit_repo)
+            limit_case = {
+                **case,
+                "id": "SF-fake-call-limit",
+                "task_prompt": "FAKE_TWO_TOOLS",
+                "limits": {"timeout_seconds": 10, "call_limit": 1},
+            }
+            limit_record, limit_exit = run_trial(
+                fake_config(limit_case, limit_repo, "call-limit")
+            )
+            if (
+                limit_exit == 0
+                or limit_record["status"] != "tool_call_limit_exceeded"
+                or limit_record["tool_call_count"] != 2
+                or limit_record["policy_violation"] is not True
+            ):
+                raise RunnerError("tool-call limit enforcement invariant failed")
+        finally:
+            for name, previous in previous_env.items():
+                if previous is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous
+    print("self-test: PASS")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments and arguments[0] == "--_fake-claude":
+        return fake_claude(arguments[1:])
+    parser = build_parser()
+    args = parser.parse_args(arguments)
+    if args.mode == "self-test":
+        return self_test()
+    config = make_config(args)
+    if args.dry_run:
+        sanitizer = Sanitizer()
+        print(canonical_json(sanitizer.sanitize_obj(command_shape(config), "dry_run")))
+        return 0
+    record, exit_code = run_trial(config)
+    print(f"trial captured: status={record['status']}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RunnerError as exc:
+        print(f"claude_task_runner: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/research/full-surface-benchmark/corpus.lock.json
+++ b/research/full-surface-benchmark/corpus.lock.json
@@ -1,0 +1,104 @@
+{
+  "version": 1,
+  "resolved_at": "2026-07-12",
+  "clone_policy": {
+    "partial_clone": false,
+    "submodules": false,
+    "lfs_smudge": false,
+    "core_autocrlf": false,
+    "core_eol": "lf",
+    "ordinary_case_materialization": "independent_local_clone_no_hardlinks"
+  },
+  "repositories": [
+    {
+      "alias": "ripgrep",
+      "url": "https://github.com/BurntSushi/ripgrep.git",
+      "commit": "d5b85d44057ff729a89be9c6549958c45d95aa99",
+      "history_depth": 128,
+      "stratum": "normal",
+      "primary_language": "Rust",
+      "overlay_language": "Rust"
+    },
+    {
+      "alias": "flask",
+      "url": "https://github.com/pallets/flask.git",
+      "commit": "36e4a824f340fdee7ed50937ba8e7f6bc7d17f81",
+      "history_depth": 128,
+      "stratum": "normal",
+      "primary_language": "Python",
+      "overlay_language": "Python"
+    },
+    {
+      "alias": "zod",
+      "url": "https://github.com/colinhacks/zod.git",
+      "commit": "912f0f51b0ced654d0069741e7160834dca742ee",
+      "history_depth": 128,
+      "stratum": "normal",
+      "primary_language": "TypeScript",
+      "overlay_language": "TypeScript"
+    },
+    {
+      "alias": "cobra",
+      "url": "https://github.com/spf13/cobra.git",
+      "commit": "adbc8813901bba65827259daa8e22ff94ec1f30e",
+      "history_depth": 32,
+      "stratum": "normal",
+      "primary_language": "Go",
+      "overlay_language": "Go"
+    },
+    {
+      "alias": "gson",
+      "url": "https://github.com/google/gson.git",
+      "commit": "c9f3fd55854a743b66f857ace3c7b268ea3e2ef7",
+      "history_depth": 32,
+      "stratum": "normal",
+      "primary_language": "Java",
+      "overlay_language": "Java"
+    },
+    {
+      "alias": "fmt",
+      "url": "https://github.com/fmtlib/fmt.git",
+      "commit": "7077b016cc19793e11f9b9aa3d909390acd3819b",
+      "history_depth": 32,
+      "stratum": "normal",
+      "primary_language": "C++",
+      "overlay_language": "C++"
+    },
+    {
+      "alias": "mojo",
+      "url": "https://github.com/mojolicious/mojo.git",
+      "commit": "6007271e9152aa0998129991030c3ed16eb407d0",
+      "history_depth": 32,
+      "stratum": "normal",
+      "primary_language": "Perl",
+      "overlay_language": "Perl"
+    },
+    {
+      "alias": "typescript",
+      "url": "https://github.com/microsoft/TypeScript.git",
+      "commit": "637d5746b70257028fb95aad32ddec6b26ab0a14",
+      "history_depth": 128,
+      "stratum": "stress",
+      "primary_language": "TypeScript",
+      "overlay_language": "TypeScript"
+    },
+    {
+      "alias": "p-map",
+      "url": "https://github.com/sindresorhus/p-map.git",
+      "commit": "3ada5f36632aca8df860c376856270b6d2ba2de8",
+      "history_depth": 32,
+      "stratum": "tiny",
+      "primary_language": "JavaScript",
+      "overlay_language": "JavaScript"
+    },
+    {
+      "alias": "json-schema-suite",
+      "url": "https://github.com/json-schema-org/JSON-Schema-Test-Suite.git",
+      "commit": "92acb61eb772a932c077d5ffa634ded719d2d738",
+      "history_depth": 32,
+      "stratum": "symbol-poor",
+      "primary_language": "JSON",
+      "overlay_language": null
+    }
+  ]
+}

--- a/research/full-surface-benchmark/direct_case_runner.py
+++ b/research/full-surface-benchmark/direct_case_runner.py
@@ -1,0 +1,3807 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "tiktoken>=0.7.0,<1",
+# ]
+# ///
+"""Deterministic direct-RPC scenario runner for the SymForge surface benchmark.
+
+The runner is deliberately local-only: it materializes disposable clones from
+the frozen corpus mirrors, speaks MCP over stdio through :mod:`mcp_harness`,
+and sanitizes every persisted record.  It never invokes a paid model API.
+
+Formal runs should pass ``--require-asset-lock`` once ``assets.lock.json`` has
+been frozen.  ``validate`` and ``self-test`` remain useful before that freeze;
+they still verify all internally pinned corpus, fixture, tokenizer, and SUT
+hashes and report the computed cases/campaign hashes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import fnmatch
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+import mcp_harness as harness
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parents[1]
+DEFAULT_CASES = SCRIPT_DIR / "cases.json"
+DEFAULT_CAMPAIGN = SCRIPT_DIR / "campaign.config.json"
+DEFAULT_CORPUS_LOCK = SCRIPT_DIR / "corpus.lock.json"
+DEFAULT_ASSET_LOCK = SCRIPT_DIR / "assets.lock.json"
+DEFAULT_BASELINE_PATCHES = SCRIPT_DIR / "baseline-patches.json"
+DEFAULT_BENCHMARK_ROOT = pathlib.Path(
+    os.environ.get(
+        "SFBENCH_ROOT",
+        r"C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface",
+    )
+)
+PLACEHOLDER = re.compile(r"\$\{([^{}]+)\}")
+CCR_HANDLE = re.compile(r'\bhash="([0-9a-f]{12})"')
+FULL_SHA = re.compile(r"[0-9a-f]{40,64}")
+RUNTIME_ALLOWLIST = (".symforge/**",)
+SMOKE_CASE_IDS = ("SF-get_repo_map-001",)
+ECONOMICS_ROLES = {
+    "task",
+    "required_prerequisite",
+    "comparison_variant",
+    "estimate_diagnostic",
+    "oracle_reference",
+    "replay_diagnostic",
+}
+
+
+class RunnerError(RuntimeError):
+    """Expected failure whose message is safe to persist and display."""
+
+
+class UnsupportedCase(RunnerError):
+    """A frozen case asks for behavior the direct runner cannot execute."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RunnerError(f"could not read {label}") from exc
+    except json.JSONDecodeError as exc:
+        raise RunnerError(
+            f"{label} is invalid JSON at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise RunnerError(f"{label} must contain one JSON object")
+    return value
+
+
+def canonical_path(path: pathlib.Path) -> str:
+    rendered = path.resolve().as_posix()
+    return rendered.casefold() if os.name == "nt" else rendered
+
+
+def project_id_for(path: pathlib.Path) -> str:
+    return "project-" + hashlib.sha256(canonical_path(path).encode("utf-8")).hexdigest()
+
+
+def safe_git_environment(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = harness.child_environment("full", False)
+    env.update(
+        {
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_LFS_SKIP_SMUDGE": "1",
+        }
+    )
+    if extra:
+        env.update(extra)
+    return env
+
+
+def run_process(
+    command: Sequence[str],
+    *,
+    cwd: pathlib.Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float = 120,
+    input_bytes: bytes | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    try:
+        result = subprocess.run(
+            list(command),
+            cwd=cwd,
+            env=env,
+            input=input_bytes,
+            stdin=None if input_bytes is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RunnerError(f"local command failed to execute: {command[0]}") from exc
+    if check and result.returncode != 0:
+        raise RunnerError(
+            f"local command returned {result.returncode}: {pathlib.Path(command[0]).name}"
+        )
+    return result
+
+
+def git(
+    repo: pathlib.Path,
+    *arguments: str,
+    env: dict[str, str] | None = None,
+    timeout: float = 120,
+    check: bool = True,
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    executable = shutil.which("git")
+    if executable is None:
+        raise RunnerError("git is required")
+    return run_process(
+        [executable, "-C", str(repo), *arguments],
+        cwd=repo if repo.exists() else None,
+        env=env or safe_git_environment(),
+        timeout=timeout,
+        input_bytes=input_bytes,
+        check=check,
+    )
+
+
+def git_text(repo: pathlib.Path, *arguments: str, **kwargs: Any) -> str:
+    result = git(repo, *arguments, **kwargs)
+    return result.stdout.decode("utf-8", errors="strict").strip()
+
+
+def require_relative_path(root: pathlib.Path, relative: str) -> pathlib.Path:
+    candidate = (root / pathlib.PurePosixPath(relative)).resolve()
+    if not harness.is_within(candidate, root.resolve()) or candidate == root.resolve():
+        raise RunnerError("a case path escaped its disposable work root")
+    return candidate
+
+
+def fixture_tree_hash(root: pathlib.Path) -> str:
+    facts: list[tuple[str, str, int]] = []
+    for directory, directories, filenames in os.walk(root, followlinks=False):
+        base = pathlib.Path(directory)
+        directories[:] = sorted(
+            name
+            for name in directories
+            if name != ".git" and not (base / name).is_symlink()
+        )
+        for filename in sorted(filenames):
+            path = base / filename
+            relative = path.relative_to(root)
+            if ".git" in relative.parts or path.is_symlink():
+                continue
+            data = path.read_bytes()
+            facts.append((relative.as_posix(), sha256_bytes(data), len(data)))
+    digest = hashlib.sha256()
+    for relative, sha, size in sorted(facts):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(sha.encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(size).encode("ascii"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def source_inventory(root: pathlib.Path) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    for directory, directories, filenames in os.walk(root, followlinks=False):
+        base = pathlib.Path(directory)
+        retained: list[str] = []
+        for name in sorted(directories):
+            path = base / name
+            if name == ".git":
+                continue
+            if path.is_symlink():
+                relative = path.relative_to(root).as_posix()
+                target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+                entries.append(
+                    {
+                        "path": relative,
+                        "kind": "directory_symlink",
+                        "bytes": len(target),
+                        "sha256": sha256_bytes(target),
+                        "mode": stat.S_IMODE(path.lstat().st_mode),
+                    }
+                )
+            else:
+                retained.append(name)
+        directories[:] = retained
+        for filename in sorted(filenames):
+            path = base / filename
+            relative = path.relative_to(root).as_posix()
+            if ".git" in pathlib.PurePosixPath(relative).parts:
+                continue
+            if path.is_symlink():
+                target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+                entries.append(
+                    {
+                        "path": relative,
+                        "kind": "symlink",
+                        "bytes": len(target),
+                        "sha256": sha256_bytes(target),
+                        "mode": stat.S_IMODE(path.lstat().st_mode),
+                    }
+                )
+                continue
+            try:
+                data = path.read_bytes()
+            except OSError as exc:
+                raise RunnerError(
+                    f"could not inventory worktree path: {relative}"
+                ) from exc
+            entries.append(
+                {
+                    "path": relative,
+                    "kind": "file",
+                    "bytes": len(data),
+                    "sha256": sha256_bytes(data),
+                    "mode": stat.S_IMODE(path.stat().st_mode),
+                }
+            )
+    entries.sort(key=lambda entry: entry["path"])
+    serialized = harness.canonical_json(entries)
+    return {
+        "entries": entries,
+        "file_count": len(entries),
+        "total_bytes": sum(entry["bytes"] for entry in entries),
+        "tree_sha256": harness.sha256_text(serialized),
+    }
+
+
+def inventory_changes(
+    before: dict[str, Any], after: dict[str, Any]
+) -> list[dict[str, Any]]:
+    left = {entry["path"]: entry for entry in before["entries"]}
+    right = {entry["path"]: entry for entry in after["entries"]}
+    changes: list[dict[str, Any]] = []
+    for path in sorted(left.keys() | right.keys()):
+        old = left.get(path)
+        new = right.get(path)
+        if old == new:
+            continue
+        changes.append(
+            {
+                "path": path,
+                "change": "added"
+                if old is None
+                else "deleted"
+                if new is None
+                else "modified",
+                "before": old,
+                "after": new,
+            }
+        )
+    return changes
+
+
+def git_state_inventory(root: pathlib.Path) -> dict[str, Any]:
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        return {"present": False}
+    status_bytes = git(root, "status", "--porcelain=v1", "--untracked-files=all").stdout
+    refs_bytes = git(root, "for-each-ref", "--format=%(refname)%00%(objectname)").stdout
+
+    def optional_hash(path: pathlib.Path) -> str | None:
+        return file_sha256(path) if path.is_file() else None
+
+    return {
+        "present": True,
+        "head": git_text(root, "rev-parse", "HEAD"),
+        "index_sha256": optional_hash(git_dir / "index"),
+        "config_sha256": optional_hash(git_dir / "config"),
+        "packed_refs_sha256": optional_hash(git_dir / "packed-refs"),
+        "refs_sha256": sha256_bytes(refs_bytes),
+        "status_sha256": sha256_bytes(status_bytes),
+        "status_porcelain_v1": status_bytes.decode(
+            "utf-8", errors="strict"
+        ).splitlines(),
+    }
+
+
+def protected_git_state_changed(
+    before: dict[str, Any], after: dict[str, Any]
+) -> list[str]:
+    protected = (
+        "present",
+        "head",
+        "index_sha256",
+        "config_sha256",
+        "packed_refs_sha256",
+        "refs_sha256",
+    )
+    return [field for field in protected if before.get(field) != after.get(field)]
+
+
+def matches_any(path: str, patterns: Iterable[str]) -> bool:
+    return any(
+        fnmatch.fnmatchcase(path, pattern.replace("\\", "/")) for pattern in patterns
+    )
+
+
+def enforce_mutation_policy(
+    case: dict[str, Any],
+    allowlist: list[str],
+    changes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    source_changes = [
+        change
+        for change in changes
+        if not matches_any(change["path"], RUNTIME_ALLOWLIST)
+    ]
+    policy = case.get("source_hash_policy")
+    violations: list[str] = []
+    if policy == "no_source_bytes_may_change":
+        violations = [change["path"] for change in source_changes]
+    elif policy == "only_allowlisted_paths_may_change":
+        violations = [
+            change["path"]
+            for change in source_changes
+            if not matches_any(change["path"], allowlist)
+        ]
+    else:
+        raise RunnerError("unknown source_hash_policy")
+    return {
+        "policy": policy,
+        "resolved_allowlist": allowlist,
+        "runtime_allowlist": list(RUNTIME_ALLOWLIST),
+        "changed_source_paths": [change["path"] for change in source_changes],
+        "violations": violations,
+        "safe": not violations,
+    }
+
+
+def flatten_asset_hashes(value: Any, result: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        path = value.get("path")
+        sha = value.get("sha256") or value.get("sha256_hex")
+        if (
+            isinstance(path, str)
+            and isinstance(sha, str)
+            and re.fullmatch(r"[0-9a-fA-F]{64}", sha)
+        ):
+            result[path.replace("\\", "/")] = sha.lower()
+        for key, child in value.items():
+            if isinstance(child, str) and re.fullmatch(r"[0-9a-fA-F]{64}", child):
+                if "/" in key or "\\" in key or "." in pathlib.PurePosixPath(key).name:
+                    result[key.replace("\\", "/")] = child.lower()
+            elif isinstance(child, dict):
+                nested_sha = child.get("sha256") or child.get("sha256_hex")
+                if isinstance(nested_sha, str) and re.fullmatch(
+                    r"[0-9a-fA-F]{64}", nested_sha
+                ):
+                    result[key.replace("\\", "/")] = nested_sha.lower()
+            flatten_asset_hashes(child, result)
+    elif isinstance(value, list):
+        for child in value:
+            flatten_asset_hashes(child, result)
+
+
+@dataclass
+class InputBundle:
+    benchmark_root: pathlib.Path
+    fixture_root: pathlib.Path
+    cases_path: pathlib.Path
+    campaign_path: pathlib.Path
+    corpus_lock_path: pathlib.Path
+    corpus_manifest_path: pathlib.Path
+    oracle_path: pathlib.Path
+    cases: dict[str, Any]
+    campaign: dict[str, Any]
+    corpus_lock: dict[str, Any]
+    corpus_manifest: dict[str, Any]
+    oracle: dict[str, Any]
+    hashes: dict[str, str]
+    repositories: dict[str, dict[str, Any]]
+    asset_lock_status: dict[str, Any]
+    baseline_patches: dict[str, Any] | None
+    baseline_patches_path: pathlib.Path | None
+
+
+def _asset_match(path: pathlib.Path, hashes: dict[str, str]) -> str | None:
+    normalized = path.resolve().as_posix()
+    candidates = [
+        digest
+        for name, digest in hashes.items()
+        if normalized.endswith(name.replace("\\", "/"))
+        or path.name == pathlib.PurePosixPath(name.replace("\\", "/")).name
+    ]
+    return candidates[0] if len(set(candidates)) == 1 else None
+
+
+def validate_inputs(
+    *,
+    benchmark_root: pathlib.Path,
+    fixture_root: pathlib.Path,
+    cases_path: pathlib.Path,
+    campaign_path: pathlib.Path,
+    corpus_lock_path: pathlib.Path,
+    asset_lock_path: pathlib.Path | None,
+    baseline_patches_path: pathlib.Path | None,
+    require_asset_lock: bool,
+) -> InputBundle:
+    benchmark_root = benchmark_root.resolve()
+    fixture_root = fixture_root.resolve()
+    cases_path = cases_path.resolve()
+    campaign_path = campaign_path.resolve()
+    corpus_lock_path = corpus_lock_path.resolve()
+    corpus_manifest_path = benchmark_root / "corpus-manifest.json"
+    oracle_path = fixture_root / "oracle.json"
+    cases = load_json(cases_path, "cases manifest")
+    campaign = load_json(campaign_path, "campaign config")
+    corpus_lock = load_json(corpus_lock_path, "corpus lock")
+    corpus_manifest = load_json(corpus_manifest_path, "corpus manifest")
+    oracle = load_json(oracle_path, "fixture oracle")
+    hashes = {
+        "cases": file_sha256(cases_path),
+        "campaign": file_sha256(campaign_path),
+        "corpus_lock": file_sha256(corpus_lock_path),
+        "corpus_manifest": file_sha256(corpus_manifest_path),
+        "oracle": file_sha256(oracle_path),
+        "direct_case_runner": file_sha256(pathlib.Path(__file__).resolve()),
+        "mcp_harness": file_sha256(SCRIPT_DIR / "mcp_harness.py"),
+        "fixture_generator": file_sha256(SCRIPT_DIR / "fixture_generator.py"),
+        "parity_normalization": file_sha256(SCRIPT_DIR / "parity-normalization.json"),
+    }
+    baseline_patches: dict[str, Any] | None = None
+    resolved_baseline_patches: pathlib.Path | None = None
+    if baseline_patches_path is not None and baseline_patches_path.is_file():
+        resolved_baseline_patches = baseline_patches_path.resolve()
+        baseline_patches = load_json(resolved_baseline_patches, "baseline patches lock")
+        hashes["baseline_patches"] = file_sha256(resolved_baseline_patches)
+
+    if cases.get("protocol") != harness.PROTOCOL_ID:
+        raise RunnerError("cases protocol does not match the harness")
+    if campaign.get("protocol_id") != harness.PROTOCOL_ID:
+        raise RunnerError("campaign protocol does not match the harness")
+    if campaign.get("mcp", {}).get("primary_transport") != "stdio":
+        raise RunnerError("campaign primary direct transport is not stdio")
+    expected_version = campaign.get("system_under_test", {}).get("version")
+    if not isinstance(expected_version, str) or expected_version not in str(
+        cases.get("system_under_test", "")
+    ):
+        raise RunnerError("cases and campaign disagree on the SUT version")
+    safety = campaign.get("safety", {})
+    required_safety = {
+        "persist_unsanitized_output": False,
+        "source_mirrors_are_immutable": True,
+        "ordinary_cases_use_independent_clones": True,
+        "oracle_visible_to_llm": False,
+        "network_during_measurement": False,
+    }
+    if any(safety.get(key) != expected for key, expected in required_safety.items()):
+        raise RunnerError("campaign safety policy is not fail-closed")
+
+    oracle_contract = cases.get("oracle_contract", {})
+    if hashes["oracle"] != oracle_contract.get("expected_oracle_sha256"):
+        raise RunnerError("fixture oracle SHA-256 does not match cases.json")
+    clean_relative = oracle.get("paths", {}).get("clean_repository")
+    if not isinstance(clean_relative, str):
+        raise RunnerError("fixture oracle omits the clean repository path")
+    clean_repo = require_relative_path(fixture_root, clean_relative)
+    clean_head = git_text(clean_repo, "rev-parse", "HEAD")
+    if clean_head != oracle_contract.get("expected_clean_head"):
+        raise RunnerError("fixture clean HEAD does not match cases.json")
+    clean_tree = fixture_tree_hash(clean_repo)
+    if clean_tree != oracle_contract.get("expected_clean_tree_sha256"):
+        raise RunnerError("fixture clean tree hash does not match cases.json")
+    if clean_tree != oracle.get("repositories", {}).get("clean", {}).get("tree_sha256"):
+        raise RunnerError("fixture clean tree hash does not match oracle.json")
+    mutation_relative = oracle.get("paths", {}).get("mutation_repository")
+    if not isinstance(mutation_relative, str):
+        raise RunnerError("fixture oracle omits the mutation repository path")
+    mutation_repo = require_relative_path(fixture_root, mutation_relative)
+    mutation_oracle = oracle.get("repositories", {}).get("mutation", {})
+    if git_text(mutation_repo, "rev-parse", "HEAD") != mutation_oracle.get("head"):
+        raise RunnerError("fixture mutation HEAD does not match oracle.json")
+    if fixture_tree_hash(mutation_repo) != mutation_oracle.get("tree_sha256"):
+        raise RunnerError("fixture mutation tree hash does not match oracle.json")
+    worktree_oracle = oracle.get("worktree", {})
+    expected_status = sorted(worktree_oracle.get("status_porcelain_v1", []))
+    actual_status = sorted(
+        git(mutation_repo, "status", "--porcelain=v1", "--untracked-files=all")
+        .stdout.decode("utf-8", errors="strict")
+        .splitlines()
+    )
+    if actual_status != expected_status:
+        raise RunnerError("fixture mutation status differs from oracle.json")
+    staged_diff = git(
+        mutation_repo, "diff", "--cached", "--binary", "--no-ext-diff"
+    ).stdout
+    unstaged_diff = git(mutation_repo, "diff", "--binary", "--no-ext-diff").stdout
+    if sha256_bytes(staged_diff) != worktree_oracle.get("staged", {}).get(
+        "diff_sha256"
+    ):
+        raise RunnerError("fixture staged diff hash differs from oracle.json")
+    if sha256_bytes(unstaged_diff) != worktree_oracle.get("unstaged", {}).get(
+        "diff_sha256"
+    ):
+        raise RunnerError("fixture unstaged diff hash differs from oracle.json")
+    if corpus_manifest.get("corpus_lock_sha256") != hashes["corpus_lock"]:
+        raise RunnerError("corpus lock hash does not match corpus-manifest.json")
+
+    locked = corpus_lock.get("repositories")
+    manifested = corpus_manifest.get("repositories")
+    if not isinstance(locked, list) or not isinstance(manifested, list):
+        raise RunnerError("corpus repository lists are malformed")
+    manifest_by_alias = {
+        item.get("alias"): item for item in manifested if isinstance(item, dict)
+    }
+    source_root = benchmark_root / "sources"
+    repositories: dict[str, dict[str, Any]] = {}
+    for item in locked:
+        if not isinstance(item, dict):
+            raise RunnerError("corpus lock contains a non-object repository")
+        alias = item.get("alias")
+        commit = item.get("commit")
+        if (
+            not isinstance(alias, str)
+            or not isinstance(commit, str)
+            or not FULL_SHA.fullmatch(commit)
+        ):
+            raise RunnerError("corpus lock repository identity is malformed")
+        manifest_item = manifest_by_alias.get(alias)
+        if not isinstance(manifest_item, dict) or manifest_item.get("commit") != commit:
+            raise RunnerError(f"corpus manifest mismatch for repository {alias}")
+        source = (source_root / alias).resolve()
+        if not source.is_dir() or not harness.is_within(source, source_root.resolve()):
+            raise RunnerError(f"frozen source mirror is missing for repository {alias}")
+        if git_text(source, "rev-parse", "HEAD") != commit:
+            raise RunnerError(
+                f"frozen source mirror HEAD mismatch for repository {alias}"
+            )
+        status = git_text(source, "status", "--porcelain=v1", "--untracked-files=all")
+        if status:
+            raise RunnerError(f"frozen source mirror is dirty for repository {alias}")
+        repositories[alias] = {**item, "root": source}
+
+    asset_status: dict[str, Any] = {"required": require_asset_lock, "present": False}
+    if asset_lock_path is not None and asset_lock_path.is_file():
+        lock = load_json(asset_lock_path.resolve(), "asset lock")
+        flattened: dict[str, str] = {}
+        flatten_asset_hashes(lock, flattened)
+        checked: dict[str, bool] = {}
+        asset_inputs: list[tuple[str, pathlib.Path]] = [
+            ("cases", cases_path),
+            ("campaign", campaign_path),
+            ("corpus_lock", corpus_lock_path),
+            ("corpus_manifest", corpus_manifest_path),
+            ("oracle", oracle_path),
+            ("direct_case_runner", pathlib.Path(__file__).resolve()),
+            ("mcp_harness", SCRIPT_DIR / "mcp_harness.py"),
+            ("fixture_generator", SCRIPT_DIR / "fixture_generator.py"),
+            ("parity_normalization", SCRIPT_DIR / "parity-normalization.json"),
+        ]
+        if resolved_baseline_patches is not None:
+            asset_inputs.append(("baseline_patches", resolved_baseline_patches))
+        for label, path in asset_inputs:
+            expected = _asset_match(path, flattened)
+            if expected is None:
+                raise RunnerError(f"asset lock has no unique SHA-256 for {label}")
+            checked[label] = expected == hashes[label]
+            if not checked[label]:
+                raise RunnerError(f"asset lock SHA-256 mismatch for {label}")
+        asset_status = {
+            "required": require_asset_lock,
+            "present": True,
+            "asset_lock_sha256": file_sha256(asset_lock_path.resolve()),
+            "checked": checked,
+        }
+    elif require_asset_lock:
+        raise RunnerError("formal run requires a frozen assets.lock.json")
+
+    validate_case_manifest(cases, repositories)
+    if baseline_patches is not None:
+        if baseline_patches.get("protocol") != harness.PROTOCOL_ID:
+            raise RunnerError("baseline patch lock protocol mismatch")
+        sources = baseline_patches.get("source_hashes", {})
+        if (
+            sources.get("cases") != hashes["cases"]
+            or sources.get("oracle") != hashes["oracle"]
+        ):
+            raise RunnerError("baseline patch lock source hashes are stale")
+        patches = baseline_patches.get("patches")
+        if not isinstance(patches, dict) or baseline_patches.get("patch_count") != len(
+            patches
+        ):
+            raise RunnerError("baseline patch lock inventory is malformed")
+        for case_id, entry in patches.items():
+            if not isinstance(entry, dict) or entry.get("case_id") != case_id:
+                raise RunnerError("baseline patch lock case identity is malformed")
+            patch_text = entry.get("patch")
+            if not isinstance(patch_text, str) or harness.sha256_text(
+                patch_text
+            ) != entry.get("patch_sha256"):
+                raise RunnerError("baseline patch text hash mismatch")
+    counter = harness.TokenCounter()
+    token_metadata = counter.metadata()
+    token_config = campaign.get("tokenization", {})
+    if token_metadata.get("version") != token_config.get("version"):
+        raise RunnerError("installed tokenizer version differs from campaign lock")
+    configured = {
+        token_config.get("primary", {}).get("encoding"): token_config.get(
+            "primary", {}
+        ).get("vocabulary_sha256"),
+        token_config.get("sensitivity", {}).get("encoding"): token_config.get(
+            "sensitivity", {}
+        ).get("vocabulary_sha256"),
+    }
+    actual = {
+        entry.get("name"): entry.get("vocabulary_sha256")
+        for entry in token_metadata.get("encodings", {}).values()
+        if isinstance(entry, dict)
+    }
+    for encoding, expected_hash in configured.items():
+        if not isinstance(encoding, str) or actual.get(encoding) != expected_hash:
+            raise RunnerError("tokenizer vocabulary hash differs from campaign lock")
+
+    return InputBundle(
+        benchmark_root=benchmark_root,
+        fixture_root=fixture_root,
+        cases_path=cases_path,
+        campaign_path=campaign_path,
+        corpus_lock_path=corpus_lock_path,
+        corpus_manifest_path=corpus_manifest_path,
+        oracle_path=oracle_path,
+        cases=cases,
+        campaign=campaign,
+        corpus_lock=corpus_lock,
+        corpus_manifest=corpus_manifest,
+        oracle=oracle,
+        hashes=hashes,
+        repositories=repositories,
+        asset_lock_status=asset_status,
+        baseline_patches=baseline_patches,
+        baseline_patches_path=resolved_baseline_patches,
+    )
+
+
+def validate_case_manifest(
+    cases: dict[str, Any], repositories: dict[str, dict[str, Any]]
+) -> None:
+    rows = cases.get("cases")
+    inventory = cases.get("inventory", {})
+    if not isinstance(rows, list) or not rows:
+        raise RunnerError("cases manifest has no cases")
+    ids: set[str] = set()
+    expected_surfaces = {
+        "full": set(inventory.get("full_surface_tools", [])),
+        "compact": set(inventory.get("compact_surface_tools", [])),
+        "meta": set(inventory.get("meta_surface_tools", [])),
+    }
+    if len(expected_surfaces["full"]) != inventory.get("full_surface_count"):
+        raise RunnerError("full surface count is internally inconsistent")
+    if len(set().union(*expected_surfaces.values())) != inventory.get(
+        "unique_tool_names"
+    ):
+        raise RunnerError("unique tool count is internally inconsistent")
+    for case in rows:
+        if not isinstance(case, dict):
+            raise RunnerError("case row is not an object")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id or case_id in ids:
+            raise RunnerError("case IDs must be non-empty and unique")
+        ids.add(case_id)
+        repo = case.get("repo")
+        if repo not in repositories:
+            raise RunnerError(f"case {case_id} names an unknown repository")
+        if case.get("commit") != f"${{repo.{repo}.commit}}":
+            raise RunnerError(
+                f"case {case_id} does not pin its declared repository commit"
+            )
+        surface = case.get("surface")
+        primary = case.get("primary_tool")
+        if (
+            surface not in expected_surfaces
+            or primary not in expected_surfaces[surface]
+        ):
+            raise RunnerError(f"case {case_id} has an invalid surface/tool identity")
+        requests = case.get("requests")
+        if not isinstance(requests, list) or not requests:
+            raise RunnerError(f"case {case_id} has no requests")
+        if len(requests) > int(case.get("limits", {}).get("call_limit", 0)):
+            raise RunnerError(f"case {case_id} exceeds its frozen call limit")
+        for expected_step, request in enumerate(requests, start=1):
+            if not isinstance(request, dict) or request.get("step") != expected_step:
+                raise RunnerError(f"case {case_id} request steps are not sequential")
+            if request.get("tool") not in expected_surfaces[surface]:
+                raise RunnerError(
+                    f"case {case_id} requests a tool absent from its surface"
+                )
+            if not isinstance(request.get("args"), dict):
+                raise RunnerError(f"case {case_id} request args are not an object")
+            if request.get("economics_role") not in ECONOMICS_ROLES:
+                raise RunnerError(
+                    f"case {case_id} request step {expected_step} lacks a valid "
+                    "economics_role"
+                )
+        if case.get("source_hash_policy") not in {
+            "no_source_bytes_may_change",
+            "only_allowlisted_paths_may_change",
+        }:
+            raise RunnerError(f"case {case_id} has an unknown mutation policy")
+        if not isinstance(case.get("correctness_oracle"), dict) or not isinstance(
+            case.get("stop_condition"), str
+        ):
+            raise RunnerError(f"case {case_id} lacks a correctness/stop contract")
+        if case.get("transport") not in {"stdio", "http"}:
+            raise RunnerError(f"case {case_id} has an unknown transport")
+
+
+def validate_sut(
+    bundle: InputBundle,
+    server: str,
+    *,
+    skip_version_probe: bool = False,
+) -> tuple[pathlib.Path, dict[str, Any]]:
+    server_path = harness.resolve_server(server)
+    expected = bundle.campaign.get("system_under_test", {})
+    actual_hash = harness.executable_sha256(server_path)
+    if actual_hash != expected.get("binary_sha256"):
+        raise RunnerError("SymForge executable SHA-256 differs from campaign lock")
+    expected_version = expected.get("version")
+    version_ok = True
+    if not skip_version_probe:
+        result = run_process(
+            [str(server_path), "--version"],
+            env=harness.child_environment("full", False),
+            timeout=15,
+            check=False,
+        )
+        rendered = (result.stdout + result.stderr).decode("utf-8", errors="replace")
+        version_ok = (
+            result.returncode == 0
+            and isinstance(expected_version, str)
+            and expected_version in rendered
+        )
+        if not version_ok:
+            raise RunnerError("SymForge executable version differs from campaign lock")
+    return server_path, {
+        "path": str(server_path),
+        "sha256": actual_hash,
+        "expected_version": expected_version,
+        "version_probe_ok": version_ok,
+    }
+
+
+def _tree_lookup(root: Any, dotted: str) -> Any:
+    current = root
+    for part in dotted.split(".") if dotted else []:
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(dotted)
+        current = current[part]
+    return current
+
+
+def _set_tree(root: dict[str, Any], dotted: str, value: Any) -> None:
+    parts = dotted.split(".")
+    current = root
+    for part in parts[:-1]:
+        child = current.setdefault(part, {})
+        if not isinstance(child, dict):
+            raise RunnerError("prior binding collides with a scalar value")
+        current = child
+    current[parts[-1]] = value
+
+
+@dataclass
+class ResolutionContext:
+    bundle: InputBundle
+    case: dict[str, Any]
+    work_root: pathlib.Path
+    run_id: str
+    project_id: str
+    baseline_relative_paths: bool = False
+    fixture_runtime_root: pathlib.Path | None = None
+    prior: dict[str, Any] = field(default_factory=dict)
+    native_oracles: dict[str, Any] = field(default_factory=dict)
+
+    def resolve_name(self, name: str) -> Any:
+        if name == "fixture.root":
+            if self.fixture_runtime_root is None:
+                raise RunnerError(
+                    "fixture.root cannot be exposed to a measured command without a disposable auxiliary copy"
+                )
+            return str(self.fixture_runtime_root)
+        if name.startswith("fixture.oracle.repositories."):
+            suffix = name.removeprefix("fixture.oracle.repositories.")
+            try:
+                return _tree_lookup(self.native_oracles, suffix)
+            except KeyError:
+                pass
+        if name.startswith("fixture.oracle.runtime."):
+            suffix = name.removeprefix("fixture.oracle.")
+            try:
+                return _tree_lookup(self.native_oracles, suffix)
+            except KeyError:
+                pass
+        if name.startswith("fixture.oracle.symbol_index."):
+            suffix = name.removeprefix("fixture.oracle.symbol_index.")
+            parts = suffix.split(".", 2)
+            if len(parts) < 2:
+                raise RunnerError(f"invalid derived symbol placeholder: {name}")
+            language, symbol = parts[:2]
+            candidates = [
+                entry
+                for entry in self.bundle.oracle.get("symbols", {}).get(language, [])
+                if isinstance(entry, dict) and entry.get("name") == symbol
+            ]
+            if len(candidates) != 1:
+                raise RunnerError(f"derived symbol placeholder is not unique: {name}")
+            if len(parts) == 2:
+                return candidates[0]
+            try:
+                return _tree_lookup(candidates[0], parts[2])
+            except KeyError as exc:
+                raise RunnerError(
+                    f"derived symbol placeholder field does not exist: {name}"
+                ) from exc
+        fixed_paths = {
+            "fixture.oracle.paths.exact_lf_source": "sfbench_fixture/exact/lf_source.py",
+            "fixture.oracle.paths.exact_crlf_source": "sfbench_fixture/exact/crlf_source.py",
+            "fixture.oracle.paths.exact_no_final_newline": "sfbench_fixture/exact/no_final_newline.py",
+            "fixture.oracle.paths.exact_binary": "sfbench_fixture/exact/deterministic.bin",
+            "fixture.oracle.history.refs.sfbench-v1": "refs/tags/sfbench-v1",
+        }
+        if name in fixed_paths:
+            return fixed_paths[name]
+        if name == "fixture.oracle.mutations.TypeScript.new_file":
+            return {
+                "path": "sfbench_fixture/typescript/src/new_probe.ts",
+                "symbol": "sfbench_new_file_probe",
+                "utf8": "export function sfbench_new_file_probe(): string { return 'SF_BENCH_SOURCE_9F31'; }\n",
+            }
+        if name.startswith("fixture.oracle.mutations.TypeScript.new_file."):
+            return _tree_lookup(
+                {
+                    "path": "sfbench_fixture/typescript/src/new_probe.ts",
+                    "symbol": "sfbench_new_file_probe",
+                    "utf8": "export function sfbench_new_file_probe(): string { return 'SF_BENCH_SOURCE_9F31'; }\n",
+                },
+                name.rsplit(".", 1)[1],
+            )
+        if name in {
+            "fixture.oracle.large_file.middle_chunk_100",
+            "fixture.oracle.large_file.final_chunk_100",
+        }:
+            relative = _tree_lookup(self.bundle.oracle, "large_file.path")
+            data = require_relative_path(self.work_root, relative).read_bytes()
+            lines = data.count(b"\n") + (0 if data.endswith(b"\n") else 1)
+            divisor = 200 if name.endswith("middle_chunk_100") else 100
+            return max(1, math.ceil(lines / divisor))
+        if name.startswith("fixture.oracle."):
+            suffix = name.removeprefix("fixture.oracle.")
+            try:
+                return _tree_lookup(self.bundle.oracle, suffix)
+            except KeyError as exc:
+                if ".patch" in suffix or suffix.endswith("_patch"):
+                    raise UnsupportedCase(
+                        f"derived baseline patch is not frozen: {name}"
+                    ) from exc
+                raise RunnerError(f"unknown oracle placeholder: {name}") from exc
+        if name.startswith("repo."):
+            _, alias, field_name = name.split(".", 2)
+            repository = self.bundle.repositories.get(alias)
+            if repository is None or field_name not in {"root", "commit"}:
+                raise RunnerError(f"unknown repository placeholder: {name}")
+            return (
+                str(repository["root"])
+                if field_name == "root"
+                else repository["commit"]
+            )
+        if name == "case.work_root":
+            return "." if self.baseline_relative_paths else str(self.work_root)
+        if name == "case.idempotency_key":
+            return f"{harness.PROTOCOL_ID}/{self.run_id}/{self.case['id']}"
+        if name == "session.project_id":
+            return self.project_id
+        if name == "session.model":
+            return self.bundle.campaign.get("paired_llm", {}).get("model_alias")
+        if name == "session.seed":
+            return None
+        if name.startswith("prior."):
+            try:
+                return _tree_lookup(self.prior, name.removeprefix("prior."))
+            except KeyError as exc:
+                raise RunnerError(f"unbound prior placeholder: {name}") from exc
+        raise RunnerError(f"unknown placeholder: {name}")
+
+    def resolve(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: self.resolve(child) for key, child in value.items()}
+        if isinstance(value, list):
+            return [self.resolve(child) for child in value]
+        if not isinstance(value, str):
+            return value
+        exact = PLACEHOLDER.fullmatch(value)
+        if exact:
+            return self.resolve_name(exact.group(1))
+        return PLACEHOLDER.sub(
+            lambda match: str(self.resolve_name(match.group(1))), value
+        )
+
+    def bind(self, dotted: str, value: Any) -> None:
+        normalized = dotted.removeprefix("prior.")
+        _set_tree(self.prior, normalized, value)
+
+
+def selected_overlay_path(path: str, language_root: str | None) -> bool:
+    prefixes = [
+        "sfbench_fixture/filter_cases/",
+        "sfbench_fixture/configs/",
+        "sfbench_fixture/exact/",
+        "sfbench_fixture/generated/",
+        "sfbench_fixture/history/",
+        "sfbench_fixture/worktree/",
+        "sfbench_fixture/ignored/",
+        ".claude/gsd-tools/",
+    ]
+    if language_root:
+        prefixes.insert(0, language_root.rstrip("/") + "/")
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def ls_tree_paths(repo: pathlib.Path, commit: str) -> list[str]:
+    raw = git(repo, "ls-tree", "-r", "--name-only", "-z", commit).stdout
+    return [part.decode("utf-8", errors="strict") for part in raw.split(b"\0") if part]
+
+
+def ls_tree_objects(repo: pathlib.Path, commit: str) -> dict[str, str]:
+    raw = git(repo, "ls-tree", "-r", "-z", commit).stdout
+    result: dict[str, str] = {}
+    for record in raw.split(b"\0"):
+        if not record:
+            continue
+        metadata, path_bytes = record.split(b"\t", 1)
+        object_id = metadata.split()[2].decode("ascii")
+        result[path_bytes.decode("utf-8", errors="strict")] = object_id
+    return result
+
+
+def clone_native(
+    source: pathlib.Path,
+    destination: pathlib.Path,
+    commit: str,
+) -> dict[str, str]:
+    if destination.exists():
+        raise RunnerError("disposable case work root already exists")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    executable = shutil.which("git")
+    if executable is None:
+        raise RunnerError("git is required")
+    run_process(
+        [
+            executable,
+            "clone",
+            "--local",
+            "--no-hardlinks",
+            "--no-checkout",
+            str(source),
+            str(destination),
+        ],
+        cwd=destination.parent,
+        env=safe_git_environment(),
+        timeout=300,
+    )
+    git(destination, "config", "core.autocrlf", "false")
+    git(destination, "config", "core.eol", "lf")
+    git(destination, "checkout", "--detach", commit, timeout=300)
+    if git_text(destination, "rev-parse", "HEAD") != commit:
+        raise RunnerError("disposable clone HEAD mismatch")
+    if git_text(destination, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise RunnerError("disposable native clone is not clean")
+    alternates = destination / ".git" / "objects" / "info" / "alternates"
+    if alternates.exists():
+        raise RunnerError(
+            "disposable clone unexpectedly uses an alternate object store"
+        )
+    return ls_tree_objects(destination, commit)
+
+
+def source_commit_metadata(repo: pathlib.Path, commit: str) -> dict[str, str]:
+    separator = "%x00"
+    rendered = (
+        git(
+            repo,
+            "show",
+            "-s",
+            f"--format=%an{separator}%ae{separator}%aI{separator}%cn{separator}%ce{separator}%cI{separator}%s",
+            commit,
+        )
+        .stdout.decode("utf-8", errors="strict")
+        .rstrip("\r\n")
+    )
+    parts = rendered.split("\0")
+    if len(parts) != 7:
+        raise RunnerError("fixture commit metadata is malformed")
+    return dict(
+        zip(
+            (
+                "author_name",
+                "author_email",
+                "author_date",
+                "committer_name",
+                "committer_email",
+                "committer_date",
+                "subject",
+            ),
+            parts,
+            strict=True,
+        )
+    )
+
+
+def replay_fixture_overlay(
+    bundle: InputBundle,
+    case: dict[str, Any],
+    destination: pathlib.Path,
+    public_objects: dict[str, str],
+) -> dict[str, Any]:
+    profile = bundle.cases.get("materialization_profiles", {}).get(
+        "public_repo_with_deterministic_fixture_history_overlay", {}
+    )
+    language_map = profile.get("language_root_map", {})
+    language_root = language_map.get(case.get("language"))
+    clean_relative = bundle.oracle.get("paths", {}).get("clean_repository")
+    fixture_repo = require_relative_path(bundle.fixture_root, clean_relative)
+    commits = bundle.oracle.get("history", {}).get("commits", [])
+    if not isinstance(commits, list) or len(commits) != 7:
+        raise RunnerError("fixture overlay requires exactly seven frozen commits")
+    source_commits = [item.get("commit") for item in commits if isinstance(item, dict)]
+    if len(source_commits) != 7 or any(
+        not isinstance(item, str) for item in source_commits
+    ):
+        raise RunnerError("fixture history commit list is malformed")
+
+    final_paths = ls_tree_paths(fixture_repo, source_commits[-1])
+    selected_final = {
+        path for path in final_paths if selected_overlay_path(path, language_root)
+    }
+    collisions = sorted(path for path in selected_final if path in public_objects)
+    if collisions:
+        raise RunnerError("fixture overlay would overwrite a public repository path")
+
+    attributes_path = destination / "sfbench_fixture" / ".gitattributes"
+    attributes_bytes = (
+        b"exact/** -text\n"
+        b"generated/large_generated.py -text\n"
+        b"configs/bom_crlf_unicode.json -text\n"
+    )
+    previous: set[str] = set()
+    replay_commits: list[str] = []
+    for index, source_commit in enumerate(source_commits):
+        source_paths = {
+            path
+            for path in ls_tree_paths(fixture_repo, source_commit)
+            if selected_overlay_path(path, language_root)
+        }
+        for removed in sorted(previous - source_paths):
+            target = require_relative_path(destination, removed)
+            if target.exists() or target.is_symlink():
+                target.unlink()
+        for relative in sorted(source_paths):
+            target = require_relative_path(destination, relative)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            data = git(fixture_repo, "show", f"{source_commit}:{relative}").stdout
+            target.write_bytes(data)
+        if index == 0:
+            attributes_path.parent.mkdir(parents=True, exist_ok=True)
+            attributes_path.write_bytes(attributes_bytes)
+        git(
+            destination,
+            "add",
+            "-A",
+            "-f",
+            "--",
+            ".claude/gsd-tools",
+            "sfbench_fixture",
+        )
+        metadata = source_commit_metadata(fixture_repo, source_commit)
+        commit_env = safe_git_environment(
+            {
+                "GIT_AUTHOR_NAME": metadata["author_name"],
+                "GIT_AUTHOR_EMAIL": metadata["author_email"],
+                "GIT_AUTHOR_DATE": metadata["author_date"],
+                "GIT_COMMITTER_NAME": metadata["committer_name"],
+                "GIT_COMMITTER_EMAIL": metadata["committer_email"],
+                "GIT_COMMITTER_DATE": metadata["committer_date"],
+            }
+        )
+        git(
+            destination,
+            "commit",
+            "--allow-empty",
+            "--no-gpg-sign",
+            "-m",
+            f"SFBENCH-OVERLAY {metadata['subject']}",
+            env=commit_env,
+        )
+        replay_commits.append(git_text(destination, "rev-parse", "HEAD"))
+        previous = source_paths
+
+    source_to_replay = dict(zip(source_commits, replay_commits, strict=True))
+    for reference, source_commit in (
+        bundle.oracle.get("history", {}).get("refs", {}).items()
+    ):
+        if not isinstance(reference, str) or not isinstance(source_commit, str):
+            continue
+        if not (
+            reference.startswith("refs/bench/") or reference.startswith("refs/tags/")
+        ):
+            continue
+        replay = source_to_replay.get(source_commit)
+        if replay is None:
+            raise RunnerError("fixture ref does not resolve to a replay ordinal")
+        git(destination, "update-ref", reference, replay)
+
+    files_oracle = bundle.oracle.get("files", {})
+    verified = 0
+    for relative in sorted(selected_final):
+        facts = files_oracle.get(relative)
+        if not isinstance(facts, dict):
+            raise RunnerError(f"selected fixture file has no oracle hash: {relative}")
+        target = require_relative_path(destination, relative)
+        if file_sha256(target) != facts.get("sha256"):
+            raise RunnerError(f"fixture overlay byte hash mismatch: {relative}")
+        verified += 1
+    current_objects = ls_tree_objects(destination, "HEAD")
+    for relative, object_id in public_objects.items():
+        if current_objects.get(relative) != object_id:
+            raise RunnerError("fixture overlay changed a public repository object")
+    if git_text(destination, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise RunnerError("fixture overlay did not produce a clean worktree")
+    return {
+        "profile": "public_repo_with_deterministic_fixture_history_overlay",
+        "language_root": language_root,
+        "source_commits": source_commits,
+        "replay_commits": replay_commits,
+        "verified_fixture_files": verified,
+        "public_objects_preserved": len(public_objects),
+    }
+
+
+def copy_file_bytes(source: pathlib.Path, destination: pathlib.Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(source.read_bytes())
+
+
+def apply_dirty_fixture_state(
+    bundle: InputBundle, destination: pathlib.Path
+) -> dict[str, Any]:
+    mutation_relative = bundle.oracle.get("paths", {}).get("mutation_repository")
+    mutation_repo = require_relative_path(bundle.fixture_root, mutation_relative)
+    worktree = bundle.oracle.get("worktree", {})
+    staged = worktree.get("staged", {})
+    staged_paths: set[str] = set(staged.get("modified", [])) | set(
+        staged.get("added", [])
+    )
+    for rename in staged.get("renamed", []):
+        if not isinstance(rename, dict):
+            raise RunnerError("dirty-state rename oracle is malformed")
+        old = require_relative_path(destination, rename["from"])
+        if old.exists():
+            old.unlink()
+        staged_paths.add(rename["from"])
+        staged_paths.add(rename["to"])
+    for relative in sorted(staged_paths):
+        target = require_relative_path(destination, relative)
+        result = git(mutation_repo, "show", f":{relative}", check=False)
+        if result.returncode == 0:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(result.stdout)
+        elif target.exists():
+            target.unlink()
+    git(destination, "add", "-A", "-f", "--", *sorted(staged_paths))
+    for relative in worktree.get("unstaged", {}).get("modified", []):
+        copy_file_bytes(
+            require_relative_path(mutation_repo, relative),
+            require_relative_path(destination, relative),
+        )
+    for relative in worktree.get("unstaged", {}).get("deleted", []):
+        target = require_relative_path(destination, relative)
+        if target.exists():
+            target.unlink()
+    for relative in worktree.get("untracked", []):
+        copy_file_bytes(
+            require_relative_path(mutation_repo, relative),
+            require_relative_path(destination, relative),
+        )
+    actual = (
+        git(destination, "status", "--porcelain=v1", "--untracked-files=all")
+        .stdout.decode("utf-8", errors="strict")
+        .splitlines()
+    )
+    expected = worktree.get("status_porcelain_v1", [])
+    if sorted(actual) != sorted(expected):
+        raise RunnerError("dirty-state materialization differs from oracle status")
+    return {"status_porcelain_v1": actual}
+
+
+def materialize_case(
+    bundle: InputBundle, case: dict[str, Any], destination: pathlib.Path
+) -> dict[str, Any]:
+    repository = bundle.repositories[case["repo"]]
+    public_objects = clone_native(repository["root"], destination, repository["commit"])
+    profiles = bundle.cases.get("materialization_profiles", {})
+    native_ids = set(profiles.get("native_only_case_ids", []))
+    fixture_repository = case.get("preconditions", {}).get("fixture_repository")
+    if case["id"] in native_ids:
+        result: dict[str, Any] = {
+            "profile": "public_repo_native_only",
+            "public_objects_preserved": len(public_objects),
+        }
+    else:
+        result = replay_fixture_overlay(bundle, case, destination, public_objects)
+        if fixture_repository == "mutation-repo":
+            result["profile"] = "public_repo_with_fixture_history_and_dirty_state"
+            result["dirty_state"] = apply_dirty_fixture_state(bundle, destination)
+    result.update(
+        {
+            "repository": case["repo"],
+            "base_commit": repository["commit"],
+            "head_after_materialization": git_text(destination, "rev-parse", "HEAD"),
+        }
+    )
+    return result
+
+
+def derive_native_oracles(alias: str, work_root: pathlib.Path) -> dict[str, Any]:
+    if alias != "p-map":
+        return {}
+    anchor = work_root / "index.js"
+    if not anchor.is_file():
+        raise RunnerError("p-map native anchor index.js is absent")
+    data = anchor.read_bytes()
+    text = data.decode("utf-8", errors="strict")
+    match = re.search(
+        r"\b(?:export\s+default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)",
+        text,
+    )
+    if match is None:
+        raise RunnerError("p-map native symbol anchor could not be derived")
+    line_end = 0
+    lines = data.splitlines(keepends=True)
+    for line in lines[:5]:
+        line_end += len(line)
+    return {
+        "p-map": {
+            "native_anchor_file": "index.js",
+            "native_anchor_symbol": match.group(1),
+            "native_slice": {"start_byte": 0, "end_byte": max(1, line_end)},
+            "native_anchor_range_sha256": sha256_bytes(data[:line_end]),
+            "inventory": source_inventory(work_root),
+        }
+    }
+
+
+@dataclass
+class ActiveSession:
+    client: harness.StdioMcpClient
+    config: harness.CaptureConfig
+    role: str
+    tools: list[Any]
+
+
+class SessionManager:
+    def __init__(
+        self,
+        *,
+        server_path: pathlib.Path,
+        server_args: list[str],
+        work_root: pathlib.Path,
+        writer: harness.JsonlWriter,
+        sanitizer: harness.Sanitizer,
+        counter: harness.TokenCounter,
+        run_id: str,
+        case_id: str,
+        timeout: float,
+        expected_tools: dict[str, set[str]],
+    ) -> None:
+        self.server_path = server_path
+        self.server_args = server_args
+        self.work_root = work_root
+        self.writer = writer
+        self.sanitizer = sanitizer
+        self.counter = counter
+        self.run_id = run_id
+        self.case_id = case_id
+        self.timeout = timeout
+        self.expected_tools = expected_tools
+        self.active: ActiveSession | None = None
+        self.lifecycle_count = 0
+
+    def start(self, surface: str, role: str) -> ActiveSession:
+        if self.active is not None:
+            raise RunnerError(
+                "attempted to start a second MCP process without closing the first"
+            )
+        config = harness.CaptureConfig(
+            mode="manifest",
+            repo=self.work_root,
+            output=self.writer.path,
+            server=str(self.server_path),
+            server_args=list(self.server_args),
+            surface=surface,
+            auto_index=True,
+            timeout=self.timeout,
+            protocol_version=harness.MCP_PROTOCOL_VERSION,
+            run_id=self.run_id,
+            case_id=self.case_id,
+            append=True,
+        )
+        client = harness.StdioMcpClient(
+            [str(self.server_path), *self.server_args],
+            self.work_root,
+            harness.child_environment(surface, True),
+            self.timeout,
+            self.sanitizer,
+            self.counter,
+        )
+        initialize = client.rpc(
+            "initialize",
+            {
+                "protocolVersion": harness.MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "symforge-sfbench-direct-case-runner",
+                    "version": "1.0",
+                },
+            },
+        )
+        record = harness.capture_record(config, initialize)
+        record.update({"record_type": "session_rpc", "session_role": role})
+        self.writer.write(record)
+        if initialize.response_raw is None or "error" in initialize.response_raw:
+            client.close()
+            raise RunnerError("MCP initialize failed")
+        initialized = client.notify("notifications/initialized", {})
+        record = harness.capture_record(config, initialized)
+        record.update({"record_type": "session_rpc", "session_role": role})
+        self.writer.write(record)
+
+        manifest: dict[str, list[Any]] = {}
+        list_metrics: dict[str, Any] = {}
+        for method, result_key in harness.LIST_METHODS:
+            items, metrics = harness.list_all(
+                client, self.writer, config, method, result_key
+            )
+            manifest[result_key] = items
+            list_metrics[method] = metrics
+            if metrics.get("error") is not None:
+                client.close()
+                raise RunnerError(f"MCP manifest pagination failed for {method}")
+        tool_names = {
+            item.get("name")
+            for item in manifest.get("tools", [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        if tool_names != self.expected_tools[surface]:
+            client.close()
+            raise RunnerError(
+                f"live {surface} tools/list differs from frozen inventory"
+            )
+        manifest_text = harness.canonical_json(manifest)
+        counts = self.counter.metrics(manifest_text)
+        tools_text = harness.canonical_json(manifest.get("tools", []))
+        tool_counts = self.counter.metrics(tools_text)
+        self.writer.write(
+            {
+                **harness.base_record(config),
+                "record_type": "session_manifest",
+                "session_role": role,
+                "manifest": manifest,
+                "manifest_sha256": harness.sha256_text(manifest_text),
+                "manifest_utf8_bytes": counts["utf8_bytes"],
+                "manifest_cl100k": counts["cl100k"],
+                "manifest_o200k": counts["o200k"],
+                "full_tools_list_tokens": {
+                    "cl100k": tool_counts["cl100k"],
+                    "o200k": tool_counts["o200k"],
+                },
+                "schema_metadata": harness.schema_metadata(
+                    manifest.get("tools", []), self.counter
+                ),
+                "list_metrics": list_metrics,
+            }
+        )
+        self.lifecycle_count += 1
+        self.active = ActiveSession(
+            client=client, config=config, role=role, tools=manifest["tools"]
+        )
+        return self.active
+
+    def call(
+        self,
+        tool: str,
+        arguments: dict[str, Any],
+        *,
+        record_type: str,
+        extra: dict[str, Any] | None = None,
+    ) -> harness.RpcCapture:
+        if self.active is None:
+            raise RunnerError("no active MCP session")
+        capture = self.active.client.rpc(
+            "tools/call", {"name": tool, "arguments": arguments}
+        )
+        record = harness.capture_record(self.active.config, capture)
+        record["record_type"] = record_type
+        record["session_role"] = self.active.role
+        if extra:
+            record.update(extra)
+        self.writer.write(record)
+        return capture
+
+    def wait_ready(self, surface: str, *, timeout: float = 120) -> None:
+        deadline = time.monotonic() + timeout
+        attempts = 0
+        if surface == "full":
+            tool, arguments = "health_compact", {}
+        elif surface == "compact":
+            tool, arguments = "status", {"detail": "compact"}
+        else:
+            # The meta facade has no side-effect-free readiness probe.
+            return
+        while True:
+            attempts += 1
+            capture = self.call(
+                tool,
+                arguments,
+                record_type="preflight_rpc",
+                extra={"economics_excluded": True, "preflight_purpose": "wait_ready"},
+            )
+            text = harness.extract_content_text(capture.response_raw).casefold()
+            if harness.rpc_status(capture) == "ok" and "loading" not in text:
+                return
+            if time.monotonic() >= deadline:
+                raise RunnerError("MCP index did not become ready before timeout")
+            time.sleep(min(0.25 * attempts, 1.0))
+
+    def close(self) -> None:
+        if self.active is None:
+            return
+        lifecycle = self.active.client.close()
+        self.writer.write(
+            {
+                **harness.base_record(self.active.config),
+                "record_type": "process_lifecycle",
+                "session_role": self.active.role,
+                "process_start_ms": self.active.client.process_start_ms,
+                **lifecycle,
+            }
+        )
+        self.active = None
+
+
+PRE_INDEX_ACTIONS = {
+    "write_fixture_file",
+    "runtime.quarantine.populate_malformed_configs",
+    "session_context.start_empty",
+}
+SUPPORTED_ORACLE_ACTIONS = {
+    "mutations.Rust.replace_symbol.apply_to_work_root",
+    "mutations.TypeScript.new_file.create",
+    "impact.Rust.leaf_dirty.apply",
+    "impact.Python.leaf_dirty.apply",
+    "impact.TypeScript.leaf_dirty_and_data.apply",
+    "mutations.Python.concurrent_divergence.prepare",
+    "mutations.stale_index.prepare",
+    "runtime.quarantine.populate_malformed_configs",
+    "session_context.start_empty",
+    "symbols.Rust.sfbench_leaf.read_exact_body",
+}
+
+
+def action_phase(action: dict[str, Any]) -> str:
+    executor = action.get("executor")
+    key = action.get("key")
+    if executor in {"oracle_lookup", "write_fixture_file"}:
+        return "pre_index"
+    if executor != "oracle_action" or not isinstance(key, str):
+        raise UnsupportedCase(f"unsupported setup executor: {executor}")
+    if key not in SUPPORTED_ORACLE_ACTIONS:
+        raise UnsupportedCase(f"unsupported setup action: {key}")
+    return "pre_index" if key in PRE_INDEX_ACTIONS else "post_index"
+
+
+def find_symbol_oracle(
+    oracle: dict[str, Any], language: str, symbol: str
+) -> dict[str, Any]:
+    candidates = [
+        item
+        for item in oracle.get("symbols", {}).get(language, [])
+        if isinstance(item, dict) and item.get("name") == symbol
+    ]
+    if len(candidates) != 1:
+        raise RunnerError(f"symbol oracle is not unique: {language}.{symbol}")
+    return candidates[0]
+
+
+def apply_replace_mutation(context: ResolutionContext, language: str) -> dict[str, Any]:
+    mutation = context.bundle.oracle.get("mutations", {}).get(language, {})
+    relative = mutation.get("path")
+    replace = mutation.get("replace_symbol", {})
+    if not isinstance(relative, str) or not isinstance(replace, dict):
+        raise RunnerError("replace mutation oracle is malformed")
+    path = require_relative_path(context.work_root, relative)
+    before = path.read_bytes()
+    if sha256_bytes(before) != replace.get("before_sha256"):
+        raise RunnerError("replace mutation before hash mismatch")
+    symbol = find_symbol_oracle(context.bundle.oracle, language, replace["symbol"])
+    start = int(symbol["start_byte"])
+    end = int(symbol["end_byte_exclusive"])
+    source = before[start:end]
+    if sha256_bytes(source) != symbol.get("source_sha256"):
+        raise RunnerError("replace mutation symbol source hash mismatch")
+    after = before[:start] + str(replace["new_body"]).encode("utf-8") + before[end:]
+    if sha256_bytes(after) != replace.get("after_sha256"):
+        raise RunnerError("replace mutation after hash mismatch")
+    path.write_bytes(after)
+    return {"path": relative, "after_sha256": sha256_bytes(after)}
+
+
+def execute_setup_action(
+    action: dict[str, Any],
+    context: ResolutionContext,
+    hooks: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    executor = action.get("executor")
+    if executor == "oracle_lookup":
+        key = action.get("key")
+        where = action.get("where")
+        save_as = action.get("save_as")
+        if (
+            not isinstance(key, str)
+            or not isinstance(where, dict)
+            or not isinstance(save_as, str)
+        ):
+            raise RunnerError("oracle_lookup action is malformed")
+        try:
+            values = _tree_lookup(context.bundle.oracle, key)
+        except KeyError as exc:
+            raise RunnerError("oracle_lookup key does not exist") from exc
+        if not isinstance(values, list):
+            raise RunnerError("oracle_lookup key does not select an array")
+        matches = [
+            item
+            for item in values
+            if isinstance(item, dict)
+            and all(item.get(name) == value for name, value in where.items())
+        ]
+        if len(matches) != 1:
+            raise RunnerError("oracle_lookup did not select exactly one item")
+        context.bind(save_as, matches[0])
+        return {
+            "executor": executor,
+            "key": key,
+            "selected_sha256": harness.sha256_text(harness.canonical_json(matches[0])),
+        }
+    if executor == "write_fixture_file":
+        relative = action.get("path")
+        utf8 = action.get("utf8")
+        if not isinstance(relative, str) or not isinstance(utf8, str):
+            raise RunnerError("write_fixture_file action is malformed")
+        path = require_relative_path(context.work_root, relative)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = utf8.encode("utf-8")
+        path.write_bytes(data)
+        return {"executor": executor, "path": relative, "sha256": sha256_bytes(data)}
+    if executor != "oracle_action":
+        raise UnsupportedCase(f"unsupported setup executor: {executor}")
+    key = action.get("key")
+    if key not in SUPPORTED_ORACLE_ACTIONS:
+        raise UnsupportedCase(f"unsupported setup action: {key}")
+    result: dict[str, Any]
+    if key in {
+        "mutations.Rust.replace_symbol.apply_to_work_root",
+        "impact.Rust.leaf_dirty.apply",
+    }:
+        result = apply_replace_mutation(context, "Rust")
+    elif key == "impact.Python.leaf_dirty.apply":
+        result = apply_replace_mutation(context, "Python")
+    elif key == "impact.TypeScript.leaf_dirty_and_data.apply":
+        result = apply_replace_mutation(context, "TypeScript")
+        data_path = require_relative_path(
+            context.work_root, "sfbench_fixture/typescript/src/impact_probe.json"
+        )
+        data = b'{"marker":"SF_BENCH_DATA_9F31"}\n'
+        data_path.write_bytes(data)
+        result["data_path"] = data_path.relative_to(context.work_root).as_posix()
+        result["data_sha256"] = sha256_bytes(data)
+    elif key == "mutations.TypeScript.new_file.create":
+        value = context.resolve_name("fixture.oracle.mutations.TypeScript.new_file")
+        path = require_relative_path(context.work_root, value["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = value["utf8"].encode("utf-8")
+        if data.count(value["symbol"].encode("utf-8")) != 1:
+            raise RunnerError("new-file setup symbol is not unique")
+        path.write_bytes(data)
+        result = {"path": value["path"], "sha256": sha256_bytes(data)}
+    elif key == "mutations.Python.concurrent_divergence.prepare":
+        relative = context.bundle.oracle["mutations"]["Python"]["path"]
+        path = require_relative_path(context.work_root, relative)
+        before = path.read_bytes()
+        after = before + b"# SFBENCH_CONCURRENT_9F31\n"
+        path.write_bytes(after)
+        result = {"path": relative, "after_sha256": sha256_bytes(after)}
+    elif key == "mutations.stale_index.prepare":
+        hooks.setdefault("repeat", []).append({"kind": "stale_index_write"})
+        result = {"hook_after_request": "repeat", "kind": "stale_index_write"}
+    elif key == "runtime.quarantine.populate_malformed_configs":
+        hashes: list[str] = []
+        for offset in range(23):
+            relative = f"sfbench_fixture/configs/quarantine/page_{offset:03d}.json"
+            path = require_relative_path(context.work_root, relative)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            data = f'{{"offset":{offset},"broken":]\n'.encode("utf-8")
+            path.write_bytes(data)
+            hashes.append(sha256_bytes(data))
+        runtime = context.native_oracles.setdefault("runtime", {}).setdefault(
+            "quarantine", {}
+        )
+        runtime.update(
+            {
+                "count": 23,
+                "middle_offset": 11,
+                "final_offset": 22,
+                "out_of_range_offset": 24,
+            }
+        )
+        result = {
+            "count": 23,
+            "aggregate_sha256": harness.sha256_text("\n".join(hashes)),
+        }
+    elif key == "session_context.start_empty":
+        result = {
+            "assertion": "runner made no commitment reads before measured request"
+        }
+    elif key == "symbols.Rust.sfbench_leaf.read_exact_body":
+        symbol = find_symbol_oracle(context.bundle.oracle, "Rust", "sfbench_leaf")
+        path = require_relative_path(context.work_root, symbol["path"])
+        data = path.read_bytes()[
+            int(symbol["start_byte"]) : int(symbol["end_byte_exclusive"])
+        ]
+        if sha256_bytes(data) != symbol["source_sha256"]:
+            raise RunnerError("exact-body setup hash mismatch")
+        value = {
+            "body": data.decode("utf-8", errors="strict"),
+            "sha256": sha256_bytes(data),
+        }
+        save_as = action.get("save_as")
+        if isinstance(save_as, str):
+            context.bind(save_as, value)
+        result = {"path": symbol["path"], "sha256": value["sha256"]}
+    else:  # pragma: no cover - guarded by the supported set
+        raise UnsupportedCase(f"unsupported setup action: {key}")
+    result.update({"executor": executor, "key": key})
+    return result
+
+
+def execute_hook(hook: dict[str, Any], context: ResolutionContext) -> dict[str, Any]:
+    kind = hook.get("kind")
+    if kind == "stale_index_write":
+        mutation = context.bundle.oracle.get("mutations", {}).get("stale_index", {})
+        path = require_relative_path(context.work_root, mutation["path"])
+        data = str(mutation["after_bytes_utf8"]).encode("utf-8")
+        if sha256_bytes(data) != mutation.get("after_sha256"):
+            raise RunnerError("stale-index hook oracle hash mismatch")
+        path.write_bytes(data)
+        return {"kind": kind, "path": mutation["path"], "sha256": sha256_bytes(data)}
+    raise UnsupportedCase(f"unsupported between-request hook: {kind}")
+
+
+def validate_shell_recipe(command: str) -> None:
+    forbidden = re.compile(
+        r"(?ix)(?:https?://|\bcurl\b|\bwget\b|invoke-webrequest|"
+        r"\bgit\s+(?:clone|fetch|pull|push)\b|"
+        r"(?:^|[|;&]\s*)symforge(?:\.exe)?(?:\s|$))"
+    )
+    if forbidden.search(command):
+        raise UnsupportedCase("baseline shell recipe violates the local-only policy")
+
+
+def canonical_unified_diff(path: str, before: bytes, after: bytes) -> str:
+    return "".join(
+        difflib.unified_diff(
+            before.decode("utf-8").splitlines(keepends=True),
+            after.decode("utf-8").splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+            lineterm="\n",
+        )
+    )
+
+
+def splice_symbol(before: bytes, symbol: dict[str, Any], replacement: bytes) -> bytes:
+    start = int(symbol["start_byte"])
+    end = int(symbol["end_byte_exclusive"])
+    return before[:start] + replacement + before[end:]
+
+
+def mutation_file_after(
+    bundle: InputBundle, language: str, operation: str
+) -> tuple[str, bytes, bytes]:
+    mutation = bundle.oracle["mutations"][language]
+    relative = mutation["path"]
+    clean_repo = require_relative_path(
+        bundle.fixture_root, bundle.oracle["paths"]["clean_repository"]
+    )
+    before = require_relative_path(clean_repo, relative).read_bytes()
+    record = mutation[operation]
+    if sha256_bytes(before) != record.get("before_sha256"):
+        raise RunnerError(
+            f"baseline patch source hash mismatch: {language}.{operation}"
+        )
+    if operation == "replace_symbol":
+        symbol = find_symbol_oracle(bundle.oracle, language, record["symbol"])
+        after = splice_symbol(before, symbol, record["new_body"].encode("utf-8"))
+    elif operation == "edit_within":
+        symbol = find_symbol_oracle(bundle.oracle, language, record["symbol"])
+        start = int(symbol["start_byte"])
+        end = int(symbol["end_byte_exclusive"])
+        body = before[start:end]
+        after = (
+            before[:start]
+            + body.replace(
+                record["old_text"].encode("utf-8"),
+                record["new_text"].encode("utf-8"),
+            )
+            + before[end:]
+        )
+    elif operation == "delete_symbol":
+        symbol = find_symbol_oracle(bundle.oracle, language, record["symbol"])
+        start = int(symbol["start_byte"])
+        end = int(symbol["end_byte_exclusive"])
+        prefix, suffix = before[:start], before[end:]
+        if not prefix.endswith(b"\n\n") or not suffix.startswith(b"\n\n"):
+            raise RunnerError("delete baseline spacing invariant failed")
+        after = prefix + suffix[2:]
+    elif operation == "rename_symbol":
+        old = record["name"].encode("utf-8")
+        new = record["new_name"].encode("utf-8")
+        references = bundle.oracle["references"][language]
+        definition = references["definition"]
+        definition_start = int(definition["start_byte"])
+        definition_end = int(definition["end_byte_exclusive"])
+        definition_offset = definition_start + before[
+            definition_start:definition_end
+        ].index(old)
+        offsets = [definition_offset] + [
+            int(item["start_byte"]) for item in references["code_references"]
+        ]
+        after = before
+        for offset in sorted(offsets, reverse=True):
+            if after[offset : offset + len(old)] != old:
+                raise RunnerError("rename baseline offset invariant failed")
+            after = after[:offset] + new + after[offset + len(old) :]
+    else:
+        raise RunnerError(f"unknown baseline mutation operation: {operation}")
+    if sha256_bytes(after) != record.get("after_sha256"):
+        raise RunnerError(
+            f"baseline patch result hash mismatch: {language}.{operation}"
+        )
+    diff = canonical_unified_diff(relative, before, after)
+    if record.get("diff_sha256") and harness.sha256_text(diff) != record["diff_sha256"]:
+        raise RunnerError(f"baseline patch diff hash mismatch: {language}.{operation}")
+    return relative, before, after
+
+
+def insert_symbols(
+    before: bytes,
+    symbols: list[dict[str, Any]],
+    content: bytes,
+    position: str,
+) -> bytes:
+    edits: list[tuple[int, bytes]] = []
+    for symbol in symbols:
+        if position == "before":
+            edits.append((int(symbol["start_byte"]), content + b"\n\n"))
+        elif position == "after":
+            edits.append((int(symbol["end_byte_exclusive"]), b"\n\n" + content))
+        else:
+            raise RunnerError("unknown insert position")
+    after = before
+    for offset, inserted in sorted(edits, reverse=True):
+        after = after[:offset] + inserted + after[offset:]
+    return after
+
+
+def generate_case_patch(bundle: InputBundle, case: dict[str, Any]) -> dict[str, Any]:
+    case_id = case["id"]
+    language = case["language"]
+    files: dict[str, tuple[bytes, bytes]] = {}
+    simple_operations = {
+        "SF-batch_rename-001": ("Rust", "rename_symbol"),
+        "SF-delete_symbol-001": ("Rust", "delete_symbol"),
+        "SF-delete_symbol-003": ("TypeScript", "delete_symbol"),
+        "SF-edit_within_symbol-001": ("Rust", "edit_within"),
+        "SF-edit_within_symbol-003": ("TypeScript", "edit_within"),
+        "SF-replace_symbol_body-001": ("Rust", "replace_symbol"),
+        "SF-replace_symbol_body-003": ("TypeScript", "replace_symbol"),
+        "SF-symforge_edit-001": ("Rust", "replace_symbol"),
+        "SF-symforge_edit-004": ("Java", "replace_symbol"),
+    }
+    if case_id in simple_operations:
+        selected_language, operation = simple_operations[case_id]
+        relative, before, after = mutation_file_after(
+            bundle, selected_language, operation
+        )
+        files[relative] = (before, after)
+    elif case_id in {
+        "SF-insert_symbol-001",
+        "SF-insert_symbol-003",
+        "SF-batch_insert-001",
+        "SF-batch_insert-003",
+    }:
+        mutation = bundle.oracle["mutations"][language]
+        clean_repo = require_relative_path(
+            bundle.fixture_root, bundle.oracle["paths"]["clean_repository"]
+        )
+        content = mutation["insert_symbol"]["body"].encode("utf-8")
+        if case_id.startswith("SF-batch_insert"):
+            apply_request = next(
+                (
+                    request
+                    for request in case["requests"]
+                    if request.get("args", {}).get("dry_run") is False
+                ),
+                case["requests"][0],
+            )
+            args = apply_request["args"]
+            position = str(args["position"])
+            targets_by_path: dict[str, list[dict[str, Any]]] = {}
+            for target in args["targets"]:
+                if isinstance(target, str):
+                    raw_path, target_name = target.rsplit("::", 1)
+                    target = {"path": raw_path, "name": target_name}
+                raw_path = target.get("path")
+                relative = (
+                    str(mutation["path"])
+                    if not raw_path or str(raw_path).startswith("${")
+                    else str(raw_path)
+                )
+                targets_by_path.setdefault(relative, []).append(target)
+            for relative, targets in sorted(targets_by_path.items()):
+                before = require_relative_path(clean_repo, relative).read_bytes()
+                symbols = [
+                    find_symbol_oracle(bundle.oracle, language, str(target["name"]))
+                    for target in targets
+                ]
+                files[relative] = (
+                    before,
+                    insert_symbols(before, symbols, content, position),
+                )
+        else:
+            relative = mutation["path"]
+            before = require_relative_path(clean_repo, relative).read_bytes()
+            symbol = find_symbol_oracle(
+                bundle.oracle, language, mutation["insert_symbol"]["anchor"]
+            )
+            position = "before" if case_id.endswith("001") else "after"
+            files[relative] = (
+                before,
+                insert_symbols(before, [symbol], content, position),
+            )
+    elif case_id in {"SF-batch_edit-001", "SF-batch_edit-003"}:
+        mutation = bundle.oracle["mutations"][language]
+        relative = mutation["path"]
+        clean_repo = require_relative_path(
+            bundle.fixture_root, bundle.oracle["paths"]["clean_repository"]
+        )
+        before = require_relative_path(clean_repo, relative).read_bytes()
+        mutable = find_symbol_oracle(bundle.oracle, language, "sfbench_mutable")
+        start, end = int(mutable["start_byte"]), int(mutable["end_byte_exclusive"])
+        edit = mutation["edit_within"]
+        body = before[start:end].replace(
+            edit["old_text"].encode("utf-8"),
+            edit["new_text"].encode("utf-8"),
+            1,
+        )
+        after = before[:start] + body + before[end:]
+        if case_id.endswith("003"):
+            delete = find_symbol_oracle(bundle.oracle, language, "sfbench_delete_me")
+            delete_source = before[
+                int(delete["start_byte"]) : int(delete["end_byte_exclusive"])
+            ]
+            location = after.index(delete_source)
+            prefix, suffix = after[:location], after[location + len(delete_source) :]
+            after = prefix + (suffix[2:] if suffix.startswith(b"\n\n") else suffix)
+        files[relative] = (before, after)
+        if case_id.endswith("001"):
+            protocol_path = (
+                f"{bundle.oracle['languages']['Rust']['root']}/src/protocol.rs"
+            )
+            protocol_before = require_relative_path(
+                clean_repo, protocol_path
+            ).read_bytes()
+            protocol_symbol = find_symbol_oracle(
+                bundle.oracle, "Rust", "SfBenchProtocol"
+            )
+            protocol_after = insert_symbols(
+                protocol_before,
+                [protocol_symbol],
+                mutation["insert_symbol"]["body"].encode("utf-8"),
+                "after",
+            )
+            files[protocol_path] = (protocol_before, protocol_after)
+    elif case_id == "SF-symforge_edit-003":
+        mutation = bundle.oracle["mutations"]["TypeScript"]
+        relative = mutation["path"]
+        clean_repo = require_relative_path(
+            bundle.fixture_root, bundle.oracle["paths"]["clean_repository"]
+        )
+        before = require_relative_path(clean_repo, relative).read_bytes()
+        edit = mutation["edit_within"]
+        mutable = find_symbol_oracle(bundle.oracle, "TypeScript", "sfbench_mutable")
+        start, end = int(mutable["start_byte"]), int(mutable["end_byte_exclusive"])
+        after = (
+            before[:start]
+            + before[start:end].replace(
+                edit["old_text"].encode(), edit["new_text"].encode()
+            )
+            + before[end:]
+        )
+        # This control case previews three alternatives. Freeze their combined
+        # request payload only; it is never applied during the baseline arm.
+        entry_source = before[
+            int(
+                find_symbol_oracle(bundle.oracle, "TypeScript", "sfbench_entry")[
+                    "start_byte"
+                ]
+            ) : int(
+                find_symbol_oracle(bundle.oracle, "TypeScript", "sfbench_entry")[
+                    "end_byte_exclusive"
+                ]
+            )
+        ]
+        entry_at = after.index(entry_source)
+        content = mutation["insert_symbol"]["body"].encode()
+        after = after[:entry_at] + content + b"\n\n" + after[entry_at:]
+        files[relative] = (before, after)
+    else:
+        raise UnsupportedCase(f"no deterministic patch generator for {case_id}")
+
+    patch = "".join(
+        canonical_unified_diff(path, before, after)
+        for path, (before, after) in sorted(files.items())
+    )
+    if not patch:
+        raise RunnerError(f"generated baseline patch is empty for {case_id}")
+    recipe_steps = [
+        index
+        for index, recipe in enumerate(case.get("baseline_recipe", []), start=1)
+        if recipe.get("executor") == "apply_patch"
+    ]
+    if len(recipe_steps) != 1:
+        raise RunnerError(f"expected one apply_patch recipe for {case_id}")
+    return {
+        "case_id": case_id,
+        "recipe_step": recipe_steps[0],
+        "placeholder": case["baseline_recipe"][recipe_steps[0] - 1]["patch"],
+        "patch": patch,
+        "patch_sha256": harness.sha256_text(patch),
+        "patch_utf8_bytes": len(patch.encode("utf-8")),
+        "before_sha256": {
+            path: sha256_bytes(before) for path, (before, _) in sorted(files.items())
+        },
+        "after_sha256": {
+            path: sha256_bytes(after) for path, (_, after) in sorted(files.items())
+        },
+        "apply_during_baseline": any(
+            request.get("args", {}).get("dry_run") is False
+            or request.get("args", {}).get("apply") is True
+            for request in case.get("requests", [])
+        ),
+    }
+
+
+def powershell_executable() -> str:
+    candidate = shutil.which("pwsh") or shutil.which("powershell")
+    if candidate is None:
+        raise UnsupportedCase("PowerShell is unavailable for a frozen baseline recipe")
+    return candidate
+
+
+def baseline_record(
+    *,
+    config: harness.CaptureConfig,
+    counter: harness.TokenCounter,
+    sanitizer: harness.Sanitizer,
+    step: int,
+    executor: str,
+    input_text: str,
+    output_bytes: bytes,
+    stderr_bytes: bytes,
+    exit_code: int | None,
+    elapsed_ms: float,
+    status: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    raw_output = output_bytes.decode("utf-8", errors="replace")
+    raw_stderr = stderr_bytes.decode("utf-8", errors="replace")
+    raw_payload = executor + "\n" + input_text + "\n" + raw_output + raw_stderr
+    input_metrics = counter.metrics(input_text)
+    output_metrics = counter.metrics(
+        raw_output + raw_stderr, byte_length=len(output_bytes) + len(stderr_bytes)
+    )
+    payload_metrics = counter.metrics(raw_payload)
+    safe_input = sanitizer.sanitize_text(input_text, f"baseline[{step}].input")
+    safe_output = sanitizer.sanitize_text(raw_output, f"baseline[{step}].stdout")
+    safe_stderr = sanitizer.sanitize_text(raw_stderr, f"baseline[{step}].stderr")
+    return {
+        **harness.base_record(config),
+        "execution_mode": "recipe_baseline",
+        "record_type": "baseline_step",
+        "baseline_step": step,
+        "executor": executor,
+        "status": status,
+        "reason": reason,
+        "elapsed_ms": elapsed_ms,
+        "exit_code": exit_code,
+        "input": safe_input,
+        "stdout": safe_output,
+        "stderr": safe_stderr,
+        "input_utf8_bytes": input_metrics["utf8_bytes"],
+        "output_utf8_bytes": output_metrics["utf8_bytes"],
+        "direct_payload_utf8_bytes": payload_metrics["utf8_bytes"],
+        "input_cl100k": input_metrics["cl100k"],
+        "output_cl100k": output_metrics["cl100k"],
+        "direct_payload_cl100k": payload_metrics["cl100k"],
+        "input_o200k": input_metrics["o200k"],
+        "output_o200k": output_metrics["o200k"],
+        "direct_payload_o200k": payload_metrics["o200k"],
+        "token_count_basis": {
+            "primary": "exact unsanitized UTF-8 counted only in memory",
+            "artifact": "sanitized persisted fields",
+        },
+    }
+
+
+def run_baseline(
+    *,
+    case: dict[str, Any],
+    context: ResolutionContext,
+    writer: harness.JsonlWriter,
+    counter: harness.TokenCounter,
+    sanitizer: harness.Sanitizer,
+    timeout: float,
+) -> None:
+    config = harness.CaptureConfig(
+        mode="baseline",
+        repo=context.work_root,
+        output=writer.path,
+        server="",
+        server_args=[],
+        surface=case["surface"],
+        auto_index=False,
+        timeout=timeout,
+        protocol_version=harness.MCP_PROTOCOL_VERSION,
+        run_id=context.run_id,
+        case_id=case["id"],
+        append=True,
+    )
+    totals = {"cl100k": 0, "o200k": 0, "utf8_bytes": 0}
+    for index, recipe in enumerate(case.get("baseline_recipe", []), start=1):
+        if not isinstance(recipe, dict):
+            raise RunnerError("baseline recipe row is not an object")
+        executor = recipe.get("executor")
+        if executor == "capability_only":
+            reason = str(recipe.get("reason", "no equivalent baseline"))
+            record = baseline_record(
+                config=config,
+                counter=counter,
+                sanitizer=sanitizer,
+                step=index,
+                executor=executor,
+                input_text=reason,
+                output_bytes=b"",
+                stderr_bytes=b"",
+                exit_code=None,
+                elapsed_ms=0.0,
+                status="not_applicable",
+                reason=reason,
+            )
+        elif executor == "apply_patch":
+            lock = context.bundle.baseline_patches
+            entry = (
+                lock.get("patches", {}).get(case["id"])
+                if isinstance(lock, dict)
+                else None
+            )
+            if (
+                not isinstance(entry, dict)
+                or entry.get("recipe_step") != index
+                or entry.get("placeholder") != recipe.get("patch")
+            ):
+                raise UnsupportedCase(
+                    "baseline apply_patch has no matching frozen lock entry"
+                )
+            patch_value = entry.get("patch")
+            if not isinstance(patch_value, str) or harness.sha256_text(
+                patch_value
+            ) != entry.get("patch_sha256"):
+                raise RunnerError(
+                    "frozen baseline patch failed its call-time hash gate"
+                )
+            patch_bytes = patch_value.encode("utf-8")
+            arguments = ["apply"]
+            if not entry.get("apply_during_baseline"):
+                arguments.append("--check")
+            arguments.extend(["--whitespace=nowarn", "-"])
+            started = time.perf_counter_ns()
+            result = git(
+                context.work_root,
+                *arguments,
+                input_bytes=patch_bytes,
+                check=False,
+                timeout=timeout,
+            )
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+            status = (
+                "ok"
+                if result.returncode == 0 and entry.get("apply_during_baseline")
+                else "preview_only"
+                if result.returncode == 0
+                else "unexpected_exit"
+            )
+            record = baseline_record(
+                config=config,
+                counter=counter,
+                sanitizer=sanitizer,
+                step=index,
+                executor=executor,
+                input_text=patch_value,
+                output_bytes=result.stdout,
+                stderr_bytes=result.stderr,
+                exit_code=result.returncode,
+                elapsed_ms=elapsed_ms,
+                status=status,
+                reason=f"frozen patch sha256={entry['patch_sha256']}",
+            )
+            if result.returncode != 0:
+                writer.write(record)
+                raise RunnerError("frozen baseline patch did not apply cleanly")
+        elif executor == "shell":
+            if recipe.get("shell") != "powershell" or not isinstance(
+                recipe.get("command"), str
+            ):
+                raise UnsupportedCase("unsupported baseline shell recipe")
+            command = context.resolve(recipe["command"])
+            if not isinstance(command, str):
+                raise RunnerError("resolved baseline command is not text")
+            validate_shell_recipe(command)
+            started = time.perf_counter_ns()
+            result = run_process(
+                [
+                    powershell_executable(),
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    command,
+                ],
+                cwd=context.work_root,
+                env=safe_git_environment(),
+                timeout=timeout,
+                check=False,
+            )
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+            expected_codes = recipe.get("expected_exit_codes", [0])
+            status = "ok" if result.returncode in expected_codes else "unexpected_exit"
+            record = baseline_record(
+                config=config,
+                counter=counter,
+                sanitizer=sanitizer,
+                step=index,
+                executor=executor,
+                input_text=command,
+                output_bytes=result.stdout,
+                stderr_bytes=result.stderr,
+                exit_code=result.returncode,
+                elapsed_ms=elapsed_ms,
+                status=status,
+            )
+            if status != "ok":
+                writer.write(record)
+                raise RunnerError("baseline recipe returned an unexpected exit code")
+        else:
+            raise UnsupportedCase(f"unsupported baseline executor: {executor}")
+        writer.write(record)
+        if record["status"] != "not_applicable":
+            totals["cl100k"] += int(record["direct_payload_cl100k"])
+            totals["o200k"] += int(record["direct_payload_o200k"])
+            totals["utf8_bytes"] += int(record["direct_payload_utf8_bytes"])
+    capability_only = bool(case.get("baseline_recipe")) and all(
+        recipe.get("executor") == "capability_only"
+        for recipe in case.get("baseline_recipe", [])
+    )
+    writer.write(
+        {
+            **harness.base_record(config),
+            "execution_mode": "recipe_baseline",
+            "record_type": "baseline_total",
+            "steps": len(case.get("baseline_recipe", [])),
+            "direct_payload_cl100k": None if capability_only else totals["cl100k"],
+            "direct_payload_o200k": None if capability_only else totals["o200k"],
+            "direct_payload_utf8_bytes": None
+            if capability_only
+            else totals["utf8_bytes"],
+            "economics_status": "N/A_CAPABILITY_GAIN"
+            if capability_only
+            else "measured_recipe_lower_bound",
+            "baseline_equivalence": case.get("baseline_equivalence"),
+        }
+    )
+
+
+def freeze_baseline_patches(
+    bundle: InputBundle, output: pathlib.Path
+) -> dict[str, Any]:
+    output = output.resolve()
+    if output.exists():
+        raise RunnerError("baseline patch lock output already exists")
+    if harness.is_within(output, PROJECT_ROOT):
+        raise RunnerError(
+            "freeze output must be external; review it before adding it to assets"
+        )
+    patch_cases = [
+        case
+        for case in bundle.cases["cases"]
+        if any(
+            recipe.get("executor") == "apply_patch"
+            for recipe in case.get("baseline_recipe", [])
+        )
+    ]
+    entries: dict[str, Any] = {}
+    clean_repo = require_relative_path(
+        bundle.fixture_root, bundle.oracle["paths"]["clean_repository"]
+    )
+    scratch_parent = bundle.benchmark_root / "work"
+    scratch_parent.mkdir(parents=True, exist_ok=True)
+    for case in patch_cases:
+        entry = generate_case_patch(bundle, case)
+        with tempfile.TemporaryDirectory(
+            prefix="sfbench-patch-freeze-", dir=scratch_parent
+        ) as scratch_text:
+            scratch = pathlib.Path(scratch_text) / "repo"
+            clone_native(
+                clean_repo,
+                scratch,
+                bundle.oracle["repositories"]["clean"]["head"],
+            )
+            patch_bytes = entry["patch"].encode("utf-8")
+            git(
+                scratch,
+                "apply",
+                "--check",
+                "--whitespace=nowarn",
+                "-",
+                input_bytes=patch_bytes,
+            )
+            git(
+                scratch,
+                "apply",
+                "--whitespace=nowarn",
+                "-",
+                input_bytes=patch_bytes,
+            )
+            for relative, expected in entry["after_sha256"].items():
+                if file_sha256(require_relative_path(scratch, relative)) != expected:
+                    raise RunnerError(
+                        f"frozen patch verification failed for {case['id']}"
+                    )
+        entries[case["id"]] = entry
+    lock = {
+        "schema_version": "SFBENCH-BASELINE-PATCHES-1",
+        "protocol": harness.PROTOCOL_ID,
+        "source_hashes": {
+            "cases": bundle.hashes["cases"],
+            "oracle": bundle.hashes["oracle"],
+            "fixture_clean_tree": bundle.cases["oracle_contract"][
+                "expected_clean_tree_sha256"
+            ],
+        },
+        "patch_count": len(entries),
+        "patches": entries,
+        "visibility": "evaluator-only; never expose to paired LLM arms",
+    }
+    _write_json(output, lock)
+    return {
+        "output": str(output),
+        "sha256": file_sha256(output),
+        "patch_count": len(entries),
+        "case_ids": sorted(entries),
+    }
+
+
+@dataclass
+class RunSettings:
+    run_id: str
+    output: pathlib.Path
+    work_parent: pathlib.Path
+    server_path: pathlib.Path
+    server_args: list[str]
+    with_baseline: bool
+    allow_stdio_shadow: bool
+    timeout_override: float | None
+    repetitions_override: int | None = None
+    self_test: bool = False
+
+
+def select_cases(
+    manifest: dict[str, Any],
+    *,
+    case_ids: list[str],
+    tools: list[str],
+    case_kinds: list[str],
+    smoke: bool,
+    all_cases: bool,
+) -> list[dict[str, Any]]:
+    filters_present = bool(case_ids or tools or case_kinds)
+    if (smoke and (all_cases or filters_present)) or (all_cases and filters_present):
+        raise RunnerError("--smoke and --all cannot be combined with cohort filters")
+    if not smoke and not all_cases and not filters_present:
+        raise RunnerError("select --smoke, --all, or at least one cohort filter")
+    rows = manifest["cases"]
+    if smoke:
+        selected_ids = set(SMOKE_CASE_IDS)
+        selected = [case for case in rows if case["id"] in selected_ids]
+    elif all_cases:
+        selected = list(rows)
+    else:
+        selected = list(rows)
+        if case_ids:
+            wanted = set(case_ids)
+            existing = {case["id"] for case in rows}
+            if wanted - existing:
+                raise RunnerError("one or more selected case IDs do not exist")
+            selected = [case for case in selected if case["id"] in wanted]
+        if tools:
+            wanted_tools = set(tools)
+            existing_tools = {case["primary_tool"] for case in rows}
+            if wanted_tools - existing_tools:
+                raise RunnerError("one or more selected tools have no cases")
+            selected = [
+                case for case in selected if case["primary_tool"] in wanted_tools
+            ]
+        if case_kinds:
+            wanted_kinds = set(case_kinds)
+            selected = [
+                case for case in selected if case.get("case_kind") in wanted_kinds
+            ]
+    if not selected:
+        raise RunnerError("case selection is empty")
+    return selected
+
+
+def case_profile_name(bundle: InputBundle, case: dict[str, Any]) -> str:
+    profiles = bundle.cases.get("materialization_profiles", {})
+    if case["id"] in set(profiles.get("native_only_case_ids", [])):
+        return "public_repo_native_only"
+    if case.get("preconditions", {}).get("fixture_repository") == "mutation-repo":
+        return "public_repo_with_fixture_history_and_dirty_state"
+    return "public_repo_with_deterministic_fixture_history_overlay"
+
+
+def setup_support(
+    case: dict[str, Any], baseline_patches: dict[str, Any] | None
+) -> tuple[bool, list[str]]:
+    unsupported: list[str] = []
+    for action in case.get("preconditions", {}).get("setup", []):
+        try:
+            action_phase(action)
+        except UnsupportedCase as exc:
+            unsupported.append(str(exc))
+    needs_patch = any(
+        recipe.get("executor") == "apply_patch"
+        for recipe in case.get("baseline_recipe", [])
+    )
+    frozen = (
+        baseline_patches.get("patches", {}).get(case["id"])
+        if baseline_patches is not None
+        else None
+    )
+    if needs_patch and not isinstance(frozen, dict):
+        unsupported.append(
+            "baseline apply_patch requires an asset-locked derived patch"
+        )
+    return not unsupported, unsupported
+
+
+def dry_run_plan(
+    bundle: InputBundle,
+    selected: list[dict[str, Any]],
+    *,
+    allow_stdio_shadow: bool,
+) -> dict[str, Any]:
+    plans: list[dict[str, Any]] = []
+    for case in selected:
+        supported, reasons = setup_support(case, bundle.baseline_patches)
+        transport = case["transport"]
+        effective = transport
+        if transport != "stdio":
+            if allow_stdio_shadow and case.get("parity_shadow_transport") == "stdio":
+                effective = "stdio_shadow"
+            else:
+                supported = False
+                reasons.append(
+                    "primary HTTP transport is unsupported by the direct stdio runner"
+                )
+        plans.append(
+            {
+                "id": case["id"],
+                "primary_tool": case["primary_tool"],
+                "repo": case["repo"],
+                "language": case["language"],
+                "surface": case["surface"],
+                "cache_state": case["cache_state"],
+                "transport": transport,
+                "effective_transport": effective,
+                "materialization_profile": case_profile_name(bundle, case),
+                "request_count": len(case["requests"]),
+                "baseline_steps": len(case.get("baseline_recipe", [])),
+                "executable": supported,
+                "unsupported_reasons": reasons,
+            }
+        )
+    return {
+        "protocol": harness.PROTOCOL_ID,
+        "input_hashes": bundle.hashes,
+        "asset_lock": bundle.asset_lock_status,
+        "selected_cases": plans,
+        "executable_count": sum(1 for plan in plans if plan["executable"]),
+        "unsupported_count": sum(1 for plan in plans if not plan["executable"]),
+    }
+
+
+def _write_setup_record(
+    writer: harness.JsonlWriter,
+    config: harness.CaptureConfig,
+    case_id: str,
+    phase: str,
+    result: dict[str, Any],
+) -> None:
+    writer.write(
+        {
+            **harness.base_record(config),
+            "record_type": "setup_action",
+            "case_id": case_id,
+            "phase": phase,
+            "result": result,
+            "result_sha256": harness.sha256_text(harness.canonical_json(result)),
+            "hidden_from_llm_arms": True,
+        }
+    )
+
+
+def record_response_binding(
+    context: ResolutionContext,
+    request: dict[str, Any],
+    capture: harness.RpcCapture,
+) -> None:
+    record_as = request.get("record_as")
+    if not isinstance(record_as, str) or not record_as:
+        return
+    result = (capture.response_safe or {}).get("result")
+    value: dict[str, Any] = {
+        "response": result,
+        "response_sha256": harness.sha256_text(harness.canonical_json(result)),
+    }
+    text = harness.extract_content_text(capture.response_safe)
+    handles = CCR_HANDLE.findall(text)
+    if handles:
+        unique = sorted(set(handles))
+        if len(unique) != 1 or len(handles) != 1:
+            raise RunnerError(
+                "CCR-producing response did not contain exactly one handle"
+            )
+        value["hash"] = unique[0]
+        value["summary_payload_sha256"] = harness.sha256_text(text)
+        value["precompression_payload_sha256"] = None
+        value["precompression_hash_status"] = "pending measured retrieve response"
+    context.bind(f"prior.{context.case['id']}.{record_as}", value)
+
+
+def request_economics_role(case: dict[str, Any], request: dict[str, Any]) -> str:
+    explicit = request.get("economics_role")
+    if explicit is not None:
+        if explicit not in ECONOMICS_ROLES:
+            raise RunnerError("request has an invalid economics_role")
+        return str(explicit)
+    label = str(request.get("label", "")).casefold()
+    if "estimate" in label or request.get("args", {}).get("estimate") is True:
+        return "estimate_diagnostic"
+    if label in {"replay", "repeat_replay"}:
+        return "replay_diagnostic"
+    if case.get("primary_tool") == "symforge_retrieve" and label == "repeat":
+        return "replay_diagnostic"
+    if (
+        case.get("primary_tool") == "investigation_suggest"
+        and request.get("tool") == "get_symbol"
+    ):
+        return "required_prerequisite"
+    if case.get("primary_tool") == "health_compact" and request.get("tool") == "health":
+        return "oracle_reference"
+    return "task"
+
+
+def pending_ccr_bindings(
+    value: Any, prefix: str = ""
+) -> list[tuple[str, dict[str, Any]]]:
+    pending: list[tuple[str, dict[str, Any]]] = []
+    if isinstance(value, dict):
+        if (
+            isinstance(value.get("hash"), str)
+            and value.get("precompression_payload_sha256") is None
+        ):
+            pending.append((prefix, value))
+        for key, child in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else key
+            pending.extend(pending_ccr_bindings(child, child_prefix))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            pending.extend(pending_ccr_bindings(child, f"{prefix}[{index}]"))
+    return pending
+
+
+def update_ccr_from_retrieve(
+    context: ResolutionContext,
+    handle: str,
+    capture: harness.RpcCapture,
+) -> list[str]:
+    if harness.rpc_status(capture) != "ok":
+        return []
+    payload = harness.extract_content_text(capture.response_safe)
+    if not payload:
+        return []
+    updated: list[str] = []
+    payload_hash = harness.sha256_text(payload)
+    for path, binding in pending_ccr_bindings(context.prior):
+        if binding.get("hash") == handle:
+            binding["precompression_payload_sha256"] = payload_hash
+            binding["precompression_hash_status"] = "measured retrieve response"
+            updated.append(path)
+    return updated
+
+
+def finalize_pending_ccr(
+    context: ResolutionContext,
+    sessions: SessionManager,
+    writer: harness.JsonlWriter,
+    config: harness.CaptureConfig,
+) -> None:
+    for path, binding in list(pending_ccr_bindings(context.prior)):
+        handle = binding["hash"]
+        capture = sessions.call(
+            "symforge_retrieve",
+            {"hash": handle},
+            record_type="evaluator_rpc",
+            extra={
+                "economics_excluded": True,
+                "evaluator_purpose": "retain_precompression_payload_hash",
+            },
+        )
+        updated = update_ccr_from_retrieve(context, handle, capture)
+        if not updated:
+            raise RunnerError(
+                "evaluator could not retain the CCR precompression payload hash"
+            )
+        writer.write(
+            {
+                **harness.base_record(config),
+                "record_type": "ccr_binding_finalized",
+                "binding": path,
+                "handle": handle,
+                "precompression_payload_sha256": binding[
+                    "precompression_payload_sha256"
+                ],
+                "economics_excluded": True,
+            }
+        )
+
+
+def resolved_allowlist(context: ResolutionContext) -> list[str]:
+    value = context.resolve(context.case.get("mutation_allowlist", []))
+    if isinstance(value, str):
+        return [value.replace("\\", "/")]
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise RunnerError("resolved mutation_allowlist is not a string list")
+    return [item.replace("\\", "/") for item in value]
+
+
+def step_target_fingerprints(
+    context: ResolutionContext, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    candidates: set[str] = set()
+    for value in resolved_allowlist(context):
+        if not any(character in value for character in "*?["):
+            candidates.add(value)
+    path_argument = arguments.get("path")
+    if isinstance(path_argument, str) and not pathlib.Path(path_argument).is_absolute():
+        candidates.add(path_argument.replace("\\", "/"))
+    result: dict[str, Any] = {}
+    for relative in sorted(candidates):
+        try:
+            path = require_relative_path(context.work_root, relative)
+        except RunnerError:
+            continue
+        if path.is_file():
+            result[relative] = {
+                "present": True,
+                "bytes": path.stat().st_size,
+                "sha256": file_sha256(path),
+            }
+        else:
+            result[relative] = {"present": False}
+    return result
+
+
+def case_exposes_fixture_root(case: dict[str, Any]) -> bool:
+    measured = {
+        "requests": case.get("requests", []),
+        "baseline_recipe": case.get("baseline_recipe", []),
+    }
+    return "${fixture.root}" in harness.canonical_json(measured)
+
+
+def materialize_fixture_auxiliary(
+    bundle: InputBundle, case: dict[str, Any], destination: pathlib.Path
+) -> pathlib.Path | None:
+    if not case_exposes_fixture_root(case):
+        return None
+    if destination.exists():
+        raise RunnerError("fixture auxiliary root already exists")
+    non_git = bundle.oracle.get("paths", {}).get("non_git_directory")
+    if not isinstance(non_git, str):
+        raise RunnerError("fixture oracle omits its non-Git directory")
+    source = require_relative_path(bundle.fixture_root, non_git)
+    destination.mkdir(parents=True)
+    shutil.copytree(source, require_relative_path(destination, non_git))
+    return destination
+
+
+def execute_case_setup_without_session(
+    case: dict[str, Any],
+    context: ResolutionContext,
+    writer: harness.JsonlWriter,
+    config: harness.CaptureConfig,
+) -> dict[str, list[dict[str, Any]]]:
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    for action in case.get("preconditions", {}).get("setup", []):
+        if action_phase(action) not in {"pre_index", "post_index"}:
+            raise UnsupportedCase("unknown setup phase")
+        result = execute_setup_action(action, context, hooks)
+        _write_setup_record(
+            writer, config, case["id"], "baseline_pre_measurement", result
+        )
+    if hooks:
+        raise UnsupportedCase(
+            "baseline parity for between-request setup hooks is not implemented"
+        )
+    return hooks
+
+
+def run_one_case(
+    bundle: InputBundle,
+    case: dict[str, Any],
+    settings: RunSettings,
+    writer: harness.JsonlWriter,
+    sanitizer: harness.Sanitizer,
+    counter: harness.TokenCounter,
+    trial_ordinal: int,
+    measured_repetition: int | None,
+    discarded_warmup: bool,
+) -> None:
+    if case["transport"] != "stdio" and not (
+        settings.allow_stdio_shadow and case.get("parity_shadow_transport") == "stdio"
+    ):
+        raise UnsupportedCase(
+            "primary HTTP transport is unsupported; explicitly enable its stdio parity shadow"
+        )
+    supported, reasons = setup_support(case, bundle.baseline_patches)
+    if not supported:
+        relevant = [
+            reason
+            for reason in reasons
+            if not reason.startswith("baseline apply_patch")
+        ]
+        if relevant or settings.with_baseline:
+            raise UnsupportedCase("; ".join(relevant or reasons))
+
+    base_safe_id = re.sub(r"[^A-Za-z0-9_.-]", "_", case["id"])
+    suffix = (
+        f"w{trial_ordinal:03d}"
+        if discarded_warmup
+        else f"r{int(measured_repetition or 0):03d}"
+    )
+    safe_id = f"{base_safe_id}-{suffix}"
+    work_root = (settings.work_parent / safe_id).resolve()
+    if not harness.is_within(work_root, settings.work_parent.resolve()):
+        raise RunnerError("case work root escaped the run work directory")
+    if work_root.exists():
+        raise RunnerError("case work root already exists; use a fresh run ID")
+    materialization = materialize_case(bundle, case, work_root)
+    fixture_auxiliary = materialize_fixture_auxiliary(
+        bundle, case, settings.work_parent / f"{safe_id}-fixture-aux"
+    )
+    harness.validate_paths(work_root, settings.output)
+    context = ResolutionContext(
+        bundle=bundle,
+        case=case,
+        work_root=work_root,
+        run_id=settings.run_id,
+        project_id=project_id_for(work_root),
+        fixture_runtime_root=fixture_auxiliary,
+    )
+    context.native_oracles = derive_native_oracles(case["repo"], work_root)
+    timeout = settings.timeout_override or float(
+        case.get("limits", {}).get("timeout_seconds", 120)
+    )
+    base_config = harness.CaptureConfig(
+        mode="scenario",
+        repo=work_root,
+        output=settings.output,
+        server=str(settings.server_path),
+        server_args=list(settings.server_args),
+        surface=case["surface"],
+        auto_index=True,
+        timeout=timeout,
+        protocol_version=harness.MCP_PROTOCOL_VERSION,
+        run_id=settings.run_id,
+        case_id=case["id"],
+        append=True,
+    )
+    writer.write(
+        {
+            **harness.base_record(base_config),
+            "record_type": "case_start",
+            "primary_tool": case["primary_tool"],
+            "language": case["language"],
+            "repo_stratum": case["repo_stratum"],
+            "cache_state": case["cache_state"],
+            "declared_transport": case["transport"],
+            "effective_transport": "stdio"
+            if case["transport"] == "stdio"
+            else "stdio_shadow",
+            "economics_mode": "formal_with_baseline"
+            if settings.with_baseline
+            else "diagnostic_direct_only",
+            "materialization": materialization,
+            "project_id_derivation": "project- + sha256(canonical absolute root)",
+            "project_id": context.project_id,
+            "trial_ordinal": trial_ordinal,
+            "measured_repetition": measured_repetition,
+            "discarded_warmup": discarded_warmup,
+            "economics_excluded": discarded_warmup,
+        }
+    )
+
+    setup = case.get("preconditions", {}).get("setup", [])
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    for action in setup:
+        if action_phase(action) == "pre_index":
+            result = execute_setup_action(action, context, hooks)
+            _write_setup_record(writer, base_config, case["id"], "pre_index", result)
+
+    pre_session_inventory = source_inventory(work_root)
+    git_state_before = git_state_inventory(work_root)
+    auxiliary_before = (
+        source_inventory(fixture_auxiliary) if fixture_auxiliary is not None else None
+    )
+    writer.write(
+        {
+            **harness.base_record(base_config),
+            "record_type": "source_inventory_pre_session",
+            "inventory": pre_session_inventory,
+            "git_state": git_state_before,
+            "fixture_auxiliary_inventory": auxiliary_before,
+        }
+    )
+
+    inventory = bundle.cases["inventory"]
+    expected_tools = {
+        "full": set(inventory["full_surface_tools"]),
+        "compact": set(inventory["compact_surface_tools"]),
+        "meta": set(inventory["meta_surface_tools"]),
+    }
+    sessions = SessionManager(
+        server_path=settings.server_path,
+        server_args=settings.server_args,
+        work_root=work_root,
+        writer=writer,
+        sanitizer=sanitizer,
+        counter=counter,
+        run_id=settings.run_id,
+        case_id=case["id"],
+        timeout=timeout,
+        expected_tools=expected_tools,
+    )
+    try:
+        cache_state = case["cache_state"]
+        if cache_state == "snapshot_warm":
+            sessions.start("full", "snapshot_preparation")
+            sessions.wait_ready("full", timeout=timeout)
+            checkpoint = sessions.call(
+                "checkpoint_now",
+                {"verify_after_write": True, "export_artifact": False},
+                record_type="preflight_rpc",
+                extra={
+                    "economics_excluded": True,
+                    "preflight_purpose": "snapshot_preparation",
+                },
+            )
+            if harness.rpc_status(checkpoint) != "ok":
+                raise RunnerError("snapshot preparation checkpoint failed")
+            sessions.close()
+            sessions.start(case["surface"], "measured")
+            sessions.wait_ready(case["surface"], timeout=timeout)
+        elif cache_state == "process_warm":
+            sessions.start(case["surface"], "measured")
+            sessions.wait_ready(case["surface"], timeout=timeout)
+        elif cache_state == "cold_build":
+            sessions.start(case["surface"], "measured")
+        else:
+            raise RunnerError("unknown cache_state")
+
+        post_actions = [
+            action for action in setup if action_phase(action) == "post_index"
+        ]
+        if post_actions:
+            sessions.wait_ready(case["surface"], timeout=timeout)
+        for action in post_actions:
+            result = execute_setup_action(action, context, hooks)
+            _write_setup_record(writer, base_config, case["id"], "post_index", result)
+
+        before = source_inventory(work_root) if post_actions else pre_session_inventory
+        writer.write(
+            {
+                **harness.base_record(base_config),
+                "record_type": "source_inventory_before",
+                "inventory": before,
+            }
+        )
+        calls = 0
+        effective_cache_state = {
+            "cold_build": "cold_build_process",
+            "snapshot_warm": "snapshot_warm_ready",
+            "process_warm": "process_warm_ready_after_readiness_probe",
+        }[case["cache_state"]]
+        for request in case["requests"]:
+            if request.get("fresh_process_before") or request.get(
+                "fresh_session_before"
+            ):
+                sessions.close()
+                snapshot = work_root / ".symforge" / "index.bin"
+                snapshot_evidence = {
+                    "present": snapshot.is_file(),
+                    "sha256": file_sha256(snapshot) if snapshot.is_file() else None,
+                    "bytes": snapshot.stat().st_size if snapshot.is_file() else None,
+                }
+                writer.write(
+                    {
+                        **harness.base_record(base_config),
+                        "record_type": "restart_boundary",
+                        "before_request_label": request["label"],
+                        "snapshot": snapshot_evidence,
+                    }
+                )
+                role = (
+                    "fresh_session"
+                    if request.get("fresh_session_before")
+                    else "fresh_process"
+                )
+                sessions.start(case["surface"], role)
+                effective_cache_state = (
+                    "fresh_process_snapshot_present_unprobed"
+                    if snapshot_evidence["present"]
+                    else "fresh_process_no_snapshot_unprobed"
+                )
+            arguments = context.resolve(request["args"])
+            if not isinstance(arguments, dict):
+                raise RunnerError("resolved request args are not an object")
+            calls += 1
+            economics_role = request_economics_role(case, request)
+            target_before = step_target_fingerprints(context, arguments)
+            capture = sessions.call(
+                request["tool"],
+                arguments,
+                record_type="direct_trial",
+                extra={
+                    "case_step": request["step"],
+                    "request_label": request["label"],
+                    "cohort": request["label"],
+                    "step_role": economics_role,
+                    "economics_role": economics_role,
+                    "expected_status": "ok"
+                    if case.get("case_kind") == "happy"
+                    else "oracle_specific",
+                    "cache_state": case["cache_state"],
+                    "effective_cache_state": effective_cache_state,
+                    "fresh_process_before": bool(request.get("fresh_process_before")),
+                    "fresh_session_before": bool(request.get("fresh_session_before")),
+                    "economics_excluded": discarded_warmup,
+                    "trial_ordinal": trial_ordinal,
+                    "measured_repetition": measured_repetition,
+                    "discarded_warmup": discarded_warmup,
+                },
+            )
+            raw_response_text = (
+                harness.canonical_json(capture.response_raw)
+                if capture.response_raw is not None
+                else ""
+            )
+            raw_content = harness.extract_content(capture.response_raw)
+            raw_content_text = (
+                harness.canonical_json(raw_content) if raw_content is not None else ""
+            )
+            writer.write(
+                {
+                    **harness.base_record(base_config),
+                    "record_type": "trial_raw_fingerprints",
+                    "case_step": request["step"],
+                    "request_label": request["label"],
+                    "trial_ordinal": trial_ordinal,
+                    "measured_repetition": measured_repetition,
+                    "raw_response_sha256": harness.sha256_text(raw_response_text),
+                    "raw_content_sha256": harness.sha256_text(raw_content_text),
+                    "raw_values_persisted": False,
+                }
+            )
+            target_after = step_target_fingerprints(context, arguments)
+            changed_targets = sorted(
+                path
+                for path in target_before.keys() | target_after.keys()
+                if target_before.get(path) != target_after.get(path)
+            )
+            writer.write(
+                {
+                    **harness.base_record(base_config),
+                    "record_type": "step_source_fingerprints",
+                    "case_step": request["step"],
+                    "request_label": request["label"],
+                    "trial_ordinal": trial_ordinal,
+                    "measured_repetition": measured_repetition,
+                    "before": target_before,
+                    "after": target_after,
+                    "changed_targets": changed_targets,
+                    "fingerprint_scope": "resolved mutation allowlist plus request path",
+                }
+            )
+            if case.get("case_kind") == "happy" and harness.rpc_status(capture) != "ok":
+                raise RunnerError("happy-path request did not return MCP status ok")
+            record_response_binding(context, request, capture)
+            if request["tool"] == "symforge_retrieve" and isinstance(
+                arguments.get("hash"), str
+            ):
+                updated = update_ccr_from_retrieve(context, arguments["hash"], capture)
+                if updated:
+                    payload_hash = harness.sha256_text(
+                        harness.extract_content_text(capture.response_safe)
+                    )
+                    for binding_path in updated:
+                        writer.write(
+                            {
+                                **harness.base_record(base_config),
+                                "record_type": "ccr_binding_finalized",
+                                "binding": binding_path,
+                                "handle": arguments["hash"],
+                                "precompression_payload_sha256": payload_hash,
+                                "economics_excluded": False,
+                                "source": "measured_retrieve",
+                            }
+                        )
+            for hook in hooks.get(request["label"], []):
+                result = execute_hook(hook, context)
+                _write_setup_record(
+                    writer,
+                    base_config,
+                    case["id"],
+                    f"after_request:{request['label']}",
+                    result,
+                )
+        if calls > int(case["limits"]["call_limit"]):
+            raise RunnerError("runtime call count exceeded the frozen case limit")
+        if pending_ccr_bindings(context.prior):
+            finalize_pending_ccr(context, sessions, writer, base_config)
+        after = source_inventory(work_root)
+        changes = inventory_changes(before, after)
+        policy = enforce_mutation_policy(case, resolved_allowlist(context), changes)
+        auxiliary_after = (
+            source_inventory(fixture_auxiliary)
+            if fixture_auxiliary is not None
+            else None
+        )
+        auxiliary_changes = (
+            inventory_changes(auxiliary_before, auxiliary_after)
+            if auxiliary_before is not None and auxiliary_after is not None
+            else []
+        )
+        auxiliary_violations = [
+            change["path"]
+            for change in auxiliary_changes
+            if not fnmatch.fnmatchcase(change["path"], "**/.symforge/**")
+            and not fnmatch.fnmatchcase(change["path"], ".symforge/**")
+        ]
+        git_state_after = git_state_inventory(work_root)
+        git_state_violations = protected_git_state_changed(
+            git_state_before, git_state_after
+        )
+        writer.write(
+            {
+                **harness.base_record(base_config),
+                "record_type": "source_inventory_after",
+                "inventory": after,
+                "changes": changes,
+                "mutation_policy": policy,
+                "fixture_auxiliary_after": auxiliary_after,
+                "fixture_auxiliary_changes": auxiliary_changes,
+                "fixture_auxiliary_violations": auxiliary_violations,
+                "git_state_before": git_state_before,
+                "git_state_after": git_state_after,
+                "git_state_violations": git_state_violations,
+            }
+        )
+        if not policy["safe"]:
+            raise RunnerError("source mutation escaped the frozen allowlist")
+        if auxiliary_violations:
+            raise RunnerError(
+                "measured tool mutated a disposable fixture auxiliary source path"
+            )
+        if git_state_violations:
+            raise RunnerError("measured tool mutated protected Git metadata")
+    finally:
+        sessions.close()
+
+    if settings.with_baseline and not discarded_warmup:
+        baseline_root = (settings.work_parent / f"{safe_id}-baseline").resolve()
+        if baseline_root.exists():
+            raise RunnerError("baseline work root already exists")
+        baseline_materialization = materialize_case(bundle, case, baseline_root)
+        baseline_auxiliary = materialize_fixture_auxiliary(
+            bundle, case, settings.work_parent / f"{safe_id}-baseline-fixture-aux"
+        )
+        harness.validate_paths(baseline_root, settings.output)
+        baseline_context = ResolutionContext(
+            bundle=bundle,
+            case=case,
+            work_root=baseline_root,
+            run_id=settings.run_id,
+            project_id=project_id_for(baseline_root),
+            baseline_relative_paths=True,
+            fixture_runtime_root=baseline_auxiliary,
+        )
+        baseline_context.native_oracles = derive_native_oracles(
+            case["repo"], baseline_root
+        )
+        baseline_config = harness.CaptureConfig(
+            mode="baseline",
+            repo=baseline_root,
+            output=settings.output,
+            server="",
+            server_args=[],
+            surface=case["surface"],
+            auto_index=False,
+            timeout=timeout,
+            protocol_version=harness.MCP_PROTOCOL_VERSION,
+            run_id=settings.run_id,
+            case_id=case["id"],
+            append=True,
+        )
+        writer.write(
+            {
+                **harness.base_record(baseline_config),
+                "execution_mode": "recipe_baseline",
+                "record_type": "baseline_case_start",
+                "materialization": baseline_materialization,
+                "cwd_policy": "commands execute in baseline clone; ${case.work_root} resolves to '.'",
+                "cwd_canonical_sha256": harness.sha256_text(
+                    canonical_path(baseline_root)
+                ),
+            }
+        )
+        execute_case_setup_without_session(
+            case, baseline_context, writer, baseline_config
+        )
+        baseline_before = source_inventory(baseline_root)
+        baseline_auxiliary_before = (
+            source_inventory(baseline_auxiliary)
+            if baseline_auxiliary is not None
+            else None
+        )
+        run_baseline(
+            case=case,
+            context=baseline_context,
+            writer=writer,
+            counter=counter,
+            sanitizer=sanitizer,
+            timeout=timeout,
+        )
+        baseline_after = source_inventory(baseline_root)
+        baseline_auxiliary_after = (
+            source_inventory(baseline_auxiliary)
+            if baseline_auxiliary is not None
+            else None
+        )
+        baseline_changes = inventory_changes(baseline_before, baseline_after)
+        baseline_policy = enforce_mutation_policy(
+            case, resolved_allowlist(baseline_context), baseline_changes
+        )
+        writer.write(
+            {
+                **harness.base_record(baseline_config),
+                "execution_mode": "recipe_baseline",
+                "record_type": "baseline_source_inventory_after",
+                "before": baseline_before,
+                "after": baseline_after,
+                "changes": baseline_changes,
+                "mutation_policy": baseline_policy,
+                "fixture_auxiliary_before": baseline_auxiliary_before,
+                "fixture_auxiliary_after": baseline_auxiliary_after,
+                "fixture_auxiliary_changes": inventory_changes(
+                    baseline_auxiliary_before, baseline_auxiliary_after
+                )
+                if baseline_auxiliary_before is not None
+                and baseline_auxiliary_after is not None
+                else [],
+            }
+        )
+        if not baseline_policy["safe"]:
+            raise RunnerError("baseline source mutation escaped the frozen allowlist")
+
+    writer.write(
+        {
+            **harness.base_record(base_config),
+            "record_type": "case_complete",
+            "status": "completed",
+            "trial_ordinal": trial_ordinal,
+            "measured_repetition": measured_repetition,
+            "discarded_warmup": discarded_warmup,
+            "economics_status": "discarded_warmup"
+            if discarded_warmup
+            else "baseline_captured"
+            if settings.with_baseline
+            else "not_formal_baseline_omitted",
+            "correctness_status": "pending_machine_or_report_evaluation",
+            "oracle_status": "unevaluated",
+            "economics_valid": False,
+            "correctness_oracle": case.get("correctness_oracle"),
+            "stop_condition": case.get("stop_condition"),
+        }
+    )
+
+
+def run_campaign(
+    bundle: InputBundle,
+    selected: list[dict[str, Any]],
+    settings: RunSettings,
+    sut: dict[str, Any],
+) -> int:
+    settings.output = settings.output.resolve()
+    settings.work_parent = settings.work_parent.resolve()
+    approved_runs = (bundle.benchmark_root / "runs").resolve()
+    approved_work = (bundle.benchmark_root / "work").resolve()
+    if not harness.is_within(settings.output, approved_runs):
+        raise RunnerError("campaign output must be under benchmark_root/runs")
+    if not harness.is_within(settings.work_parent, approved_work):
+        raise RunnerError("campaign work roots must be under benchmark_root/work")
+    forbidden_roots = [
+        PROJECT_ROOT.resolve(),
+        (bundle.benchmark_root / "sources").resolve(),
+        bundle.fixture_root.resolve(),
+        *[entry["root"].resolve() for entry in bundle.repositories.values()],
+    ]
+    if any(harness.is_within(settings.output, root) for root in forbidden_roots):
+        raise RunnerError("campaign output overlaps an immutable or project root")
+    if any(harness.is_within(settings.work_parent, root) for root in forbidden_roots):
+        raise RunnerError("campaign work root overlaps an immutable or project root")
+    settings.work_parent.mkdir(parents=True, exist_ok=False)
+    sanitizer = harness.Sanitizer()
+    counter = harness.TokenCounter()
+    writer = harness.JsonlWriter(settings.output, sanitizer, append=False)
+    failures = 0
+    completed_trials = 0
+    scheduled_trials = sum(
+        (
+            settings.repetitions_override
+            if settings.repetitions_override is not None
+            else int(case.get("limits", {}).get("repetitions", 1))
+        )
+        + int(case.get("limits", {}).get("discarded_warmups", 0))
+        for case in selected
+    )
+    try:
+        writer.write(
+            {
+                "protocol": harness.PROTOCOL_ID,
+                "run_id": settings.run_id,
+                "record_type": "campaign_start",
+                "execution_mode": "direct_rpc",
+                "transport": "stdio",
+                "input_hashes": bundle.hashes,
+                "asset_lock": bundle.asset_lock_status,
+                "sut": sut,
+                "tokenizer": counter.metadata(),
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "selected_case_ids": [case["id"] for case in selected],
+                "economics_mode": "formal_with_baseline"
+                if settings.with_baseline
+                else "diagnostic_direct_only",
+                "formal_economics": False,
+                "oracle_status": "unevaluated",
+                "economics_valid": False,
+                "validity_gate": "external oracle adjudication required",
+                "repetitions_policy": "frozen_per_case"
+                if settings.repetitions_override is None
+                else "diagnostic_override",
+                "repetitions_override": settings.repetitions_override,
+                "scheduled_trials": scheduled_trials,
+                "paid_api_calls": 0,
+            }
+        )
+        for case in selected:
+            warmups = int(case.get("limits", {}).get("discarded_warmups", 0))
+            repetitions = (
+                settings.repetitions_override
+                if settings.repetitions_override is not None
+                else int(case.get("limits", {}).get("repetitions", 1))
+            )
+            for ordinal in range(1, warmups + repetitions + 1):
+                discarded = ordinal <= warmups
+                measured_repetition = None if discarded else ordinal - warmups
+                try:
+                    run_one_case(
+                        bundle,
+                        case,
+                        settings,
+                        writer,
+                        sanitizer,
+                        counter,
+                        trial_ordinal=ordinal,
+                        measured_repetition=measured_repetition,
+                        discarded_warmup=discarded,
+                    )
+                    completed_trials += 1
+                except Exception as exc:
+                    failures += 1
+                    safe_message = (
+                        str(exc) if isinstance(exc, RunnerError) else type(exc).__name__
+                    )
+                    writer.write(
+                        {
+                            "protocol": harness.PROTOCOL_ID,
+                            "run_id": settings.run_id,
+                            "case_id": case.get("id"),
+                            "record_type": "case_error",
+                            "trial_ordinal": ordinal,
+                            "measured_repetition": measured_repetition,
+                            "discarded_warmup": discarded,
+                            "error_type": type(exc).__name__,
+                            "message": safe_message,
+                        }
+                    )
+        writer.write(
+            {
+                "protocol": harness.PROTOCOL_ID,
+                "run_id": settings.run_id,
+                "record_type": "campaign_complete",
+                "selected_cases": len(selected),
+                "scheduled_trials": scheduled_trials,
+                "completed_trials": completed_trials,
+                "failed": failures,
+                "sanitizer_redactions": sanitizer.event_count(),
+                "paid_api_calls": 0,
+            }
+        )
+    finally:
+        writer.close()
+    return failures
+
+
+def _write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _init_test_repo(path: pathlib.Path, files: dict[str, bytes]) -> str:
+    path.mkdir(parents=True)
+    git(path, "init")
+    git(path, "config", "user.name", "SFBENCH Test")
+    git(path, "config", "user.email", "sfbench@example.invalid")
+    for relative, data in files.items():
+        target = require_relative_path(path, relative)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    git(path, "add", "-A")
+    git(path, "commit", "--no-gpg-sign", "-m", "fixture")
+    return git_text(path, "rev-parse", "HEAD")
+
+
+def self_test() -> int:
+    if CCR_HANDLE.findall('retrieve with hash="012345abcdef"') != ["012345abcdef"]:
+        raise RunnerError("self-test CCR footer parser invariant failed")
+    with tempfile.TemporaryDirectory(prefix="sfbench-direct-runner-") as root_text:
+        root = pathlib.Path(root_text)
+        benchmark = root / "benchmark"
+        source = benchmark / "sources" / "tiny"
+        source_head = _init_test_repo(
+            source,
+            {"index.py": b"def native_anchor():\n    return 31\n"},
+        )
+        fixture_root = benchmark / "fixtures" / "control-v1"
+        clean_repo = fixture_root / "control-repo"
+        clean_head = _init_test_repo(clean_repo, {"fixture.txt": b"fixture\n"})
+        clean_tree = fixture_tree_hash(clean_repo)
+        mutation_repo = fixture_root / "mutation-repo"
+        mutation_head = _init_test_repo(mutation_repo, {"fixture.txt": b"fixture\n"})
+        mutation_tree = fixture_tree_hash(mutation_repo)
+        oracle = {
+            "paths": {
+                "clean_repository": "control-repo",
+                "mutation_repository": "mutation-repo",
+            },
+            "repositories": {
+                "clean": {
+                    "head": clean_head,
+                    "tree_sha256": clean_tree,
+                },
+                "mutation": {
+                    "head": mutation_head,
+                    "tree_sha256": mutation_tree,
+                },
+            },
+            "worktree": {
+                "status_porcelain_v1": [],
+                "staged": {"diff_sha256": sha256_bytes(b"")},
+                "unstaged": {"diff_sha256": sha256_bytes(b"")},
+            },
+            "history": {"commits": [], "refs": {}},
+            "files": {},
+            "symbols": {},
+            "mutations": {},
+        }
+        oracle_path = fixture_root / "oracle.json"
+        _write_json(oracle_path, oracle)
+        corpus_lock = {
+            "version": 1,
+            "repositories": [
+                {
+                    "alias": "tiny",
+                    "url": "local-only",
+                    "commit": source_head,
+                    "history_depth": 1,
+                    "stratum": "tiny",
+                    "primary_language": "Python",
+                    "overlay_language": "Python",
+                }
+            ],
+        }
+        corpus_lock_path = root / "corpus.lock.json"
+        _write_json(corpus_lock_path, corpus_lock)
+        corpus_manifest = {
+            "version": 1,
+            "corpus_lock_sha256": file_sha256(corpus_lock_path),
+            "root": str(benchmark / "sources"),
+            "repositories": [{"alias": "tiny", "commit": source_head}],
+        }
+        _write_json(benchmark / "corpus-manifest.json", corpus_manifest)
+        token_metadata = harness.TokenCounter().metadata()
+        primary = token_metadata["encodings"]["cl100k"]
+        sensitivity = token_metadata["encodings"]["o200k"]
+        campaign = {
+            "schema_version": "self-test",
+            "protocol_id": harness.PROTOCOL_ID,
+            "system_under_test": {
+                "version": "self-test",
+                "binary_sha256": harness.executable_sha256(
+                    pathlib.Path(sys.executable)
+                ),
+                "surface_modes": ["full", "compact", "meta"],
+            },
+            "mcp": {
+                "protocol_version": harness.MCP_PROTOCOL_VERSION,
+                "primary_transport": "stdio",
+            },
+            "tokenization": {
+                "package": "tiktoken",
+                "version": token_metadata["version"],
+                "primary": {
+                    "encoding": primary["name"],
+                    "vocabulary_sha256": primary["vocabulary_sha256"],
+                },
+                "sensitivity": {
+                    "encoding": sensitivity["name"],
+                    "vocabulary_sha256": sensitivity["vocabulary_sha256"],
+                },
+            },
+            "paired_llm": {"model_alias": "none"},
+            "safety": {
+                "persist_unsanitized_output": False,
+                "source_mirrors_are_immutable": True,
+                "ordinary_cases_use_independent_clones": True,
+                "oracle_visible_to_llm": False,
+                "network_during_measurement": False,
+            },
+        }
+        campaign_path = root / "campaign.json"
+        _write_json(campaign_path, campaign)
+        sensitive_input = "request" + "-sensitive" + "-fixture"
+        case_id = "SELF-health_compact-001"
+        fake_full_tools = sorted(harness.EXPECTED_TOOLS["full"])
+        fake_compact_tools = sorted(harness.EXPECTED_TOOLS["compact"])
+        fake_meta_tools = sorted(harness.EXPECTED_TOOLS["meta"])
+        cases = {
+            "schema_version": "self-test",
+            "protocol": harness.PROTOCOL_ID,
+            "system_under_test": "self-test",
+            "oracle_contract": {
+                "expected_oracle_sha256": file_sha256(oracle_path),
+                "expected_clean_head": clean_head,
+                "expected_clean_tree_sha256": clean_tree,
+                "forbid_symforge_derived_oracles": True,
+            },
+            "inventory": {
+                "full_surface_tools": fake_full_tools,
+                "full_surface_count": len(fake_full_tools),
+                "compact_surface_tools": fake_compact_tools,
+                "meta_surface_tools": fake_meta_tools,
+                "unique_tool_names": len(
+                    set(fake_full_tools + fake_compact_tools + fake_meta_tools)
+                ),
+            },
+            "materialization_profiles": {
+                "native_only_case_ids": [case_id],
+            },
+            "cases": [
+                {
+                    "id": case_id,
+                    "primary_tool": "health_compact",
+                    "case_kind": "happy",
+                    "repo": "tiny",
+                    "repo_stratum": "tiny",
+                    "commit": "${repo.tiny.commit}",
+                    "language": "Python",
+                    "preconditions": {
+                        "fixture_repository": "control-repo",
+                        "setup": [],
+                    },
+                    "cache_state": "process_warm",
+                    "transport": "stdio",
+                    "surface": "full",
+                    "requests": [
+                        {
+                            "step": 1,
+                            "label": "first",
+                            "tool": "health_compact",
+                            "economics_role": "task",
+                            "args": {"password": sensitive_input},
+                            "fresh_process_before": False,
+                            "fresh_session_before": False,
+                            "record_as": None,
+                        },
+                        {
+                            "step": 2,
+                            "label": "restart",
+                            "tool": "health_compact",
+                            "economics_role": "replay_diagnostic",
+                            "args": {"project": "${session.project_id}"},
+                            "fresh_process_before": True,
+                            "fresh_session_before": False,
+                            "record_as": None,
+                        },
+                    ],
+                    "baseline_recipe": [
+                        {
+                            "executor": "capability_only",
+                            "reason": "self-test capability",
+                        }
+                    ],
+                    "baseline_equivalence": "not_applicable",
+                    "correctness_oracle": {
+                        "key": "self_test.fake_success",
+                        "expected_outcome": "two successful sanitized fake calls",
+                    },
+                    "stop_condition": "both requests captured and source unchanged",
+                    "limits": {"call_limit": 2, "timeout_seconds": 10},
+                    "mutation_allowlist": [],
+                    "source_hash_policy": "no_source_bytes_may_change",
+                }
+            ],
+        }
+        cases_path = root / "cases.json"
+        _write_json(cases_path, cases)
+        bundle = validate_inputs(
+            benchmark_root=benchmark,
+            fixture_root=fixture_root,
+            cases_path=cases_path,
+            campaign_path=campaign_path,
+            corpus_lock_path=corpus_lock_path,
+            asset_lock_path=None,
+            baseline_patches_path=None,
+            require_asset_lock=False,
+        )
+        server_path, sut = validate_sut(bundle, sys.executable, skip_version_probe=True)
+        output = benchmark / "runs" / "self-test.jsonl"
+        settings = RunSettings(
+            run_id="self-test",
+            output=output,
+            work_parent=benchmark / "work" / "self-test",
+            server_path=server_path,
+            server_args=[str(SCRIPT_DIR / "mcp_harness.py"), "--_fake-server"],
+            with_baseline=True,
+            allow_stdio_shadow=False,
+            timeout_override=10,
+            self_test=True,
+        )
+        failures = run_campaign(bundle, bundle.cases["cases"], settings, sut)
+        if failures:
+            rows = [
+                json.loads(line)
+                for line in output.read_text(encoding="utf-8").splitlines()
+            ]
+            errors = [row for row in rows if row.get("record_type") == "case_error"]
+            detail = errors[0].get("message", "unknown") if errors else "unknown"
+            raise RunnerError(f"self-test campaign reported a failed case: {detail}")
+        persisted = output.read_text(encoding="utf-8")
+        forbidden = {
+            sensitive_input,
+            "unit" + "-sensitive" + "-fixture",
+        }
+        if any(value in persisted for value in forbidden):
+            raise RunnerError("self-test sanitizer invariant failed")
+        rows = [json.loads(line) for line in persisted.splitlines()]
+        if sum(row.get("record_type") == "direct_trial" for row in rows) != 2:
+            raise RunnerError("self-test did not capture both measured requests")
+        if sum(row.get("record_type") == "process_lifecycle" for row in rows) < 2:
+            raise RunnerError("self-test did not exercise fresh_process_before")
+        if not any(row.get("record_type") == "baseline_total" for row in rows):
+            raise RunnerError("self-test did not capture baseline accounting")
+        if harness.REDACTED not in persisted:
+            raise RunnerError("self-test artifact contains no sanitizer evidence")
+    print("direct-case-runner self-test: PASS")
+    return 0
+
+
+def add_input_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--benchmark-root", default=str(DEFAULT_BENCHMARK_ROOT))
+    parser.add_argument("--fixture-root")
+    parser.add_argument("--cases", default=str(DEFAULT_CASES))
+    parser.add_argument("--campaign", default=str(DEFAULT_CAMPAIGN))
+    parser.add_argument("--corpus-lock", default=str(DEFAULT_CORPUS_LOCK))
+    parser.add_argument("--asset-lock")
+    parser.add_argument("--baseline-patches")
+    parser.add_argument("--require-asset-lock", action="store_true")
+    parser.add_argument("--server", default="symforge")
+    parser.add_argument("--server-arg", action="append", default=[])
+
+
+def add_selection_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--case-id", action="append", default=[])
+    parser.add_argument("--tool", action="append", default=[])
+    parser.add_argument(
+        "--case-kind",
+        action="append",
+        choices=("happy", "adverse", "control", "stateful"),
+        default=[],
+    )
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--allow-stdio-shadow",
+        action="store_true",
+        help="Run a case's declared stdio parity shadow when its primary transport is HTTP.",
+    )
+
+
+def bundle_from_args(args: argparse.Namespace) -> InputBundle:
+    benchmark = pathlib.Path(args.benchmark_root)
+    fixture = (
+        pathlib.Path(args.fixture_root)
+        if args.fixture_root
+        else benchmark / "fixtures" / "control-v1"
+    )
+    if args.asset_lock:
+        asset_lock: pathlib.Path | None = pathlib.Path(args.asset_lock)
+    elif DEFAULT_ASSET_LOCK.is_file():
+        asset_lock = DEFAULT_ASSET_LOCK
+    else:
+        asset_lock = None
+    if args.baseline_patches:
+        baseline_patches = pathlib.Path(args.baseline_patches)
+    elif (
+        args.command != "freeze-baseline-patches" and DEFAULT_BASELINE_PATCHES.is_file()
+    ):
+        baseline_patches = DEFAULT_BASELINE_PATCHES
+    else:
+        baseline_patches = None
+    return validate_inputs(
+        benchmark_root=benchmark,
+        fixture_root=fixture,
+        cases_path=pathlib.Path(args.cases),
+        campaign_path=pathlib.Path(args.campaign),
+        corpus_lock_path=pathlib.Path(args.corpus_lock),
+        asset_lock_path=asset_lock,
+        baseline_patches_path=baseline_patches,
+        require_asset_lock=args.require_asset_lock,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run frozen SymForge direct-RPC cases in disposable external clones. "
+            "No paid model APIs are used."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser(
+        "validate", help="Validate every frozen input and the SUT identity."
+    )
+    add_input_arguments(validate)
+    dry_run = subparsers.add_parser(
+        "dry-run", help="Resolve a case plan without materializing or calling MCP."
+    )
+    add_input_arguments(dry_run)
+    add_selection_arguments(dry_run)
+    run = subparsers.add_parser("run", help="Execute selected direct-RPC cases.")
+    add_input_arguments(run)
+    add_selection_arguments(run)
+    run.add_argument("--run-id", required=True)
+    run.add_argument("--output")
+    run.add_argument("--work-parent")
+    baseline_mode = run.add_mutually_exclusive_group()
+    baseline_mode.add_argument(
+        "--with-baseline",
+        dest="with_baseline",
+        action="store_true",
+        help="Run the baseline arm (default; retained for explicit scripts).",
+    )
+    baseline_mode.add_argument(
+        "--direct-only",
+        dest="with_baseline",
+        action="store_false",
+        help="Diagnostic only: omit baseline and mark the artifact non-formal.",
+    )
+    run.set_defaults(with_baseline=True)
+    run.add_argument("--timeout", type=float)
+    run.add_argument(
+        "--allow-unlocked-diagnostic",
+        action="store_true",
+        help="Allow evidence collection before assets.lock.json is frozen; output remains invalid for economics.",
+    )
+    run.add_argument(
+        "--repetitions",
+        type=int,
+        help="Diagnostic override for measured repetitions; omission uses each frozen case limit.",
+    )
+    subparsers.add_parser(
+        "self-test",
+        help="Run fake-MCP transport, restart, sanitizer, and baseline tests.",
+    )
+    freeze = subparsers.add_parser(
+        "freeze-baseline-patches",
+        help="Generate and scratch-verify evaluator-only baseline patch text before asset freeze.",
+    )
+    add_input_arguments(freeze)
+    freeze.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "self-test":
+        return self_test()
+    bundle = bundle_from_args(args)
+    if args.command == "freeze-baseline-patches":
+        result = freeze_baseline_patches(bundle, pathlib.Path(args.output))
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    server_path, sut = validate_sut(bundle, args.server)
+    if args.command == "validate":
+        summary = {
+            "status": "valid",
+            "protocol": harness.PROTOCOL_ID,
+            "case_count": len(bundle.cases["cases"]),
+            "repository_count": len(bundle.repositories),
+            "input_hashes": bundle.hashes,
+            "asset_lock": bundle.asset_lock_status,
+            "sut": sut,
+            "paid_api_calls": 0,
+        }
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+    selected = select_cases(
+        bundle.cases,
+        case_ids=args.case_id,
+        tools=args.tool,
+        case_kinds=args.case_kind,
+        smoke=args.smoke,
+        all_cases=args.all,
+    )
+    plan = dry_run_plan(bundle, selected, allow_stdio_shadow=args.allow_stdio_shadow)
+    if args.command == "dry-run":
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+    if args.timeout is not None and args.timeout <= 0:
+        raise RunnerError("--timeout must be greater than zero")
+    if args.repetitions is not None and args.repetitions <= 0:
+        raise RunnerError("--repetitions must be greater than zero")
+    if (
+        not bundle.asset_lock_status.get("present")
+        and not args.allow_unlocked_diagnostic
+    ):
+        raise RunnerError(
+            "run requires a verified asset lock; use --allow-unlocked-diagnostic only for pre-freeze evidence"
+        )
+    output = (
+        pathlib.Path(args.output)
+        if args.output
+        else bundle.benchmark_root / "runs" / f"{args.run_id}.jsonl"
+    )
+    work_parent = (
+        pathlib.Path(args.work_parent)
+        if args.work_parent
+        else bundle.benchmark_root / "work" / f"direct-{args.run_id}"
+    )
+    settings = RunSettings(
+        run_id=args.run_id,
+        output=output,
+        work_parent=work_parent,
+        server_path=server_path,
+        server_args=list(args.server_arg),
+        with_baseline=args.with_baseline,
+        allow_stdio_shadow=args.allow_stdio_shadow,
+        timeout_override=args.timeout,
+        repetitions_override=args.repetitions,
+    )
+    failures = run_campaign(bundle, selected, settings, sut)
+    print(
+        f"direct campaign complete: selected_cases={len(selected)} failed_trials={failures}; "
+        f"sanitized evidence={settings.output}"
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RunnerError, harness.HarnessError) as exc:
+        print(f"direct_case_runner: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/research/full-surface-benchmark/fixture_generator.py
+++ b/research/full-surface-benchmark/fixture_generator.py
@@ -1,0 +1,1652 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Generate the deterministic SFBENCH-1.0 external control repositories."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import tomllib
+from typing import Iterable
+
+
+PROTOCOL_ID = "SFBENCH-1.0"
+FIXTURE_VERSION = 1
+AUTHOR_NAME = "SymForge Fixture"
+AUTHOR_EMAIL = "sfbench@example.invalid"
+
+MARKERS = {
+    "source": "SF_BENCH_SOURCE_9F31",
+    "test": "SF_BENCH_TEST_ONLY_9F31",
+    "generated": "SF_BENCH_GENERATED_9F31",
+    "vendor": "SF_BENCH_VENDOR_9F31",
+    "edit_old": "SF_BENCH_EDIT_OLD_9F31",
+    "edit_new": "SF_BENCH_EDIT_NEW_9F31",
+    "ccr": "SF_BENCH_CCR_9F31",
+    "personal": "SF_BENCH_PERSONAL_9F31",
+}
+
+
+@dataclass(frozen=True)
+class SymbolLocator:
+    language: str
+    path: str
+    name: str
+    kind: str
+    source: str
+
+
+@dataclass(frozen=True)
+class ImportLocator:
+    language: str
+    from_path: str
+    to_path: str
+    alias: str | None
+    source: str
+
+
+@dataclass
+class FixtureModel:
+    files: dict[str, bytes]
+    symbols: list[SymbolLocator]
+    imports: list[ImportLocator]
+    call_edges: dict[str, list[tuple[str, str]]]
+    reference_callers: dict[str, list[str]]
+    implementors: dict[str, dict[str, str]]
+    dependents: dict[str, dict[str, list[str]]]
+    mutation_bodies: dict[str, dict[str, str]]
+
+
+def utf8(value: str) -> bytes:
+    return value.encode("utf-8")
+
+
+def block(value: str) -> str:
+    return textwrap.dedent(value).strip("\n")
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def add_file(files: dict[str, bytes], path: str, value: str | bytes) -> None:
+    data = utf8(value) if isinstance(value, str) else value
+    if path in files:
+        raise RuntimeError(f"duplicate fixture path: {path}")
+    files[path] = data
+
+
+def assemble(header: str, blocks: Iterable[str], footer: str = "") -> str:
+    parts = [header.strip("\n"), *(item.strip("\n") for item in blocks)]
+    if footer:
+        parts.append(footer.strip("\n"))
+    return "\n\n".join(parts) + "\n"
+
+
+def rust_fixture(model: FixtureModel) -> None:
+    language = "Rust"
+    root = "sfbench_fixture/rust"
+    protocol_path = f"{root}/src/protocol.rs"
+    core_path = f"{root}/src/core.rs"
+    protocol = block(
+        """
+        pub trait SfBenchProtocol {
+            fn run(&self) -> String;
+        }
+        """
+    )
+    parts = {
+        "leaf": block(
+            """
+            pub fn sfbench_leaf() -> String {
+                "leaf".to_owned()
+            }
+            """
+        ),
+        "mid": block(
+            """
+            pub fn sfbench_mid() -> String {
+                sfbench_leaf()
+            }
+            """
+        ),
+        "rename": block(
+            """
+            pub fn sfbench_rename_me() -> String {
+                "rename".to_owned()
+            }
+            """
+        ),
+        "worker_struct": block(
+            """
+            pub struct SfBenchWorker;
+            """
+        ),
+        "worker_impl": block(
+            """
+            impl SfBenchProtocol for SfBenchWorker {
+                fn run(&self) -> String {
+                    sfbench_rename_me()
+                }
+            }
+            """
+        ),
+        "entry": block(
+            """
+            pub fn sfbench_entry() -> String {
+                let worker = SfBenchWorker;
+                format!("{}:{}", sfbench_mid(), worker.run())
+            }
+            """
+        ),
+        "unused": block(
+            """
+            pub fn sfbench_unused() -> String {
+                "unused".to_owned()
+            }
+            """
+        ),
+        "user_one": block(
+            """
+            pub fn sfbench_rename_user_one() -> String {
+                sfbench_rename_me()
+            }
+            """
+        ),
+        "user_two": block(
+            """
+            pub fn sfbench_rename_user_two() -> String {
+                sfbench_rename_me()
+            }
+            """
+        ),
+        "user_three": block(
+            """
+            pub fn sfbench_rename_user_three() -> String {
+                sfbench_rename_me()
+            }
+            """
+        ),
+        "mutable": block(
+            f"""
+            pub fn sfbench_mutable() -> (&'static str, &'static str, &'static str) {{
+                let first = "{MARKERS['edit_old']}";
+                let unicode_inside = "žarek λ";
+                let second = "{MARKERS['edit_old']}";
+                (first, unicode_inside, second)
+            }}
+            """
+        ),
+        "outside": block(
+            f"""
+            pub fn sfbench_outside_literal() -> &'static str {{
+                "{MARKERS['edit_old']}"
+            }}
+            """
+        ),
+        "delete": block(
+            """
+            pub fn sfbench_delete_me() -> &'static str {
+                "delete"
+            }
+            """
+        ),
+        "nested": block(
+            """
+            pub mod sfbench_outer {
+                pub mod inner {
+                    pub fn sfbench_nested() -> &'static str {
+                        "nested"
+                    }
+                }
+            }
+            """
+        ),
+    }
+    header = block(
+        f"""
+        use super::protocol::SfBenchProtocol;
+
+        pub const SF_BENCH_SOURCE_MARKER: &str = "{MARKERS['source']}";
+        pub const SF_BENCH_UNICODE_BEFORE: &str = "naïve λ";
+        """
+    )
+    footer = block(
+        """
+        // Non-code mention: sfbench_rename_me
+        pub const SF_BENCH_RENAME_TEXT: &str = "sfbench_rename_me";
+        """
+    )
+    core = assemble(header, parts.values(), footer)
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, core)
+    add_file(
+        model.files,
+        f"{root}/src/mod.rs",
+        "pub mod core;\npub mod cycle_a;\npub mod cycle_b;\npub mod protocol;\n",
+    )
+    cycle_a = block(
+        """
+        use super::cycle_b::CycleB as OtherB;
+
+        pub struct CycleA {
+            pub other: Option<Box<OtherB>>,
+        }
+        """
+    )
+    cycle_b = block(
+        """
+        use super::cycle_a::CycleA as OtherA;
+
+        pub struct CycleB {
+            pub other: Option<Box<OtherA>>,
+        }
+        """
+    )
+    add_file(model.files, f"{root}/src/cycle_a.rs", cycle_a + "\n")
+    add_file(model.files, f"{root}/src/cycle_b.rs", cycle_b + "\n")
+    test_path = f"{root}/tests/test_core.rs"
+    add_file(
+        model.files,
+        test_path,
+        f"use sfbench_fixture::rust::core::sfbench_entry;\n\nconst TEST_MARKER: &str = \"{MARKERS['test']}\";\n\n#[test]\nfn sfbench_test_entry() {{\n    assert!(!TEST_MARKER.is_empty());\n    assert!(!sfbench_entry().is_empty());\n}}\n",
+    )
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.rs"
+        duplicate = "pub fn sfbench_duplicate() -> &'static str {\n    \"duplicate\"\n}\n"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(
+            SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", duplicate.strip("\n"))
+        )
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "trait", protocol),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "struct", parts["worker_struct"]),
+            SymbolLocator(language, core_path, "run", "method", "    fn run(&self) -> String {\n        sfbench_rename_me()\n    }"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "fn", "        pub fn sfbench_nested() -> &'static str {\n            \"nested\"\n        }"),
+            SymbolLocator(language, f"{root}/src/cycle_a.rs", "CycleA", "struct", "pub struct CycleA {\n    pub other: Option<Box<OtherB>>,\n}"),
+            SymbolLocator(language, f"{root}/src/cycle_b.rs", "CycleB", "struct", "pub struct CycleB {\n    pub other: Option<Box<OtherA>>,\n}"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, protocol_path, None, "use super::protocol::SfBenchProtocol;"),
+            ImportLocator(language, f"{root}/src/cycle_a.rs", f"{root}/src/cycle_b.rs", "OtherB", "use super::cycle_b::CycleB as OtherB;"),
+            ImportLocator(language, f"{root}/src/cycle_b.rs", f"{root}/src/cycle_a.rs", "OtherA", "use super::cycle_a::CycleA as OtherA;"),
+            ImportLocator(language, test_path, core_path, None, "use sfbench_fixture::rust::core::sfbench_entry;"),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def python_fixture(model: FixtureModel) -> None:
+    language = "Python"
+    root = "sfbench_fixture/python"
+    protocol_path = f"{root}/src/protocol.py"
+    core_path = f"{root}/src/core.py"
+    protocol = block(
+        """
+        from typing import Protocol
+
+        class SfBenchProtocol(Protocol):
+            def run(self) -> str: ...
+        """
+    )
+    parts = {
+        "leaf": "def sfbench_leaf() -> str:\n    return \"leaf\"",
+        "mid": "def sfbench_mid() -> str:\n    return sfbench_leaf()",
+        "rename": "def sfbench_rename_me() -> str:\n    return \"rename\"",
+        "worker": "class SfBenchWorker(SfBenchProtocol):\n    def run(self) -> str:\n        return sfbench_rename_me()",
+        "entry": "def sfbench_entry() -> str:\n    worker = SfBenchWorker()\n    return f\"{sfbench_mid()}:{worker.run()}\"",
+        "unused": "def sfbench_unused() -> str:\n    return \"unused\"",
+        "user_one": "def sfbench_rename_user_one() -> str:\n    return sfbench_rename_me()",
+        "user_two": "def sfbench_rename_user_two() -> str:\n    return sfbench_rename_me()",
+        "user_three": "def sfbench_rename_user_three() -> str:\n    return sfbench_rename_me()",
+        "mutable": f"def sfbench_mutable() -> tuple[str, str, str]:\n    first = \"{MARKERS['edit_old']}\"\n    unicode_inside = \"žarek λ\"\n    second = \"{MARKERS['edit_old']}\"\n    return first, unicode_inside, second",
+        "outside": f"def sfbench_outside_literal() -> str:\n    return \"{MARKERS['edit_old']}\"",
+        "delete": "def sfbench_delete_me() -> str:\n    return \"delete\"",
+        "nested": "class SfBenchOuter:\n    class Inner:\n        def sfbench_nested(self) -> str:\n            return \"nested\"",
+    }
+    header = f"from .protocol import SfBenchProtocol\n\nSF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\"\nSF_BENCH_UNICODE_BEFORE = \"naïve λ\""
+    footer = "# Non-code mention: sfbench_rename_me\nSF_BENCH_RENAME_TEXT = \"sfbench_rename_me\""
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    add_file(model.files, f"{root}/src/__init__.py", "from .core import sfbench_entry\n")
+    cycle_a = "from .cycle_b import CycleB as OtherB\n\nclass CycleA:\n    def __init__(self, other: OtherB | None = None):\n        self.other = other\n"
+    cycle_b = "from .cycle_a import CycleA as OtherA\n\nclass CycleB:\n    def __init__(self, other: OtherA | None = None):\n        self.other = other\n"
+    add_file(model.files, f"{root}/src/cycle_a.py", cycle_a)
+    add_file(model.files, f"{root}/src/cycle_b.py", cycle_b)
+    test_path = f"{root}/tests/test_core.py"
+    add_file(model.files, test_path, f"from sfbench_fixture.python.src.core import sfbench_entry\n\nTEST_MARKER = \"{MARKERS['test']}\"\n\ndef test_entry() -> None:\n    assert sfbench_entry()\n")
+    duplicate = "def sfbench_duplicate() -> str:\n    return \"duplicate\"\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.py"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", duplicate.strip("\n")))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "class", "class SfBenchProtocol(Protocol):\n    def run(self) -> str: ..."),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "class", parts["worker"]),
+            SymbolLocator(language, core_path, "run", "method", "    def run(self) -> str:\n        return sfbench_rename_me()"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "method", "        def sfbench_nested(self) -> str:\n            return \"nested\""),
+            SymbolLocator(language, f"{root}/src/cycle_a.py", "CycleA", "class", "class CycleA:\n    def __init__(self, other: OtherB | None = None):\n        self.other = other"),
+            SymbolLocator(language, f"{root}/src/cycle_b.py", "CycleB", "class", "class CycleB:\n    def __init__(self, other: OtherA | None = None):\n        self.other = other"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, protocol_path, None, "from .protocol import SfBenchProtocol"),
+            ImportLocator(language, f"{root}/src/cycle_a.py", f"{root}/src/cycle_b.py", "OtherB", "from .cycle_b import CycleB as OtherB"),
+            ImportLocator(language, f"{root}/src/cycle_b.py", f"{root}/src/cycle_a.py", "OtherA", "from .cycle_a import CycleA as OtherA"),
+            ImportLocator(language, test_path, core_path, None, "from sfbench_fixture.python.src.core import sfbench_entry"),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def typescript_fixture(model: FixtureModel) -> None:
+    language = "TypeScript"
+    root = "sfbench_fixture/typescript"
+    protocol_path = f"{root}/src/protocol.ts"
+    core_path = f"{root}/src/core.ts"
+    protocol = "export interface SfBenchProtocol {\n  run(): string;\n}"
+    parts = {
+        "leaf": "export function sfbench_leaf(): string {\n  return \"leaf\";\n}",
+        "mid": "export function sfbench_mid(): string {\n  return sfbench_leaf();\n}",
+        "rename": "export function sfbench_rename_me(): string {\n  return \"rename\";\n}",
+        "worker": "export class SfBenchWorker implements SfBenchProtocol {\n  run(): string {\n    return sfbench_rename_me();\n  }\n}",
+        "entry": "export function sfbench_entry(): string {\n  const worker = new SfBenchWorker();\n  return `${sfbench_mid()}:${worker.run()}`;\n}",
+        "unused": "export function sfbench_unused(): string {\n  return \"unused\";\n}",
+        "user_one": "export function sfbench_rename_user_one(): string {\n  return sfbench_rename_me();\n}",
+        "user_two": "export function sfbench_rename_user_two(): string {\n  return sfbench_rename_me();\n}",
+        "user_three": "export function sfbench_rename_user_three(): string {\n  return sfbench_rename_me();\n}",
+        "mutable": f"export function sfbench_mutable(): [string, string, string] {{\n  const first = \"{MARKERS['edit_old']}\";\n  const unicodeInside = \"žarek λ\";\n  const second = \"{MARKERS['edit_old']}\";\n  return [first, unicodeInside, second];\n}}",
+        "outside": f"export function sfbench_outside_literal(): string {{\n  return \"{MARKERS['edit_old']}\";\n}}",
+        "delete": "export function sfbench_delete_me(): string {\n  return \"delete\";\n}",
+        "nested": "export namespace SfBenchOuter {\n  export class Inner {\n    sfbench_nested(): string {\n      return \"nested\";\n    }\n  }\n}",
+    }
+    header = f"import type {{ SfBenchProtocol }} from \"./protocol\";\n\nexport const SF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\";\nexport const SF_BENCH_UNICODE_BEFORE = \"naïve λ\";"
+    footer = "// Non-code mention: sfbench_rename_me\nexport const SF_BENCH_RENAME_TEXT = \"sfbench_rename_me\";"
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    cycle_a = "import type { CycleB as OtherB } from \"./cycle_b\";\n\nexport interface CycleA {\n  other?: OtherB;\n}\n"
+    cycle_b = "import type { CycleA as OtherA } from \"./cycle_a\";\n\nexport interface CycleB {\n  other?: OtherA;\n}\n"
+    add_file(model.files, f"{root}/src/cycle_a.ts", cycle_a)
+    add_file(model.files, f"{root}/src/cycle_b.ts", cycle_b)
+    test_path = f"{root}/tests/test_core.ts"
+    add_file(model.files, test_path, f"import {{ sfbench_entry }} from \"../src/core\";\n\nconst TEST_MARKER = \"{MARKERS['test']}\";\nvoid sfbench_entry();\nvoid TEST_MARKER;\n")
+    duplicate = "export function sfbench_duplicate(): string {\n  return \"duplicate\";\n}\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.ts"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", duplicate.strip("\n")))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "interface", protocol),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "class", parts["worker"]),
+            SymbolLocator(language, core_path, "run", "method", "  run(): string {\n    return sfbench_rename_me();\n  }"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "method", "    sfbench_nested(): string {\n      return \"nested\";\n    }"),
+            SymbolLocator(language, f"{root}/src/cycle_a.ts", "CycleA", "interface", "export interface CycleA {\n  other?: OtherB;\n}"),
+            SymbolLocator(language, f"{root}/src/cycle_b.ts", "CycleB", "interface", "export interface CycleB {\n  other?: OtherA;\n}"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, protocol_path, None, "import type { SfBenchProtocol } from \"./protocol\";"),
+            ImportLocator(language, f"{root}/src/cycle_a.ts", f"{root}/src/cycle_b.ts", "OtherB", "import type { CycleB as OtherB } from \"./cycle_b\";"),
+            ImportLocator(language, f"{root}/src/cycle_b.ts", f"{root}/src/cycle_a.ts", "OtherA", "import type { CycleA as OtherA } from \"./cycle_a\";"),
+            ImportLocator(language, test_path, core_path, None, "import { sfbench_entry } from \"../src/core\";"),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def go_fixture(model: FixtureModel) -> None:
+    language = "Go"
+    root = "sfbench_fixture/go"
+    protocol_path = f"{root}/src/protocol.go"
+    core_path = f"{root}/src/core.go"
+    protocol = "package fixture\n\ntype SfBenchProtocol interface {\n\trun() string\n}"
+    parts = {
+        "leaf": "func sfbench_leaf() string {\n\treturn sfstrings.TrimSpace(\" leaf \")\n}",
+        "mid": "func sfbench_mid() string {\n\treturn sfbench_leaf()\n}",
+        "rename": "func sfbench_rename_me() string {\n\treturn \"rename\"\n}",
+        "worker": "type SfBenchWorker struct{}\n\nfunc (SfBenchWorker) run() string {\n\treturn sfbench_rename_me()\n}",
+        "entry": "func sfbench_entry() string {\n\tworker := SfBenchWorker{}\n\treturn sfbench_mid() + \":\" + worker.run()\n}",
+        "unused": "func sfbench_unused() string {\n\treturn \"unused\"\n}",
+        "user_one": "func sfbench_rename_user_one() string {\n\treturn sfbench_rename_me()\n}",
+        "user_two": "func sfbench_rename_user_two() string {\n\treturn sfbench_rename_me()\n}",
+        "user_three": "func sfbench_rename_user_three() string {\n\treturn sfbench_rename_me()\n}",
+        "mutable": f"func sfbench_mutable() (string, string, string) {{\n\tfirst := \"{MARKERS['edit_old']}\"\n\tunicodeInside := \"žarek λ\"\n\tsecond := \"{MARKERS['edit_old']}\"\n\treturn first, unicodeInside, second\n}}",
+        "outside": f"func sfbench_outside_literal() string {{\n\treturn \"{MARKERS['edit_old']}\"\n}}",
+        "delete": "func sfbench_delete_me() string {\n\treturn \"delete\"\n}",
+        "nested": "type SfBenchOuter struct{}\n\ntype SfBenchInner struct{}\n\nfunc (SfBenchInner) sfbench_nested() string {\n\treturn \"nested\"\n}",
+    }
+    header = f"package fixture\n\nimport sfstrings \"strings\"\n\nconst SF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\"\nconst SF_BENCH_UNICODE_BEFORE = \"naïve λ\"\n\nvar _ SfBenchProtocol = SfBenchWorker{{}}"
+    footer = "// Non-code mention: sfbench_rename_me\nconst SF_BENCH_RENAME_TEXT = \"sfbench_rename_me\""
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    cycle_a = "package fixture\n\ntype CycleA struct {\n\tOther *CycleAliasB\n}\n\ntype CycleAliasB = CycleB\n"
+    cycle_b = "package fixture\n\ntype CycleB struct {\n\tOther *CycleAliasA\n}\n\ntype CycleAliasA = CycleA\n"
+    add_file(model.files, f"{root}/src/cycle_a.go", cycle_a)
+    add_file(model.files, f"{root}/src/cycle_b.go", cycle_b)
+    test_path = f"{root}/tests/test_core.go"
+    add_file(model.files, test_path, f"package fixture_test\n\nimport _ \"example.invalid/sfbench/sfbench_fixture/go/src\"\n\nconst testMarker = \"{MARKERS['test']}\"\n\nfunc sfbench_test_entry() string {{\n\treturn testMarker\n}}\n")
+    duplicate = "package duplicate\n\nfunc sfbench_duplicate() string {\n\treturn \"duplicate\"\n}\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.go"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", "func sfbench_duplicate() string {\n\treturn \"duplicate\"\n}"))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "interface", "type SfBenchProtocol interface {\n\trun() string\n}"),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "struct", "type SfBenchWorker struct{}"),
+            SymbolLocator(language, core_path, "run", "method", "func (SfBenchWorker) run() string {\n\treturn sfbench_rename_me()\n}"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "method", "func (SfBenchInner) sfbench_nested() string {\n\treturn \"nested\"\n}"),
+            SymbolLocator(language, f"{root}/src/cycle_a.go", "CycleA", "struct", "type CycleA struct {\n\tOther *CycleAliasB\n}"),
+            SymbolLocator(language, f"{root}/src/cycle_b.go", "CycleB", "struct", "type CycleB struct {\n\tOther *CycleAliasA\n}"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, "stdlib:strings", "sfstrings", "import sfstrings \"strings\""),
+            ImportLocator(language, test_path, core_path, None, "import _ \"example.invalid/sfbench/sfbench_fixture/go/src\""),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def java_fixture(model: FixtureModel) -> None:
+    language = "Java"
+    root = "sfbench_fixture/java"
+    protocol_path = f"{root}/src/SfBenchProtocol.java"
+    core_path = f"{root}/src/SfBenchCore.java"
+    protocol = "interface SfBenchProtocol {\n    String run();\n}"
+    parts = {
+        "leaf": "    static String sfbench_leaf() {\n        return \"leaf\";\n    }",
+        "mid": "    static String sfbench_mid() {\n        return sfbench_leaf();\n    }",
+        "rename": "    static String sfbench_rename_me() {\n        return \"rename\";\n    }",
+        "worker": "    static final class SfBenchWorker implements SfBenchProtocol {\n        public String run() {\n            return sfbench_rename_me();\n        }\n    }",
+        "entry": "    static String sfbench_entry() {\n        SfBenchWorker worker = new SfBenchWorker();\n        return sfbench_mid() + \":\" + worker.run();\n    }",
+        "unused": "    static String sfbench_unused() {\n        return \"unused\";\n    }",
+        "user_one": "    static String sfbench_rename_user_one() {\n        return sfbench_rename_me();\n    }",
+        "user_two": "    static String sfbench_rename_user_two() {\n        return sfbench_rename_me();\n    }",
+        "user_three": "    static String sfbench_rename_user_three() {\n        return sfbench_rename_me();\n    }",
+        "mutable": f"    static String[] sfbench_mutable() {{\n        String first = \"{MARKERS['edit_old']}\";\n        String unicodeInside = \"žarek λ\";\n        String second = \"{MARKERS['edit_old']}\";\n        return new String[] {{first, unicodeInside, second}};\n    }}",
+        "outside": f"    static String sfbench_outside_literal() {{\n        return \"{MARKERS['edit_old']}\";\n    }}",
+        "delete": "    static String sfbench_delete_me() {\n        return \"delete\";\n    }",
+        "nested": "    static final class SfBenchOuter {\n        static final class Inner {\n            String sfbench_nested() {\n                return \"nested\";\n            }\n        }\n    }",
+    }
+    header = f"final class SfBenchCore {{\n    static final String SF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\";\n    static final String SF_BENCH_UNICODE_BEFORE = \"naïve λ\";"
+    footer = "    // Non-code mention: sfbench_rename_me\n    static final String SF_BENCH_RENAME_TEXT = \"sfbench_rename_me\";\n}"
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    cycle_a = "final class CycleA {\n    CycleB other;\n}\n"
+    cycle_b = "final class CycleB {\n    CycleA other;\n}\n"
+    add_file(model.files, f"{root}/src/CycleA.java", cycle_a)
+    add_file(model.files, f"{root}/src/CycleB.java", cycle_b)
+    test_path = f"{root}/tests/SfBenchCoreTest.java"
+    add_file(model.files, test_path, f"final class SfBenchCoreTest {{\n    static final String TEST_MARKER = \"{MARKERS['test']}\";\n\n    static String exercise() {{\n        return SfBenchCore.sfbench_entry();\n    }}\n}}\n")
+    duplicate = "final class Duplicate {\n    static String sfbench_duplicate() {\n        return \"duplicate\";\n    }\n}\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/Duplicate.java"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "method", "    static String sfbench_duplicate() {\n        return \"duplicate\";\n    }"))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "interface", protocol),
+            SymbolLocator(language, core_path, "sfbench_leaf", "method", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "method", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "method", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "class", parts["worker"]),
+            SymbolLocator(language, core_path, "run", "method", "        public String run() {\n            return sfbench_rename_me();\n        }"),
+            SymbolLocator(language, core_path, "sfbench_entry", "method", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "method", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "method", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "method", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "method", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "method", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "method", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "method", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "method", "            String sfbench_nested() {\n                return \"nested\";\n            }"),
+            SymbolLocator(language, f"{root}/src/CycleA.java", "CycleA", "class", cycle_a.strip("\n")),
+            SymbolLocator(language, f"{root}/src/CycleB.java", "CycleB", "class", cycle_b.strip("\n")),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def cpp_fixture(model: FixtureModel) -> None:
+    language = "C++"
+    root = "sfbench_fixture/cpp"
+    protocol_path = f"{root}/src/protocol.hpp"
+    core_path = f"{root}/src/core.cpp"
+    protocol = "struct SfBenchProtocol {\n  virtual ~SfBenchProtocol() = default;\n  virtual std::string run() const = 0;\n};"
+    parts = {
+        "leaf": "std::string sfbench_leaf() {\n  return \"leaf\";\n}",
+        "mid": "std::string sfbench_mid() {\n  return sfbench_leaf();\n}",
+        "rename": "std::string sfbench_rename_me() {\n  return \"rename\";\n}",
+        "worker": "struct SfBenchWorker final : SfBenchProtocol {\n  std::string run() const override {\n    return sfbench_rename_me();\n  }\n};",
+        "entry": "std::string sfbench_entry() {\n  SfBenchWorker worker;\n  return sfbench_mid() + \":\" + worker.run();\n}",
+        "unused": "std::string sfbench_unused() {\n  return \"unused\";\n}",
+        "user_one": "std::string sfbench_rename_user_one() {\n  return sfbench_rename_me();\n}",
+        "user_two": "std::string sfbench_rename_user_two() {\n  return sfbench_rename_me();\n}",
+        "user_three": "std::string sfbench_rename_user_three() {\n  return sfbench_rename_me();\n}",
+        "mutable": f"std::array<std::string, 3> sfbench_mutable() {{\n  const std::string first = \"{MARKERS['edit_old']}\";\n  const std::string unicode_inside = \"žarek λ\";\n  const std::string second = \"{MARKERS['edit_old']}\";\n  return {{first, unicode_inside, second}};\n}}",
+        "outside": f"std::string sfbench_outside_literal() {{\n  return \"{MARKERS['edit_old']}\";\n}}",
+        "delete": "std::string sfbench_delete_me() {\n  return \"delete\";\n}",
+        "nested": "struct SfBenchOuter {\n  struct Inner {\n    std::string sfbench_nested() const {\n      return \"nested\";\n    }\n  };\n};",
+    }
+    header = f"#include \"protocol.hpp\"\n\n#include <array>\n#include <string>\n\nconst std::string SF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\";\nconst std::string SF_BENCH_UNICODE_BEFORE = \"naïve λ\";"
+    footer = "// Non-code mention: sfbench_rename_me\nconst std::string SF_BENCH_RENAME_TEXT = \"sfbench_rename_me\";"
+    add_file(model.files, protocol_path, "#pragma once\n#include <string>\n\n" + protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    cycle_a = "#pragma once\n#include \"cycle_b.hpp\"\nusing OtherB = CycleB;\nstruct CycleA { OtherB* other; };\n"
+    cycle_b = "#pragma once\n#include \"cycle_a.hpp\"\nusing OtherA = CycleA;\nstruct CycleB { OtherA* other; };\n"
+    add_file(model.files, f"{root}/src/cycle_a.hpp", cycle_a)
+    add_file(model.files, f"{root}/src/cycle_b.hpp", cycle_b)
+    test_path = f"{root}/tests/test_core.cpp"
+    add_file(model.files, test_path, f"#include \"../src/core.cpp\"\nconst char* TEST_MARKER = \"{MARKERS['test']}\";\n")
+    duplicate = "std::string sfbench_duplicate() {\n  return \"duplicate\";\n}\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.cpp"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", duplicate.strip("\n")))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "struct", protocol),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "struct", parts["worker"]),
+            SymbolLocator(language, core_path, "run", "method", "  std::string run() const override {\n    return sfbench_rename_me();\n  }"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "method", "    std::string sfbench_nested() const {\n      return \"nested\";\n    }"),
+            SymbolLocator(language, f"{root}/src/cycle_a.hpp", "CycleA", "struct", "struct CycleA { OtherB* other; };"),
+            SymbolLocator(language, f"{root}/src/cycle_b.hpp", "CycleB", "struct", "struct CycleB { OtherA* other; };"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, protocol_path, None, "#include \"protocol.hpp\""),
+            ImportLocator(language, f"{root}/src/cycle_a.hpp", f"{root}/src/cycle_b.hpp", "OtherB", "#include \"cycle_b.hpp\""),
+            ImportLocator(language, f"{root}/src/cycle_b.hpp", f"{root}/src/cycle_a.hpp", "OtherA", "#include \"cycle_a.hpp\""),
+            ImportLocator(language, test_path, core_path, None, "#include \"../src/core.cpp\""),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def perl_fixture(model: FixtureModel) -> None:
+    language = "Perl"
+    root = "sfbench_fixture/perl"
+    protocol_path = f"{root}/src/SfBenchProtocol.pm"
+    core_path = f"{root}/src/SfBenchCore.pm"
+    protocol = "package SfBenchProtocol;\nuse strict;\nuse warnings;\n\nsub run { die \"abstract\" }\n\n1;"
+    parts = {
+        "leaf": "sub sfbench_leaf {\n    return \"leaf\";\n}",
+        "mid": "sub sfbench_mid {\n    return sfbench_leaf();\n}",
+        "rename": "sub sfbench_rename_me {\n    return \"rename\";\n}",
+        "worker": "package SfBenchWorker;\nour @ISA = ('SfBenchProtocol');\n\nsub run {\n    return SfBenchCore::sfbench_rename_me();\n}\n\npackage SfBenchCore;",
+        "entry": "sub sfbench_entry {\n    my $worker = bless {}, 'SfBenchWorker';\n    return sfbench_mid() . ':' . $worker->run();\n}",
+        "unused": "sub sfbench_unused {\n    return \"unused\";\n}",
+        "user_one": "sub sfbench_rename_user_one {\n    return sfbench_rename_me();\n}",
+        "user_two": "sub sfbench_rename_user_two {\n    return sfbench_rename_me();\n}",
+        "user_three": "sub sfbench_rename_user_three {\n    return sfbench_rename_me();\n}",
+        "mutable": f"sub sfbench_mutable {{\n    my $first = \"{MARKERS['edit_old']}\";\n    my $unicode_inside = \"žarek λ\";\n    my $second = \"{MARKERS['edit_old']}\";\n    return ($first, $unicode_inside, $second);\n}}",
+        "outside": f"sub sfbench_outside_literal {{\n    return \"{MARKERS['edit_old']}\";\n}}",
+        "delete": "sub sfbench_delete_me {\n    return \"delete\";\n}",
+        "nested": "package SfBenchOuter::Inner;\nsub sfbench_nested { return \"nested\"; }\npackage SfBenchCore;",
+    }
+    header = f"package SfBenchCore;\nuse strict;\nuse warnings;\nuse utf8;\nrequire './SfBenchProtocol.pm';\n\nour $SF_BENCH_SOURCE_MARKER = \"{MARKERS['source']}\";\nour $SF_BENCH_UNICODE_BEFORE = \"naïve λ\";"
+    footer = "# Non-code mention: sfbench_rename_me\nour $SF_BENCH_RENAME_TEXT = \"sfbench_rename_me\";\n\n1;"
+    add_file(model.files, protocol_path, protocol + "\n")
+    add_file(model.files, core_path, assemble(header, parts.values(), footer))
+    cycle_a = "package CycleA;\nuse CycleB ();\nsub new { bless { other => undef }, shift }\n1;\n"
+    cycle_b = "package CycleB;\nuse CycleA ();\nsub new { bless { other => undef }, shift }\n1;\n"
+    add_file(model.files, f"{root}/src/CycleA.pm", cycle_a)
+    add_file(model.files, f"{root}/src/CycleB.pm", cycle_b)
+    test_path = f"{root}/tests/test_core.t"
+    add_file(model.files, test_path, f"use strict;\nuse warnings;\nrequire '../src/SfBenchCore.pm';\nmy $test_marker = \"{MARKERS['test']}\";\nprint $test_marker . SfBenchCore::sfbench_entry();\n")
+    duplicate = "package Duplicate;\nsub sfbench_duplicate { return \"duplicate\"; }\n1;\n"
+    for directory in ("a", "b"):
+        duplicate_path = f"{root}/duplicates/{directory}/duplicate.pm"
+        add_file(model.files, duplicate_path, duplicate)
+        model.symbols.append(SymbolLocator(language, duplicate_path, "sfbench_duplicate", "fn", "sub sfbench_duplicate { return \"duplicate\"; }"))
+    model.symbols.extend(
+        [
+            SymbolLocator(language, protocol_path, "SfBenchProtocol", "module", "package SfBenchProtocol;"),
+            SymbolLocator(language, core_path, "sfbench_leaf", "fn", parts["leaf"]),
+            SymbolLocator(language, core_path, "sfbench_mid", "fn", parts["mid"]),
+            SymbolLocator(language, core_path, "sfbench_rename_me", "fn", parts["rename"]),
+            SymbolLocator(language, core_path, "SfBenchWorker", "module", "package SfBenchWorker;"),
+            SymbolLocator(language, core_path, "run", "fn", "sub run {\n    return SfBenchCore::sfbench_rename_me();\n}"),
+            SymbolLocator(language, core_path, "sfbench_entry", "fn", parts["entry"]),
+            SymbolLocator(language, core_path, "sfbench_unused", "fn", parts["unused"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_one", "fn", parts["user_one"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_two", "fn", parts["user_two"]),
+            SymbolLocator(language, core_path, "sfbench_rename_user_three", "fn", parts["user_three"]),
+            SymbolLocator(language, core_path, "sfbench_mutable", "fn", parts["mutable"]),
+            SymbolLocator(language, core_path, "sfbench_outside_literal", "fn", parts["outside"]),
+            SymbolLocator(language, core_path, "sfbench_delete_me", "fn", parts["delete"]),
+            SymbolLocator(language, core_path, "sfbench_nested", "fn", "sub sfbench_nested { return \"nested\"; }"),
+            SymbolLocator(language, f"{root}/src/CycleA.pm", "CycleA", "module", "package CycleA;"),
+            SymbolLocator(language, f"{root}/src/CycleB.pm", "CycleB", "module", "package CycleB;"),
+        ]
+    )
+    model.imports.extend(
+        [
+            ImportLocator(language, core_path, protocol_path, None, "require './SfBenchProtocol.pm';"),
+            ImportLocator(language, f"{root}/src/CycleA.pm", f"{root}/src/CycleB.pm", None, "use CycleB ();"),
+            ImportLocator(language, f"{root}/src/CycleB.pm", f"{root}/src/CycleA.pm", None, "use CycleA ();"),
+            ImportLocator(language, test_path, core_path, None, "require '../src/SfBenchCore.pm';"),
+        ]
+    )
+    register_language_relations(model, language, core_path, protocol_path, test_path, parts)
+
+
+def register_language_relations(
+    model: FixtureModel,
+    language: str,
+    core_path: str,
+    protocol_path: str,
+    test_path: str,
+    parts: dict[str, str],
+) -> None:
+    model.call_edges[language] = [
+        ("sfbench_entry", "sfbench_mid"),
+        ("sfbench_entry", "SfBenchWorker.run"),
+        ("sfbench_mid", "sfbench_leaf"),
+        ("SfBenchWorker.run", "sfbench_rename_me"),
+        ("sfbench_rename_user_one", "sfbench_rename_me"),
+        ("sfbench_rename_user_two", "sfbench_rename_me"),
+        ("sfbench_rename_user_three", "sfbench_rename_me"),
+    ]
+    model.reference_callers[language] = [
+        "run",
+        "sfbench_rename_user_one",
+        "sfbench_rename_user_two",
+        "sfbench_rename_user_three",
+    ]
+    model.implementors[language] = {
+        "protocol": "SfBenchProtocol",
+        "implementor": "SfBenchWorker",
+        "protocol_path": protocol_path,
+        "implementor_path": core_path,
+    }
+    model.dependents[language] = {
+        protocol_path: [core_path],
+        core_path: [test_path],
+    }
+    model.mutation_bodies[language] = {
+        "leaf_original": parts["leaf"],
+        "leaf_replacement": replacement_leaf(language),
+        "insert_after_entry": inserted_symbol(language),
+    }
+
+
+def replacement_leaf(language: str) -> str:
+    return {
+        "Rust": "pub fn sfbench_leaf() -> String {\n    \"leaf-v2\".to_owned()\n}",
+        "Python": "def sfbench_leaf() -> str:\n    return \"leaf-v2\"",
+        "TypeScript": "export function sfbench_leaf(): string {\n  return \"leaf-v2\";\n}",
+        "Go": "func sfbench_leaf() string {\n\treturn \"leaf-v2\"\n}",
+        "Java": "    static String sfbench_leaf() {\n        return \"leaf-v2\";\n    }",
+        "C++": "std::string sfbench_leaf() {\n  return \"leaf-v2\";\n}",
+        "Perl": "sub sfbench_leaf {\n    return \"leaf-v2\";\n}",
+    }[language]
+
+
+def inserted_symbol(language: str) -> str:
+    return {
+        "Rust": "pub fn sfbench_inserted() -> &'static str {\n    \"inserted\"\n}",
+        "Python": "def sfbench_inserted() -> str:\n    return \"inserted\"",
+        "TypeScript": "export function sfbench_inserted(): string {\n  return \"inserted\";\n}",
+        "Go": "func sfbench_inserted() string {\n\treturn \"inserted\"\n}",
+        "Java": "    static String sfbench_inserted() {\n        return \"inserted\";\n    }",
+        "C++": "std::string sfbench_inserted() {\n  return \"inserted\";\n}",
+        "Perl": "sub sfbench_inserted {\n    return \"inserted\";\n}",
+    }[language]
+
+
+def common_fixture(model: FixtureModel) -> None:
+    add_file(
+        model.files,
+        ".gitattributes",
+        "sfbench_fixture/exact/** -text\nsfbench_fixture/generated/large_generated.py -text\nsfbench_fixture/configs/bom_crlf_unicode.json -text\n",
+    )
+    add_file(model.files, ".gitignore", ".symforge/\nsfbench_fixture/ignored/\n")
+    add_file(model.files, "README.md", "# SFBENCH deterministic control repository\n")
+    add_file(model.files, "go.mod", "module example.invalid/sfbench\n\ngo 1.23\n")
+    add_file(model.files, "sfbench_fixture/filter_cases/source/marker.py", f"MARKER = \"{MARKERS['source']}\"\n")
+    add_file(model.files, "sfbench_fixture/filter_cases/tests/marker.py", f"MARKER = \"{MARKERS['test']}\"\n")
+    add_file(model.files, "sfbench_fixture/filter_cases/generated/marker.py", f"MARKER = \"{MARKERS['generated']}\"\n")
+    add_file(model.files, "sfbench_fixture/filter_cases/vendor/marker.py", f"MARKER = \"{MARKERS['vendor']}\"\n")
+    add_file(model.files, "sfbench_fixture/ignored/marker.py", "IGNORED_FIXTURE = True\n")
+    add_file(model.files, ".claude/gsd-tools/marker.py", f"MARKER = \"{MARKERS['personal']}\"\n")
+    add_file(model.files, "sfbench_fixture/configs/valid.json", "{\n  \"enabled\": true,\n  \"name\": \"žarek\"\n}\n")
+    add_file(model.files, "sfbench_fixture/configs/malformed.json", "{\n  \"enabled\": true,\n  \"items\": [1, 2,]\n}\n")
+    add_file(model.files, "sfbench_fixture/configs/valid.toml", "enabled = true\nname = \"žarek\"\n")
+    add_file(model.files, "sfbench_fixture/configs/malformed.toml", "enabled = true\nname = \"unterminated\ncount = 3\n")
+    add_file(model.files, "sfbench_fixture/configs/valid.yaml", "enabled: true\nname: žarek\nitems:\n  - one\n")
+    add_file(model.files, "sfbench_fixture/configs/malformed.yaml", "enabled: true\nitems:\n  - one\n  - [two, three\n")
+    add_file(model.files, "sfbench_fixture/configs/bom_crlf_unicode.json", b"\xef\xbb\xbf{\r\n  \"name\": \"\xc5\xbearek\"\r\n}\r\n")
+    add_file(model.files, "sfbench_fixture/exact/lf_source.py", "LF_VALUE = \"naïve λ\"\n")
+    add_file(model.files, "sfbench_fixture/exact/crlf_source.py", b"CRLF_VALUE = \"na\xc3\xafve \xce\xbb\"\r\n")
+    add_file(model.files, "sfbench_fixture/exact/no_final_newline.py", "NO_FINAL_NEWLINE = \"žarek\"")
+    binary = bytes(range(256)) * 4 + b"\x00SFBENCH-BINARY\x00" + bytes(reversed(range(256)))
+    add_file(model.files, "sfbench_fixture/exact/deterministic.bin", binary)
+    large_lines = ["# SF_BENCH_LARGE_START_9F31", f"# {MARKERS['generated']}"]
+    for number in range(1400):
+        if number == 700:
+            large_lines.append("# SF_BENCH_LARGE_MIDDLE_9F31")
+        large_lines.extend(
+            [
+                f"def sfbench_bulk_result_{number:04d}():",
+                f"    return \"{MARKERS['ccr']}:{number:04d}\"",
+                "",
+            ]
+        )
+    large_lines.append("# SF_BENCH_LARGE_END_9F31")
+    large_source = "\n".join(large_lines) + "\n"
+    if len(utf8(large_source)) <= 60 * 1024:
+        raise RuntimeError("large fixture did not exceed 60 KiB")
+    add_file(model.files, "sfbench_fixture/generated/large_generated.py", large_source)
+    history_source = block(
+        """
+        COCHANGE_EVENTS = []
+
+        def sfbench_history_modified() -> str:
+            return "v1"
+
+        def sfbench_history_removed() -> str:
+            return "remove-in-commit-six"
+        """
+    ) + "\n"
+    history_test = "from sfbench_fixture.history.source import sfbench_history_modified\n\nCOCHANGE_TEST_EVENTS = []\n\ndef test_history_modified() -> None:\n    assert sfbench_history_modified() == \"v1\"\n"
+    add_file(model.files, "sfbench_fixture/history/source.py", history_source)
+    add_file(model.files, "sfbench_fixture/history/test_source.py", history_test)
+    add_file(model.files, "docs/history.txt", "unrelated-history-base\n")
+    worktree_files = {
+        "staged.py": "STATE = \"base\"\n",
+        "unstaged.py": "STATE = \"base\"\n",
+        "rename_from.py": "STATE = \"rename-base\"\n",
+        "deleted.py": "STATE = \"delete-base\"\n",
+        "stale_target.py": "STALE_STATE = \"before-fetch\"\n",
+    }
+    for name, value in worktree_files.items():
+        add_file(model.files, f"sfbench_fixture/worktree/{name}", value)
+
+
+def build_model() -> FixtureModel:
+    model = FixtureModel({}, [], [], {}, {}, {}, {}, {})
+    rust_fixture(model)
+    python_fixture(model)
+    typescript_fixture(model)
+    go_fixture(model)
+    java_fixture(model)
+    cpp_fixture(model)
+    perl_fixture(model)
+    common_fixture(model)
+    return model
+
+
+def write_file(root: Path, relative: str, data: bytes) -> None:
+    path = root.joinpath(*relative.split("/"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def safe_git_env(global_config: Path, timestamp: str | None = None) -> dict[str, str]:
+    allowed = ("PATH", "PATHEXT", "SYSTEMROOT", "WINDIR", "COMSPEC", "TEMP", "TMP")
+    env = {name: os.environ[name] for name in allowed if name in os.environ}
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(global_config),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_NAME": AUTHOR_NAME,
+            "GIT_AUTHOR_EMAIL": AUTHOR_EMAIL,
+            "GIT_COMMITTER_NAME": AUTHOR_NAME,
+            "GIT_COMMITTER_EMAIL": AUTHOR_EMAIL,
+            "LC_ALL": "C",
+            "TZ": "UTC",
+        }
+    )
+    if timestamp is not None:
+        env["GIT_AUTHOR_DATE"] = timestamp
+        env["GIT_COMMITTER_DATE"] = timestamp
+    return env
+
+
+def git(repo: Path, global_config: Path, *arguments: str, timestamp: str | None = None) -> bytes:
+    command = ["git", *arguments]
+    result = subprocess.run(
+        command,
+        cwd=repo,
+        env=safe_git_env(global_config, timestamp),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git command failed ({' '.join(command)}): {detail}")
+    return result.stdout
+
+
+def replace_once(path: Path, old: bytes, new: bytes) -> None:
+    source = path.read_bytes()
+    if source.count(old) != 1:
+        raise RuntimeError(f"expected one replacement target in {path.name}")
+    path.write_bytes(source.replace(old, new, 1))
+
+
+def append_bytes(path: Path, value: bytes) -> None:
+    path.write_bytes(path.read_bytes() + value)
+
+
+def commit_all(
+    repo: Path,
+    global_config: Path,
+    message: str,
+    timestamp: str,
+    expected_paths: list[str],
+    force_paths: tuple[str, ...] = (),
+) -> str:
+    git(repo, global_config, "add", "--all")
+    if force_paths:
+        git(repo, global_config, "add", "--force", "--", *force_paths)
+    actual = git(repo, global_config, "diff", "--cached", "--name-only", "--format=").decode("utf-8").splitlines()
+    if sorted(actual) != sorted(expected_paths):
+        raise RuntimeError(f"staged path mismatch for commit {message!r}")
+    git(repo, global_config, "commit", "--no-verify", "--no-gpg-sign", "-m", message, timestamp=timestamp)
+    return git(repo, global_config, "rev-parse", "HEAD").decode("ascii").strip()
+
+
+def history_timestamp(index: int) -> str:
+    return f"2026-01-{index:02d}T00:00:00+00:00"
+
+
+def build_repository(repo: Path, model: FixtureModel, global_config: Path, template_dir: Path) -> list[dict[str, object]]:
+    repo.mkdir()
+    git(repo, global_config, "init", f"--template={template_dir}", "--quiet")
+    git(repo, global_config, "symbolic-ref", "HEAD", "refs/heads/trunk")
+    settings = {
+        "core.autocrlf": "false",
+        "core.eol": "lf",
+        "core.filemode": "false",
+        "core.longpaths": "true",
+        "commit.gpgSign": "false",
+        "tag.gpgSign": "false",
+        "user.useConfigOnly": "true",
+    }
+    for key, value in settings.items():
+        git(repo, global_config, "config", "--local", key, value)
+    for path, data in sorted(model.files.items()):
+        write_file(repo, path, data)
+
+    commits: list[dict[str, object]] = []
+    commit_paths = sorted(model.files)
+    commit_id = commit_all(
+        repo,
+        global_config,
+        "fixture: initialize controlled graph",
+        history_timestamp(1),
+        commit_paths,
+        ("sfbench_fixture/ignored/marker.py",),
+    )
+    commits.append(commit_record(1, commit_id, "fixture: initialize controlled graph", commit_paths, [], False))
+
+    source = repo / "sfbench_fixture/history/source.py"
+    test = repo / "sfbench_fixture/history/test_source.py"
+    append_bytes(source, b"\nCOCHANGE_EVENTS.append(\"one\")\n")
+    append_bytes(test, b"\nCOCHANGE_TEST_EVENTS.append(\"one\")\n")
+    paths = ["sfbench_fixture/history/source.py", "sfbench_fixture/history/test_source.py"]
+    commit_id = commit_all(repo, global_config, "history: source test cochange one", history_timestamp(2), paths)
+    commits.append(commit_record(2, commit_id, "history: source test cochange one", paths, [], True))
+
+    history_doc = repo / "docs/history.txt"
+    append_bytes(history_doc, b"unrelated-change-one\n")
+    paths = ["docs/history.txt"]
+    commit_id = commit_all(repo, global_config, "docs: unrelated history change", history_timestamp(3), paths)
+    commits.append(commit_record(3, commit_id, "docs: unrelated history change", paths, [], False))
+
+    append_bytes(source, b"\ndef sfbench_history_added() -> str:\n    return \"added\"\n")
+    append_bytes(test, b"\ndef test_history_added() -> None:\n    assert True\n")
+    paths = ["sfbench_fixture/history/source.py", "sfbench_fixture/history/test_source.py"]
+    commit_id = commit_all(repo, global_config, "history: add symbol with cochange two", history_timestamp(4), paths)
+    commits.append(commit_record(4, commit_id, "history: add symbol with cochange two", paths, [{"name": "sfbench_history_added", "change": "added", "kind": "fn"}], True))
+
+    replace_once(source, b'return "v1"', b'return "v2"')
+    replace_once(test, b'== "v1"', b'== "v2"')
+    paths = ["sfbench_fixture/history/source.py", "sfbench_fixture/history/test_source.py"]
+    commit_id = commit_all(repo, global_config, "history: modify symbol with cochange three", history_timestamp(5), paths)
+    commits.append(commit_record(5, commit_id, "history: modify symbol with cochange three", paths, [{"name": "sfbench_history_modified", "change": "modified", "kind": "fn"}], True))
+
+    removed = b'\ndef sfbench_history_removed() -> str:\n    return "remove-in-commit-six"\n'
+    replace_once(source, removed, b"")
+    append_bytes(history_doc, b"unrelated-change-two\n")
+    paths = ["docs/history.txt", "sfbench_fixture/history/source.py"]
+    commit_id = commit_all(repo, global_config, "history: remove symbol and unrelated change", history_timestamp(6), paths)
+    commits.append(commit_record(6, commit_id, "history: remove symbol and unrelated change", paths, [{"name": "sfbench_history_removed", "change": "removed", "kind": "fn"}], False))
+
+    append_bytes(source, b"\nCOCHANGE_EVENTS.append(\"four\")\n")
+    append_bytes(test, b"\nCOCHANGE_TEST_EVENTS.append(\"four\")\n")
+    paths = ["sfbench_fixture/history/source.py", "sfbench_fixture/history/test_source.py"]
+    commit_id = commit_all(repo, global_config, "history: source test cochange four", history_timestamp(7), paths)
+    commits.append(commit_record(7, commit_id, "history: source test cochange four", paths, [], True))
+
+    git(repo, global_config, "update-ref", "refs/bench/initial", str(commits[0]["commit"]))
+    git(repo, global_config, "update-ref", "refs/bench/cochange-2", str(commits[3]["commit"]))
+    git(repo, global_config, "update-ref", "refs/bench/pre-removal", str(commits[4]["commit"]))
+    git(repo, global_config, "update-ref", "refs/tags/sfbench-v1", str(commits[6]["commit"]))
+    head_refs = git(repo, global_config, "for-each-ref", "--format=%(refname)", "refs/heads").decode("utf-8").splitlines()
+    if head_refs != ["refs/heads/trunk"]:
+        raise RuntimeError(f"unexpected branch refs: {head_refs!r}")
+    if git(repo, global_config, "status", "--porcelain=v1"):
+        raise RuntimeError("clean control repository unexpectedly dirty")
+    return commits
+
+
+def commit_record(
+    sequence: int,
+    commit: str,
+    message: str,
+    changed_paths: list[str],
+    symbol_changes: list[dict[str, str]],
+    source_test_cochange: bool,
+) -> dict[str, object]:
+    return {
+        "sequence": sequence,
+        "commit": commit,
+        "message": message,
+        "timestamp": history_timestamp(sequence),
+        "changed_paths": sorted(changed_paths),
+        "symbol_changes": symbol_changes,
+        "source_test_cochange": source_test_cochange,
+    }
+
+
+def prepare_dirty_repository(repo: Path, global_config: Path) -> dict[str, object]:
+    fixture = repo / "sfbench_fixture/worktree"
+    write_file(repo, "sfbench_fixture/worktree/staged.py", b'STATE = "staged"\n')
+    write_file(repo, "sfbench_fixture/worktree/staged_added.py", b'STATE = "staged-added"\n')
+    git(repo, global_config, "mv", "--", "sfbench_fixture/worktree/rename_from.py", "sfbench_fixture/worktree/rename_to.py")
+    git(repo, global_config, "add", "--", "sfbench_fixture/worktree/staged.py", "sfbench_fixture/worktree/staged_added.py")
+    write_file(repo, "sfbench_fixture/worktree/unstaged.py", b'STATE = "unstaged"\n')
+    (fixture / "deleted.py").unlink()
+    write_file(repo, "sfbench_fixture/worktree/untracked.py", b'STATE = "untracked"\n')
+    expected_status = sorted(
+        [
+            "M  sfbench_fixture/worktree/staged.py",
+            "A  sfbench_fixture/worktree/staged_added.py",
+            "R  sfbench_fixture/worktree/rename_from.py -> sfbench_fixture/worktree/rename_to.py",
+            " M sfbench_fixture/worktree/unstaged.py",
+            " D sfbench_fixture/worktree/deleted.py",
+            "?? sfbench_fixture/worktree/untracked.py",
+        ]
+    )
+    actual_status = sorted(git(repo, global_config, "status", "--porcelain=v1", "--untracked-files=all").decode("utf-8").splitlines())
+    if actual_status != expected_status:
+        raise RuntimeError(f"dirty worktree status mismatch: {actual_status!r}")
+    staged_diff = git(repo, global_config, "diff", "--cached", "--binary", "--no-ext-diff")
+    unstaged_diff = git(repo, global_config, "diff", "--binary", "--no-ext-diff")
+    return {
+        "status_porcelain_v1": expected_status,
+        "staged": {
+            "added": ["sfbench_fixture/worktree/staged_added.py"],
+            "modified": ["sfbench_fixture/worktree/staged.py"],
+            "renamed": [{"from": "sfbench_fixture/worktree/rename_from.py", "to": "sfbench_fixture/worktree/rename_to.py"}],
+            "diff_sha256": sha256(staged_diff),
+            "diff_bytes": len(staged_diff),
+        },
+        "unstaged": {
+            "modified": ["sfbench_fixture/worktree/unstaged.py"],
+            "deleted": ["sfbench_fixture/worktree/deleted.py"],
+            "diff_sha256": sha256(unstaged_diff),
+            "diff_bytes": len(unstaged_diff),
+        },
+        "untracked": ["sfbench_fixture/worktree/untracked.py"],
+    }
+
+
+def relative_files(root: Path) -> list[Path]:
+    result: list[Path] = []
+    for directory, directories, filenames in os.walk(root, followlinks=False):
+        directories[:] = sorted(name for name in directories if name != ".git" and not Path(directory, name).is_symlink())
+        for filename in sorted(filenames):
+            path = Path(directory, filename)
+            if ".git" not in path.relative_to(root).parts and not path.is_symlink():
+                result.append(path)
+    return sorted(result, key=lambda path: path.relative_to(root).as_posix())
+
+
+def line_ending(data: bytes) -> str:
+    if b"\x00" in data:
+        return "binary"
+    crlf = data.count(b"\r\n")
+    bare_lf = data.count(b"\n") - crlf
+    if crlf and bare_lf:
+        return "mixed"
+    if crlf:
+        return "CRLF"
+    if bare_lf:
+        return "LF"
+    return "none"
+
+
+def file_inventory(root: Path) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    for path in relative_files(root):
+        data = path.read_bytes()
+        relative = path.relative_to(root).as_posix()
+        result[relative] = {
+            "sha256": sha256(data),
+            "bytes": len(data),
+            "line_ending": line_ending(data),
+            "final_newline": data.endswith(b"\n"),
+            "binary": b"\x00" in data,
+        }
+    return result
+
+
+def inventory_tree_hash(inventory: dict[str, dict[str, object]]) -> str:
+    digest = hashlib.sha256()
+    for path, facts in sorted(inventory.items()):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(facts["sha256"]).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(facts["bytes"]).encode("ascii"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def locate_unique(data: bytes, needle: bytes, label: str) -> tuple[int, int, int, int]:
+    if data.count(needle) != 1:
+        raise RuntimeError(f"oracle locator is not unique: {label}")
+    start = data.index(needle)
+    end = start + len(needle)
+    start_line = data.count(b"\n", 0, start) + 1
+    end_line = data.count(b"\n", 0, max(start, end - 1)) + 1
+    return start, end, start_line, end_line
+
+
+def symbol_oracle(repo: Path, model: FixtureModel) -> dict[str, list[dict[str, object]]]:
+    result: dict[str, list[dict[str, object]]] = {}
+    for item in model.symbols:
+        data = (repo / item.path).read_bytes()
+        source = utf8(item.source)
+        start, end, start_line, end_line = locate_unique(data, source, f"{item.path}::{item.name}")
+        result.setdefault(item.language, []).append(
+            {
+                "name": item.name,
+                "kind": item.kind,
+                "path": item.path,
+                "start_line": start_line,
+                "end_line": end_line,
+                "start_byte": start,
+                "end_byte_exclusive": end,
+                "source_sha256": sha256(source),
+            }
+        )
+    for values in result.values():
+        values.sort(key=lambda value: (str(value["path"]), int(value["start_byte"]), str(value["name"])))
+    return result
+
+
+def import_oracle(repo: Path, model: FixtureModel) -> dict[str, list[dict[str, object]]]:
+    result: dict[str, list[dict[str, object]]] = {}
+    for item in model.imports:
+        data = (repo / item.from_path).read_bytes()
+        source = utf8(item.source)
+        start, end, start_line, end_line = locate_unique(data, source, f"import:{item.from_path}")
+        result.setdefault(item.language, []).append(
+            {
+                "from_path": item.from_path,
+                "to_path": item.to_path,
+                "alias": item.alias,
+                "start_line": start_line,
+                "end_line": end_line,
+                "start_byte": start,
+                "end_byte_exclusive": end,
+            }
+        )
+    for values in result.values():
+        values.sort(key=lambda value: (str(value["from_path"]), int(value["start_byte"])))
+    return result
+
+
+def dependent_file_oracle(model: FixtureModel) -> dict[str, dict[str, list[str]]]:
+    result = {
+        language: {path: list(dependents) for path, dependents in paths.items()}
+        for language, paths in model.dependents.items()
+    }
+    for item in model.imports:
+        if item.to_path.startswith("stdlib:"):
+            continue
+        values = result.setdefault(item.language, {}).setdefault(item.to_path, [])
+        if item.from_path not in values:
+            values.append(item.from_path)
+    for paths in result.values():
+        for dependents in paths.values():
+            dependents.sort()
+    return result
+
+
+def all_occurrences(data: bytes, needle: bytes) -> list[int]:
+    offsets: list[int] = []
+    cursor = 0
+    while True:
+        found = data.find(needle, cursor)
+        if found < 0:
+            return offsets
+        offsets.append(found)
+        cursor = found + len(needle)
+
+
+def reference_oracle(
+    repo: Path,
+    model: FixtureModel,
+    symbols: dict[str, list[dict[str, object]]],
+) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    needle = utf8("sfbench_rename_me")
+    for language, caller_names in model.reference_callers.items():
+        language_symbols = symbols[language]
+        definition = next(value for value in language_symbols if value["name"] == "sfbench_rename_me")
+        path = str(definition["path"])
+        data = (repo / path).read_bytes()
+        code: list[dict[str, object]] = []
+        consumed = {int(definition["start_byte"]) + data[int(definition["start_byte"]):int(definition["end_byte_exclusive"])].index(needle)}
+        for caller in caller_names:
+            symbol = next(value for value in language_symbols if value["name"] == caller and value["path"] == path)
+            start = int(symbol["start_byte"])
+            end = int(symbol["end_byte_exclusive"])
+            span = data[start:end]
+            matches = all_occurrences(span, needle)
+            if len(matches) != 1:
+                raise RuntimeError(f"expected one rename reference in {language}::{caller}")
+            offset = start + matches[0]
+            consumed.add(offset)
+            code.append(
+                {
+                    "caller": "SfBenchWorker.run" if caller == "run" else caller,
+                    "path": path,
+                    "line": data.count(b"\n", 0, offset) + 1,
+                    "start_byte": offset,
+                    "end_byte_exclusive": offset + len(needle),
+                }
+            )
+        mentions = []
+        for offset in all_occurrences(data, needle):
+            if offset in consumed:
+                continue
+            mentions.append(
+                {
+                    "path": path,
+                    "line": data.count(b"\n", 0, offset) + 1,
+                    "start_byte": offset,
+                    "end_byte_exclusive": offset + len(needle),
+                }
+            )
+        if len(code) != 4 or len(mentions) != 2 or len(all_occurrences(data, needle)) != 7:
+            raise RuntimeError(f"rename reference invariant failed for {language}")
+        result[language] = {
+            "target": "sfbench_rename_me",
+            "definition": definition,
+            "code_references": sorted(code, key=lambda value: int(value["start_byte"])),
+            "comment_or_string_mentions": mentions,
+            "expected_code_reference_count": 4,
+            "expected_non_code_mention_count": 2,
+        }
+    return result
+
+
+def marker_oracle(repo: Path) -> dict[str, dict[str, object]]:
+    inventory = file_inventory(repo)
+    result: dict[str, dict[str, object]] = {}
+    for name, marker in MARKERS.items():
+        marker_bytes = utf8(marker)
+        paths = []
+        count = 0
+        for path in inventory:
+            data = (repo / path).read_bytes()
+            occurrences = data.count(marker_bytes)
+            if occurrences:
+                paths.append(path)
+                count += occurrences
+        result[name] = {"value": marker, "paths": sorted(paths), "occurrences": count}
+    return result
+
+
+def mutation_oracle(
+    repo: Path,
+    model: FixtureModel,
+    symbols: dict[str, list[dict[str, object]]],
+    references: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    cases: dict[str, object] = {}
+    old = utf8(MARKERS["edit_old"])
+    new = utf8(MARKERS["edit_new"])
+    for language, bodies in model.mutation_bodies.items():
+        language_symbols = symbols[language]
+        mutable = next(value for value in language_symbols if value["name"] == "sfbench_mutable")
+        leaf = next(value for value in language_symbols if value["name"] == "sfbench_leaf")
+        delete = next(value for value in language_symbols if value["name"] == "sfbench_delete_me")
+        path = str(mutable["path"])
+        before = (repo / path).read_bytes()
+        mutable_start = int(mutable["start_byte"])
+        mutable_end = int(mutable["end_byte_exclusive"])
+        mutable_bytes = before[mutable_start:mutable_end]
+        if mutable_bytes.count(old) != 2 or before.count(old) != 3:
+            raise RuntimeError(f"edit literal invariant failed for {language}")
+        edited = before[:mutable_start] + mutable_bytes.replace(old, new) + before[mutable_end:]
+        leaf_start = int(leaf["start_byte"])
+        leaf_end = int(leaf["end_byte_exclusive"])
+        replaced = before[:leaf_start] + utf8(bodies["leaf_replacement"]) + before[leaf_end:]
+        delete_start = int(delete["start_byte"])
+        delete_end = int(delete["end_byte_exclusive"])
+        delete_prefix = before[:delete_start]
+        delete_suffix = before[delete_end:]
+        if not delete_prefix.endswith(b"\n\n") or not delete_suffix.startswith(b"\n\n"):
+            raise RuntimeError(f"delete symbol spacing invariant failed for {language}")
+        deleted = delete_prefix + delete_suffix[2:]
+        rename_target = b"sfbench_rename_me"
+        rename_replacement = b"sfbench_renamed"
+        definition = references[language]["definition"]
+        definition_start = int(definition["start_byte"])
+        definition_end = int(definition["end_byte_exclusive"])
+        definition_offset = definition_start + before[definition_start:definition_end].index(rename_target)
+        rename_offsets = [definition_offset]
+        rename_offsets.extend(int(value["start_byte"]) for value in references[language]["code_references"])
+        renamed = before
+        for offset in sorted(rename_offsets, reverse=True):
+            if renamed[offset : offset + len(rename_target)] != rename_target:
+                raise RuntimeError(f"rename offset invariant failed for {language}")
+            renamed = renamed[:offset] + rename_replacement + renamed[offset + len(rename_target):]
+        if renamed.count(rename_target) != 2 or renamed.count(rename_replacement) != 5:
+            raise RuntimeError(f"rename occurrence invariant failed for {language}")
+        cases[language] = {
+            "path": path,
+            "edit_within": {
+                "symbol": "sfbench_mutable",
+                "old_text": MARKERS["edit_old"],
+                "new_text": MARKERS["edit_new"],
+                "replace_all": True,
+                "inside_occurrences": 2,
+                "outside_occurrences_unchanged": 1,
+                "before_sha256": sha256(before),
+                "after_sha256": sha256(edited),
+                "diff_sha256": unified_diff_hash(path, before, edited),
+            },
+            "replace_symbol": {
+                "symbol": "sfbench_leaf",
+                "new_body": bodies["leaf_replacement"],
+                "before_sha256": sha256(before),
+                "after_sha256": sha256(replaced),
+                "diff_sha256": unified_diff_hash(path, before, replaced),
+            },
+            "delete_symbol": {
+                "symbol": "sfbench_delete_me",
+                "before_sha256": sha256(before),
+                "after_sha256": sha256(deleted),
+                "diff_sha256": unified_diff_hash(path, before, deleted),
+            },
+            "rename_symbol": {
+                "name": "sfbench_rename_me",
+                "new_name": "sfbench_renamed",
+                "changed_code_occurrences": 5,
+                "unchanged_comment_or_string_mentions": 2,
+                "before_sha256": sha256(before),
+                "after_sha256": sha256(renamed),
+                "diff_sha256": unified_diff_hash(path, before, renamed),
+            },
+            "insert_symbol": {
+                "anchor": "sfbench_entry",
+                "position": "after",
+                "body": bodies["insert_after_entry"],
+            },
+        }
+    stale_path = "sfbench_fixture/worktree/stale_target.py"
+    before = (repo / stale_path).read_bytes()
+    after = b'STALE_STATE = "after-fetch"\n'
+    cases["stale_index"] = {
+        "path": stale_path,
+        "before_sha256": sha256(before),
+        "after_sha256": sha256(after),
+        "after_bytes_utf8": after.decode("utf-8"),
+        "sequence": ["fetch", "write_after_bytes", "query_without_refresh", "query_with_force_refresh"],
+    }
+    return cases
+
+
+def unified_diff_hash(path: str, before: bytes, after: bytes) -> str:
+    before_lines = before.decode("utf-8").splitlines(keepends=True)
+    after_lines = after.decode("utf-8").splitlines(keepends=True)
+    diff = "".join(difflib.unified_diff(before_lines, after_lines, fromfile=f"a/{path}", tofile=f"b/{path}", lineterm="\n"))
+    return sha256(utf8(diff))
+
+
+def config_oracle(repo: Path) -> dict[str, dict[str, object]]:
+    expectations: dict[str, tuple[bool, int | None]] = {
+        "sfbench_fixture/configs/valid.json": (True, None),
+        "sfbench_fixture/configs/malformed.json": (False, 3),
+        "sfbench_fixture/configs/valid.toml": (True, None),
+        "sfbench_fixture/configs/malformed.toml": (False, 2),
+        "sfbench_fixture/configs/valid.yaml": (True, None),
+        "sfbench_fixture/configs/malformed.yaml": (False, 4),
+        "sfbench_fixture/configs/bom_crlf_unicode.json": (True, None),
+    }
+    result = {}
+    for path, (valid, diagnostic_line) in expectations.items():
+        data = (repo / path).read_bytes()
+        result[path] = {
+            "valid": valid,
+            "diagnostic_line": diagnostic_line,
+            "sha256": sha256(data),
+            "bytes": len(data),
+            "line_ending": line_ending(data),
+        }
+    json.loads((repo / "sfbench_fixture/configs/valid.json").read_text(encoding="utf-8"))
+    try:
+        json.loads((repo / "sfbench_fixture/configs/malformed.json").read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        if error.lineno != 3:
+            raise RuntimeError("malformed JSON diagnostic moved") from error
+    else:
+        raise RuntimeError("malformed JSON unexpectedly parsed")
+    tomllib.loads((repo / "sfbench_fixture/configs/valid.toml").read_text(encoding="utf-8"))
+    try:
+        tomllib.loads((repo / "sfbench_fixture/configs/malformed.toml").read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        pass
+    else:
+        raise RuntimeError("malformed TOML unexpectedly parsed")
+    return result
+
+
+def create_non_git(root: Path) -> dict[str, object]:
+    root.mkdir()
+    write_file(root, "plain.py", b'def sfbench_non_git():\n    return "plain"\n')
+    write_file(root, "nested/config.json", b'{"non_git": true}\n')
+    inventory = file_inventory(root)
+    return {"path": "non-git", "tree_sha256": inventory_tree_hash(inventory), "files": inventory}
+
+
+def create_symlink_cohort(root: Path) -> dict[str, object]:
+    root.mkdir()
+    write_file(root, "target.txt", b"symlink-target\n")
+    (root / "loop-a").mkdir()
+    (root / "loop-b").mkdir()
+    links = [
+        (root / "file-link", "target.txt", False),
+        (root / "loop-a" / "to-b", "../loop-b", True),
+        (root / "loop-b" / "to-a", "../loop-a", True),
+    ]
+    created: list[Path] = []
+    try:
+        for path, target, is_directory in links:
+            os.symlink(target, path, target_is_directory=is_directory)
+            created.append(path)
+    except OSError:
+        for path in reversed(created):
+            path.unlink()
+        return {"path": "symlink-cohort", "supported": False, "links": []}
+    return {
+        "path": "symlink-cohort",
+        "supported": True,
+        "links": [
+            {"path": path.relative_to(root).as_posix(), "target": target, "directory": is_directory}
+            for path, target, is_directory in links
+        ],
+    }
+
+
+def repository_refs(repo: Path, global_config: Path) -> dict[str, str]:
+    refs = [
+        "refs/heads/trunk",
+        "refs/bench/initial",
+        "refs/bench/cochange-2",
+        "refs/bench/pre-removal",
+        "refs/tags/sfbench-v1",
+    ]
+    return {name: git(repo, global_config, "rev-parse", name).decode("ascii").strip() for name in refs}
+
+
+def write_oracle(
+    output: Path,
+    model: FixtureModel,
+    commits: list[dict[str, object]],
+    dirty: dict[str, object],
+    non_git: dict[str, object],
+    symlinks: dict[str, object],
+    global_config: Path,
+) -> dict[str, object]:
+    clean_repo = output / "control-repo"
+    mutation_repo = output / "mutation-repo"
+    clean_inventory = file_inventory(clean_repo)
+    dirty_inventory = file_inventory(mutation_repo)
+    symbols = symbol_oracle(clean_repo, model)
+    refs = repository_refs(clean_repo, global_config)
+    imports = import_oracle(clean_repo, model)
+    references = reference_oracle(clean_repo, model, symbols)
+    head = str(commits[-1]["commit"])
+    mutation_head = git(mutation_repo, global_config, "rev-parse", "HEAD").decode("ascii").strip()
+    if mutation_head != head:
+        raise RuntimeError("independent repository histories are not identical")
+    exact_paths = [
+        "sfbench_fixture/exact/lf_source.py",
+        "sfbench_fixture/exact/crlf_source.py",
+        "sfbench_fixture/exact/no_final_newline.py",
+        "sfbench_fixture/exact/deterministic.bin",
+        "sfbench_fixture/configs/bom_crlf_unicode.json",
+    ]
+    oracle: dict[str, object] = {
+        "protocol": PROTOCOL_ID,
+        "fixture": {
+            "version": FIXTURE_VERSION,
+            "frozen_at": "2026-07-12",
+            "generator_sha256": sha256(Path(__file__).read_bytes()),
+            "encoding": "UTF-8 unless a file is explicitly binary",
+            "path_style": "POSIX-relative",
+            "oracle_source": "fixture templates and Python hashlib; never SymForge output",
+        },
+        "paths": {
+            "clean_repository": "control-repo",
+            "mutation_repository": "mutation-repo",
+            "non_git_directory": "non-git",
+            "symlink_cohort": "symlink-cohort",
+        },
+        "repositories": {
+            "clean": {
+                "path": "control-repo",
+                "branch": "trunk",
+                "head": head,
+                "main_ref_absent": True,
+                "clean": True,
+                "tree_sha256": inventory_tree_hash(clean_inventory),
+                "file_count": len(clean_inventory),
+                "source_bytes": sum(int(value["bytes"]) for value in clean_inventory.values()),
+            },
+            "mutation": {
+                "path": "mutation-repo",
+                "branch": "trunk",
+                "head": mutation_head,
+                "independent_object_database": True,
+                "clean": False,
+                "tree_sha256": inventory_tree_hash(dirty_inventory),
+                "file_count": len(dirty_inventory),
+                "source_bytes": sum(int(value["bytes"]) for value in dirty_inventory.values()),
+            },
+        },
+        "files": clean_inventory,
+        "exact_byte_files": {path: clean_inventory[path] for path in exact_paths},
+        "languages": {
+            "Rust": {"root": "sfbench_fixture/rust", "extension": ".rs"},
+            "Python": {"root": "sfbench_fixture/python", "extension": ".py"},
+            "TypeScript": {"root": "sfbench_fixture/typescript", "extension": ".ts"},
+            "Go": {"root": "sfbench_fixture/go", "extension": ".go"},
+            "Java": {"root": "sfbench_fixture/java", "extension": ".java"},
+            "C++": {"root": "sfbench_fixture/cpp", "extension": ".cpp/.hpp"},
+            "Perl": {"root": "sfbench_fixture/perl", "extension": ".pm/.t"},
+        },
+        "symbols": symbols,
+        "references": references,
+        "graphs": {
+            "call_edges": {key: [{"caller": caller, "callee": callee} for caller, callee in value] for key, value in model.call_edges.items()},
+            "recursive_custom_type_cycles": {
+                language: ["CycleA", "CycleB", "CycleA"] for language in model.call_edges
+            },
+            "import_cycles": {
+                "Rust": ["cycle_a.rs", "cycle_b.rs", "cycle_a.rs"],
+                "Python": ["cycle_a.py", "cycle_b.py", "cycle_a.py"],
+                "TypeScript": ["cycle_a.ts", "cycle_b.ts", "cycle_a.ts"],
+                "C++": ["cycle_a.hpp", "cycle_b.hpp", "cycle_a.hpp"],
+                "Perl": ["CycleA.pm", "CycleB.pm", "CycleA.pm"],
+            },
+        },
+        "imports": imports,
+        "implementors": model.implementors,
+        "dependent_files": dependent_file_oracle(model),
+        "markers": marker_oracle(clean_repo),
+        "configs": config_oracle(clean_repo),
+        "large_file": {
+            "path": "sfbench_fixture/generated/large_generated.py",
+            "minimum_bytes_exclusive": 60 * 1024,
+            "actual_bytes": clean_inventory["sfbench_fixture/generated/large_generated.py"]["bytes"],
+            "sha256": clean_inventory["sfbench_fixture/generated/large_generated.py"]["sha256"],
+            "result_symbol_count": 1400,
+            "anchors": ["SF_BENCH_LARGE_START_9F31", "SF_BENCH_LARGE_MIDDLE_9F31", "SF_BENCH_LARGE_END_9F31"],
+            "search_marker": MARKERS["ccr"],
+        },
+        "duplicate_basenames": {
+            language: sorted(
+                value["path"]
+                for value in symbols[language]
+                if value["name"] == "sfbench_duplicate"
+            )
+            for language in symbols
+        },
+        "history": {
+            "commit_count": 7,
+            "source_test_cochange_count": sum(bool(value["source_test_cochange"]) for value in commits),
+            "commits": commits,
+            "refs": refs,
+            "default_comparison_ref": "trunk",
+        },
+        "worktree": dirty,
+        "mutations": mutation_oracle(clean_repo, model, symbols, references),
+        "non_git": non_git,
+        "symlinks": symlinks,
+    }
+    encoded = utf8(json.dumps(oracle, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+    (output / "oracle.json").write_bytes(encoded)
+    return oracle
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_root", type=Path, help="new directory outside the SymForge checkout")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    output = args.output_root.expanduser().resolve(strict=False)
+    project_root = Path(__file__).resolve().parents[2]
+    if output == project_root or output.is_relative_to(project_root):
+        raise SystemExit("refusing output inside the SymForge checkout")
+    if os.path.lexists(output):
+        raise SystemExit(f"refusing existing output root: {output}")
+    output.mkdir(parents=True)
+    global_config = output / "gitconfig.empty"
+    global_config.write_bytes(b"")
+    template_dir = output / "git-template.empty"
+    template_dir.mkdir()
+    model = build_model()
+    commits = build_repository(output / "control-repo", model, global_config, template_dir)
+    mutation_commits = build_repository(output / "mutation-repo", model, global_config, template_dir)
+    if [value["commit"] for value in commits] != [value["commit"] for value in mutation_commits]:
+        raise RuntimeError("independent commit graphs differ")
+    dirty = prepare_dirty_repository(output / "mutation-repo", global_config)
+    non_git = create_non_git(output / "non-git")
+    symlinks = create_symlink_cohort(output / "symlink-cohort")
+    oracle = write_oracle(output, model, commits, dirty, non_git, symlinks, global_config)
+    summary = {
+        "protocol": PROTOCOL_ID,
+        "output_root": str(output),
+        "oracle_sha256": sha256((output / "oracle.json").read_bytes()),
+        "clean_tree_sha256": oracle["repositories"]["clean"]["tree_sha256"],
+        "mutation_tree_sha256": oracle["repositories"]["mutation"]["tree_sha256"],
+        "head": oracle["repositories"]["clean"]["head"],
+    }
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/full-surface-benchmark/happy-v2-evaluator.json
+++ b/research/full-surface-benchmark/happy-v2-evaluator.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": "SFBENCH-adjudication-decisions-1",
+  "evidence_artifact": {
+    "name": "formal-happy-v2-20260712.jsonl",
+    "sha256": "4f3418ce3b949c9e504a936fd34a56a3c527571323f57753998ddbaac919dee1"
+  },
+  "cases": {
+    "SF-analyze_file_impact-001": {
+      "status": "fail",
+      "checks": [{"id": "same-file-dependent", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-analyze_file_impact-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-ask-001": {
+      "status": "pass",
+      "checks": [{"id": "route-and-answer", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-ask-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-batch_edit-001": {
+      "status": "pass",
+      "checks": [{"id": "patch-hash-and-replay", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-batch_edit-001:rep1-3", "baseline-patches.json:SF-batch_edit-001"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-batch_insert-001": {
+      "status": "fail",
+      "checks": [{"id": "exact-inserted-bytes", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-batch_insert-001:rep1-3", "baseline-patches.json:SF-batch_insert-001"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-batch_rename-001": {
+      "status": "pass",
+      "checks": [{"id": "exact-bound-sites", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-batch_rename-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-checkpoint_now-001": {
+      "status": "pass",
+      "checks": [{"id": "write-verify-restore", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-checkpoint_now-001:rep1-5"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "pass"
+    },
+    "SF-context_inventory-001": {
+      "status": "manual_pending",
+      "checks": [{"id": "fresh-session-inventory", "status": "manual_pending", "evidence": ["runner preflight populated the measured session before SF-context_inventory-001"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "manual_pending"
+    },
+    "SF-conventions-001": {
+      "status": "manual_pending",
+      "checks": [{"id": "project-convention-rubric", "status": "manual_pending", "evidence": ["formal-happy-v2-20260712:SF-conventions-001:rep1-3", "no frozen semantic scoring rubric"]}],
+      "baseline_equivalence": "invalid",
+      "baseline_correctness": "fail"
+    },
+    "SF-delete_symbol-001": {
+      "status": "pass",
+      "checks": [{"id": "patch-hash-and-replay", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-delete_symbol-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-detect_impact-001": {
+      "status": "fail",
+      "checks": [{"id": "changed-symbol-and-blast-set", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-detect_impact-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-diff_symbols-001": {
+      "status": "pass",
+      "checks": [{"id": "symbol-delta", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-diff_symbols-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-edit_plan-001": {
+      "status": "pass",
+      "checks": [{"id": "target-reference-sequence", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-edit_plan-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-edit_within_symbol-001": {
+      "status": "pass",
+      "checks": [{"id": "bounded-edit-and-replay", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-edit_within_symbol-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-explore-001": {
+      "status": "manual_pending",
+      "checks": [{"id": "concept-ranking-rubric", "status": "manual_pending", "evidence": ["formal-happy-v2-20260712:SF-explore-001:rep1-3", "no frozen relevance-grade rubric"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "manual_pending"
+    },
+    "SF-find_dependents-001": {
+      "status": "fail",
+      "checks": [{"id": "python-relative-import", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-find_dependents-001:rep1-3", "oracle.json:dependent_files.Python"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-find_references-001": {
+      "status": "fail",
+      "checks": [{"id": "matching-local-project-selector", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-find_references-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-get_file_content-001": {
+      "status": "pass",
+      "checks": [{"id": "exact-bytes-and-pagination", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-get_file_content-001:rep1-3"]}],
+      "baseline_equivalence": "invalid",
+      "baseline_correctness": "fail"
+    },
+    "SF-get_file_context-001": {
+      "status": "fail",
+      "checks": [{"id": "exact-file-context-sets", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-get_file_context-001:rep1-3", "oracle.json:dependent_files.Python"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-get_repo_map-001": {
+      "status": "pass",
+      "checks": [{"id": "inventory-counts", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-get_repo_map-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-get_symbol-001": {
+      "status": "pass",
+      "checks": [{"id": "exact-symbol-body-and-span", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-get_symbol-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-get_symbol_context-001": {
+      "status": "fail",
+      "checks": [{"id": "resolved-project-call-graph", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-get_symbol_context-001:rep1-3", "oracle.json:graphs.call_edges.Rust"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-health-001": {
+      "status": "fail",
+      "checks": [{"id": "snapshot-admission-parity", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-health-001:rep1-5"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "pass"
+    },
+    "SF-health_compact-001": {
+      "status": "pass",
+      "checks": [{"id": "same-session-full-parity", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-health_compact-001:rep1-3"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "pass"
+    },
+    "SF-index_folder-001": {
+      "status": "fail",
+      "checks": [{"id": "identity-counts-and-replay-evidence", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-index_folder-001:rep1-5"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "pass"
+    },
+    "SF-insert_symbol-001": {
+      "status": "fail",
+      "checks": [{"id": "exact-inserted-bytes", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-insert_symbol-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-inspect_match-001": {
+      "status": "pass",
+      "checks": [{"id": "nested-enclosure", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-inspect_match-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-investigation_suggest-001": {
+      "status": "fail",
+      "checks": [{"id": "unloaded-call-graph-suggestions", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-investigation_suggest-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-replace_symbol_body-001": {
+      "status": "pass",
+      "checks": [{"id": "patch-hash-and-replay", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-replace_symbol_body-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-search_files-001": {
+      "status": "pass",
+      "checks": [{"id": "duplicate-paths-and-ranking", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-search_files-001:rep1-3"]}],
+      "baseline_equivalence": "invalid",
+      "baseline_correctness": "fail"
+    },
+    "SF-search_symbols-001": {
+      "status": "fail",
+      "checks": [{"id": "matching-local-project-selector", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-search_symbols-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-search_text-001": {
+      "status": "fail",
+      "checks": [{"id": "matching-local-project-selector", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-search_text-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-status-001": {
+      "status": "fail",
+      "checks": [{"id": "manifest-and-runtime-identity", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-status-001:rep1-3"]}],
+      "baseline_equivalence": "capability_only",
+      "baseline_correctness": "pass"
+    },
+    "SF-symforge_edit-001": {
+      "status": "fail",
+      "checks": [{"id": "same-key-replay", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-symforge_edit-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-symforge_retrieve-001": {
+      "status": "pass",
+      "checks": [{"id": "stored-payload-hash-and-repeat", "status": "pass", "evidence": ["formal-happy-v2-20260712:SF-symforge_retrieve-001:rep1-3"]}],
+      "baseline_equivalence": "invalid",
+      "baseline_correctness": "fail"
+    },
+    "SF-validate_file_syntax-001": {
+      "status": "fail",
+      "checks": [{"id": "malformed-json-rejection", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-validate_file_syntax-001:rep1-3"]}],
+      "baseline_equivalence": "valid",
+      "baseline_correctness": "pass"
+    },
+    "SF-what_changed-001": {
+      "status": "fail",
+      "checks": [{"id": "git-status-and-rename-fidelity", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-what_changed-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    },
+    "SF-symforge-001": {
+      "status": "fail",
+      "checks": [{"id": "intent-route-and-fact-parity", "status": "fail", "evidence": ["formal-happy-v2-20260712:SF-symforge-001:rep1-3"]}],
+      "baseline_equivalence": "lower_bound",
+      "baseline_correctness": "pass"
+    }
+  }
+}

--- a/research/full-surface-benchmark/mcp_harness.py
+++ b/research/full-surface-benchmark/mcp_harness.py
@@ -1,0 +1,1746 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "tiktoken==0.13.0",
+# ]
+# ///
+"""Sanitized stdio MCP capture harness for SFBENCH-1.0.
+
+Run with ``uv run mcp_harness.py --help``.  The harness deliberately supports
+stdio only.  Streamable HTTP parity should use the official MCP Python SDK in a
+separate runner instead of approximating the protocol here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import queue
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import tiktoken
+except ImportError:  # pragma: no cover - exercised only when not run through uv
+    tiktoken = None  # type: ignore[assignment]
+
+
+PROTOCOL_ID = "SFBENCH-1.0"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+REDACTED = "<redacted>"
+EXPECTED_TIKTOKEN_VERSION = "0.13.0"
+EXPECTED_VOCABULARY_SHA256 = {
+    "cl100k": "83d6504082a038c7aa769af6e2808471f94bf303ac150db2060cfc2a57020aa4",
+    "o200k": "5d2372a38d68a4f7d6b65369719645d2aad38694af99b2a5274f5649ca47f591",
+}
+EXPECTED_TOOLS = {
+    "full": {
+        "analyze_file_impact",
+        "ask",
+        "batch_edit",
+        "batch_insert",
+        "batch_rename",
+        "checkpoint_now",
+        "context_inventory",
+        "conventions",
+        "delete_symbol",
+        "detect_impact",
+        "diff_symbols",
+        "edit_plan",
+        "edit_within_symbol",
+        "explore",
+        "find_dependents",
+        "find_references",
+        "get_file_content",
+        "get_file_context",
+        "get_repo_map",
+        "get_symbol",
+        "get_symbol_context",
+        "health",
+        "health_compact",
+        "index_folder",
+        "insert_symbol",
+        "inspect_match",
+        "investigation_suggest",
+        "replace_symbol_body",
+        "search_files",
+        "search_symbols",
+        "search_text",
+        "status",
+        "symforge_edit",
+        "symforge_retrieve",
+        "validate_file_syntax",
+        "what_changed",
+    },
+    "compact": {"status", "symforge", "symforge_edit"},
+    "meta": {"symforge"},
+}
+LIST_METHODS = (
+    ("tools/list", "tools"),
+    ("resources/list", "resources"),
+    ("resources/templates/list", "resourceTemplates"),
+    ("prompts/list", "prompts"),
+)
+
+
+class HarnessError(RuntimeError):
+    """An expected, safe-to-display harness failure."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def wire_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":")) + "\n"
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class TokenCounter:
+    """Count the same text independently with cl100k_base and o200k_base."""
+
+    def __init__(self) -> None:
+        if tiktoken is None:
+            raise HarnessError(
+                "tiktoken is unavailable; run this PEP 723 script with `uv run`."
+            )
+        if getattr(tiktoken, "__version__", None) != EXPECTED_TIKTOKEN_VERSION:
+            raise HarnessError(
+                f"campaign requires tiktoken {EXPECTED_TIKTOKEN_VERSION}"
+            )
+        self.encodings = {
+            "cl100k": tiktoken.get_encoding("cl100k_base"),
+            "o200k": tiktoken.get_encoding("o200k_base"),
+        }
+        self.vocabulary_hashes = {
+            name: self._encoding_hash(encoding)
+            for name, encoding in self.encodings.items()
+        }
+        if self.vocabulary_hashes != EXPECTED_VOCABULARY_SHA256:
+            raise HarnessError(
+                "tokenizer vocabulary does not match the frozen campaign"
+            )
+
+    def metrics(self, text: str, *, byte_length: int | None = None) -> dict[str, int]:
+        return {
+            "utf8_bytes": (
+                len(text.encode("utf-8")) if byte_length is None else byte_length
+            ),
+            "cl100k": len(self.encodings["cl100k"].encode(text, disallowed_special=())),
+            "o200k": len(self.encodings["o200k"].encode(text, disallowed_special=())),
+        }
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "package": "tiktoken",
+            "version": EXPECTED_TIKTOKEN_VERSION,
+            "encodings": {
+                name: {
+                    "name": encoding.name,
+                    "vocabulary_sha256": self.vocabulary_hashes[name],
+                }
+                for name, encoding in self.encodings.items()
+            },
+        }
+
+    @staticmethod
+    def _encoding_hash(encoding: Any) -> str | None:
+        """Hash tokenizer tables without relying on a cache-file location."""
+        ranks = getattr(encoding, "_mergeable_ranks", None)
+        special = getattr(encoding, "_special_tokens", None)
+        if not isinstance(ranks, dict) or not isinstance(special, dict):
+            return None
+        digest = hashlib.sha256()
+        for token, rank in sorted(ranks.items(), key=lambda item: item[1]):
+            digest.update(int(rank).to_bytes(8, "big", signed=False))
+            digest.update(len(token).to_bytes(8, "big", signed=False))
+            digest.update(token)
+        for token, rank in sorted(special.items()):
+            encoded = token.encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big", signed=False))
+            digest.update(encoded)
+            digest.update(int(rank).to_bytes(8, "big", signed=False))
+        return digest.hexdigest()
+
+
+class Sanitizer:
+    """Redact secret-shaped values while retaining rule/location evidence."""
+
+    _sensitive_name_pattern = r"""
+        (?:
+            [a-z][a-z0-9]*(?:[_-](?:token|key|secret|password|passwd)) |
+            (?:api|access|refresh|auth|client|private)[_-]?
+                (?:key|token|secret|password) |
+            password | passwd | authorization | credential | cookie
+        )
+    """
+    _quoted_assignments = (
+        r"""(?ix)
+        (?P<prefix>
+            \b"""
+        + _sensitive_name_pattern
+        + r"""\b\s*(?:=|:)\s*
+        )
+        (?P<quote>")(?P<value>(?:\\.|[^"\\])*)(?P=quote)
+        """,
+        r"""(?ix)
+        (?P<prefix>
+            \b"""
+        + _sensitive_name_pattern
+        + r"""\b\s*(?:=|:)\s*
+        )
+        (?P<quote>')(?P<value>(?:\\.|[^'\\])*)(?P=quote)
+        """,
+    )
+    _quoted_assignments = (
+        re.compile(_quoted_assignments[0]),
+        re.compile(_quoted_assignments[1]),
+    )
+    _bare_assignment = re.compile(
+        r"""(?ix)
+        (?P<prefix>
+            \b"""
+        + _sensitive_name_pattern
+        + r"""\b\s*(?:=|:)\s*
+        )
+        (?P<quote>)
+        (?P<value>[^\s\\"',;}\]]+)
+        (?P=quote)
+        """
+    )
+    _bearer = re.compile(
+        r"(?i)(?P<prefix>\b(?:authorization\s*:\s*)?bearer\s+)"
+        r"(?P<value>[A-Za-z0-9._~+/=-]{8,})"
+    )
+    _credentialed_url = re.compile(
+        r"(?i)(?P<prefix>[a-z][a-z0-9+.-]*://[^/\s:@]+:)"
+        r"(?P<value>[^@\s/]+)(?P<suffix>@)"
+    )
+    _private_key = re.compile(
+        r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?"
+        r"-----END [A-Z0-9 ]*PRIVATE KEY-----"
+    )
+    _unterminated_private_key = re.compile(
+        r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*\Z"
+    )
+    _known_tokens = (
+        re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+        re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+        re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        re.compile(
+            r"\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\."
+            r"[A-Za-z0-9_-]{16,}\b"
+        ),
+    )
+
+    def __init__(self) -> None:
+        self._events: list[dict[str, str]] = []
+        self._lock = threading.Lock()
+
+    def event_count(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def events_since(self, offset: int) -> list[dict[str, str]]:
+        with self._lock:
+            return [dict(event) for event in self._events[offset:]]
+
+    def _record(self, rule: str, location: str) -> None:
+        with self._lock:
+            self._events.append({"rule": rule, "location": location})
+
+    @staticmethod
+    def _sensitive_key(key: str) -> bool:
+        normalized = key.lower().replace("-", "_")
+        parts = normalized.split("_")
+        if normalized in {
+            "authorization",
+            "cookie",
+            "credential",
+            "credentials",
+            "password",
+            "passwd",
+            "pwd",
+            "secret",
+            "token",
+        }:
+            return True
+        if len(parts) > 1 and parts[-1] in {
+            "key",
+            "password",
+            "passwd",
+            "secret",
+            "token",
+        }:
+            return True
+        collapsed = re.sub(r"[^A-Za-z0-9]", "", key)
+        return bool(
+            re.search(
+                r"(?:api|access|refresh|auth|client|private)"
+                r"(?:key|token|secret|password)$",
+                collapsed,
+                re.IGNORECASE,
+            )
+        )
+
+    @classmethod
+    def _sensitive_cli_flag(cls, value: str) -> bool:
+        flag = value.strip().split("=", 1)[0]
+        return flag.startswith("-") and cls._sensitive_key(flag.lstrip("-"))
+
+    def sanitize_text(self, text: str, location: str) -> str:
+        def located(rule: str, start: int) -> None:
+            line = text.count("\n", 0, start) + 1
+            self._record(rule, f"{location}:line:{line}")
+
+        def assignment_replacement(match: re.Match[str]) -> str:
+            if match.group("value") in {"", REDACTED, "null", "None"}:
+                return match.group(0)
+            located("secret_name_assignment", match.start())
+            quote = match.group("quote")
+            return f"{match.group('prefix')}{quote}{REDACTED}{quote}"
+
+        sanitized = text
+        for pattern in self._quoted_assignments:
+            sanitized = pattern.sub(assignment_replacement, sanitized)
+        sanitized = self._bare_assignment.sub(assignment_replacement, sanitized)
+
+        def bearer_replacement(match: re.Match[str]) -> str:
+            located("bearer_token", match.start())
+            return f"{match.group('prefix')}{REDACTED}"
+
+        sanitized = self._bearer.sub(bearer_replacement, sanitized)
+
+        def url_replacement(match: re.Match[str]) -> str:
+            located("credentialed_url", match.start())
+            return f"{match.group('prefix')}{REDACTED}{match.group('suffix')}"
+
+        sanitized = self._credentialed_url.sub(url_replacement, sanitized)
+
+        def private_key_replacement(match: re.Match[str]) -> str:
+            located("private_key", match.start())
+            return REDACTED
+
+        sanitized = self._private_key.sub(private_key_replacement, sanitized)
+        sanitized = self._unterminated_private_key.sub(
+            private_key_replacement, sanitized
+        )
+
+        for pattern in self._known_tokens:
+
+            def known_replacement(
+                match: re.Match[str], *, _pattern: Any = pattern
+            ) -> str:
+                del _pattern
+                located("known_token_shape", match.start())
+                return REDACTED
+
+            sanitized = pattern.sub(known_replacement, sanitized)
+        return sanitized
+
+    def sanitize_obj(self, value: Any, location: str = "record") -> Any:
+        if isinstance(value, dict):
+            result: dict[str, Any] = {}
+            for key, child in value.items():
+                key_text = str(key)
+                child_location = f"{location}.{key_text}"
+                if self._sensitive_key(key_text) and not isinstance(child, dict):
+                    already_safe = child is None or child == REDACTED
+                    if isinstance(child, list):
+                        already_safe = all(
+                            item is None or item == REDACTED for item in child
+                        )
+                    if already_safe:
+                        result[key_text] = child
+                        continue
+                    self._record("secret_named_field", f"{child_location}:line:1")
+                    if isinstance(child, list):
+                        result[key_text] = [REDACTED for _ in child]
+                    elif child is None:
+                        result[key_text] = None
+                    else:
+                        result[key_text] = REDACTED
+                else:
+                    result[key_text] = self.sanitize_obj(child, child_location)
+            return result
+        if isinstance(value, list):
+            result: list[Any] = []
+            redact_next = False
+            for index, child in enumerate(value):
+                child_location = f"{location}[{index}]"
+                if redact_next:
+                    if child is None or child == REDACTED:
+                        result.append(child)
+                    else:
+                        self._record("split_cli_secret", f"{child_location}:line:1")
+                        result.append(REDACTED)
+                    redact_next = False
+                    continue
+                result.append(self.sanitize_obj(child, child_location))
+                if isinstance(child, str) and self._sensitive_cli_flag(child):
+                    redact_next = "=" not in child
+            return result
+        if isinstance(value, str):
+            return self.sanitize_text(value, location)
+        return value
+
+
+class JsonlWriter:
+    def __init__(
+        self,
+        path: pathlib.Path,
+        sanitizer: Sanitizer,
+        *,
+        append: bool,
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._handle = path.open(
+                "a" if append else "x", encoding="utf-8", newline="\n"
+            )
+        except FileExistsError as exc:
+            raise HarnessError(
+                "output already exists; pass --append only for an intentional continuation"
+            ) from exc
+        self.path = path
+        self.sanitizer = sanitizer
+        self.rows = 0
+
+    def write(self, record: dict[str, Any]) -> None:
+        before = self.sanitizer.event_count()
+        safe = self.sanitizer.sanitize_obj(record, f"jsonl[{self.rows}]")
+        record_events = self.sanitizer.events_since(before)
+        if record_events:
+            safe.setdefault("sanitizer", {})["record_redactions"] = record_events
+        serialized = canonical_json(safe)
+        final_scan = Sanitizer()
+        rescanned_obj = final_scan.sanitize_obj(safe, f"jsonl[{self.rows}].final")
+        rescanned = final_scan.sanitize_text(
+            canonical_json(rescanned_obj), f"jsonl[{self.rows}].final_serialized"
+        )
+        if rescanned != serialized or final_scan.event_count():
+            rules = sorted({event["rule"] for event in final_scan.events_since(0)})
+            raise HarnessError(
+                "final serialized-row secret scan failed; row was not persisted "
+                f"(record_type: {safe.get('record_type', 'unknown')}, "
+                f"rules: {','.join(rules)})"
+            )
+        self._handle.write(serialized + "\n")
+        self._handle.flush()
+        self.rows += 1
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+@dataclass
+class RpcCapture:
+    method: str
+    request_id: int | None
+    rpc_ms: float
+    request_safe: dict[str, Any]
+    response_safe: dict[str, Any] | None
+    response_raw: dict[str, Any] | None
+    content_safe: Any
+    full_wire_safe: dict[str, list[str]]
+    request_metrics: dict[str, int]
+    response_metrics: dict[str, int]
+    content_metrics: dict[str, int]
+    full_wire_metrics: dict[str, int]
+    sanitized_request_metrics: dict[str, int]
+    sanitized_response_metrics: dict[str, int]
+    sanitized_content_metrics: dict[str, int]
+    sanitized_full_wire_metrics: dict[str, int]
+    schema_free_request_metrics: dict[str, int] | None
+    schema_free_response_metrics: dict[str, int] | None
+    sanitized_schema_free_request_metrics: dict[str, int] | None
+    sanitized_schema_free_response_metrics: dict[str, int] | None
+    direct_payload_metrics: dict[str, int] | None
+    sanitized_direct_payload_metrics: dict[str, int] | None
+    redactions: list[dict[str, str]]
+
+
+def extract_content(response: dict[str, Any] | None) -> Any:
+    if not isinstance(response, dict):
+        return None
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    extracted: dict[str, Any] = {}
+    if "content" in result:
+        extracted["content"] = result["content"]
+    if "structuredContent" in result:
+        extracted["structuredContent"] = result["structuredContent"]
+    return extracted or None
+
+
+def extract_content_text(response: dict[str, Any] | None) -> str:
+    if not isinstance(response, dict):
+        return ""
+    result = response.get("result")
+    if not isinstance(result, dict):
+        error = response.get("error")
+        return canonical_json(error) if isinstance(error, dict) else ""
+    content = result.get("content")
+    texts = (
+        [
+            item["text"]
+            for item in content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        ]
+        if isinstance(content, list)
+        else []
+    )
+    if "structuredContent" in result:
+        texts.append(canonical_json(result["structuredContent"]))
+    if not texts and result.get("isError") is True:
+        texts.append(canonical_json(result))
+    return "\n".join(texts)
+
+
+def validate_jsonrpc_response(message: Any, expected_id: int) -> None:
+    if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+        raise HarnessError("invalid JSON-RPC 2.0 response envelope")
+    response_id = message.get("id")
+    if type(response_id) is not type(expected_id) or response_id != expected_id:
+        raise HarnessError("JSON-RPC response id did not match the request")
+    has_result = "result" in message
+    has_error = "error" in message
+    if has_result == has_error:
+        raise HarnessError("JSON-RPC response must contain exactly one result or error")
+    if has_error:
+        error = message["error"]
+        if (
+            not isinstance(error, dict)
+            or not isinstance(error.get("code"), int)
+            or isinstance(error.get("code"), bool)
+            or not isinstance(error.get("message"), str)
+        ):
+            raise HarnessError("invalid JSON-RPC error object")
+
+
+class StdioMcpClient:
+    def __init__(
+        self,
+        command: list[str],
+        cwd: pathlib.Path,
+        env: dict[str, str],
+        timeout: float,
+        sanitizer: Sanitizer,
+        counter: TokenCounter,
+    ) -> None:
+        self.timeout = timeout
+        self.sanitizer = sanitizer
+        self.counter = counter
+        self._next_id = 1
+        self._stdout: queue.Queue[bytes | None] = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._stderr_lock = threading.Lock()
+        self._stderr_line_number = 0
+        started = time.perf_counter_ns()
+        creationflags = 0
+        if os.name == "nt":
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        try:
+            self.process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+                creationflags=creationflags,
+            )
+        except OSError as exc:
+            raise HarnessError(
+                "failed to start the supplied server executable"
+            ) from exc
+        self.process_start_ms = (time.perf_counter_ns() - started) / 1_000_000
+        self._stdout_thread = threading.Thread(
+            target=self._read_stdout, name="mcp-stdout", daemon=True
+        )
+        self._stderr_thread = threading.Thread(
+            target=self._read_stderr, name="mcp-stderr", daemon=True
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+
+    def _read_stdout(self) -> None:
+        assert self.process.stdout is not None
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                self._stdout.put(None)
+                return
+            self._stdout.put(line)
+
+    def _read_stderr(self) -> None:
+        assert self.process.stderr is not None
+        while True:
+            line = self.process.stderr.readline()
+            if not line:
+                return
+            decoded = line.decode("utf-8", errors="replace")
+            with self._stderr_lock:
+                self._stderr_line_number += 1
+                location = f"server_stderr:{self._stderr_line_number}"
+            safe = self.sanitizer.sanitize_text(decoded, location)
+            with self._stderr_lock:
+                self._stderr_lines.append(safe)
+
+    def rpc(self, method: str, params: dict[str, Any]) -> RpcCapture:
+        request_id = self._next_id
+        self._next_id += 1
+        request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        return self._exchange(request, method, request_id)
+
+    def notify(self, method: str, params: dict[str, Any]) -> RpcCapture:
+        request = {"jsonrpc": "2.0", "method": method, "params": params}
+        return self._exchange(request, method, None)
+
+    def _exchange(
+        self,
+        request: dict[str, Any],
+        method: str,
+        request_id: int | None,
+    ) -> RpcCapture:
+        redaction_offset = self.sanitizer.event_count()
+        request_raw_wire = wire_json(request)
+        request_raw_bytes = request_raw_wire.encode("utf-8")
+        request_safe = self.sanitizer.sanitize_obj(request, f"{method}.request")
+        request_safe_wire = wire_json(request_safe)
+        inbound_raw: list[str] = []
+        inbound_raw_bytes = 0
+        inbound_safe: list[str] = []
+        response_raw: dict[str, Any] | None = None
+        response_safe: dict[str, Any] | None = None
+        response_raw_text = ""
+        response_raw_bytes = 0
+
+        assert self.process.stdin is not None
+        start = time.perf_counter_ns()
+        try:
+            self.process.stdin.write(request_raw_bytes)
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise HarnessError(
+                "server stdio closed while sending an MCP request"
+            ) from exc
+
+        if request_id is not None:
+            deadline = time.monotonic() + self.timeout
+            unsolicited = 0
+            while response_raw is None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise HarnessError(f"MCP RPC timed out for method {method}")
+                try:
+                    raw_line = self._stdout.get(timeout=remaining)
+                except queue.Empty as exc:
+                    raise HarnessError(
+                        f"MCP RPC timed out for method {method}"
+                    ) from exc
+                if raw_line is None:
+                    raise HarnessError("server stdout closed before the MCP response")
+                decoded = raw_line.decode("utf-8", errors="replace")
+                inbound_raw.append(decoded)
+                inbound_raw_bytes += len(raw_line)
+                try:
+                    message = json.loads(decoded)
+                except json.JSONDecodeError:
+                    inbound_safe.append(
+                        self.sanitizer.sanitize_text(
+                            decoded, f"{method}.stdout_non_json"
+                        )
+                    )
+                    unsolicited += 1
+                    if unsolicited > 100:
+                        raise HarnessError(
+                            "too many non-response frames on server stdout"
+                        )
+                    continue
+                safe_message = self.sanitizer.sanitize_obj(
+                    message, f"{method}.response_frame"
+                )
+                inbound_safe.append(wire_json(safe_message))
+                if (
+                    isinstance(message, dict)
+                    and "id" in message
+                    and "method" in message
+                ):
+                    raise HarnessError(
+                        "server-initiated MCP requests are unsupported by this capture harness"
+                    )
+                if isinstance(message, dict) and "id" in message:
+                    validate_jsonrpc_response(message, request_id)
+                    response_raw = message
+                    response_safe = safe_message
+                    response_raw_text = decoded
+                    response_raw_bytes = len(raw_line)
+                    break
+                unsolicited += 1
+                if unsolicited > 100:
+                    raise HarnessError("too many unsolicited MCP frames")
+
+        rpc_ms = (time.perf_counter_ns() - start) / 1_000_000
+        response_safe_wire = (
+            wire_json(response_safe) if response_safe is not None else ""
+        )
+        content_raw = extract_content(response_raw)
+        content_safe = extract_content(response_safe)
+        content_raw_text = (
+            canonical_json(content_raw) if content_raw is not None else ""
+        )
+        content_safe_text = (
+            canonical_json(content_safe) if content_safe is not None else ""
+        )
+        full_raw_text = request_raw_wire + "".join(inbound_raw)
+        full_safe_text = request_safe_wire + "".join(inbound_safe)
+
+        direct_raw_metrics: dict[str, int] | None = None
+        direct_safe_metrics: dict[str, int] | None = None
+        schema_free_request_metrics: dict[str, int] | None = None
+        schema_free_response_metrics: dict[str, int] | None = None
+        safe_schema_free_request_metrics: dict[str, int] | None = None
+        safe_schema_free_response_metrics: dict[str, int] | None = None
+        if method == "tools/call":
+            name = str(request.get("params", {}).get("name", ""))
+            arguments = request.get("params", {}).get("arguments", {})
+            safe_params = request_safe.get("params", {})
+            safe_arguments = (
+                safe_params.get("arguments", {})
+                if isinstance(safe_params, dict)
+                else {}
+            )
+            schema_free_request = name + "\n" + canonical_json(arguments)
+            schema_free_response = extract_content_text(response_raw)
+            safe_schema_free_request = name + "\n" + canonical_json(safe_arguments)
+            safe_schema_free_response = extract_content_text(response_safe)
+            direct_raw = schema_free_request + "\n" + schema_free_response
+            direct_safe = safe_schema_free_request + "\n" + safe_schema_free_response
+            schema_free_request_metrics = self.counter.metrics(schema_free_request)
+            schema_free_response_metrics = self.counter.metrics(schema_free_response)
+            safe_schema_free_request_metrics = self.counter.metrics(
+                safe_schema_free_request
+            )
+            safe_schema_free_response_metrics = self.counter.metrics(
+                safe_schema_free_response
+            )
+            direct_raw_metrics = self.counter.metrics(direct_raw)
+            direct_safe_metrics = self.counter.metrics(direct_safe)
+
+        return RpcCapture(
+            method=method,
+            request_id=request_id,
+            rpc_ms=rpc_ms,
+            request_safe=request_safe,
+            response_safe=response_safe,
+            response_raw=response_raw,
+            content_safe=content_safe,
+            full_wire_safe={
+                "outbound": [request_safe_wire],
+                "inbound": inbound_safe,
+            },
+            request_metrics=self.counter.metrics(
+                request_raw_wire, byte_length=len(request_raw_bytes)
+            ),
+            response_metrics=self.counter.metrics(
+                response_raw_text, byte_length=response_raw_bytes
+            ),
+            content_metrics=self.counter.metrics(content_raw_text),
+            full_wire_metrics=self.counter.metrics(
+                full_raw_text,
+                byte_length=len(request_raw_bytes) + inbound_raw_bytes,
+            ),
+            sanitized_request_metrics=self.counter.metrics(request_safe_wire),
+            sanitized_response_metrics=self.counter.metrics(response_safe_wire),
+            sanitized_content_metrics=self.counter.metrics(content_safe_text),
+            sanitized_full_wire_metrics=self.counter.metrics(full_safe_text),
+            schema_free_request_metrics=schema_free_request_metrics,
+            schema_free_response_metrics=schema_free_response_metrics,
+            sanitized_schema_free_request_metrics=safe_schema_free_request_metrics,
+            sanitized_schema_free_response_metrics=safe_schema_free_response_metrics,
+            direct_payload_metrics=direct_raw_metrics,
+            sanitized_direct_payload_metrics=direct_safe_metrics,
+            redactions=self.sanitizer.events_since(redaction_offset),
+        )
+
+    def close(self) -> dict[str, Any]:
+        started = time.perf_counter_ns()
+        if self.process.stdin is not None and not self.process.stdin.closed:
+            try:
+                self.process.stdin.close()
+            except OSError:
+                pass
+        try:
+            exit_code = self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.terminate()
+            try:
+                exit_code = self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                exit_code = self.process.wait(timeout=2)
+        self._stdout_thread.join(timeout=1)
+        self._stderr_thread.join(timeout=1)
+
+        trailing_stdout: list[str] = []
+        while True:
+            try:
+                raw_line = self._stdout.get_nowait()
+            except queue.Empty:
+                break
+            if raw_line is None:
+                continue
+            trailing_stdout.append(
+                self.sanitizer.sanitize_text(
+                    raw_line.decode("utf-8", errors="replace"),
+                    "trailing_stdout",
+                )
+            )
+        with self._stderr_lock:
+            stderr = list(self._stderr_lines)
+        return {
+            "exit_code": exit_code,
+            "shutdown_ms": (time.perf_counter_ns() - started) / 1_000_000,
+            "server_stderr": stderr,
+            "trailing_stdout": trailing_stdout,
+        }
+
+
+@dataclass
+class CaptureConfig:
+    mode: str
+    repo: pathlib.Path
+    output: pathlib.Path
+    server: str
+    server_args: list[str]
+    surface: str
+    auto_index: bool
+    timeout: float
+    protocol_version: str
+    run_id: str
+    case_id: str
+    append: bool
+    tool: str | None = None
+    arguments: dict[str, Any] | None = None
+    execution_mode: str = "direct_rpc"
+
+
+def is_within(path: pathlib.Path, parent: pathlib.Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def validate_paths(repo: pathlib.Path, output: pathlib.Path) -> None:
+    if not repo.is_dir():
+        raise HarnessError("--repo must name an existing directory")
+    script_repo = pathlib.Path(__file__).resolve().parents[2]
+    if is_within(output, repo) or is_within(output, script_repo):
+        raise HarnessError(
+            "capture output must be outside both the tested repository and the SymForge checkout"
+        )
+
+
+def resolve_server(server: str) -> pathlib.Path:
+    candidate = pathlib.Path(server).expanduser()
+    if candidate.is_absolute() or candidate.parent != pathlib.Path("."):
+        resolved = candidate.resolve()
+        if not resolved.is_file():
+            raise HarnessError("the supplied server executable does not exist")
+        return resolved
+    found = shutil.which(server)
+    if found is None:
+        raise HarnessError("the supplied server executable was not found on PATH")
+    return pathlib.Path(found).resolve()
+
+
+def executable_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def child_environment(surface: str, auto_index: bool) -> dict[str, str]:
+    """Build a credential-minimized environment without ever serializing it."""
+    allowed = (
+        "PATH",
+        "PATHEXT",
+        "SystemRoot",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+    )
+    env = {key: os.environ[key] for key in allowed if key in os.environ}
+    env.update(
+        {
+            "SYMFORGE_SURFACE": surface,
+            "SYMFORGE_NO_DAEMON": "1",
+            "SYMFORGE_AUTO_INDEX": "true" if auto_index else "false",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_LFS_SKIP_SMUDGE": "1",
+            "NO_COLOR": "1",
+        }
+    )
+    if os.name != "nt":
+        env["LANG"] = "C.UTF-8"
+        env["LC_ALL"] = "C.UTF-8"
+    return env
+
+
+def repository_commit(repo: pathlib.Path, env: dict[str, str]) -> str | None:
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        result = subprocess.run(
+            [git, "-C", str(repo), "rev-parse", "HEAD"],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    candidate = result.stdout.decode("ascii", errors="ignore").strip()
+    return candidate if re.fullmatch(r"[0-9a-fA-F]{40,64}", candidate) else None
+
+
+def rpc_status(capture: RpcCapture) -> str:
+    response = capture.response_safe
+    if response is None:
+        return "sent"
+    if "error" in response:
+        return "jsonrpc_error"
+    result = response.get("result")
+    if isinstance(result, dict) and result.get("isError") is True:
+        return "tool_error"
+    return "ok"
+
+
+def base_record(config: CaptureConfig) -> dict[str, Any]:
+    return {
+        "protocol": PROTOCOL_ID,
+        "run_id": config.run_id,
+        "case_id": config.case_id,
+        "repo": str(config.repo),
+        "transport": "stdio",
+        "surface": config.surface,
+        "execution_mode": config.execution_mode,
+    }
+
+
+def capture_record(config: CaptureConfig, capture: RpcCapture) -> dict[str, Any]:
+    response_wire = "".join(capture.full_wire_safe["inbound"])
+    request_wire = "".join(capture.full_wire_safe["outbound"])
+    tool = None
+    params = capture.request_safe.get("params")
+    if capture.method == "tools/call" and isinstance(params, dict):
+        tool = params.get("name")
+    record = {
+        **base_record(config),
+        "record_type": "trial" if capture.method == "tools/call" else "rpc",
+        "method": capture.method,
+        "tool": tool,
+        "rpc_ms": capture.rpc_ms,
+        "status": rpc_status(capture),
+        "request_sha256": sha256_text(request_wire),
+        "response_sha256": sha256_text(response_wire) if response_wire else "",
+        "request_utf8_bytes": capture.request_metrics["utf8_bytes"],
+        "response_utf8_bytes": capture.response_metrics["utf8_bytes"],
+        "full_wire_utf8_bytes": capture.full_wire_metrics["utf8_bytes"],
+        "request_cl100k": capture.request_metrics["cl100k"],
+        "response_cl100k": capture.response_metrics["cl100k"],
+        "request_o200k": capture.request_metrics["o200k"],
+        "response_o200k": capture.response_metrics["o200k"],
+        "content_cl100k": capture.content_metrics["cl100k"],
+        "content_o200k": capture.content_metrics["o200k"],
+        "full_wire_cl100k": capture.full_wire_metrics["cl100k"],
+        "full_wire_o200k": capture.full_wire_metrics["o200k"],
+        "wire_request_cl100k": capture.request_metrics["cl100k"],
+        "wire_response_cl100k": capture.response_metrics["cl100k"],
+        "wire_request_o200k": capture.request_metrics["o200k"],
+        "wire_response_o200k": capture.response_metrics["o200k"],
+        "sanitized_request_cl100k": capture.sanitized_request_metrics["cl100k"],
+        "sanitized_response_cl100k": capture.sanitized_response_metrics["cl100k"],
+        "sanitized_content_cl100k": capture.sanitized_content_metrics["cl100k"],
+        "sanitized_full_wire_cl100k": capture.sanitized_full_wire_metrics["cl100k"],
+        "sanitized_request_o200k": capture.sanitized_request_metrics["o200k"],
+        "sanitized_response_o200k": capture.sanitized_response_metrics["o200k"],
+        "sanitized_content_o200k": capture.sanitized_content_metrics["o200k"],
+        "sanitized_full_wire_o200k": capture.sanitized_full_wire_metrics["o200k"],
+        "schema_free_tool_request_cl100k": (
+            capture.schema_free_request_metrics["cl100k"]
+            if capture.schema_free_request_metrics is not None
+            else None
+        ),
+        "schema_free_tool_request_utf8_bytes": (
+            capture.schema_free_request_metrics["utf8_bytes"]
+            if capture.schema_free_request_metrics is not None
+            else None
+        ),
+        "schema_free_tool_request_o200k": (
+            capture.schema_free_request_metrics["o200k"]
+            if capture.schema_free_request_metrics is not None
+            else None
+        ),
+        "schema_free_tool_response_cl100k": (
+            capture.schema_free_response_metrics["cl100k"]
+            if capture.schema_free_response_metrics is not None
+            else None
+        ),
+        "schema_free_tool_response_utf8_bytes": (
+            capture.schema_free_response_metrics["utf8_bytes"]
+            if capture.schema_free_response_metrics is not None
+            else None
+        ),
+        "schema_free_tool_response_o200k": (
+            capture.schema_free_response_metrics["o200k"]
+            if capture.schema_free_response_metrics is not None
+            else None
+        ),
+        "schema_free_direct_payload_cl100k": (
+            capture.direct_payload_metrics["cl100k"]
+            if capture.direct_payload_metrics is not None
+            else None
+        ),
+        "schema_free_direct_payload_utf8_bytes": (
+            capture.direct_payload_metrics["utf8_bytes"]
+            if capture.direct_payload_metrics is not None
+            else None
+        ),
+        "schema_free_direct_payload_o200k": (
+            capture.direct_payload_metrics["o200k"]
+            if capture.direct_payload_metrics is not None
+            else None
+        ),
+        "measurement_views": {
+            "schema_free_direct_payload": (
+                "tool name + canonical arguments + content[*].text + "
+                "canonical structuredContent; canonical JSON-RPC/tool-error payload "
+                "when result content is absent"
+            ),
+            "wire": "exact JSON-RPC request and response UTF-8",
+            "interpretation": "diagnostic token counts, not a net-savings claim",
+        },
+        "token_count_basis": {
+            "primary": "exact unsanitized UTF-8 stream counted only in memory",
+            "artifact": "sanitized persisted stream",
+        },
+        "request": capture.request_safe,
+        "response": capture.response_safe,
+        "content": capture.content_safe,
+        "full_wire": capture.full_wire_safe,
+        "sanitizer": {
+            "redaction_count": len(capture.redactions),
+            "events": capture.redactions,
+        },
+        "provider_total_tokens": None,
+        "cached_input_tokens": None,
+        "reasoning_tokens": None,
+    }
+    if capture.sanitized_direct_payload_metrics is not None:
+        record["sanitized_schema_free_direct_payload_cl100k"] = (
+            capture.sanitized_direct_payload_metrics["cl100k"]
+        )
+        record["sanitized_schema_free_direct_payload_o200k"] = (
+            capture.sanitized_direct_payload_metrics["o200k"]
+        )
+    if capture.sanitized_schema_free_request_metrics is not None:
+        record["sanitized_schema_free_tool_request_cl100k"] = (
+            capture.sanitized_schema_free_request_metrics["cl100k"]
+        )
+        record["sanitized_schema_free_tool_request_o200k"] = (
+            capture.sanitized_schema_free_request_metrics["o200k"]
+        )
+    if capture.sanitized_schema_free_response_metrics is not None:
+        record["sanitized_schema_free_tool_response_cl100k"] = (
+            capture.sanitized_schema_free_response_metrics["cl100k"]
+        )
+        record["sanitized_schema_free_tool_response_o200k"] = (
+            capture.sanitized_schema_free_response_metrics["o200k"]
+        )
+    return record
+
+
+def list_all(
+    client: StdioMcpClient,
+    writer: JsonlWriter,
+    config: CaptureConfig,
+    method: str,
+    result_key: str,
+) -> tuple[list[Any], dict[str, Any]]:
+    safe_items: list[Any] = []
+    raw_items: list[Any] = []
+    cursor: Any = None
+    seen_cursors: set[str] = set()
+    page_count = 0
+    while page_count < 100:
+        params = {} if cursor is None else {"cursor": cursor}
+        capture = client.rpc(method, params)
+        writer.write(capture_record(config, capture))
+        page_count += 1
+        raw_response = capture.response_raw or {}
+        safe_response = capture.response_safe or {}
+        if "error" in raw_response:
+            raise HarnessError(f"{method} returned a JSON-RPC error")
+        raw_result = raw_response.get("result", {})
+        safe_result = safe_response.get("result", {})
+        if not isinstance(raw_result, dict) or not isinstance(safe_result, dict):
+            raise HarnessError(f"{method} result was not an object")
+        page_raw_items = raw_result.get(result_key, [])
+        page_safe_items = safe_result.get(result_key, [])
+        if not isinstance(page_raw_items, list) or not isinstance(
+            page_safe_items, list
+        ):
+            raise HarnessError(f"{method} did not return {result_key} as a list")
+        raw_items.extend(page_raw_items)
+        safe_items.extend(page_safe_items)
+        cursor = raw_result.get("nextCursor")
+        if cursor is None:
+            break
+        if not isinstance(cursor, str) or not cursor:
+            raise HarnessError(f"{method} returned an invalid pagination cursor")
+        cursor_fingerprint = sha256_text(canonical_json(cursor))
+        if cursor_fingerprint in seen_cursors:
+            raise HarnessError(f"{method} repeated a pagination cursor")
+        seen_cursors.add(cursor_fingerprint)
+    else:
+        raise HarnessError(f"{method} pagination exceeded 100 pages")
+
+    raw_text = canonical_json(raw_items)
+    safe_text = canonical_json(safe_items)
+    return safe_items, {
+        "pages": page_count,
+        "items": len(safe_items),
+        "error": None,
+        "raw_counts": client.counter.metrics(raw_text),
+        "sanitized_counts": client.counter.metrics(safe_text),
+        "sanitized_sha256": sha256_text(safe_text),
+    }
+
+
+def schema_metadata(tools: list[Any], counter: TokenCounter) -> list[dict[str, Any]]:
+    metadata: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        serialized = canonical_json(tool)
+        counts = counter.metrics(serialized)
+        metadata.append(
+            {
+                "name": tool.get("name"),
+                "schema_sha256": sha256_text(serialized),
+                "utf8_bytes": counts["utf8_bytes"],
+                "cl100k": counts["cl100k"],
+                "o200k": counts["o200k"],
+            }
+        )
+    return metadata
+
+
+def validate_tool_identity(surface: str, tools: list[Any]) -> None:
+    names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+    if len(names) != len(tools) or not all(isinstance(name, str) for name in names):
+        raise HarnessError("tools/list contained an invalid tool identity")
+    if len(set(names)) != len(names):
+        raise HarnessError("tools/list contained duplicate tool identities")
+    if set(names) != EXPECTED_TOOLS[surface]:
+        raise HarnessError(
+            f"tools/list did not match the frozen {surface} surface identity"
+        )
+
+
+def run_capture(config: CaptureConfig) -> int:
+    config.repo = config.repo.resolve()
+    config.output = config.output.resolve()
+    validate_paths(config.repo, config.output)
+    if config.auto_index and config.repo.parent.name.casefold() == "sources":
+        raise HarnessError(
+            "auto-index requires a disposable case clone, not an immutable source mirror"
+        )
+    if config.timeout <= 0:
+        raise HarnessError("--timeout must be greater than zero")
+
+    server_path = resolve_server(config.server)
+    counter = TokenCounter()
+    sanitizer = Sanitizer()
+    writer = JsonlWriter(config.output, sanitizer, append=config.append)
+    env = child_environment(config.surface, config.auto_index)
+    client: StdioMcpClient | None = None
+    pending_error: BaseException | None = None
+
+    try:
+        writer.write(
+            {
+                **base_record(config),
+                "record_type": "run_metadata",
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "tokenizer": counter.metadata(),
+                "server_executable": str(server_path),
+                "server_executable_sha256": executable_sha256(server_path),
+                "server_argument_count": len(config.server_args),
+                "repository_commit": repository_commit(config.repo, env),
+                "runtime_policy": {
+                    "surface": config.surface,
+                    "no_daemon": True,
+                    "auto_index": config.auto_index,
+                },
+                "http_streamable_supported": False,
+            }
+        )
+        client = StdioMcpClient(
+            [str(server_path), *config.server_args],
+            config.repo,
+            env,
+            config.timeout,
+            sanitizer,
+            counter,
+        )
+        initialize = client.rpc(
+            "initialize",
+            {
+                "protocolVersion": config.protocol_version,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "symforge-sfbench-harness",
+                    "version": "1.0",
+                },
+            },
+        )
+        writer.write(capture_record(config, initialize))
+        if initialize.response_raw is None or "error" in initialize.response_raw:
+            raise HarnessError("MCP initialize failed")
+        initialized = client.notify("notifications/initialized", {})
+        writer.write(capture_record(config, initialized))
+
+        manifest: dict[str, list[Any]] = {}
+        list_metrics: dict[str, Any] = {}
+        for method, result_key in LIST_METHODS:
+            items, metrics = list_all(client, writer, config, method, result_key)
+            manifest[result_key] = items
+            list_metrics[method] = metrics
+
+        manifest_text = canonical_json(manifest)
+        manifest_counts = counter.metrics(manifest_text)
+        tools = manifest.get("tools", [])
+        validate_tool_identity(config.surface, tools)
+        tools_text = canonical_json(tools)
+        tools_counts = counter.metrics(tools_text)
+        writer.write(
+            {
+                **base_record(config),
+                "record_type": "manifest",
+                "manifest": manifest,
+                "manifest_sha256": sha256_text(manifest_text),
+                "manifest_utf8_bytes": manifest_counts["utf8_bytes"],
+                "manifest_cl100k": manifest_counts["cl100k"],
+                "manifest_o200k": manifest_counts["o200k"],
+                "full_tools_list_tokens": {
+                    "cl100k": tools_counts["cl100k"],
+                    "o200k": tools_counts["o200k"],
+                },
+                "schema_metadata": schema_metadata(tools, counter),
+                "list_metrics": list_metrics,
+            }
+        )
+
+        if config.mode == "call":
+            assert config.tool is not None
+            arguments = config.arguments or {}
+            call = client.rpc(
+                "tools/call", {"name": config.tool, "arguments": arguments}
+            )
+            writer.write(capture_record(config, call))
+    except BaseException as exc:
+        pending_error = exc
+        safe_message = str(exc) if isinstance(exc, HarnessError) else type(exc).__name__
+        writer.write(
+            {
+                **base_record(config),
+                "record_type": "harness_error",
+                "error_type": type(exc).__name__,
+                "message": safe_message,
+            }
+        )
+    finally:
+        if client is not None:
+            writer.write(
+                {
+                    **base_record(config),
+                    "record_type": "process_lifecycle",
+                    "process_start_ms": client.process_start_ms,
+                    **client.close(),
+                }
+            )
+        rows = writer.rows
+        writer.close()
+
+    if pending_error is not None:
+        if isinstance(pending_error, HarnessError):
+            raise pending_error
+        raise HarnessError(
+            f"unexpected harness failure ({type(pending_error).__name__})"
+        ) from pending_error
+    return rows
+
+
+def parse_arguments(args: argparse.Namespace) -> dict[str, Any]:
+    if args.arguments_file is not None:
+        try:
+            text = pathlib.Path(args.arguments_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise HarnessError("could not read --arguments-file") from exc
+    else:
+        text = args.arguments if args.arguments is not None else "{}"
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise HarnessError(
+            f"tool arguments are invalid JSON at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise HarnessError("tool arguments must be a JSON object")
+    return value
+
+
+def config_from_args(args: argparse.Namespace) -> CaptureConfig:
+    arguments = parse_arguments(args) if args.mode == "call" else None
+    return CaptureConfig(
+        mode=args.mode,
+        repo=pathlib.Path(args.repo),
+        output=pathlib.Path(args.output),
+        server=args.server,
+        server_args=list(args.server_arg),
+        surface=args.surface,
+        auto_index=args.auto_index == "true",
+        timeout=args.timeout,
+        protocol_version=args.protocol_version,
+        run_id=args.run_id,
+        case_id=args.case_id,
+        append=args.append,
+        tool=getattr(args, "tool", None),
+        arguments=arguments,
+    )
+
+
+def add_capture_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", required=True, help="Repository used as server cwd.")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Sanitized JSONL path outside both repositories.",
+    )
+    parser.add_argument(
+        "--server",
+        default="symforge",
+        help="SymForge executable path or PATH name (default: symforge).",
+    )
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="Repeat for server arguments; use --server-arg=--flag for flags.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "http"),
+        default="stdio",
+        help=(
+            "Transport. Only stdio is implemented; http fails explicitly because "
+            "Streamable HTTP requires the official MCP SDK parity runner."
+        ),
+    )
+    parser.add_argument(
+        "--surface", choices=("full", "compact", "meta"), default="full"
+    )
+    parser.add_argument("--auto-index", choices=("true", "false"), default="true")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--protocol-version", default=MCP_PROTOCOL_VERSION)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="Append to an existing JSONL campaign intentionally.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Capture sanitized SymForge MCP manifests and tool calls with exact "
+            "in-memory cl100k/o200k accounting. Streamable HTTP is deliberately "
+            "unsupported in this minimal harness; use an official-SDK parity runner."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    manifest = subparsers.add_parser(
+        "manifest",
+        help="Initialize and capture tools/resources/templates/prompts lists.",
+    )
+    add_capture_options(manifest)
+
+    call = subparsers.add_parser(
+        "call",
+        help="Capture the manifest, then make one tools/call in the same process.",
+    )
+    add_capture_options(call)
+    call.add_argument("--tool", required=True)
+    arguments = call.add_mutually_exclusive_group()
+    arguments.add_argument(
+        "--arguments", help="Tool arguments as one JSON object (default: {})."
+    )
+    arguments.add_argument(
+        "--arguments-file", help="UTF-8 file containing one JSON object."
+    )
+
+    subparsers.add_parser(
+        "self-test",
+        help="Run an end-to-end fake-stdio transport and sanitizer test.",
+    )
+    return parser
+
+
+def fake_server(mode: str = "normal") -> int:
+    """Harmless internal MCP server used only by ``self-test``."""
+    synthetic_value = "unit" + "-sensitive" + "-fixture"
+    spaced_value = "unit" + " sensitive" + " fixture"
+    for raw_line in sys.stdin.buffer:
+        try:
+            request = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if "id" not in request:
+            continue
+        method = request.get("method")
+        if method == "initialize":
+            result: Any = {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
+                "serverInfo": {"name": "sfbench-fake", "version": "0"},
+            }
+        elif method == "tools/list":
+            tools: Any = [
+                {
+                    "name": name,
+                    "description": "Harmless fake read tool.",
+                    "inputSchema": {"type": "object", "properties": {}},
+                }
+                for name in sorted(
+                    EXPECTED_TOOLS[os.environ.get("SYMFORGE_SURFACE", "full")]
+                )
+            ]
+            if mode == "bad-list":
+                tools = "not-a-list"
+            result = {"tools": tools}
+            if mode == "repeat-cursor":
+                result["nextCursor"] = "repeated"
+        elif method == "resources/list":
+            result = {"resources": []}
+        elif method == "resources/templates/list":
+            result = {"resourceTemplates": []}
+        elif method == "prompts/list":
+            result = {"prompts": []}
+        elif method == "tools/call":
+            result = {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (f'API_TOKEN = "{spaced_value}" special=<|endoftext|>'),
+                    }
+                ],
+                "structuredContent": {
+                    "APIKey": synthetic_value,
+                    "argv": ["--api-key", synthetic_value],
+                    "nested": [["--clientSecret", synthetic_value]],
+                    "answer": "ok",
+                },
+                "isError": False,
+            }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+            sys.stdout.buffer.write(wire_json(response).encode("utf-8"))
+            sys.stdout.buffer.flush()
+            continue
+        response = {"jsonrpc": "2.0", "id": request["id"], "result": result}
+        sys.stdout.buffer.write(wire_json(response).encode("utf-8"))
+        sys.stdout.buffer.flush()
+    return 0
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory(prefix="sfbench-harness-test-") as root_text:
+        root = pathlib.Path(root_text)
+        repo = root / "repo"
+        repo.mkdir()
+        sensitive_input = "request" + "-sensitive" + "-fixture"
+        spaced_value = "unit" + " sensitive" + " fixture"
+        counter = TokenCounter()
+        if counter.metrics("<|endoftext|>")["cl100k"] <= 0:
+            raise HarnessError("self-test special-token accounting invariant failed")
+
+        sanitizer = Sanitizer()
+        sanitized_probe = sanitizer.sanitize_obj(
+            {
+                "APIKey": sensitive_input,
+                "argv": ["--api-key", sensitive_input],
+                "nested": [["--clientSecret", sensitive_input]],
+                "text": f'PASSWORD = "{spaced_value}"',
+            },
+            "self_test",
+        )
+        forbidden = {
+            "unit" + "-sensitive" + "-fixture",
+            sensitive_input,
+            spaced_value,
+        }
+        if any(value in canonical_json(sanitized_probe) for value in forbidden):
+            raise HarnessError("self-test sanitizer invariant failed")
+
+        valid_response = {"jsonrpc": "2.0", "id": 1, "result": {}}
+        validate_jsonrpc_response(valid_response, 1)
+        invalid_responses = (
+            {"id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": True, "result": {}},
+            {"jsonrpc": "2.0", "id": 1, "result": {}, "error": {}},
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": "bad"}},
+        )
+        for response in invalid_responses:
+            try:
+                validate_jsonrpc_response(response, 1)
+            except HarnessError:
+                pass
+            else:
+                raise HarnessError("self-test JSON-RPC validation invariant failed")
+
+        jsonrpc_error = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32602, "message": "synthetic invalid parameters"},
+        }
+        tool_level_error = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"isError": True},
+        }
+        error_texts = (
+            extract_content_text(jsonrpc_error),
+            extract_content_text(tool_level_error),
+        )
+        if error_texts[0] != canonical_json(jsonrpc_error["error"]) or any(
+            not text
+            or counter.metrics(text)["cl100k"] <= 0
+            or counter.metrics(text)["o200k"] <= 0
+            for text in error_texts
+        ):
+            raise HarnessError("self-test schema-free error accounting failed")
+
+        execution_mode_probe = CaptureConfig(
+            mode="baseline",
+            repo=repo,
+            output=root / "unused.jsonl",
+            server="",
+            server_args=[],
+            surface="full",
+            auto_index=False,
+            timeout=1,
+            protocol_version=MCP_PROTOCOL_VERSION,
+            run_id="self-test",
+            case_id="execution-mode-probe",
+            append=False,
+            execution_mode="recipe_baseline",
+        )
+        if base_record(execution_mode_probe)["execution_mode"] != "recipe_baseline":
+            raise HarnessError("self-test execution-mode override failed")
+
+        class PassthroughSanitizer(Sanitizer):
+            def sanitize_obj(self, value: Any, location: str = "record") -> Any:
+                del location
+                return value
+
+        fail_path = root / "fail-closed.jsonl"
+        fail_writer = JsonlWriter(fail_path, PassthroughSanitizer(), append=False)
+        try:
+            fail_writer.write({"password": sensitive_input})
+        except HarnessError:
+            pass
+        else:
+            raise HarnessError("self-test final secret scan invariant failed")
+        finally:
+            fail_writer.close()
+        if fail_path.stat().st_size != 0:
+            raise HarnessError("self-test fail-closed row was persisted")
+
+        script = str(pathlib.Path(__file__).resolve())
+        for surface in ("full", "compact", "meta"):
+            output = root / f"capture-{surface}.jsonl"
+            config = CaptureConfig(
+                mode="call" if surface == "full" else "manifest",
+                repo=repo,
+                output=output,
+                server=sys.executable,
+                server_args=[script, "--_fake-server"],
+                surface=surface,
+                auto_index=True,
+                timeout=10,
+                protocol_version=MCP_PROTOCOL_VERSION,
+                run_id="self-test",
+                case_id=f"fake-{surface}",
+                append=False,
+                tool="health_compact" if surface == "full" else None,
+                arguments={
+                    "APIKey": sensitive_input,
+                    "argv": ["--api-key", sensitive_input],
+                },
+            )
+            run_capture(config)
+            persisted = output.read_text(encoding="utf-8")
+            if (
+                any(value in persisted for value in forbidden)
+                or "--_fake-server" in persisted
+            ):
+                raise HarnessError("self-test persisted sanitizer invariant failed")
+            rows = [json.loads(line) for line in persisted.splitlines()]
+            metadata = next(
+                row for row in rows if row.get("record_type") == "run_metadata"
+            )
+            if (
+                metadata.get("server_argument_count") != 2
+                or "server_arguments" in metadata
+            ):
+                raise HarnessError("self-test server-argument privacy invariant failed")
+            manifest = next(row for row in rows if row.get("record_type") == "manifest")
+            names = {tool["name"] for tool in manifest["manifest"]["tools"]}
+            if names != EXPECTED_TOOLS[surface]:
+                raise HarnessError("self-test surface identity invariant failed")
+            if surface != "full":
+                continue
+            methods = {row.get("method") for row in rows}
+            required = {
+                "initialize",
+                "notifications/initialized",
+                "tools/list",
+                "resources/list",
+                "resources/templates/list",
+                "prompts/list",
+                "tools/call",
+            }
+            if not required.issubset(methods):
+                raise HarnessError("self-test MCP coverage invariant failed")
+            trials = [row for row in rows if row.get("record_type") == "trial"]
+            if len(trials) != 1 or REDACTED not in canonical_json(trials[0]):
+                raise HarnessError("self-test persisted capture invariant failed")
+            trial = trials[0]
+            if not all(
+                isinstance(trial.get(field), int) and trial[field] > 0
+                for field in (
+                    "wire_request_cl100k",
+                    "wire_response_cl100k",
+                    "schema_free_tool_request_cl100k",
+                    "schema_free_tool_response_cl100k",
+                    "schema_free_direct_payload_cl100k",
+                )
+            ):
+                raise HarnessError("self-test token accounting invariant failed")
+            structured = trial["response"]["result"].get("structuredContent")
+            if not isinstance(structured, dict) or structured.get("APIKey") != REDACTED:
+                raise HarnessError("self-test structuredContent invariant failed")
+
+        for failure_mode in ("bad-list", "repeat-cursor"):
+            failure_config = CaptureConfig(
+                mode="manifest",
+                repo=repo,
+                output=root / f"failure-{failure_mode}.jsonl",
+                server=sys.executable,
+                server_args=[script, "--_fake-server", failure_mode],
+                surface="full",
+                auto_index=True,
+                timeout=10,
+                protocol_version=MCP_PROTOCOL_VERSION,
+                run_id="self-test",
+                case_id=failure_mode,
+                append=False,
+            )
+            try:
+                run_capture(failure_config)
+            except HarnessError:
+                pass
+            else:
+                raise HarnessError("self-test list failure was not fatal")
+
+        try:
+            validate_tool_identity("meta", [{"name": "unexpected"}])
+        except HarnessError:
+            pass
+        else:
+            raise HarnessError("self-test manifest rejection invariant failed")
+    print("self-test: PASS")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments and arguments[0] == "--_fake-server":
+        return fake_server(arguments[1] if len(arguments) > 1 else "normal")
+    parser = build_parser()
+    args = parser.parse_args(arguments)
+    if args.mode == "self-test":
+        return self_test()
+    if args.transport == "http":
+        raise HarnessError(
+            "HTTP Streamable transport is unsupported in this harness; use the "
+            "official MCP Python SDK parity runner described in --help."
+        )
+    rows = run_capture(config_from_args(args))
+    print(f"capture complete: {rows} sanitized JSONL rows")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HarnessError as exc:
+        print(f"mcp_harness: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/research/full-surface-benchmark/non_tool_surface_smoke.py
+++ b/research/full-surface-benchmark/non_tool_surface_smoke.py
@@ -1,0 +1,760 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "tiktoken==0.13.0",
+# ]
+# ///
+"""Smoke-test SymForge resources, resource templates, and prompts over stdio."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from mcp_harness import (
+    MCP_PROTOCOL_VERSION,
+    REDACTED,
+    CaptureConfig,
+    HarnessError,
+    JsonlWriter,
+    Sanitizer,
+    StdioMcpClient,
+    TokenCounter,
+    base_record,
+    canonical_json,
+    capture_record,
+    child_environment,
+    executable_sha256,
+    is_within,
+    list_all,
+    resolve_server,
+    validate_paths,
+    wire_json,
+)
+
+
+STATIC_RESOURCES = {
+    "symforge://repo/health": "repo-health",
+    "symforge://repo/outline": "repo-outline",
+    "symforge://repo/map": "repo-map",
+    "symforge://repo/changes/uncommitted": "repo-changes-uncommitted",
+    "symforge://tools/catalog": "tools-catalog",
+    "symforge://glossary": "glossary",
+}
+RESOURCE_TEMPLATES = {
+    "symforge://file/context?path={path}&max_tokens={max_tokens}": "file-context",
+    (
+        "symforge://file/content?path={path}&start_line={start_line}&end_line={end_line}"
+        "&around_line={around_line}&around_match={around_match}"
+        "&match_occurrence={match_occurrence}&context_lines={context_lines}"
+        "&show_line_numbers={show_line_numbers}&header={header}"
+    ): "file-content",
+    "symforge://symbol/detail?path={path}&name={name}&kind={kind}": "symbol-detail",
+    "symforge://symbol/context?name={name}&file={file}": "symbol-context",
+}
+PROMPT_ARGUMENTS = {
+    "symforge-review": {"path": False, "focus": False},
+    "symforge-architecture": {"area": False},
+    "symforge-triage": {"symptom": True, "path": False},
+    "symforge-onboard": {"area": False},
+    "symforge-refactor": {"goal": True, "target": False},
+    "symforge-debug": {"error": True, "path": False},
+    "symforge-admin": {},
+}
+
+
+@dataclass
+class SmokeConfig:
+    repo: pathlib.Path
+    output: pathlib.Path
+    fixture_path: str
+    fixture_symbol: str
+    fixture_kind: str
+    server: str
+    server_args: list[str]
+    timeout: float
+    run_id: str
+    case_id: str
+
+
+def normalize_repo_path(value: str) -> str:
+    normalized = value.replace("\\", "/").casefold()
+    return normalized.removeprefix("//?/")
+
+
+def validate_fixture(config: SmokeConfig) -> None:
+    relative = pathlib.PurePosixPath(config.fixture_path.replace("\\", "/"))
+    if relative.is_absolute() or ".." in relative.parts or not relative.parts:
+        raise HarnessError("--fixture-path must be a safe repository-relative path")
+    target = config.repo.joinpath(*relative.parts).resolve()
+    if not target.is_file() or not is_within(target, config.repo):
+        raise HarnessError("--fixture-path must identify a file inside --repo")
+    if not re.fullmatch(r"[\w:.$<>-]{1,200}", config.fixture_symbol, re.UNICODE):
+        raise HarnessError("--fixture-symbol contains unsupported characters")
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,31}", config.fixture_kind):
+        raise HarnessError("--fixture-kind contains unsupported characters")
+
+
+def validate_external_repo(repo: pathlib.Path) -> None:
+    project_root = pathlib.Path(__file__).resolve().parents[2]
+    if is_within(repo, project_root):
+        raise HarnessError(
+            "the SymForge checkout cannot be used as the smoke repository"
+        )
+
+
+def validate_static_resources(resources: list[Any]) -> None:
+    if len(resources) != len(STATIC_RESOURCES):
+        raise HarnessError("resources/list returned the wrong static resource count")
+    identities: dict[str, str] = {}
+    for resource in resources:
+        if not isinstance(resource, dict):
+            raise HarnessError("resources/list contained a non-object identity")
+        uri = resource.get("uri")
+        name = resource.get("name")
+        if not isinstance(uri, str) or not isinstance(name, str):
+            raise HarnessError("resources/list contained an invalid identity")
+        if resource.get("mimeType") != "text/markdown":
+            raise HarnessError("static resource MIME type drifted")
+        identities[uri] = name
+    if identities != STATIC_RESOURCES:
+        raise HarnessError(
+            "static resource identities drifted from the frozen contract"
+        )
+
+
+def validate_resource_templates(templates: list[Any]) -> None:
+    if len(templates) != len(RESOURCE_TEMPLATES):
+        raise HarnessError("resources/templates/list returned the wrong count")
+    identities: dict[str, str] = {}
+    for template in templates:
+        if not isinstance(template, dict):
+            raise HarnessError("resource template list contained a non-object")
+        uri = template.get("uriTemplate")
+        name = template.get("name")
+        if not isinstance(uri, str) or not isinstance(name, str):
+            raise HarnessError("resource template list contained an invalid identity")
+        if template.get("mimeType") != "text/markdown":
+            raise HarnessError("resource template MIME type drifted")
+        identities[uri] = name
+    if identities != RESOURCE_TEMPLATES:
+        raise HarnessError(
+            "resource template identities drifted from the frozen contract"
+        )
+
+
+def validate_prompts(prompts: list[Any]) -> None:
+    if len(prompts) != len(PROMPT_ARGUMENTS):
+        raise HarnessError("prompts/list returned the wrong prompt count")
+    observed: dict[str, dict[str, bool]] = {}
+    for prompt in prompts:
+        if not isinstance(prompt, dict) or not isinstance(prompt.get("name"), str):
+            raise HarnessError("prompts/list contained an invalid prompt identity")
+        arguments = prompt.get("arguments", [])
+        if not isinstance(arguments, list):
+            raise HarnessError("prompt argument schema was not a list")
+        schema: dict[str, bool] = {}
+        for argument in arguments:
+            if not isinstance(argument, dict) or not isinstance(
+                argument.get("name"), str
+            ):
+                raise HarnessError("prompt argument schema contained an invalid entry")
+            schema[argument["name"]] = bool(argument.get("required", False))
+        observed[prompt["name"]] = schema
+    if observed != PROMPT_ARGUMENTS:
+        raise HarnessError("prompt identities or argument schemas drifted")
+
+
+def template_instances(config: SmokeConfig) -> dict[str, tuple[str, str]]:
+    path = config.fixture_path.replace("\\", "/")
+    symbol = config.fixture_symbol
+    return {
+        "file-context": (
+            "symforge://file/context?" + urlencode({"path": path, "max_tokens": 400}),
+            path,
+        ),
+        "file-content": (
+            "symforge://file/content?"
+            + urlencode(
+                {
+                    "path": path,
+                    "start_line": 1,
+                    "end_line": 20,
+                    "show_line_numbers": "true",
+                    "header": "true",
+                }
+            ),
+            path,
+        ),
+        "symbol-detail": (
+            "symforge://symbol/detail?"
+            + urlencode({"path": path, "name": symbol, "kind": config.fixture_kind}),
+            symbol,
+        ),
+        "symbol-context": (
+            "symforge://symbol/context?" + urlencode({"name": symbol, "file": path}),
+            symbol,
+        ),
+    }
+
+
+def prompt_requests(config: SmokeConfig) -> dict[str, dict[str, str]]:
+    path = config.fixture_path.replace("\\", "/")
+    symbol = config.fixture_symbol
+    return {
+        "symforge-review": {"path": path, "focus": f"correctness near {symbol}"},
+        "symforge-architecture": {"area": symbol},
+        "symforge-triage": {
+            "symptom": f"controlled symptom near {symbol}",
+            "path": path,
+        },
+        "symforge-onboard": {"area": symbol},
+        "symforge-refactor": {
+            "goal": f"review controlled refactor of {symbol}",
+            "target": path,
+        },
+        "symforge-debug": {
+            "error": f"controlled error near {symbol}",
+            "path": path,
+        },
+        "symforge-admin": {},
+    }
+
+
+def successful_result(capture: Any, method: str) -> dict[str, Any]:
+    response = capture.response_raw
+    if not isinstance(response, dict) or "error" in response:
+        raise HarnessError(f"{method} did not return a successful response")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise HarnessError(f"{method} result was not an object")
+    return result
+
+
+def resource_text(result: dict[str, Any], requested_uri: str) -> str:
+    contents = result.get("contents")
+    if not isinstance(contents, list) or not contents:
+        raise HarnessError("resources/read returned no contents")
+    texts: list[str] = []
+    for content in contents:
+        if not isinstance(content, dict):
+            raise HarnessError("resources/read content was not an object")
+        if content.get("uri") != requested_uri:
+            raise HarnessError("resources/read returned content for a different URI")
+        if content.get("mimeType") != "text/markdown":
+            raise HarnessError("resources/read returned an unexpected MIME type")
+        text = content.get("text")
+        if not isinstance(text, str) or not text:
+            raise HarnessError("resources/read returned empty non-text content")
+        texts.append(text)
+    return "\n".join(texts)
+
+
+def prompt_text(result: dict[str, Any]) -> str:
+    messages = result.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise HarnessError("prompts/get returned no messages")
+    texts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise HarnessError("prompts/get returned an invalid message")
+        content = message.get("content")
+        if isinstance(content, dict) and isinstance(content.get("text"), str):
+            texts.append(content["text"])
+    if not texts:
+        raise HarnessError("prompts/get returned no text message")
+    return "\n".join(texts)
+
+
+def write_call(
+    writer: JsonlWriter,
+    capture_config: CaptureConfig,
+    capture: Any,
+    counter: TokenCounter,
+    kind: str,
+    identity: str,
+    project_evidence: bool | None,
+) -> None:
+    record = capture_record(capture_config, capture)
+    component = "messages" if kind == "prompt" else "contents"
+    raw_result = (capture.response_raw or {}).get("result", {})
+    safe_result = (capture.response_safe or {}).get("result", {})
+    raw_payload = raw_result.get(component)
+    safe_payload = safe_result.get(component)
+    if not isinstance(raw_payload, list) or not isinstance(safe_payload, list):
+        raise HarnessError("non-tool payload component was not a list")
+    raw_counts = counter.metrics(canonical_json(raw_payload))
+    safe_counts = counter.metrics(canonical_json(safe_payload))
+    record.update(
+        {
+            "record_type": "non_tool_surface_call",
+            "non_tool_kind": kind,
+            "identity": identity,
+            "project_evidence": project_evidence,
+            "schema_free_non_tool_payload_component": f"result.{component}",
+            "schema_free_non_tool_payload_basis": (
+                f"one canonical JSON serialization of result.{component}; "
+                "no per-block summation"
+            ),
+            "schema_free_non_tool_payload_utf8_bytes": raw_counts["utf8_bytes"],
+            "schema_free_non_tool_payload_cl100k": raw_counts["cl100k"],
+            "schema_free_non_tool_payload_o200k": raw_counts["o200k"],
+            "sanitized_schema_free_non_tool_payload_utf8_bytes": safe_counts[
+                "utf8_bytes"
+            ],
+            "sanitized_schema_free_non_tool_payload_cl100k": safe_counts["cl100k"],
+            "sanitized_schema_free_non_tool_payload_o200k": safe_counts["o200k"],
+        }
+    )
+    writer.write(record)
+
+
+def run_smoke(config: SmokeConfig) -> int:
+    config.repo = config.repo.resolve()
+    config.output = config.output.resolve()
+    validate_paths(config.repo, config.output)
+    validate_external_repo(config.repo)
+    validate_fixture(config)
+    if config.timeout <= 0:
+        raise HarnessError("--timeout must be greater than zero")
+
+    server_path = resolve_server(config.server)
+    sanitizer = Sanitizer()
+    counter = TokenCounter()
+    writer = JsonlWriter(config.output, sanitizer, append=False)
+    env = child_environment("full", True)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    capture_config = CaptureConfig(
+        mode="manifest",
+        repo=config.repo,
+        output=config.output,
+        server=config.server,
+        server_args=config.server_args,
+        surface="full",
+        auto_index=True,
+        timeout=config.timeout,
+        protocol_version=MCP_PROTOCOL_VERSION,
+        run_id=config.run_id,
+        case_id=config.case_id,
+        append=False,
+    )
+    client: StdioMcpClient | None = None
+    pending: BaseException | None = None
+
+    try:
+        writer.write(
+            {
+                **base_record(capture_config),
+                "record_type": "non_tool_run_metadata",
+                "server_executable_sha256": executable_sha256(server_path),
+                "server_argument_count": len(config.server_args),
+                "tokenizer": counter.metadata(),
+                "expected_counts": {"resources": 6, "templates": 4, "prompts": 7},
+            }
+        )
+        client = StdioMcpClient(
+            [str(server_path), *config.server_args],
+            config.repo,
+            env,
+            config.timeout,
+            sanitizer,
+            counter,
+        )
+        initialize = client.rpc(
+            "initialize",
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "symforge-non-tool-smoke", "version": "1.0"},
+            },
+        )
+        writer.write(capture_record(capture_config, initialize))
+        successful_result(initialize, "initialize")
+        initialized = client.notify("notifications/initialized", {})
+        writer.write(capture_record(capture_config, initialized))
+
+        resources, resource_metrics = list_all(
+            client, writer, capture_config, "resources/list", "resources"
+        )
+        templates, template_metrics = list_all(
+            client,
+            writer,
+            capture_config,
+            "resources/templates/list",
+            "resourceTemplates",
+        )
+        prompts, prompt_metrics = list_all(
+            client, writer, capture_config, "prompts/list", "prompts"
+        )
+        validate_static_resources(resources)
+        validate_resource_templates(templates)
+        validate_prompts(prompts)
+
+        health_evidence = False
+        for uri in STATIC_RESOURCES:
+            capture = client.rpc("resources/read", {"uri": uri})
+            result = successful_result(capture, "resources/read")
+            text = resource_text(result, uri)
+            evidence: bool | None = None
+            if uri == "symforge://repo/health":
+                health_evidence = normalize_repo_path(
+                    str(config.repo)
+                ) in normalize_repo_path(text)
+                if not health_evidence:
+                    raise HarnessError(
+                        "health resource did not prove the bound project"
+                    )
+                evidence = True
+            write_call(
+                writer,
+                capture_config,
+                capture,
+                counter,
+                "static_resource",
+                uri,
+                evidence,
+            )
+
+        for name, (uri, anchor) in template_instances(config).items():
+            capture = client.rpc("resources/read", {"uri": uri})
+            result = successful_result(capture, "resources/read")
+            text = resource_text(result, uri)
+            if anchor not in text:
+                raise HarnessError(
+                    "templated resource omitted its path or symbol evidence"
+                )
+            write_call(
+                writer,
+                capture_config,
+                capture,
+                counter,
+                "resource_template",
+                name,
+                True,
+            )
+
+        project_name = config.repo.name.casefold()
+        prompt_evidence = 0
+        for name, arguments in prompt_requests(config).items():
+            if set(arguments) != set(PROMPT_ARGUMENTS[name]):
+                raise HarnessError(
+                    "prompt request did not use its exact declared arguments"
+                )
+            capture = client.rpc("prompts/get", {"name": name, "arguments": arguments})
+            result = successful_result(capture, "prompts/get")
+            text = prompt_text(result)
+            evidence = project_name in text.casefold()
+            if not evidence:
+                raise HarnessError("prompt text did not prove the bound project")
+            prompt_evidence += 1
+            write_call(writer, capture_config, capture, counter, "prompt", name, True)
+
+        writer.write(
+            {
+                **base_record(capture_config),
+                "record_type": "non_tool_summary",
+                "status": "ok",
+                "static_resources_read": len(STATIC_RESOURCES),
+                "resource_templates_read": len(RESOURCE_TEMPLATES),
+                "prompts_fetched": len(PROMPT_ARGUMENTS),
+                "health_project_evidence": health_evidence,
+                "prompt_project_evidence_count": prompt_evidence,
+                "list_metrics": {
+                    "resources/list": resource_metrics,
+                    "resources/templates/list": template_metrics,
+                    "prompts/list": prompt_metrics,
+                },
+            }
+        )
+    except BaseException as exc:
+        pending = exc
+        writer.write(
+            {
+                **base_record(capture_config),
+                "record_type": "harness_error",
+                "error_type": type(exc).__name__,
+                "message": str(exc)
+                if isinstance(exc, HarnessError)
+                else type(exc).__name__,
+            }
+        )
+    finally:
+        if client is not None:
+            writer.write(
+                {
+                    **base_record(capture_config),
+                    "record_type": "process_lifecycle",
+                    "process_start_ms": client.process_start_ms,
+                    **client.close(),
+                }
+            )
+        rows = writer.rows
+        writer.close()
+
+    if pending is not None:
+        if isinstance(pending, HarnessError):
+            raise pending
+        raise HarnessError(
+            f"unexpected smoke-runner failure ({type(pending).__name__})"
+        ) from pending
+    return rows
+
+
+def prompt_definitions() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "description": "Harmless fake prompt.",
+            "arguments": [
+                {"name": argument, "required": required}
+                for argument, required in arguments.items()
+            ],
+        }
+        for name, arguments in PROMPT_ARGUMENTS.items()
+    ]
+
+
+def fake_server() -> int:
+    secret = "unit" + "-sensitive" + "-surface"
+    project = pathlib.Path.cwd()
+    for raw_line in sys.stdin.buffer:
+        try:
+            request = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if "id" not in request:
+            continue
+        method = request.get("method")
+        params = request.get("params", {})
+        if method == "initialize":
+            result: Any = {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {"resources": {}, "prompts": {}},
+                "serverInfo": {"name": "non-tool-fake", "version": "0"},
+            }
+        elif method == "resources/list":
+            result = {
+                "resources": [
+                    {
+                        "uri": uri,
+                        "name": name,
+                        "description": "Harmless fake resource.",
+                        "mimeType": "text/markdown",
+                    }
+                    for uri, name in STATIC_RESOURCES.items()
+                ]
+            }
+        elif method == "resources/templates/list":
+            result = {
+                "resourceTemplates": [
+                    {
+                        "uriTemplate": uri,
+                        "name": name,
+                        "description": "Harmless fake template.",
+                        "mimeType": "text/markdown",
+                    }
+                    for uri, name in RESOURCE_TEMPLATES.items()
+                ]
+            }
+        elif method == "prompts/list":
+            result = {"prompts": prompt_definitions()}
+        elif method == "resources/read":
+            uri = str(params.get("uri", ""))
+            parsed = urlparse(uri)
+            query = parse_qs(parsed.query)
+            anchor = (
+                query.get("name", query.get("path", [project.name]))[0]
+                if query
+                else project.name
+            )
+            text = f"project_root={project.as_posix()}\nanchor={anchor}"
+            if uri == "symforge://glossary":
+                text += f'\nAPI_TOKEN="{secret}"'
+            result = {
+                "contents": [{"uri": uri, "mimeType": "text/markdown", "text": text}]
+            }
+        elif method == "prompts/get":
+            name = str(params.get("name", ""))
+            result = {
+                "description": "Harmless fake prompt result.",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": {
+                            "type": "text",
+                            "text": f"Project {project.name}; prompt {name}",
+                        },
+                    }
+                ],
+            }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+            sys.stdout.buffer.write(wire_json(response).encode("utf-8"))
+            sys.stdout.buffer.flush()
+            continue
+        response = {"jsonrpc": "2.0", "id": request["id"], "result": result}
+        sys.stdout.buffer.write(wire_json(response).encode("utf-8"))
+        sys.stdout.buffer.flush()
+    return 0
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory(prefix="sfbench-non-tool-test-") as root_text:
+        root = pathlib.Path(root_text)
+        repo = root / "repo"
+        repo.mkdir()
+        fixture = repo / "fixture.py"
+        fixture.write_text("def fixture_symbol():\n    return 1\n", encoding="utf-8")
+        output = root / "non-tool.jsonl"
+        config = SmokeConfig(
+            repo=repo,
+            output=output,
+            fixture_path="fixture.py",
+            fixture_symbol="fixture_symbol",
+            fixture_kind="fn",
+            server=sys.executable,
+            server_args=[str(pathlib.Path(__file__).resolve()), "--_fake-server"],
+            timeout=10,
+            run_id="self-test",
+            case_id="non-tool",
+        )
+        run_smoke(config)
+        persisted = output.read_text(encoding="utf-8")
+        if "unit" + "-sensitive" + "-surface" in persisted:
+            raise HarnessError("self-test secret sanitizer invariant failed")
+        if REDACTED not in persisted or "--_fake-server" in persisted:
+            raise HarnessError("self-test fail-closed artifact invariant failed")
+        rows = [json.loads(line) for line in persisted.splitlines()]
+        calls = [
+            row for row in rows if row.get("record_type") == "non_tool_surface_call"
+        ]
+        if len(calls) != 17 or any(row.get("status") != "ok" for row in calls):
+            raise HarnessError("self-test non-tool call coverage invariant failed")
+        if sum(row.get("method") == "resources/read" for row in calls) != 10:
+            raise HarnessError("self-test resource read count invariant failed")
+        if sum(row.get("method") == "prompts/get" for row in calls) != 7:
+            raise HarnessError("self-test prompt count invariant failed")
+        counter = TokenCounter()
+        fake_secret = "unit" + "-sensitive" + "-surface"
+        for row in calls:
+            component = row["schema_free_non_tool_payload_component"].split(".", 1)[1]
+            safe_payload = row["response"]["result"][component]
+            safe_expected = counter.metrics(canonical_json(safe_payload))
+            raw_payload = json.loads(canonical_json(safe_payload))
+            if row["identity"] == "symforge://glossary":
+                raw_payload[0]["text"] = raw_payload[0]["text"].replace(
+                    REDACTED, fake_secret
+                )
+            raw_expected = counter.metrics(canonical_json(raw_payload))
+            for suffix in ("utf8_bytes", "cl100k", "o200k"):
+                if (
+                    row[f"schema_free_non_tool_payload_{suffix}"]
+                    != raw_expected[suffix]
+                ):
+                    raise HarnessError("self-test raw non-tool payload count drifted")
+                if (
+                    row[f"sanitized_schema_free_non_tool_payload_{suffix}"]
+                    != safe_expected[suffix]
+                ):
+                    raise HarnessError(
+                        "self-test sanitized non-tool payload count drifted"
+                    )
+            if (
+                row["schema_free_non_tool_payload_cl100k"] <= 0
+                or row["schema_free_non_tool_payload_o200k"] <= 0
+            ):
+                raise HarnessError("self-test non-tool payload count was zero")
+        if any(
+            not isinstance(row.get("response_cl100k"), int)
+            or row["response_cl100k"] <= 0
+            or row.get("rpc_ms") is None
+            for row in calls
+        ):
+            raise HarnessError("self-test call measurement invariant failed")
+        summary = next(
+            row for row in rows if row.get("record_type") == "non_tool_summary"
+        )
+        if (
+            not summary["health_project_evidence"]
+            or summary["prompt_project_evidence_count"] != 7
+        ):
+            raise HarnessError("self-test project evidence invariant failed")
+        try:
+            validate_static_resources([{"uri": "wrong"}])
+        except HarnessError:
+            pass
+        else:
+            raise HarnessError("self-test identity rejection invariant failed")
+    print("self-test: PASS")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test all SymForge resources, templates, and prompts in one "
+            "isolated stdio session. HTTP is intentionally unsupported."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    run = subparsers.add_parser("run", help="Run the sanitized non-tool smoke suite.")
+    run.add_argument("--repo", required=True)
+    run.add_argument("--output", required=True)
+    run.add_argument("--fixture-path", required=True)
+    run.add_argument("--fixture-symbol", required=True)
+    run.add_argument("--fixture-kind", default="fn")
+    run.add_argument("--server", default="symforge")
+    run.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="Repeat for server arguments; values are never persisted.",
+    )
+    run.add_argument("--timeout", type=float, default=120.0)
+    run.add_argument("--run-id", required=True)
+    run.add_argument("--case-id", required=True)
+    subparsers.add_parser("self-test", help="Run against an internal fake MCP server.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments == ["--_fake-server"]:
+        return fake_server()
+    args = build_parser().parse_args(arguments)
+    if args.mode == "self-test":
+        return self_test()
+    config = SmokeConfig(
+        repo=pathlib.Path(args.repo),
+        output=pathlib.Path(args.output),
+        fixture_path=args.fixture_path,
+        fixture_symbol=args.fixture_symbol,
+        fixture_kind=args.fixture_kind,
+        server=args.server,
+        server_args=list(args.server_arg),
+        timeout=args.timeout,
+        run_id=args.run_id,
+        case_id=args.case_id,
+    )
+    rows = run_smoke(config)
+    print(f"non-tool smoke complete: {rows} sanitized JSONL rows")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HarnessError as exc:
+        print(f"non_tool_surface_smoke: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/research/full-surface-benchmark/parity-normalization.json
+++ b/research/full-surface-benchmark/parity-normalization.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "purpose": "Allow only transport- or process-identity differences in normalized stdio versus HTTP comparisons.",
+  "json_pointer_allowlist": [
+    "/id"
+  ],
+  "text_replacements": [],
+  "freeform_text_policy": "Never regex-normalize freeform tool content. Normalize only typed protocol fields named in json_pointer_allowlist; otherwise report the transport difference.",
+  "never_normalize": [
+    "paths",
+    "project_id",
+    "file_or_symbol_counts",
+    "symbols_or_references",
+    "ranked_result_order",
+    "trust_or_completeness_fields",
+    "errors",
+    "substantive_content"
+  ]
+}

--- a/research/full-surface-benchmark/setup_corpus.ps1
+++ b/research/full-surface-benchmark/setup_corpus.ps1
@@ -1,0 +1,506 @@
+[CmdletBinding()]
+param(
+    [string] $BenchRoot = 'C:\AI_STUFF\BENCHMARKS\symforge-8.14.0-surface',
+    [string] $ProjectRoot = 'C:\AI_STUFF\PROGRAMMING\symforge',
+    [switch] $Resume
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-ValidAlias {
+    param([Parameter(Mandatory)] [string] $Alias)
+
+    $isReservedDevice = $Alias -match '^(?i:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$'
+    if ($Alias.Length -gt 64 -or
+        $Alias -notmatch '^[a-z0-9][a-z0-9._-]*$' -or
+        $Alias.EndsWith('.') -or
+        $Alias -in @('.', '..') -or
+        $isReservedDevice) {
+        throw 'Corpus lock contains an invalid repository alias.'
+    }
+}
+
+function Get-SafeGitHubUrl {
+    param(
+        [Parameter(Mandatory)] [string] $Url,
+        [Parameter(Mandatory)] [string] $Alias
+    )
+
+    $invalid = "Repository '$Alias' has an invalid source URL."
+    if ($Url -match '[\x00-\x20\x7f]' -or $Url.Contains('\') -or $Url.Contains('%')) {
+        throw $invalid
+    }
+
+    [Uri] $uri = $null
+    if (-not [Uri]::TryCreate($Url, [UriKind]::Absolute, [ref] $uri) -or
+        $uri.Scheme -ne 'https' -or
+        $uri.IdnHost -ne 'github.com' -or
+        $uri.Port -ne 443 -or
+        $uri.UserInfo -or
+        $uri.Query -or
+        $uri.Fragment) {
+        throw $invalid
+    }
+
+    $segments = @($uri.AbsolutePath.Trim('/') -split '/')
+    if ($segments.Count -ne 2 -or
+        $segments[0] -notmatch '^[A-Za-z0-9_.-]+$' -or
+        $segments[1] -notmatch '^[A-Za-z0-9_.-]+$' -or
+        $segments[0] -in @('.', '..') -or
+        $segments[1] -in @('.', '..')) {
+        throw $invalid
+    }
+
+    return "https://github.com/$($segments[0])/$($segments[1])"
+}
+
+function Assert-PlainDirectory {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $Description
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "$Description must be an ordinary directory."
+    }
+    $item = Get-Item -Force -LiteralPath $Path
+    if (-not $item.PSIsContainer -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw "$Description must be an ordinary directory."
+    }
+}
+
+function Get-ContainedSourceDestination {
+    param(
+        [Parameter(Mandatory)] [string] $SourcesRoot,
+        [Parameter(Mandatory)] [string] $Alias
+    )
+
+    Assert-ValidAlias $Alias
+    $source = [IO.Path]::GetFullPath($SourcesRoot).TrimEnd(
+        [IO.Path]::DirectorySeparatorChar,
+        [IO.Path]::AltDirectorySeparatorChar
+    )
+    $destination = [IO.Path]::GetFullPath((Join-Path $source $Alias))
+    $parent = [IO.Path]::GetDirectoryName($destination)
+    $prefix = $source + [IO.Path]::DirectorySeparatorChar
+    if (-not $parent.Equals($source, [StringComparison]::OrdinalIgnoreCase) -or
+        -not $destination.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Repository '$Alias' resolves outside the sources directory."
+    }
+
+    if (Test-Path -LiteralPath $destination) {
+        Assert-PlainDirectory $destination "Repository '$Alias' destination"
+    }
+    return $destination
+}
+
+function Invoke-Git {
+    param(
+        [AllowNull()] [string] $Repository,
+        [Parameter(Mandatory)] [string[]] $Arguments,
+        [int[]] $AllowedExitCodes = @(0),
+        [switch] $Raw
+    )
+
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = 'git'
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.StandardOutputEncoding = [Text.Encoding]::UTF8
+    $start.StandardErrorEncoding = [Text.Encoding]::UTF8
+    $start.Environment.Clear()
+
+    foreach ($name in @('PATH', 'Path', 'PATHEXT', 'SystemRoot', 'WINDIR', 'ComSpec', 'TEMP', 'TMP')) {
+        $value = [Environment]::GetEnvironmentVariable($name, 'Process')
+        if ($value -and -not $start.Environment.ContainsKey($name)) {
+            $start.Environment[$name] = $value
+        }
+    }
+    $start.Environment['GIT_CONFIG_NOSYSTEM'] = '1'
+    $start.Environment['GIT_CONFIG_SYSTEM'] = $script:IsolatedGitConfig
+    $start.Environment['GIT_CONFIG_GLOBAL'] = $script:IsolatedGitConfig
+    $start.Environment['GIT_TEMPLATE_DIR'] = $script:EmptyGitTemplate
+    $start.Environment['GIT_TERMINAL_PROMPT'] = '0'
+    $start.Environment['GCM_INTERACTIVE'] = 'Never'
+    $start.Environment['GIT_LFS_SKIP_SMUDGE'] = '1'
+    $start.Environment['GIT_PROTOCOL_FROM_USER'] = '0'
+
+    foreach ($argument in @(
+        '-c', 'credential.helper=',
+        '-c', 'credential.interactive=never',
+        '-c', 'core.askPass=',
+        '-c', "core.hooksPath=$script:EmptyGitHooks",
+        '-c', 'core.fsmonitor=false'
+    )) {
+        $start.ArgumentList.Add($argument)
+    }
+    if ($Repository) {
+        $start.ArgumentList.Add('-c')
+        $start.ArgumentList.Add("core.worktree=$Repository")
+        $start.ArgumentList.Add('-c')
+        $start.ArgumentList.Add('core.bare=false')
+        $start.ArgumentList.Add('-C')
+        $start.ArgumentList.Add($Repository)
+    }
+    foreach ($argument in $Arguments) {
+        $start.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    try {
+        if (-not $process.Start()) {
+            throw 'Unable to start Git.'
+        }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $null = $stderrTask.GetAwaiter().GetResult()
+        if ($AllowedExitCodes -notcontains $process.ExitCode) {
+            throw "Git operation failed with exit code $($process.ExitCode)."
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+
+    if ($Raw) {
+        return $stdout
+    }
+    if (-not $stdout) {
+        return @()
+    }
+    return @($stdout.TrimEnd([char] 13, [char] 10) -split '\r?\n')
+}
+
+function Get-GitBlobObjectId {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $ExpectedObjectId,
+        [switch] $Symlink
+    )
+
+    $algorithm = switch ($ExpectedObjectId.Length) {
+        40 { [Security.Cryptography.HashAlgorithmName]::SHA1; break }
+        64 { [Security.Cryptography.HashAlgorithmName]::SHA256; break }
+        default { throw 'Pinned commit uses an unsupported Git object format.' }
+    }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw 'Tracked worktree blob verification failed.'
+    }
+    $item = Get-Item -Force -LiteralPath $Path
+    [byte[]] $linkBytes = $null
+    if ($Symlink -and ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        if (-not $item.LinkTarget) {
+            throw 'Tracked worktree blob verification failed.'
+        }
+        $linkBytes = [Text.Encoding]::UTF8.GetBytes($item.LinkTarget.Replace('\', '/'))
+        [long] $length = $linkBytes.Length
+    }
+    else {
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf) -or
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+            throw 'Tracked worktree blob verification failed.'
+        }
+        [long] $length = $item.Length
+    }
+
+    $hasher = [Security.Cryptography.IncrementalHash]::CreateHash($algorithm)
+    try {
+        $header = [Text.Encoding]::ASCII.GetBytes("blob $length$([char] 0)")
+        $hasher.AppendData($header)
+        if ($null -ne $linkBytes) {
+            $hasher.AppendData($linkBytes)
+        }
+        else {
+            $buffer = [byte[]]::new(1MB)
+            $stream = [IO.File]::Open($Path, 'Open', 'Read', 'Read')
+            try {
+                while (($count = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                    $hasher.AppendData($buffer, 0, $count)
+                }
+            }
+            finally {
+                $stream.Dispose()
+            }
+        }
+        return [Convert]::ToHexString($hasher.GetHashAndReset()).ToLowerInvariant()
+    }
+    finally {
+        $hasher.Dispose()
+    }
+}
+
+function Assert-PinnedWorktreeBlobs {
+    param(
+        [Parameter(Mandatory)] [string] $Repository,
+        [Parameter(Mandatory)] [string] $Commit,
+        [Parameter(Mandatory)] [string] $Alias
+    )
+
+    $rawTree = Invoke-Git -Repository $Repository -Arguments @(
+        'ls-tree', '-r', '-z', '--full-tree', $Commit
+    ) -Raw
+    $prefix = [IO.Path]::GetFullPath($Repository).TrimEnd(
+        [IO.Path]::DirectorySeparatorChar,
+        [IO.Path]::AltDirectorySeparatorChar
+    ) + [IO.Path]::DirectorySeparatorChar
+    [int] $verified = 0
+    foreach ($record in $rawTree.Split([char] 0, [StringSplitOptions]::RemoveEmptyEntries)) {
+        $match = [regex]::Match(
+            $record,
+            '\A([0-9]{6}) (blob|commit) ([0-9a-f]{40}|[0-9a-f]{64})\t([\s\S]+)\z'
+        )
+        if (-not $match.Success) {
+            throw "Repository '$Alias' has an invalid pinned tree entry."
+        }
+        if ($match.Groups[2].Value -eq 'commit') {
+            continue
+        }
+
+        $relative = $match.Groups[4].Value
+        $path = [IO.Path]::GetFullPath((Join-Path $Repository $relative))
+        if (-not $path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Repository '$Alias' has a tracked path outside its worktree."
+        }
+        $blobParameters = @{
+            Path = $path
+            ExpectedObjectId = $match.Groups[3].Value
+            Symlink = ($match.Groups[1].Value -eq '120000')
+        }
+        $actual = Get-GitBlobObjectId @blobParameters
+        if ($actual -ne $match.Groups[3].Value) {
+            throw "Repository '$Alias' failed pinned worktree blob verification."
+        }
+        $verified += 1
+    }
+    if ($verified -eq 0) {
+        throw "Repository '$Alias' pinned tree contained no blobs."
+    }
+}
+
+function Get-Sha256Text {
+    param([Parameter(Mandatory)] [string] $Text)
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Text)
+    $hash = [Security.Cryptography.SHA256]::HashData($bytes)
+    return [Convert]::ToHexString($hash).ToLowerInvariant()
+}
+
+function Test-BinaryPrefix {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    $buffer = [byte[]]::new(8192)
+    $stream = [IO.File]::Open($Path, 'Open', 'Read', 'ReadWrite')
+    try {
+        $count = $stream.Read($buffer, 0, $buffer.Length)
+        for ($index = 0; $index -lt $count; $index += 1) {
+            if ($buffer[$index] -eq 0) {
+                return $true
+            }
+        }
+        return $false
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+$project = [IO.Path]::GetFullPath($ProjectRoot)
+$root = [IO.Path]::GetFullPath($BenchRoot)
+$separator = [IO.Path]::DirectorySeparatorChar
+
+if ($root.Equals($project, [StringComparison]::OrdinalIgnoreCase) -or
+    $root.StartsWith($project + $separator, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Benchmark root must be outside the SymForge checkout.'
+}
+
+if ((Test-Path -LiteralPath $root) -and -not $Resume) {
+    throw "Refusing to reuse an existing benchmark root: $root"
+}
+
+$lockPath = Join-Path $PSScriptRoot 'corpus.lock.json'
+$lock = Get-Content -Raw -LiteralPath $lockPath | ConvertFrom-Json
+$aliases = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+$safeUrls = @{}
+foreach ($repo in $lock.repositories) {
+    $alias = [string] $repo.alias
+    Assert-ValidAlias $alias
+    if (-not $aliases.Add($alias)) {
+        throw 'Corpus lock contains duplicate repository aliases.'
+    }
+    $safeUrls[$alias] = Get-SafeGitHubUrl -Url ([string] $repo.url) -Alias $alias
+    if ([string] $repo.commit -notmatch '^[0-9a-f]{40}$') {
+        throw "Repository '$alias' has an invalid pinned commit."
+    }
+    if ([int] $repo.history_depth -lt 1) {
+        throw "Repository '$alias' has an invalid history depth."
+    }
+}
+
+if (-not (Test-Path -LiteralPath $root)) {
+    New-Item -ItemType Directory -Path $root | Out-Null
+}
+Assert-PlainDirectory $root 'Benchmark root'
+$sourceRoot = New-Item -ItemType Directory -Path (Join-Path $root 'sources') -Force
+Assert-PlainDirectory $sourceRoot.FullName 'Sources root'
+New-Item -ItemType Directory -Path (Join-Path $root 'runs') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $root 'work') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $root 'artifacts') -Force | Out-Null
+
+$isolatedGitConfig = Join-Path $root 'gitconfig.empty'
+if (-not (Test-Path -LiteralPath $isolatedGitConfig)) {
+    New-Item -ItemType File -Path $isolatedGitConfig | Out-Null
+}
+else {
+    $configItem = Get-Item -Force -LiteralPath $isolatedGitConfig
+    if ($configItem.PSIsContainer -or
+        ($configItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -or
+        $configItem.Length -ne 0) {
+        throw 'Isolated Git configuration must remain an empty regular file.'
+    }
+}
+$emptyGitTemplate = Join-Path $root 'git-template.empty'
+$emptyGitHooks = Join-Path $root 'git-hooks.empty'
+foreach ($emptyDirectory in @($emptyGitTemplate, $emptyGitHooks)) {
+    if (-not (Test-Path -LiteralPath $emptyDirectory)) {
+        New-Item -ItemType Directory -Path $emptyDirectory | Out-Null
+    }
+    Assert-PlainDirectory $emptyDirectory 'Git isolation directory'
+    if (@(Get-ChildItem -Force -LiteralPath $emptyDirectory).Count -ne 0) {
+        throw 'Git isolation directories must remain empty.'
+    }
+}
+$script:IsolatedGitConfig = $isolatedGitConfig
+$script:EmptyGitTemplate = $emptyGitTemplate
+$script:EmptyGitHooks = $emptyGitHooks
+
+$rows = [Collections.Generic.List[object]]::new()
+
+foreach ($repo in $lock.repositories) {
+    $alias = [string] $repo.alias
+    $destination = Get-ContainedSourceDestination -SourcesRoot $sourceRoot.FullName -Alias $alias
+    if (-not (Test-Path -LiteralPath $destination)) {
+        Invoke-Git -Repository $null -Arguments @(
+            'init', '--quiet', "--template=$emptyGitTemplate", $destination
+        ) | Out-Null
+
+        Invoke-Git $destination @('config', 'core.autocrlf', 'false') | Out-Null
+        Invoke-Git $destination @('config', 'core.eol', 'lf') | Out-Null
+        Invoke-Git $destination @('config', 'core.filemode', 'false') | Out-Null
+        Invoke-Git $destination @('config', 'core.longpaths', 'true') | Out-Null
+        Invoke-Git $destination @('config', 'core.quotepath', 'false') | Out-Null
+        Invoke-Git $destination @('remote', 'add', 'origin', $safeUrls[$alias]) | Out-Null
+        Invoke-Git $destination @(
+            'fetch', '--quiet', '--no-tags', "--depth=$($repo.history_depth)",
+            'origin', $repo.commit
+        ) | Out-Null
+        Invoke-Git $destination @('checkout', '--quiet', '--detach', 'FETCH_HEAD') | Out-Null
+    }
+    elseif (-not $Resume) {
+        throw "Source destination already exists: $destination"
+    }
+
+    Assert-PlainDirectory (Join-Path $destination '.git') "Repository '$alias' Git metadata"
+    $origin = @(Invoke-Git $destination @('remote', 'get-url', 'origin'))
+    if ($origin.Count -ne 1 -or $origin[0].Trim() -cne $safeUrls[$alias]) {
+        throw "Repository '$alias' has an unexpected origin configuration."
+    }
+
+    $head = (Invoke-Git $destination @('rev-parse', 'HEAD') | Select-Object -First 1).Trim()
+    if ($head -ne $repo.commit) {
+        throw "$($repo.alias) checked out $head instead of $($repo.commit)"
+    }
+
+    $status = @(Invoke-Git $destination @('status', '--porcelain=v1'))
+    if ($status.Count -gt 0) {
+        throw "$($repo.alias) is dirty immediately after checkout"
+    }
+    if ($Resume) {
+        Assert-PinnedWorktreeBlobs -Repository $destination -Commit $repo.commit -Alias $alias
+    }
+
+    Invoke-Git $destination @('fsck', '--connectivity-only', '--no-dangling') | Out-Null
+
+    $partialCloneConfig = @(Invoke-Git -Repository $destination -Arguments @(
+        'config', '--get-regexp', '^remote\.origin\.(promisor|partialclonefilter)$'
+    ) -AllowedExitCodes @(0, 1))
+    if ($partialCloneConfig.Count -gt 0) {
+        throw "$($repo.alias) unexpectedly has promisor/partial-clone configuration"
+    }
+
+    $missing = @(
+        Invoke-Git $destination @('rev-list', '--objects', '--missing=print', 'HEAD') |
+            Where-Object { $_.StartsWith('?') }
+    )
+    if ($missing.Count -gt 0) {
+        throw "$($repo.alias) has missing Git objects"
+    }
+
+    $tracked = @(Invoke-Git $destination @('ls-files'))
+    [long] $trackedBytes = 0
+    [int] $binaryFiles = 0
+    $extensionCounts = @{}
+    foreach ($relative in $tracked) {
+        $path = Join-Path $destination $relative
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            $trackedBytes += (Get-Item -LiteralPath $path).Length
+            $extension = [IO.Path]::GetExtension($relative).ToLowerInvariant()
+            if (-not $extension) {
+                $extension = '<none>'
+            }
+            $extensionCounts[$extension] = 1 + [int]($extensionCounts[$extension] ?? 0)
+
+            if (Test-BinaryPrefix $path) {
+                $binaryFiles += 1
+            }
+        }
+    }
+
+    $indexRows = (Invoke-Git $destination @('ls-files', '--stage')) -join "`n"
+    $showRefs = (Invoke-Git $destination @('show-ref', '--head')) -join "`n"
+    $tree = (Invoke-Git $destination @('rev-parse', 'HEAD^{tree}') | Select-Object -First 1).Trim()
+    $commitCount = [int](Invoke-Git $destination @('rev-list', '--count', 'HEAD') | Select-Object -First 1)
+    $isShallow = ((Invoke-Git $destination @('rev-parse', '--is-shallow-repository') | Select-Object -First 1).Trim() -eq 'true')
+
+    $row = [ordered]@{
+        alias = $repo.alias
+        source_url_sha256 = Get-Sha256Text $safeUrls[$alias]
+        commit = $head
+        tree = $tree
+        history_depth_requested = [int]$repo.history_depth
+        commit_count_present = $commitCount
+        is_shallow = $isShallow
+        stratum = $repo.stratum
+        primary_language = $repo.primary_language
+        overlay_language = $repo.overlay_language
+        tracked_files = $tracked.Count
+        tracked_worktree_bytes = $trackedBytes
+        binary_files = $binaryFiles
+        extension_counts = [ordered]@{}
+        index_manifest_sha256 = Get-Sha256Text $indexRows
+        show_ref_sha256 = Get-Sha256Text $showRefs
+    }
+    foreach ($extension in ($extensionCounts.Keys | Sort-Object)) {
+        $row.extension_counts[$extension] = $extensionCounts[$extension]
+    }
+    $rows.Add([pscustomobject]$row)
+    Write-Host "$($repo.alias): $($tracked.Count) tracked files, $trackedBytes bytes"
+}
+
+$manifest = [ordered]@{
+    version = 2
+    corpus_lock_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $lockPath).Hash.ToLowerInvariant()
+    git_version = (Invoke-Git -Repository $null -Arguments @('--version') | Select-Object -First 1)
+    root = $root
+    repositories = $rows
+}
+
+$manifestPath = Join-Path $root 'corpus-manifest.json'
+$manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding utf8NoBOM
+Write-Host "Corpus manifest: $manifestPath"


### PR DESCRIPTION
## What

- Add the **8.14.0 full-surface benchmark** dogfood protocol + report (`docs/dogfood/2026-07-12-*`).
- Add the `research/full-surface-benchmark/` harness — cases corpus, direct/MCP runners, adjudicator, fixture generator, and lockfiles.
- **README** surface-table fixes:
  - Document tools missing from the table: `status`, `symforge_retrieve`, `detect_impact`, `symforge_edit`.
  - Rewrite the `batch_rename` row for its fail-closed ambiguity behavior.
  - Add the *"Renames that stay sound on ambiguous names"* subsection.
  - Mark `trace_symbol` **retired** (was "planned for removal in v8.0").

## Notes

- README changes were reconciled onto latest `main` — the upstream "token economics" note and `SYMFORGE_DAEMON_IDLE_SHUTDOWN_SECS` row are preserved; only net-new content added.
- Docs/research only — no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to README and dogfood/research documentation; they do not alter runtime behavior, auth, or mutation paths in the product.
> 
> **Overview**
> Adds the frozen **SFBENCH-1.0** full-surface benchmark for SymForge 8.14.0: a long-form protocol (`docs/dogfood/…-protocol.md`), an executed campaign report with per-tool findings and economics (`…-report.md`), and a PowerShell execution runbook under `research/full-surface-benchmark/README.md` that ties cases, locks, runners, and adjudication together.
> 
> **README** updates align public docs with the live 36-tool surface: new rows for `status`, `symforge_retrieve`, `detect_impact`, and `symforge_edit`; expanded `batch_rename` behavior plus an innovations subsection on ambiguous-name renames; and `trace_symbol` documented as **retired** (replacing the prior v8.0 removal note).
> 
> No Rust or test changes—documentation and benchmark methodology only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3f1ddc1e9381249ecd40cebd32b5535039f997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->