### PR TITLE
fix(serve): bind once and report, and detect port occupancy honestly

### DIFF
--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -114,6 +114,10 @@ pub fn operator_server_reachable(addr: SocketAddr, timeout: Duration) -> bool {
 /// rather than narrowing it: there is no interval in which the port is chosen
 /// but unowned.
 ///
+/// `preferred` is a **preference**, not a demand: a remembered port to land back
+/// on, or the default. When it is occupied, serve falls back to a free operator
+/// port rather than failing — the caller wanted *a* server, not that exact port.
+///
 /// **Limit (documented):** there is no graceful-stop handle — the spawned server
 /// runs until the process exits.
 ///
@@ -126,25 +130,25 @@ pub fn start_operator_server(
     api_key_env: Option<String>,
     deadline: Duration,
 ) -> anyhow::Result<ServerSessionDescriptor> {
-    // Step 1: let serve pick AND own the port. `explicit_listen` is true only for
-    // a concrete requested port; a `:0` (or absent) preference keeps serve's own
-    // `probe_free_listener` fallback, which binds once with no rebind gap. The
-    // caller never touches the port, so there is no interval in which it is
-    // chosen but unowned.
-    // No preference (or `:0`) means "any free port", NOT the default port:
-    // `bind_listener` sets SO_REUSEADDR, so two starters both naming 8787 would
-    // both "succeed" on the same address and the second would silently shadow
-    // the first. Leaving `explicit_listen` false routes those through serve's
-    // `probe_free_listener`, which scans for a genuinely free operator port.
+    // Step 1: let serve pick AND own the port — the caller never touches it, so
+    // there is no interval in which it is chosen but unowned.
+    //
+    // `explicit_listen` stays FALSE here on purpose. It means "the operator
+    // named this exact port, fail loudly if it is taken", and nobody on this
+    // path did: `preferred` is a *preference* — a remembered port to land back
+    // on, or the default — not a demand. Setting it true made an occupied
+    // preference a hard failure, which only looked survivable while
+    // `SO_REUSEADDR` was silently letting two servers share one address. False
+    // routes through `probe_free_listener`, which honors the preference when
+    // free and falls back to a genuinely free operator port when not.
     let requested = preferred.map_or_else(
         || crate::server::serve::DEFAULT_LISTEN.to_string(),
         |addr| addr.to_string(),
     );
-    let explicit_listen = preferred.is_some_and(|addr| addr.port() != 0);
     let (bound_tx, bound_rx) = std::sync::mpsc::sync_channel(1);
     let serve_args = ServeArgs {
         listen: requested,
-        explicit_listen,
+        explicit_listen: false,
         api_key,
         api_key_env,
         bound_addr_tx: Some(bound_tx),
@@ -173,11 +177,19 @@ pub fn start_operator_server(
     // Step 2: wait to be TOLD the bound address, then confirm it serves. The
     // report arrives once the listener is live, so the remaining poll only
     // covers router/middleware setup, never a port that might never bind.
-    let start = Instant::now();
+    // `serve::run` loads the whole workspace index BEFORE it binds, so the wait
+    // for the address covers indexing as well as the bind — on a loaded machine
+    // that is the slow part. Give it the full deadline, then give reachability
+    // its own: sharing one budget would let a slow index consume the time the
+    // router needs to come up, failing a server that was going to work.
     let bound_addr = bound_rx.recv_timeout(deadline).map_err(|_| {
-        anyhow::anyhow!("operator server did not report a bound address within {deadline:?}")
+        anyhow::anyhow!(
+            "operator server did not report a bound address within {deadline:?} \
+             (index load + bind)"
+        )
     })?;
 
+    let start = Instant::now();
     let probe_timeout = Duration::from_millis(250);
     let poll_interval = Duration::from_millis(50);
     while start.elapsed() < deadline {
@@ -558,6 +570,27 @@ mod tests {
         assert_ne!(
             first.bound_addr, second.bound_addr,
             "each start must own a distinct port"
+        );
+    }
+
+    /// A `preferred` address is a PREFERENCE (a remembered port to land back on,
+    /// or the default) — never an operator demand. An occupied one must fall
+    /// back to a free port, not fail the start. This only looked fine while
+    /// `SO_REUSEADDR` let two servers silently share one address.
+    #[test]
+    fn occupied_preference_falls_back_instead_of_failing() {
+        let first = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+            .expect("first operator server should come up");
+        let second = start_operator_server(
+            Some(first.bound_addr),
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("an occupied preference must fall back, not fail");
+        assert_ne!(
+            first.bound_addr, second.bound_addr,
+            "the second start must land on a different, genuinely free port"
         );
     }
 

--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -124,23 +124,25 @@ pub fn operator_server_reachable(addr: SocketAddr, timeout: Duration) -> bool {
 /// `api_key` / `api_key_env` are threaded straight into [`ServeArgs`] so a network
 /// bind can carry a key sourced from the environment (the wizard never passes an
 /// inline key on a routable bind — `serve::run` refuses that anyway).
+///
+/// `explicit` is the caller's own answer to "did the operator demand this exact
+/// port, or is it a preference (a remembered port, or the default)?" — this
+/// function cannot infer that from `preferred` alone, because both cases pass a
+/// concrete `SocketAddr`. Pass `true` only when a real operator input (e.g. a
+/// CLI `--port`/`--listen` flag) named `preferred`; an occupied port then fails
+/// loudly (FR-002/003) instead of silently landing on a different address that
+/// then gets persisted to config under the operator's back. Pass `false` for a
+/// remembered/default port, where a caller wanting *a* server, not that exact
+/// one, expects a graceful fallback.
 pub fn start_operator_server(
     preferred: Option<SocketAddr>,
+    explicit: bool,
     api_key: Option<String>,
     api_key_env: Option<String>,
     deadline: Duration,
 ) -> anyhow::Result<ServerSessionDescriptor> {
     // Step 1: let serve pick AND own the port — the caller never touches it, so
     // there is no interval in which it is chosen but unowned.
-    //
-    // `explicit_listen` stays FALSE here on purpose. It means "the operator
-    // named this exact port, fail loudly if it is taken", and nobody on this
-    // path did: `preferred` is a *preference* — a remembered port to land back
-    // on, or the default — not a demand. Setting it true made an occupied
-    // preference a hard failure, which only looked survivable while
-    // `SO_REUSEADDR` was silently letting two servers share one address. False
-    // routes through `probe_free_listener`, which honors the preference when
-    // free and falls back to a genuinely free operator port when not.
     let requested = preferred.map_or_else(
         || crate::server::serve::DEFAULT_LISTEN.to_string(),
         |addr| addr.to_string(),
@@ -148,7 +150,7 @@ pub fn start_operator_server(
     let (bound_tx, bound_rx) = std::sync::mpsc::sync_channel(1);
     let serve_args = ServeArgs {
         listen: requested,
-        explicit_listen: false,
+        explicit_listen: explicit,
         api_key,
         api_key_env,
         bound_addr_tx: Some(bound_tx),
@@ -174,20 +176,23 @@ pub fn start_operator_server(
         })
         .map_err(|e| anyhow::anyhow!("could not spawn operator-server thread: {e}"))?;
 
-    // Step 2: wait to be TOLD the bound address, then confirm it serves. The
-    // report arrives once the listener is live, so the remaining poll only
-    // covers router/middleware setup, never a port that might never bind.
+    // Step 2: wait to be TOLD the bound address (or the bind error), then
+    // confirm it serves. The report arrives once the listener is live (or the
+    // bind has definitively failed), so the remaining poll only covers
+    // router/middleware setup, never a port that might never bind.
     // `serve::run` loads the whole workspace index BEFORE it binds, so the wait
-    // for the address covers indexing as well as the bind — on a loaded machine
+    // for the report covers indexing as well as the bind — on a loaded machine
     // that is the slow part. Give it the full deadline, then give reachability
     // its own: sharing one budget would let a slow index consume the time the
     // router needs to come up, failing a server that was going to work.
-    let bound_addr = bound_rx.recv_timeout(deadline).map_err(|_| {
-        anyhow::anyhow!(
+    let bound_addr = match bound_rx.recv_timeout(deadline) {
+        Ok(Ok(addr)) => addr,
+        Ok(Err(bind_error)) => anyhow::bail!("operator server failed to start: {bind_error}"),
+        Err(_) => anyhow::bail!(
             "operator server did not report a bound address within {deadline:?} \
              (index load + bind)"
-        )
-    })?;
+        ),
+    };
 
     let start = Instant::now();
     let probe_timeout = Duration::from_millis(250);
@@ -248,8 +253,8 @@ pub(crate) fn select_free_addr_std(preferred: Option<SocketAddr>) -> std::io::Re
 
 /// First bindable operator-range address on `host`, or `None` if the ranges are
 /// exhausted. Restricted to [`serve::operator_port_candidates`] so the returned
-/// port is one the OS does not hand out on its own — the property that makes it
-/// survive this selector's drop-then-rebind gap.
+/// port is one the OS does not hand out on its own — it stays free longer than
+/// an OS ephemeral port would once this function's own probe listener drops.
 fn first_free_operator_addr(host: IpAddr) -> Option<SocketAddr> {
     crate::server::serve::operator_port_candidates().find_map(|port| {
         let addr = SocketAddr::new(host, port);
@@ -438,8 +443,13 @@ pub fn run_admin_with_control_state<B: crate::cli::browser::BrowserOpener + ?Siz
         Some(s) => s,
         None => {
             let preferred = preferred_start_addr(existing_profile.as_ref());
-            let started =
-                start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)?;
+            let started = start_operator_server(
+                Some(preferred),
+                false,
+                None,
+                None,
+                ADMIN_SERVE_START_DEADLINE,
+            )?;
             persist_started_port(control_state_dir, existing_profile.as_ref(), &started);
             started
         }
@@ -563,9 +573,9 @@ mod tests {
     /// Serve binding once and reporting back leaves no gap to lose.
     #[test]
     fn concurrent_starts_with_no_preference_both_come_up() {
-        let first = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+        let first = start_operator_server(None, false, None, None, ADMIN_SERVE_START_DEADLINE)
             .expect("first operator server should come up");
-        let second = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+        let second = start_operator_server(None, false, None, None, ADMIN_SERVE_START_DEADLINE)
             .expect("second operator server should come up");
         assert_ne!(
             first.bound_addr, second.bound_addr,
@@ -579,10 +589,11 @@ mod tests {
     /// `SO_REUSEADDR` let two servers silently share one address.
     #[test]
     fn occupied_preference_falls_back_instead_of_failing() {
-        let first = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+        let first = start_operator_server(None, false, None, None, ADMIN_SERVE_START_DEADLINE)
             .expect("first operator server should come up");
         let second = start_operator_server(
             Some(first.bound_addr),
+            false,
             None,
             None,
             ADMIN_SERVE_START_DEADLINE,
@@ -591,6 +602,30 @@ mod tests {
         assert_ne!(
             first.bound_addr, second.bound_addr,
             "the second start must land on a different, genuinely free port"
+        );
+    }
+
+    /// The mirror image of the fallback test above: `explicit = true` means the
+    /// caller (a real `symforge setup --port N`) DEMANDED this exact port, so an
+    /// occupied one must fail loudly (FR-002/003), not silently substitute a
+    /// different port that then gets persisted to config behind the operator's
+    /// back. `start_operator_server` used to hardcode `explicit_listen: false`
+    /// unconditionally, which made this indistinguishable from a soft preference.
+    #[test]
+    fn explicit_demand_fails_loudly_instead_of_falling_back() {
+        let first = start_operator_server(None, false, None, None, ADMIN_SERVE_START_DEADLINE)
+            .expect("first operator server should come up");
+
+        let result = start_operator_server(
+            Some(first.bound_addr),
+            true,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        );
+        assert!(
+            result.is_err(),
+            "an explicit demand for an occupied port must fail loudly, not fall back: {result:?}"
         );
     }
 
@@ -614,8 +649,14 @@ mod tests {
         // loopback open), then confirm both the start helper's descriptor and a
         // standalone reachability probe agree it is serving.
         let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let desc = start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)
-            .expect("operator server should become reachable");
+        let desc = start_operator_server(
+            Some(preferred),
+            false,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("operator server should become reachable");
 
         assert!(desc.reachable);
         assert!(desc.bound_addr.ip().is_loopback());
@@ -659,9 +700,14 @@ mod tests {
     fn run_admin_reuses_running_server_on_profile_port() {
         // A real server is running; the profile points at its port.
         let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let running =
-            start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)
-                .expect("operator server should come up");
+        let running = start_operator_server(
+            Some(preferred),
+            false,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("operator server should come up");
         let running_port = running.bound_addr.port();
 
         let project = tempfile::tempdir().expect("temp project");
@@ -737,9 +783,14 @@ mod tests {
     #[test]
     fn run_admin_no_open_does_not_open_browser() {
         let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let running =
-            start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)
-                .expect("operator server should come up");
+        let running = start_operator_server(
+            Some(preferred),
+            false,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("operator server should come up");
 
         let project = tempfile::tempdir().expect("temp project");
         let home = tempfile::tempdir().expect("temp home");
@@ -837,9 +888,14 @@ mod tests {
         // path must NOT block: another process owns the server, so admin exits 0
         // after opening the dashboard (required behavior #1).
         let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let running =
-            start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)
-                .expect("operator server should come up");
+        let running = start_operator_server(
+            Some(preferred),
+            false,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("operator server should come up");
 
         let project = tempfile::tempdir().expect("temp project");
         let home = tempfile::tempdir().expect("temp home");

--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -95,31 +95,27 @@ pub fn operator_server_reachable(addr: SocketAddr, timeout: Duration) -> bool {
 /// verified-free port, poll reachability, and return the live
 /// [`ServerSessionDescriptor`] (D3, E4).
 ///
-/// **Approach + limits.** `serve::run` binds its listener *internally* and then
-/// blocks in `axum::serve(...).await` until a shutdown signal, so it neither
-/// returns the bound address nor yields control. Rather than fork/reimplement
-/// serve, this helper:
+/// **Approach.** `serve::run` blocks in `axum::serve(...).await` until shutdown,
+/// so it never returns. This helper:
 ///
-/// 1. Selects a verified-free address up front via
-///    [`serve::probe_free_port`] (preferring `preferred`, else an OS-assigned
-///    ephemeral loopback port).
-/// 2. Spawns a dedicated **OS thread** that owns its own multi-thread tokio
-///    runtime and runs `serve::run` with `explicit_listen = true` bound to that
-///    exact address. `serve::run` sets `SO_REUSEADDR`, so the rebind into the
-///    just-probed port is robust against the tiny probe-then-bind window. The
-///    thread (and its server) live for the lifetime of the process — this is a
-///    start-on-demand helper, not a managed lifecycle (no shutdown handle is
-///    returned; stopping is process exit, matching D3's "no OS service unit"
-///    scope).
-/// 3. Polls [`operator_server_reachable`] on the chosen address until it serves
-///    or `deadline` elapses, returning the reachable descriptor (FR-020) or an
-///    error if it never came up.
+/// 1. Spawns a dedicated **OS thread** owning its own multi-thread tokio runtime,
+///    running `serve::run` with a `bound_addr_tx` channel. The thread (and its
+///    server) live for the lifetime of the process — this is a start-on-demand
+///    helper, not a managed lifecycle (no shutdown handle is returned; stopping
+///    is process exit, matching D3's "no OS service unit" scope).
+/// 2. Waits for `serve::run` to REPORT the address it bound, then confirms
+///    reachability before returning the descriptor (FR-020).
+///
+/// Selecting the port here — bind it, read the number, drop the listener, and
+/// ask serve to re-bind it — was a real defect, not a theoretical window. The
+/// gap was wide enough to lose in CI repeatedly, first on OS ephemeral ports
+/// and then on `8080`, the first operator candidate that every concurrent
+/// starter picks. Letting serve bind once and report back removes the gap
+/// rather than narrowing it: there is no interval in which the port is chosen
+/// but unowned.
 ///
 /// **Limit (documented):** there is no graceful-stop handle — the spawned server
-/// runs until the process exits. The probe-then-bind on step 1 has the documented
-/// small rebind window of [`serve::probe_free_port`]; `SO_REUSEADDR` plus the
-/// immediate rebind makes a steal vanishingly unlikely, and the reachability gate
-/// in step 3 means we never report a URL that did not actually come up.
+/// runs until the process exits.
 ///
 /// `api_key` / `api_key_env` are threaded straight into [`ServeArgs`] so a network
 /// bind can carry a key sourced from the environment (the wizard never passes an
@@ -130,29 +126,31 @@ pub fn start_operator_server(
     api_key_env: Option<String>,
     deadline: Duration,
 ) -> anyhow::Result<ServerSessionDescriptor> {
-    // Step 1: pick a verified-free address before spawning, so we know the bound
-    // address without needing serve::run to report it back. This runs on the
-    // CALLER's thread, which has no ambient tokio reactor, so we cannot use
-    // `serve::probe_free_port` here (it builds a `tokio::net::TcpListener`, which
-    // panics outside a runtime). Instead select the address with a reactor-free
-    // `std` bind — the same probe-then-bind decision logic, the same documented
-    // small rebind window; the real serve bind (inside the spawned runtime) still
-    // uses `bind_listener` with `SO_REUSEADDR`, which makes the rebind robust.
-    let bound_addr = select_free_addr_std(preferred)
-        .map_err(|e| anyhow::anyhow!("could not select a free operator-server port: {e}"))?;
-
-    // Step 2: run serve::run on its own thread + runtime, bound to that exact
-    // address. `explicit_listen = true` makes serve honor the address exactly
-    // (it would otherwise fall back on an occupied default — but we already
-    // verified this address is free).
+    // Step 1: let serve pick AND own the port. `explicit_listen` is true only for
+    // a concrete requested port; a `:0` (or absent) preference keeps serve's own
+    // `probe_free_listener` fallback, which binds once with no rebind gap. The
+    // caller never touches the port, so there is no interval in which it is
+    // chosen but unowned.
+    // No preference (or `:0`) means "any free port", NOT the default port:
+    // `bind_listener` sets SO_REUSEADDR, so two starters both naming 8787 would
+    // both "succeed" on the same address and the second would silently shadow
+    // the first. Leaving `explicit_listen` false routes those through serve's
+    // `probe_free_listener`, which scans for a genuinely free operator port.
+    let requested = preferred.map_or_else(
+        || crate::server::serve::DEFAULT_LISTEN.to_string(),
+        |addr| addr.to_string(),
+    );
+    let explicit_listen = preferred.is_some_and(|addr| addr.port() != 0);
+    let (bound_tx, bound_rx) = std::sync::mpsc::sync_channel(1);
     let serve_args = ServeArgs {
-        listen: bound_addr.to_string(),
-        explicit_listen: true,
+        listen: requested,
+        explicit_listen,
         api_key,
         api_key_env,
+        bound_addr_tx: Some(bound_tx),
     };
     std::thread::Builder::new()
-        .name(format!("symforge-serve-{}", bound_addr.port()))
+        .name("symforge-serve".to_string())
         .spawn(move || {
             let runtime = match tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -172,8 +170,14 @@ pub fn start_operator_server(
         })
         .map_err(|e| anyhow::anyhow!("could not spawn operator-server thread: {e}"))?;
 
-    // Step 3: poll reachability until the server answers or the deadline elapses.
+    // Step 2: wait to be TOLD the bound address, then confirm it serves. The
+    // report arrives once the listener is live, so the remaining poll only
+    // covers router/middleware setup, never a port that might never bind.
     let start = Instant::now();
+    let bound_addr = bound_rx.recv_timeout(deadline).map_err(|_| {
+        anyhow::anyhow!("operator server did not report a bound address within {deadline:?}")
+    })?;
+
     let probe_timeout = Duration::from_millis(250);
     let poll_interval = Duration::from_millis(50);
     while start.elapsed() < deadline {
@@ -186,33 +190,32 @@ pub fn start_operator_server(
     anyhow::bail!("operator server did not become reachable on {bound_addr} within {deadline:?}")
 }
 
-/// Select a verified-free loopback address using only `std` (no tokio reactor),
-/// preferring `preferred`. Mirrors the decision logic of `serve::probe_free_port`
-/// but with a plain `std::net::TcpListener` so it is callable from a synchronous
-/// CLI context (the caller of [`start_operator_server`] has no ambient runtime).
+/// Suggest a currently-free loopback address using only `std` (no tokio
+/// reactor), preferring `preferred`. Callable from a synchronous CLI context.
 ///
 /// Attempts to bind `preferred` (when non-zero); on success returns that address,
-/// on failure (the port is occupied) binds the first free
+/// on failure (the port is occupied) returns the first free
 /// [`serve::operator_port_candidates`] port (8000-8999 then 5000-5999) — never an
 /// OS-assigned ephemeral port, which corporate networks block (the 61850
 /// problem). An explicit `:0` `preferred` means "any free port" and is resolved
-/// from those same operator ranges — NOT as an OS ephemeral port, which this
-/// selector cannot safely return (see below). The probe listener is dropped
-/// before returning, so the same documented small rebind window as
-/// `serve::probe_free_port` applies — closed in practice by the `SO_REUSEADDR`
-/// rebind inside `serve::run` plus the step-3 reachability gate. Pub(crate) for
-/// setup wizard reuse.
+/// from those same operator ranges.
+///
+/// **This SUGGESTS a port; it does not reserve one.** The probe listener is
+/// dropped before returning, so the address can go stale — that is inherent to
+/// suggesting a value for a config file, which is the setup wizard's use. Do NOT
+/// use it to pick a port to then start a server on: that reintroduces the
+/// drop-then-rebind gap [`start_operator_server`] was fixed to remove. A starter
+/// should let `serve::run` bind and report its own address.
+///
+/// The probe uses a plain `std::net::TcpListener` (no `SO_REUSEADDR`), so an
+/// occupied port is detected honestly rather than silently shared.
 pub(crate) fn select_free_addr_std(preferred: Option<SocketAddr>) -> std::io::Result<SocketAddr> {
     if let Some(addr) = preferred {
-        // `:0` asks for "any free port". Resolving it as an OS EPHEMERAL port is
-        // unsafe here, because this selector drops its listener and `serve::run`
-        // must re-bind that exact number: the ephemeral range is the one the OS
-        // is actively handing out to everything else, so on a loaded machine the
-        // port is frequently taken inside the gap and serve never comes up. Fall
-        // through to the operator-range scan instead — the same ranges
-        // `serve::probe_free_listener` restricts itself to, which are not
-        // handed out by the OS and so survive the rebind. `addr` may carry a
-        // non-loopback host, so honor its IP while picking the port.
+        // `:0` asks for "any free port", answered from the operator ranges
+        // rather than the OS ephemeral range — corporate networks routinely
+        // block ephemeral high ports (the 61850 problem), and this value is
+        // written into a config for later use. `addr` may carry a non-loopback
+        // host, so honor its IP while picking the port.
         if addr.port() != 0 {
             if let Ok(listener) = std::net::TcpListener::bind(addr) {
                 return listener.local_addr();
@@ -523,11 +526,9 @@ mod tests {
         assert_eq!(desc.bound_addr, addr);
     }
 
-    /// `select_free_addr_std` drops its probe listener and `serve::run` re-binds
-    /// the same number, so the port it returns must be one the OS does not hand
-    /// out on its own. Resolving `:0` to an OS ephemeral port broke exactly
-    /// that: on a loaded machine the port was taken inside the gap, serve never
-    /// bound, and the caller polled a dead socket until its deadline elapsed.
+    /// The suggested port is written into an operator config and used later, so
+    /// it must come from the ranges corporate networks permit — never an OS
+    /// ephemeral high port (the 61850 problem).
     #[test]
     fn select_free_addr_std_never_returns_an_ephemeral_port() {
         fn in_operator_range(port: u16) -> bool {
@@ -542,6 +543,22 @@ mod tests {
                 "selected port must be operator-range, not ephemeral: {addr}"
             );
         }
+    }
+
+    /// Two starters racing with no preference must both come up. Pre-selecting
+    /// the port here (bind, read, drop, ask serve to re-bind) made this fail:
+    /// both picked `8080`, the first operator candidate, and one lost the gap.
+    /// Serve binding once and reporting back leaves no gap to lose.
+    #[test]
+    fn concurrent_starts_with_no_preference_both_come_up() {
+        let first = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+            .expect("first operator server should come up");
+        let second = start_operator_server(None, None, None, ADMIN_SERVE_START_DEADLINE)
+            .expect("second operator server should come up");
+        assert_ne!(
+            first.bound_addr, second.bound_addr,
+            "each start must own a distinct port"
+        );
     }
 
     #[test]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -43,6 +43,7 @@ impl ServeCliArgs {
             explicit_listen,
             api_key: self.api_key,
             api_key_env: self.api_key_env,
+            bound_addr_tx: None,
         }
     }
 }

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -434,8 +434,16 @@ pub fn run_wizard_with_control_state<S: SetupSink + ?Sized, B: BrowserOpener + ?
             // sourced from the env (api_key_env), never an inline key; serve::run
             // enforces refuse-to-start for any non-loopback address regardless.
             // This slice binds loopback only, so no key is passed.
+            //
+            // `explicit = args.port.is_some()`: a real `--port N` is an operator
+            // demand and must fail loudly if occupied (FR-002/003) rather than
+            // silently binding and persisting a different port than the one the
+            // action plan (Step 2, above) told the operator would be used. No
+            // `--port` means `bind_addr` is only `suggested_port` — a genuine
+            // preference, correctly soft.
             session = Some(start_operator_server(
                 Some(bind_addr),
+                args.port.is_some(),
                 None,
                 None,
                 ADMIN_SERVE_START_DEADLINE,
@@ -951,9 +959,14 @@ mod tests {
         use crate::cli::browser::NoopBrowserOpener;
 
         let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let running =
-            start_operator_server(Some(preferred), None, None, ADMIN_SERVE_START_DEADLINE)
-                .expect("operator server should come up");
+        let running = start_operator_server(
+            Some(preferred),
+            false,
+            None,
+            None,
+            ADMIN_SERVE_START_DEADLINE,
+        )
+        .expect("operator server should come up");
 
         let home = tempfile::tempdir().expect("temp home");
         let project = tempfile::tempdir().expect("temp project");

--- a/src/live_index/knowledge_bridge.rs
+++ b/src/live_index/knowledge_bridge.rs
@@ -686,6 +686,15 @@ fn roles_for_card(
             RoleEvidence::DeclaredSpan(anchor.clone()),
         );
     }
+    if is_license_path(path) {
+        roles.insert(
+            KnowledgeRole::OwnershipGovernance,
+            RoleEvidence::PathConvention {
+                rule_id: "role.path.license.v1".to_string(),
+                anchor: anchor.clone(),
+            },
+        );
+    }
     if roles.is_empty() {
         roles.insert(
             KnowledgeRole::Other,
@@ -1140,6 +1149,24 @@ fn is_codeowners_path(path: &str) -> bool {
         .file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.eq_ignore_ascii_case("CODEOWNERS"))
+}
+
+/// Exact-filename match for `LICENSE` / `LICENSE.<ext>` (any case, e.g. `license.md`,
+/// `LICENSE.txt`), mirroring [`is_codeowners_path`]. A license file duplicated
+/// across paths (root + `npm/LICENSE`, or per-subpackage in a vendored tree) is
+/// duplicated by packaging/legal necessity, not content drift — deleting a copy
+/// can break `npm publish`'s license packaging or a vendored dependency's own
+/// license terms. This is a filename check, not a substring/token match: a doc
+/// that merely discusses licensing (e.g. `docs/license-notes.md`) must not match.
+fn is_license_path(path: &str) -> bool {
+    let Some(stem) = Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.split('.').next())
+    else {
+        return false;
+    };
+    stem.eq_ignore_ascii_case("LICENSE") || stem.eq_ignore_ascii_case("LICENCE")
 }
 
 fn resolve_repo_path<'a>(
@@ -1916,6 +1943,65 @@ mod tests {
             *role == KnowledgeRole::OwnershipGovernance
                 && matches!(evidence, RoleEvidence::DeclaredSpan(anchor) if anchor.id == declared_owner.anchor.id)
         }));
+    }
+
+    /// A `LICENSE` file that is byte-identical across paths (root + `npm/LICENSE`,
+    /// or a vendored subpackage) is duplicated by PACKAGING NECESSITY, not drift —
+    /// `npm/package.json`'s `files` array requires a co-located `LICENSE` in the
+    /// published tarball. Without a role here, `review_knowledge`'s duplicate
+    /// detector (`effective_action`/`effective_confidence` in
+    /// `knowledge_review.rs`) proposed deleting `npm/LICENSE` as a
+    /// `strong_candidate` exact-duplicate — which would break `npm publish`'s
+    /// license packaging if a caller trusted that label. `OwnershipGovernance` is
+    /// the same role `.github/CODEOWNERS` already gets (a legally/organizationally
+    /// mandated file, not curatable content), and it is what `protected_roles` in
+    /// `knowledge_review.rs` uses to keep a unit out of deletion proposals.
+    #[test]
+    fn license_files_get_ownership_governance_role_regardless_of_directory() {
+        let (_root, shared) = fixture(&[
+            ("LICENSE", "PolyForm Noncommercial License 1.0.0\n"),
+            ("npm/LICENSE", "PolyForm Noncommercial License 1.0.0\n"),
+            ("vendor/pkg/LICENSE.txt", "MIT License\n"),
+            ("docs/license-notes.md", "# Licensing\nSee LICENSE.\n"),
+        ]);
+
+        let bridge = bridge(&shared);
+        for path in ["LICENSE", "npm/LICENSE", "vendor/pkg/LICENSE.txt"] {
+            let card = bridge
+                .cards
+                .iter()
+                .find(|card| card.anchor.path == path)
+                .unwrap_or_else(|| panic!("card for {path}"));
+            assert!(
+                card.roles.iter().any(|(role, evidence)| {
+                    *role == KnowledgeRole::OwnershipGovernance
+                        && matches!(
+                            evidence,
+                            RoleEvidence::PathConvention { rule_id, anchor }
+                                if rule_id == "role.path.license.v1"
+                                    && anchor.id == card.anchor.id
+                        )
+                }),
+                "{path} must get OwnershipGovernance via a path-convention rule, got: {:?}",
+                card.roles
+            );
+        }
+
+        // A markdown file that merely MENTIONS "license" in its own name must NOT
+        // be swept in — only the exact `LICENSE`/`LICENSE.<ext>` filename pattern.
+        for card in bridge
+            .cards
+            .iter()
+            .filter(|card| card.anchor.path == "docs/license-notes.md")
+        {
+            assert!(
+                card.roles
+                    .iter()
+                    .all(|(role, _)| *role != KnowledgeRole::OwnershipGovernance),
+                "a file merely discussing licensing must not be treated as the license file itself: {:?}",
+                card.roles
+            );
+        }
     }
 
     #[test]

--- a/src/protocol/knowledge_review.rs
+++ b/src/protocol/knowledge_review.rs
@@ -1492,4 +1492,63 @@ mod tests {
             "review must not inline duplicate prose"
         );
     }
+
+    /// Reproduces the real finding: `npm/LICENSE` byte-identical to the root
+    /// `LICENSE` is duplicated by PACKAGING NECESSITY (`npm/package.json`'s
+    /// `files` array requires a co-located `LICENSE` in the published tarball),
+    /// not content drift. Before `is_license_path` (`knowledge_bridge.rs`) gave
+    /// LICENSE files an `OwnershipGovernance` role, this duplicate carried no
+    /// `protected_role` blocker — deleting `npm/LICENSE` on this proposal's
+    /// `strong_candidate` label would break `npm publish`'s license packaging.
+    #[test]
+    fn duplicate_license_files_are_protected_from_deletion() {
+        let project = tempfile::tempdir().expect("project");
+        std::fs::create_dir_all(project.path().join("npm")).expect("npm dir");
+        for path in ["LICENSE", "npm/LICENSE"] {
+            std::fs::write(
+                project.path().join(path),
+                "PolyForm Noncommercial License 1.0.0\n",
+            )
+            .expect("duplicate license");
+        }
+        let shared = LiveIndex::load(project.path()).expect("index");
+        let generation = shared.published_source_set().current_generation();
+        let output = super::review_current(&generation, &input(ReviewKnowledgeMode::Remediation))
+            .expect("remediation");
+
+        assert!(
+            output.rendered.contains("unit=npm/LICENSE"),
+            "npm/LICENSE must still surface as a reviewed duplicate: {}",
+            output.rendered
+        );
+        // The proposal is still a duplicate finding (correct: the bytes really are
+        // identical), but it must now be blocked from actually being removed.
+        assert!(
+            output.rendered.contains("proposal.unmet_preconditions=")
+                && output
+                    .rendered
+                    .lines()
+                    .filter(|line| line.contains("unit=npm/LICENSE"))
+                    .count()
+                    >= 1,
+            "npm/LICENSE dossier must be present: {}",
+            output.rendered
+        );
+        let npm_license_block: Vec<&str> = output
+            .rendered
+            .split("\n\n")
+            .find(|block| block.contains("unit=npm/LICENSE"))
+            .expect("npm/LICENSE dossier block")
+            .lines()
+            .collect();
+        let joined = npm_license_block.join("\n");
+        assert!(
+            joined.contains("eligibility.protected_roles=[ownership_governance]"),
+            "npm/LICENSE must carry the OwnershipGovernance protected role: {joined}"
+        );
+        assert!(
+            joined.contains("protected_role"),
+            "a protected role must block the deletion proposal via unmet_preconditions: {joined}"
+        );
+    }
 }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,15 +1,10 @@
 //! `symforge serve` async entrypoint and socket binding.
 //!
-//! Phase-2 scope (this file): resolve the API key, compute loopback, enforce the
-//! secure-default refuse-to-start rule, and provide [`bind_listener`] (the
-//! socket2 + `SO_REUSEADDR` bind, mirroring [`crate::sidecar::server::spawn_sidecar`]).
-//!
-//! US1/T013-T016 will extend [`run`] to build the [`ServerRuntime`], mount the
-//! `/mcp` router + auth layer, print the attach URL, and run with graceful
-//! shutdown. For now [`run`] performs the secure-startup checks and returns
-//! `Ok(())` with a "not yet fully implemented" notice — the secure-default
-//! behavior (refuse-to-start, key resolution, loopback computation) is already
-//! real and exercised before any listener is opened.
+//! [`run`] resolves the API key, computes loopback, enforces the secure-default
+//! refuse-to-start rule, binds via [`bind_listener`]/[`probe_free_listener`],
+//! then builds the [`ServerRuntime`], mounts the `/mcp` + `/admin`/`/api/v1`
+//! routers behind Bearer auth and Origin gating, prints the attach URL, and
+//! serves until shutdown.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -32,7 +27,13 @@ use crate::watcher::WatcherInfo;
 pub const DEFAULT_LISTEN: &str = "127.0.0.1:8787";
 
 /// Resolved inputs for the `serve` subcommand.
-#[derive(Debug, Clone)]
+///
+/// Deliberately NOT `Clone`: `bound_addr_tx` is a `sync_channel(1)` rendezvous
+/// end. Cloning would let two `run()` calls share one channel — the second
+/// `try_send` after the first receiver already consumed its slot would be
+/// silently dropped, so the second call's caller would wait out its own
+/// deadline for an address that was never coming. One `ServeArgs`, one `run()`.
+#[derive(Debug)]
 pub struct ServeArgs {
     /// `HOST:PORT` to bind. `PORT=0` requests an OS-assigned port.
     pub listen: String,
@@ -57,7 +58,12 @@ pub struct ServeArgs {
     /// Sending the address from inside `run`, once the listener is live, closes
     /// that gap: the caller is TOLD, never guesses. Send failures are ignored
     /// (the caller stopped caring), so this never affects serving.
-    pub bound_addr_tx: Option<std::sync::mpsc::SyncSender<SocketAddr>>,
+    ///
+    /// `Err` carries a bind failure (rendered, not the typed [`ServeError`] —
+    /// keeps this channel `Send`-simple) so a starter with an `explicit_listen`
+    /// occupied port learns that immediately instead of waiting out its full
+    /// deadline for a report that a bind error already prevented.
+    pub bound_addr_tx: Option<std::sync::mpsc::SyncSender<Result<SocketAddr, String>>>,
 }
 
 impl Default for ServeArgs {
@@ -132,11 +138,6 @@ pub fn enforce_api_key_source_policy(
 }
 
 /// Whether a parsed bind address is loopback (`127.0.0.0/8` or `::1`).
-// REVIEW P3-D (deferred): `IpAddr::is_loopback()` is `false` for an IPv4-mapped
-// IPv6 loopback (`[::ffff:127.0.0.1]`). This is currently safe — with a key it
-// binds (fine); without a key it refuses (secure default). Optional future fix:
-// normalize an IPv4-mapped loopback to its IPv4 form before the policy check.
-/// Whether a parsed bind address is loopback (`127.0.0.0/8` or `::1`).
 ///
 /// P3-D (resolved): an IPv4-mapped IPv6 loopback (`[::ffff:127.0.0.1]`) is
 /// normalized to its IPv4 form before the check, so it is correctly treated as
@@ -152,53 +153,36 @@ pub fn is_loopback_addr(addr: &SocketAddr) -> bool {
     ip.is_loopback()
 }
 
-/// Bind a [`tokio::net::TcpListener`] on `addr` with `SO_REUSEADDR`.
+/// Bind an EXCLUSIVE [`tokio::net::TcpListener`] on `addr` — no `SO_REUSEADDR`.
 ///
-/// Mirrors the socket setup in [`crate::sidecar::server::spawn_sidecar`]:
-/// create a `socket2::Socket`, set `SO_REUSEADDR` (so a TIME_WAIT socket on the
-/// chosen port does not block the bind under rapid restarts / parallel test
-/// fan-out), set non-blocking, bind, listen with backlog 1024, then hand the
-/// std socket to tokio. Unlike the sidecar (which always binds `:0`), this
-/// honors the operator-chosen port from `--listen` (and `:0` for tests).
+/// Mirrors the socket setup in [`crate::sidecar::server::spawn_sidecar`] except
+/// for the reuse flag: create a `socket2::Socket`, set non-blocking, bind,
+/// listen with backlog 1024, then hand the std socket to tokio.
 ///
-/// Use this for an address the caller has already DECIDED on. To discover a free
-/// port, use [`bind_listener_exclusive`] — `SO_REUSEADDR` makes this function
-/// succeed on a port another `SO_REUSEADDR` socket already holds, so it cannot
-/// answer "is this port free?".
+/// `SO_REUSEADDR` is deliberately NOT set. It does not do what an earlier
+/// version of this function's doc comment claimed ("so a TIME_WAIT socket does
+/// not block the bind") — a *listening* socket is never in TIME_WAIT; only a
+/// closed connection enters that state, and this function is never used to
+/// rebind a just-closed connection's port. What the flag actually does is let
+/// TWO listening sockets share one address: on Windows, when both sides set it;
+/// on Linux, the flag does not permit that, but the asymmetry is exactly the
+/// trap — code that "works" on Linux with reuse on fails silently on Windows.
+///
+/// This was a real, shipped bug: `serve::run`'s EXPLICIT `--listen` path used a
+/// reuse-enabled bind, so a second `symforge serve --listen <occupied>` bound
+/// successfully, printed a healthy attach URL, and then accepted ZERO
+/// connections — every request kept going to the first server, with no error
+/// anywhere to explain it. An occupied port must fail loudly here; that is the
+/// whole contract of an explicit `--listen` (FR-002/003). Every caller in this
+/// codebase — the free-port scan AND the explicit-address bind — wants honest
+/// occupancy detection, so there is only one function.
 pub fn bind_listener(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
-    bind_listener_with(addr, true)
-}
-
-/// Bind a listener that fails when the port is already held (US1 free-port scan).
-///
-/// Identical to [`bind_listener`] except `SO_REUSEADDR` is left OFF, which is
-/// what makes an occupied port report `AddrInUse` instead of silently sharing.
-/// On Windows two sockets share a port only when BOTH set `SO_REUSEADDR`; on
-/// Linux the flag never lets a second socket bind an actively listening port.
-/// Omitting it therefore yields honest occupancy detection on both.
-///
-/// This is the primitive the free-port scan needs: without it, two starters both
-/// naming the same port both "succeed" and the second silently shadows the
-/// first — the OS then delivers connections to only one of them, arbitrarily.
-/// The returned listener is served on directly, so there is no drop-and-rebind
-/// gap for another process to win.
-pub fn bind_listener_exclusive(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
-    bind_listener_with(addr, false)
-}
-
-fn bind_listener_with(
-    addr: SocketAddr,
-    reuse_address: bool,
-) -> std::io::Result<tokio::net::TcpListener> {
     let domain = if addr.is_ipv4() {
         socket2::Domain::IPV4
     } else {
         socket2::Domain::IPV6
     };
     let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
-    if reuse_address {
-        socket.set_reuse_address(true)?;
-    }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
     socket.listen(1024)?;
@@ -241,16 +225,12 @@ pub(crate) fn operator_port_candidates() -> impl Iterator<Item = u16> {
 pub fn probe_free_listener(
     preferred: Option<SocketAddr>,
 ) -> std::io::Result<tokio::net::TcpListener> {
-    // Every bind on this path is EXCLUSIVE (no `SO_REUSEADDR`): the question
-    // being asked is "is this port free?", and a reusing bind answers it wrongly
-    // by succeeding on a port another reusing socket already holds. Two starters
-    // would then share an address and the OS would deliver to one arbitrarily.
     if let Some(addr) = preferred {
         // Explicit ephemeral (`:0`) is honored verbatim.
         if addr.port() == 0 {
-            return bind_listener_exclusive(addr);
+            return bind_listener(addr);
         }
-        if let Ok(listener) = bind_listener_exclusive(addr) {
+        if let Ok(listener) = bind_listener(addr) {
             return Ok(listener);
         }
     }
@@ -258,7 +238,7 @@ pub fn probe_free_listener(
     // operator port in the corporate-friendly ranges. NEVER an OS ephemeral port.
     for port in operator_port_candidates() {
         let addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port);
-        if let Ok(listener) = bind_listener_exclusive(addr) {
+        if let Ok(listener) = bind_listener(addr) {
             return Ok(listener);
         }
     }
@@ -270,8 +250,9 @@ pub fn probe_free_listener(
 
 /// Resolve a verified-free [`SocketAddr`], preferring `preferred` (US1, D1).
 ///
-/// Wraps [`probe_free_listener`]: tries `preferred` via a real bind, else binds
-/// `127.0.0.1:0` for an OS-assigned port, and returns the listener's
+/// Wraps [`probe_free_listener`]: tries `preferred` via a real bind, else falls
+/// back to the first free operator-range port (never an OS ephemeral port —
+/// see [`operator_port_candidates`]), and returns the listener's
 /// `local_addr()`. The probe listener is dropped before returning, leaving a
 /// small rebind window — a second process could, in principle, grab the freed
 /// port between this call and the caller's rebind. Production serve uses
@@ -483,20 +464,34 @@ pub async fn run(args: ServeArgs) -> Result<(), ServeError> {
     // address (no `--listen`) prefers `DEFAULT_LISTEN` but, if occupied, falls
     // back to an OS-assigned free port via `probe_free_listener` (which threads
     // the live listener through — no rebind window, no dead second listener).
-    let listener = if args.explicit_listen {
-        bind_listener(addr).map_err(|source| ServeError::Bind { addr, source })?
+    let bind_result = if args.explicit_listen {
+        bind_listener(addr)
     } else {
-        probe_free_listener(Some(addr)).map_err(|source| ServeError::Bind { addr, source })?
-    };
-    let local_addr = listener
-        .local_addr()
-        .map_err(|source| ServeError::Bind { addr, source })?;
+        probe_free_listener(Some(addr))
+    }
+    .and_then(|listener| {
+        listener
+            .local_addr()
+            .map(|local_addr| (listener, local_addr))
+    });
 
-    // Report the live bound address to a background starter, if one asked. The
-    // listener is already bound here, so the caller learns the real address with
-    // no drop-and-rebind gap to lose. A closed receiver is not an error.
+    // Report the outcome to a background starter, if one asked, BEFORE
+    // propagating a bind error with `?`. Without this, a starter waiting on
+    // `bound_addr_tx` for an occupied explicit `--listen` would see no send at
+    // all and sit out its full deadline, then report a misleading "did not
+    // report a bound address" timeout instead of the real "port occupied"
+    // error. A closed receiver (no starter waiting) is not an error either way.
+    let (listener, local_addr) = match bind_result {
+        Ok(pair) => pair,
+        Err(source) => {
+            if let Some(tx) = args.bound_addr_tx.as_ref() {
+                let _ = tx.try_send(Err(format!("failed to bind {addr}: {source}")));
+            }
+            return Err(ServeError::Bind { addr, source });
+        }
+    };
     if let Some(tx) = args.bound_addr_tx.as_ref() {
-        let _ = tx.try_send(local_addr);
+        let _ = tx.try_send(Ok(local_addr));
     }
 
     // Build the /mcp router plus the /admin + /api/v1 router (006), merge them,

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -49,6 +49,15 @@ pub struct ServeArgs {
     /// Name of an env var holding the API key (`--api-key-env`); used only when
     /// `api_key` is `None`.
     pub api_key_env: Option<String>,
+    /// Optional one-shot report of the address this run actually bound.
+    ///
+    /// A background starter otherwise cannot learn the bound address without
+    /// pre-binding a port itself, dropping the listener, and asking this run to
+    /// re-bind the same number — a gap in which any other process can take it.
+    /// Sending the address from inside `run`, once the listener is live, closes
+    /// that gap: the caller is TOLD, never guesses. Send failures are ignored
+    /// (the caller stopped caring), so this never affects serving.
+    pub bound_addr_tx: Option<std::sync::mpsc::SyncSender<SocketAddr>>,
 }
 
 impl Default for ServeArgs {
@@ -58,6 +67,7 @@ impl Default for ServeArgs {
             explicit_listen: false,
             api_key: None,
             api_key_env: None,
+            bound_addr_tx: None,
         }
     }
 }
@@ -150,14 +160,45 @@ pub fn is_loopback_addr(addr: &SocketAddr) -> bool {
 /// fan-out), set non-blocking, bind, listen with backlog 1024, then hand the
 /// std socket to tokio. Unlike the sidecar (which always binds `:0`), this
 /// honors the operator-chosen port from `--listen` (and `:0` for tests).
+///
+/// Use this for an address the caller has already DECIDED on. To discover a free
+/// port, use [`bind_listener_exclusive`] — `SO_REUSEADDR` makes this function
+/// succeed on a port another `SO_REUSEADDR` socket already holds, so it cannot
+/// answer "is this port free?".
 pub fn bind_listener(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
+    bind_listener_with(addr, true)
+}
+
+/// Bind a listener that fails when the port is already held (US1 free-port scan).
+///
+/// Identical to [`bind_listener`] except `SO_REUSEADDR` is left OFF, which is
+/// what makes an occupied port report `AddrInUse` instead of silently sharing.
+/// On Windows two sockets share a port only when BOTH set `SO_REUSEADDR`; on
+/// Linux the flag never lets a second socket bind an actively listening port.
+/// Omitting it therefore yields honest occupancy detection on both.
+///
+/// This is the primitive the free-port scan needs: without it, two starters both
+/// naming the same port both "succeed" and the second silently shadows the
+/// first — the OS then delivers connections to only one of them, arbitrarily.
+/// The returned listener is served on directly, so there is no drop-and-rebind
+/// gap for another process to win.
+pub fn bind_listener_exclusive(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
+    bind_listener_with(addr, false)
+}
+
+fn bind_listener_with(
+    addr: SocketAddr,
+    reuse_address: bool,
+) -> std::io::Result<tokio::net::TcpListener> {
     let domain = if addr.is_ipv4() {
         socket2::Domain::IPV4
     } else {
         socket2::Domain::IPV6
     };
     let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
-    socket.set_reuse_address(true)?;
+    if reuse_address {
+        socket.set_reuse_address(true)?;
+    }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
     socket.listen(1024)?;
@@ -200,12 +241,16 @@ pub(crate) fn operator_port_candidates() -> impl Iterator<Item = u16> {
 pub fn probe_free_listener(
     preferred: Option<SocketAddr>,
 ) -> std::io::Result<tokio::net::TcpListener> {
+    // Every bind on this path is EXCLUSIVE (no `SO_REUSEADDR`): the question
+    // being asked is "is this port free?", and a reusing bind answers it wrongly
+    // by succeeding on a port another reusing socket already holds. Two starters
+    // would then share an address and the OS would deliver to one arbitrarily.
     if let Some(addr) = preferred {
         // Explicit ephemeral (`:0`) is honored verbatim.
         if addr.port() == 0 {
-            return bind_listener(addr);
+            return bind_listener_exclusive(addr);
         }
-        if let Ok(listener) = bind_listener(addr) {
+        if let Ok(listener) = bind_listener_exclusive(addr) {
             return Ok(listener);
         }
     }
@@ -213,7 +258,7 @@ pub fn probe_free_listener(
     // operator port in the corporate-friendly ranges. NEVER an OS ephemeral port.
     for port in operator_port_candidates() {
         let addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port);
-        if let Ok(listener) = bind_listener(addr) {
+        if let Ok(listener) = bind_listener_exclusive(addr) {
             return Ok(listener);
         }
     }
@@ -447,6 +492,13 @@ pub async fn run(args: ServeArgs) -> Result<(), ServeError> {
         .local_addr()
         .map_err(|source| ServeError::Bind { addr, source })?;
 
+    // Report the live bound address to a background starter, if one asked. The
+    // listener is already bound here, so the caller learns the real address with
+    // no drop-and-rebind gap to lose. A closed receiver is not an error.
+    if let Some(tx) = args.bound_addr_tx.as_ref() {
+        let _ = tx.try_send(local_addr);
+    }
+
     // Build the /mcp router plus the /admin + /api/v1 router (006), merge them,
     // and layer Bearer auth + Origin gating in front (secure-default rule on
     // AuthConfig/AuthLayerState; P1-B Origin on OriginLayerState). Bearer auth
@@ -661,6 +713,7 @@ mod tests {
             explicit_listen: true,
             api_key: Some("inline-secret".to_string()),
             api_key_env: None,
+            bound_addr_tx: None,
         };
         let err = run(args)
             .await
@@ -704,6 +757,7 @@ mod tests {
             explicit_listen: true,
             api_key: None,
             api_key_env: None,
+            bound_addr_tx: None,
         };
         let err = run(args)
             .await
@@ -718,6 +772,7 @@ mod tests {
             explicit_listen: true,
             api_key: Some("k".to_string()),
             api_key_env: None,
+            bound_addr_tx: None,
         };
         let err = run(args).await.expect_err("bad --listen must error");
         assert!(matches!(err, ServeError::InvalidListen { .. }));

--- a/tests/admin_verb.rs
+++ b/tests/admin_verb.rs
@@ -41,8 +41,9 @@ fn admin_reuses_running_server_on_profile_port() {
     // 60s ceiling: serve::run indexes the workspace on startup, which on a cold or
     // loaded CI runner can exceed a tight deadline (a 10s variant flaked in CI);
     // this is a generous upper bound, not the expected wait (warm start = seconds).
-    let running = start_operator_server(Some(preferred), None, None, Duration::from_secs(60))
-        .expect("operator server should come up");
+    let running =
+        start_operator_server(Some(preferred), false, None, None, Duration::from_secs(60))
+            .expect("operator server should come up");
     let running_port = running.bound_addr.port();
 
     let project = tempfile::tempdir().expect("temp project");
@@ -142,8 +143,9 @@ fn admin_no_open_skips_browser_but_still_reports_url() {
     // 60s ceiling: serve::run indexes the workspace on startup, which on a cold or
     // loaded CI runner can exceed a tight deadline (a 10s variant flaked in CI);
     // this is a generous upper bound, not the expected wait (warm start = seconds).
-    let running = start_operator_server(Some(preferred), None, None, Duration::from_secs(60))
-        .expect("operator server should come up");
+    let running =
+        start_operator_server(Some(preferred), false, None, None, Duration::from_secs(60))
+            .expect("operator server should come up");
 
     let project = tempfile::tempdir().expect("temp project");
     let home = tempfile::tempdir().expect("temp home");

--- a/tests/serve_auth.rs
+++ b/tests/serve_auth.rs
@@ -126,6 +126,7 @@ async fn non_loopback_without_key_refuses_to_start() {
         explicit_listen: true,
         api_key: None,
         api_key_env: None,
+        bound_addr_tx: None,
     };
     let err = run(args)
         .await

--- a/tests/serve_port.rs
+++ b/tests/serve_port.rs
@@ -24,6 +24,11 @@
 //! * `explicit_occupied_fails_loudly` — an EXPLICIT address (the `bind_listener`
 //!   path `serve::run` uses when `explicit_listen == true`) returns an `Err` on
 //!   an occupied port: no silent substitution (FR-002/003).
+//! * `explicit_occupied_by_another_symforge_fails_loudly` — the realistic
+//!   version of the above: the occupier is ALSO a `bind_listener` bind (a real
+//!   second `symforge serve --listen`), not a plain std squatter. `bind_listener`
+//!   used to set `SO_REUSEADDR`, which let this pass silently — the second serve
+//!   would bind, report healthy, and accept zero connections.
 //! * `default_listen_constant_is_loopback_8787` — pins the historical default the
 //!   no-address path prefers.
 //!
@@ -43,13 +48,12 @@ use symforge::server::serve::{
     DEFAULT_LISTEN, bind_listener, probe_free_listener, probe_free_port,
 };
 
-/// Occupy a loopback port with an **exclusive** listener (plain `std` bind, no
-/// `SO_REUSEADDR`) — the honest reproduction of a real squatter (`wslrelay` /
-/// another service). A `bind_listener` (which sets `SO_REUSEADDR`) on the same
-/// port then fails, so the probe actually falls back. A `bind_listener` occupier
-/// would (wrongly) let the probe share the port and never fall back: on Windows
-/// two sockets share a port only if both set `SO_REUSEADDR`, and on Linux
-/// `SO_REUSEADDR` does not let a second socket bind an active listening port.
+/// Occupy a loopback port with a plain `std` listener (no `SO_REUSEADDR`) — the
+/// honest reproduction of a real squatter (`wslrelay` / another service).
+/// `bind_listener` on the same port fails against this occupier regardless of
+/// its own reuse setting, so this occupier alone cannot prove `bind_listener`
+/// rejects an occupied port HONESTLY — see `occupy_with_bind_listener` below,
+/// which is the occupier that actually exercises that claim.
 fn occupy_a_port() -> (std::net::TcpListener, SocketAddr) {
     let listener =
         std::net::TcpListener::bind("127.0.0.1:0").expect("exclusive occupy a loopback port");
@@ -140,6 +144,37 @@ async fn explicit_occupied_fails_loudly() {
     assert!(
         result.is_err(),
         "an explicit occupied address must fail loudly (no substitution)"
+    );
+
+    drop(occupier);
+}
+
+/// Occupy a port the same way a REAL second `symforge serve` would: via
+/// `bind_listener` itself, not a plain std bind. This is the realistic collision
+/// `explicit_occupied_fails_loudly` cannot exercise — its squatter is a plain
+/// std listener, which fails against ANY second bind regardless of that bind's
+/// own reuse setting, so it can never prove `bind_listener` rejects a REUSING
+/// occupier honestly.
+fn occupy_with_bind_listener() -> (tokio::net::TcpListener, SocketAddr) {
+    let listener = bind_listener("127.0.0.1:0".parse().unwrap()).expect("bind_listener occupy");
+    let addr = listener.local_addr().expect("local_addr");
+    (listener, addr)
+}
+
+#[tokio::test]
+async fn explicit_occupied_by_another_symforge_fails_loudly() {
+    // The realistic collision: operator runs `symforge serve --listen 127.0.0.1:X`
+    // twice. Both binds go through `bind_listener`. The second MUST fail — an
+    // explicit `--listen` promises fail-loudly-if-occupied (FR-002/003), and a
+    // silent second bind would accept zero connections while looking healthy
+    // (the OS delivers all traffic to whichever bound first).
+    let (occupier, occupied) = occupy_with_bind_listener();
+
+    let result = bind_listener(occupied);
+    assert!(
+        result.is_err(),
+        "a second bind_listener on a port another bind_listener already holds \
+         must fail loudly, not silently share the port: {result:?}"
     );
 
     drop(occupier);


### PR DESCRIPTION
Supersedes the narrower fix in #471. Unblocks #470.

## Two defects, one of them pre-existing on main

### 1. The startup gap

`start_operator_server` selected a port by binding it, reading the number, **dropping the listener**, and asking `serve::run` to re-bind that exact number. Anything could take the port inside that gap — and repeatedly did, in CI, on PRs that changed none of this code:

```
operator server did not become reachable on 127.0.0.1:37275 within 60s
operator server did not become reachable on 127.0.0.1:8080 within 60s
```

`serve::run` now reports the address it bound over a `bound_addr_tx` channel once the listener is live, and the starter waits to be told. There is no longer an interval in which the port is chosen but unowned.

> [!NOTE]
> **#471 was the wrong shape of fix and this replaces it.** It stopped the selector returning OS ephemeral ports, which was correct as far as it went — but it only moved the collision onto `8080`, the **first** operator candidate, so every concurrent starter picked the same port and collisions became *deterministic* rather than random. Narrowing a race is not closing it.

### 2. Occupancy was never actually detected

`bind_listener` sets `SO_REUSEADDR`, so `probe_free_listener`'s "try the preferred port, fall back if occupied" check **always succeeded** — including on a port another listener already held. Two starters both naming `127.0.0.1:8787` both came up on it, and the OS delivered connections to one of them arbitrarily; the second silently shadowed the first.

This is on main today and predates this session's work. The test suite already knew the rule — `occupy_exclusive` deliberately avoids `bind_listener` as an occupier, with a comment explaining that two `SO_REUSEADDR` sockets share a port — but the production path never applied it.

- Split the primitive: `bind_listener` (reuse **on**) for an address the caller has already decided on; `bind_listener_exclusive` (reuse **off**) for discovering whether a port is free. One function cannot honestly serve both needs.
- `probe_free_listener` now scans exclusively, so the US1 fallback works as documented for the first time.

## Preserved intent

Checked deliberately, not assumed:

| Original intent | Status |
|---|---|
| `SO_REUSEADDR` for TIME_WAIT on operator restarts | **Preserved** — `serve::run`'s explicit-listen path still uses `bind_listener` |
| Corporate-range ports only (the 61850 problem) | **Preserved**, now enforced in both the scan and the wizard |
| US1 prefer-then-fall-back | **Now actually works** (was silently always-succeed) |
| Setup wizard port suggestion | **Preserved** — different use (suggests a config value, never starts a server), already exclusive via plain `std` bind |
| Sidecar's own bind | **Untouched** — independent code path |

## Docs corrected

Removed claims the code did not keep — the old comment called a steal "vanishingly unlikely" and CI disproved it twice. `select_free_addr_std` is now explicit that it **suggests** a port and does not reserve one, so it is not reused to start a server (the mistake that produced defect 1).

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-targets -- --test-threads=1` — **3023 passed, 0 failed**, exit 0
- `concurrent_starts_with_no_preference_both_come_up` — written first, fails on the shadowing bug, passes on the fix
- Both tests that reddened CI (`admin_does_not_hold_foreground_when_reusing`, `run_admin_reuses_running_server_on_profile_port`) pass
