### PR TITLE
fix(023): capture credentials inside inline arrays

### DIFF
--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -32,7 +32,11 @@ pub fn decode_searchable_text(bytes: &[u8]) -> Result<DecodedText<'_>, std::str:
 /// consumption, embedded-literal tightening) and whole-buffer encoding
 /// validation now runs on code paths, so every manifest persisted under v1 is
 /// stale and must be re-scouted rather than trusted.
-pub const SECRET_POLICY_VERSION: u32 = 2;
+///
+/// Bumped to 3: the context-assignment rule now enters inline arrays and skips
+/// short leading elements (`key = ["dev", "<cred>"]`), so files a v2 manifest
+/// recorded as clean can carry findings under v3.
+pub const SECRET_POLICY_VERSION: u32 = 3;
 const SECRET_SCAN_MAX_BYTES: usize = crate::domain::index::METADATA_ONLY_CODE_BYTES as usize;
 /// The one reserved rule id every [`DetectorFailure`] collapses onto. Public so
 /// the disclosure gate can tell an indeterminate verdict — which a reindex
@@ -120,7 +124,16 @@ fn compile_secret_rules() -> Result<Vec<SecretRule>, DetectorFailure> {
         (
             CONTEXT_ASSIGNMENT_RULE_ID,
             &[b"key", b"secret", b"token", b"password", b"passwd", b"pwd"],
-            r#"(?i)(?:api[_-]?key|secret|token|password|passwd|pwd|client[_-]?secret)[ \t]*[:=][ \t]*["']?([^\s"'#]{8,})"#,
+            // After the separator: an optional inline-array opener, then EITHER
+            // one-or-more short quoted elements (each under the capture floor,
+            // so they could never match on their own) followed by a mandatory
+            // opening quote, OR the plain optional quote. The mandatory quote
+            // after a skip is load-bearing: without it the capture lands on the
+            // next unquoted run past the comma — in a YAML flow mapping that is
+            // the NEXT KEY (`{token: "ab", environment: production}` would
+            // capture `environment:`), the exact false-positive class the FO-5
+            // ruling refuses. Zero skips keeps the historical shape byte-for-byte.
+            r#"(?i)(?:api[_-]?key|secret|token|password|passwd|pwd|client[_-]?secret)[ \t]*[:=][ \t]*(?:\[[ \t]*)?(?:(?:["'][^"'\n]{0,7}["'][ \t]*,[ \t]*)+["']|["']?)([^\s"'#]{8,})"#,
             1,
             true,
         ),
@@ -1289,12 +1302,15 @@ mod tests {
                 .concat(),
                 MxVerdict::Sensitive(1),
             ),
-            // B1: bracketed arrays never match — stated blind spot.
+            // B1: bracketed arrays — the stated blind spot, closed by the
+            // inline-array capture (owner ruling 2026-08-03). The first
+            // substantive element sits in credential-bound position, exactly
+            // like the unbracketed comma-list form of this row.
             (
                 "B1 toml bracketed array",
                 "config.toml",
                 [&apikey, " = [\"placeholder\", \"", &v, "\"]"].concat(),
-                MxVerdict::Clean,
+                MxVerdict::Sensitive(1),
             ),
             // Parity addendum (beyond spec §6, sizes the C1/C2 backstop and
             // what the D4 mate check would close): unquoted capture before a
@@ -1340,6 +1356,108 @@ mod tests {
         assert!(
             failures.is_empty(),
             "matrix rows off expectation: {failures:?}"
+        );
+    }
+
+    /// (row id, path, body, expected verdict) for the inline-array capture
+    /// (owner ruling 2026-08-03, closes the bracketed-array ceiling).
+    ///
+    /// Every fixture is assembled at runtime from non-secret fragments; `v` is
+    /// benign filler. Each capture-bearing row's counterpart control proves the
+    /// row could fail (no vacuous CLEANs under the 8-byte floor).
+    fn bracketed_array_rows() -> Vec<(&'static str, &'static str, String, MxVerdict)> {
+        let token = mx_token();
+        let apikey = mx_apikey();
+        let deploy_token = mx_deploy_token();
+        let v = mx_value();
+        vec![
+            // AR1: opener alone — a single substantive element is captured.
+            (
+                "AR1 toml single-element array",
+                "config.toml",
+                [&apikey, " = [\"", &v, "\"]"].concat(),
+                MxVerdict::Sensitive(1),
+            ),
+            // AR2: a short leading element must not hide the credential — the
+            // skip group carries the capture past it.
+            (
+                "AR2 toml short-first element",
+                "config.toml",
+                [&apikey, " = [\"dev\", \"", &v, "\"]"].concat(),
+                MxVerdict::Sensitive(1),
+            ),
+            // AR3 control for AR1/AR2: nothing reaches the 8-byte floor, so the
+            // array machinery alone must not manufacture a finding.
+            (
+                "AR3 toml all-short elements",
+                "config.toml",
+                [&apikey, " = [\"dev\", \"shrt\"]"].concat(),
+                MxVerdict::Clean,
+            ),
+            // AR4: the false-positive guard the FO-5 ruling demands. After a
+            // skipped short element the capture MUST open with a quote —
+            // otherwise it would land on the next flow-mapping KEY.
+            (
+                "AR4 yaml flow-map key not captured",
+                "probe.yaml",
+                ["{", &token, ": \"ab\", environment: production}"].concat(),
+                MxVerdict::Clean,
+            ),
+            // AR5: a placeholder-only element stays exempt (H1 discipline
+            // composes with the array capture; ${DEPLOY_TOKEN} clears the floor
+            // so this row cannot pass for the vacuous no-match reason).
+            (
+                "AR5 toml placeholder-only element",
+                "config.toml",
+                [&apikey, " = [\"${", &deploy_token, "}\"]"].concat(),
+                MxVerdict::Clean,
+            ),
+            // AR6 control for AR5: a substantive element after the placeholder
+            // withdraws the exemption — the H1 payload walk crosses the comma.
+            (
+                "AR6 toml placeholder then payload",
+                "config.toml",
+                [&apikey, " = [\"${", &deploy_token, "}\", \"", &v, "\"]"].concat(),
+                MxVerdict::Sensitive(1),
+            ),
+            // AR7: on a code path the captured element is a QUOTED literal, so
+            // the code-expression exemption (unquoted RHS only) does not apply
+            // — same semantics as `let token = "literal"`. Measured 2026-08-03.
+            (
+                "AR7 js array on code path",
+                "src/probe.js",
+                ["const ", &token, " = [\"dev\", \"", &v, "\"];"].concat(),
+                MxVerdict::Sensitive(1),
+            ),
+            // AR8: YAML flow sequences are the same shape as TOML arrays.
+            (
+                "AR8 yaml flow sequence",
+                "probe.yaml",
+                [&token, ": [\"dev\", \"", &v, "\"]"].concat(),
+                MxVerdict::Sensitive(1),
+            ),
+        ]
+    }
+
+    #[test]
+    fn bracketed_array_capture_pins() {
+        let mut failures = Vec::new();
+        for (id, path, body, expected) in bracketed_array_rows() {
+            let actual = match scan_secret_bytes(path, body.as_bytes()) {
+                SecretScan::Clean => MxVerdict::Clean,
+                SecretScan::Sensitive { finding_count, .. } => MxVerdict::Sensitive(finding_count),
+                SecretScan::Indeterminate { reason } => {
+                    failures.push(format!("{id}: unexpected Indeterminate: {reason:?}"));
+                    continue;
+                }
+            };
+            if actual != expected {
+                failures.push(format!("{id}: expected {expected:?}, got {actual:?}"));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "array rows off expectation: {failures:?}"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -14108,8 +14108,11 @@ mod tests {
         // The daemon is fail-closed; pin a token so the direct open call and the
         // proxy client (which resolves the token via env) can authenticate.
         // Assembled at runtime so no credential-shaped literal enters this file;
-        // see `repository_source_is_clean_under_its_own_detector`.
-        let auth_token = ["repo-map-proxy-test-", "to", "ken"].concat();
+        // see `repository_source_is_clean_under_its_own_detector`. The prefix
+        // is hoisted off the token-bound line: the v3 detector follows the
+        // capture into inline arrays.
+        let pfx = "repo-map-proxy-test-";
+        let auth_token = [pfx, "to", "ken"].concat();
         let _auth_guard = EnvVarGuard::set("SYMFORGE_DAEMON_AUTH_TOKEN", &auth_token);
         let project = TempDir::new().expect("project dir");
         fs::create_dir_all(project.path().join("src")).expect("src dir");

--- a/tests/daemon_aliases.rs
+++ b/tests/daemon_aliases.rs
@@ -82,8 +82,11 @@ async fn trace_symbol_alias_routes_to_get_symbol_context() {
     // known token via the env var so this test (which exercises the real MCP
     // dispatch path) can present it with `.bearer_auth`, mirroring how the real
     // MCP front-end authenticates against the daemon.
-    // Assembled at runtime so no credential-shaped literal enters this file.
-    let auth_token = ["daemon-aliases-test-", "to", "ken"].concat();
+    // Assembled at runtime so no credential-shaped literal enters this file;
+    // the prefix is hoisted off the token-bound line (v3 detector follows the
+    // capture into inline arrays).
+    let pfx = "daemon-aliases-test-";
+    let auth_token = [pfx, "to", "ken"].concat();
     // SAFETY: single-threaded test binary; no concurrent env access.
     unsafe {
         std::env::set_var("SYMFORGE_HOME", daemon_home.path());
@@ -230,8 +233,11 @@ async fn trace_symbol_alias_routes_to_get_symbol_context() {
 #[tokio::test]
 async fn detect_changes_alias_routes_to_detect_impact() {
     let daemon_home = TempDir::new().expect("daemon home temp dir");
-    // Assembled at runtime so no credential-shaped literal enters this file.
-    let auth_token = ["daemon-aliases-detect-changes-test-", "to", "ken"].concat();
+    // Assembled at runtime so no credential-shaped literal enters this file;
+    // the prefix is hoisted off the token-bound line (v3 detector follows the
+    // capture into inline arrays).
+    let pfx = "daemon-aliases-detect-changes-test-";
+    let auth_token = [pfx, "to", "ken"].concat();
     // SAFETY: single-threaded test binary; no concurrent env access.
     unsafe {
         std::env::set_var("SYMFORGE_HOME", daemon_home.path());

--- a/tests/status_truth.rs
+++ b/tests/status_truth.rs
@@ -57,8 +57,11 @@ async fn wait_for_shutdown(port: u16) {
 #[tokio::test]
 async fn status_index_matches_daemon_after_index_over_http() {
     let daemon_home = TempDir::new().expect("daemon home temp dir");
-    // Assembled at runtime so no credential-shaped literal enters this file.
-    let auth_token = ["status-truth-test-", "to", "ken"].concat();
+    // Assembled at runtime so no credential-shaped literal enters this file;
+    // the prefix is hoisted off the token-bound line (v3 detector follows the
+    // capture into inline arrays).
+    let pfx = "status-truth-test-";
+    let auth_token = [pfx, "to", "ken"].concat();
     // SAFETY: integration test binaries run single-threaded
     // (`--test-threads=1`) and in their own process; no concurrent env access.
     unsafe {

--- a/tests/watcher_aap_shaped_fixture.rs
+++ b/tests/watcher_aap_shaped_fixture.rs
@@ -328,8 +328,11 @@ async fn run_aap_smoke(idle: Duration) -> SmokeObservation {
     let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "30");
     // The daemon is fail-closed and always requires a token; pin a known one so
     // the HTTP `index_folder` calls below can authenticate.
-    // Assembled at runtime so no credential-shaped literal enters this file.
-    let auth_token = ["watcher-aap-smoke-", "to", "ken"].concat();
+    // Assembled at runtime so no credential-shaped literal enters this file;
+    // the prefix is hoisted off the token-bound line (v3 detector follows the
+    // capture into inline arrays).
+    let pfx = "watcher-aap-smoke-";
+    let auth_token = [pfx, "to", "ken"].concat();
     let _auth = EnvVarGuard::set("SYMFORGE_DAEMON_AUTH_TOKEN", &auth_token);
 
     let root_a = build_fixture("aap_a");

--- a/tests/watcher_reload_cancellation.rs
+++ b/tests/watcher_reload_cancellation.rs
@@ -230,8 +230,11 @@ fn index_folder_for_session_signals_token_before_drop() {
         let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "1");
         // The daemon is fail-closed and always requires a token; pin a known one
         // so the HTTP `index_folder` call below can authenticate.
-        // Assembled at runtime so no credential-shaped literal enters this file.
-        let auth_token = ["watcher-rebind-test-", "to", "ken"].concat();
+        // Assembled at runtime so no credential-shaped literal enters this file;
+        // the prefix is hoisted off the token-bound line (v3 detector follows
+        // the capture into inline arrays).
+        let pfx = "watcher-rebind-test-";
+        let auth_token = [pfx, "to", "ken"].concat();
         let _auth = EnvVarGuard::set("SYMFORGE_DAEMON_AUTH_TOKEN", &auth_token);
         let project_a = TempDir::new().expect("project a");
         let project_b = TempDir::new().expect("project b");


### PR DESCRIPTION
Closes the **bracketed-array blind spot** from the 023 disposition ledger (owner ruling 2026-08-03): `api_key = ["placeholder", "<cred>"]` never matched `secret.context-assignment` at all — the capture started at `[`, died at the first quote under the 8-byte floor, and the keyword cannot re-match later in the line. Whole-class miss across TOML, YAML flow sequences, and env-style config.

## The fix

The rule consumes an optional inline-array opener and skips short quoted leading elements, with the skip **coupled to a mandatory opening quote** on the capture:

- `key = ["<cred>"]` → SENSITIVE (was CLEAN)
- `key = ["dev", "<cred>"]` → SENSITIVE (was CLEAN — a short first element must not hide the credential)
- `{token: "ab", environment: production}` → stays CLEAN (the coupling prevents capturing the next flow-map key — the false-positive class the FO-5 ruling refuses)
- `key = ["${PLACEHOLDER}"]` → stays CLEAN; `key = ["${PLACEHOLDER}", "<cred>"]` → SENSITIVE (H1 discipline composes across the comma)

## Verification

- **Mutation-checked both ways:** reverting the regex flips every new SENSITIVE row to CLEAN and nothing else; dropping the quote coupling flips exactly AR4 and nothing else.
- **AR7 measured, not assumed:** on code paths a quoted array element flags, same as `let token = "literal"` — pinned as measured.
- `SECRET_POLICY_VERSION` 2 → 3 (v2 manifests recorded these shapes as clean).
- The whole-tree tripwire caught six true positives in our own test fixtures — the `["<long-prefix>-", "to", "ken"].concat()` idiom is now visible one layer deeper; fixed at source per Ruling 1 (prefix hoisted off the token-bound line).
- Gates: fmt, clippy `-D warnings`, full serial suite (3084 lib + all integration, 0 failures), release build.

Remaining accepted ceilings (F1/F2, FO-5, FO-3) are recorded with rationale in `specs/023-raw-read-admission-gate/FINDINGS-LEDGER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)