### PR TITLE
feat(025): migrate to rmcp 3.1.0 at protocol parity (PR-A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,26 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --check
 
+      - name: Assert single rmcp major (spec 025 FR-A4)
+        # Two rmcp majors in one graph produce identically-named, incompatible
+        # types. `cargo tree -d` cannot distinguish this (it lists any
+        # duplicated crate's subtrees), so parse the metadata instead.
+        run: |
+          python3 - <<'EOF'
+          import json, subprocess, sys
+          md = json.loads(subprocess.run(
+              ["cargo", "metadata", "--format-version", "1"],
+              capture_output=True, text=True, check=True).stdout)
+          majors = {}
+          for p in md["packages"]:
+              if p["name"] in ("rmcp", "rmcp-macros"):
+                  majors.setdefault(p["name"], set()).add(p["version"].split(".")[0])
+          bad = {k: sorted(v) for k, v in majors.items() if v != {"3"}}
+          if bad or len(majors) < 2:
+              sys.exit(f"rmcp major-version assertion failed: {majors}")
+          print(f"rmcp majors OK: { {k: sorted(v) for k, v in majors.items()} }")
+          EOF
+
       - name: Run cargo check
         run: cargo check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ squash unless there's a specific reason not to.
 
 ## Architecture
 
-Rust MCP server providing symbol-aware code and repository-knowledge navigation, review, curation, and editing tools. The **default** MCP `tools/list` surface is the full **39-tool** surface (including `health_compact`, `search_knowledge`, `review_knowledge`, and `curate_knowledge`); the compact-3 surface (`symforge`, `symforge_edit`, `status`) is a documented opt-in escape hatch via `SYMFORGE_SURFACE=compact`, with backward-compat aliases for removed tools in `src/daemon.rs`. Resources and prompts are first-class protocol surfaces, not side notes.
+Rust MCP server providing symbol-aware code and repository-knowledge navigation, review, curation, and editing tools. The **default** MCP `tools/list` surface is the full **40-tool** surface (as_of 2026-08-03; counting rule: `#[tool(` attribute sites — 33 in `tools.rs` + 7 in `edit_tools.rs` — equal to the 40 names in `SYMFORGE_TOOL_NAMES`; including `health_compact`, `search_knowledge`, `review_knowledge`, and `curate_knowledge`); the compact-3 surface (`symforge`, `symforge_edit`, `status`) is a documented opt-in escape hatch via `SYMFORGE_SURFACE=compact`, with backward-compat aliases for removed tools in `src/daemon.rs`. Resources and prompts are first-class protocol surfaces, not side notes.
 
 Key source files:
 - `src/protocol/tools.rs` — Tool handlers, input structs, tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bit-set"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,7 +1023,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1869,7 +1875,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1917,12 +1923,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -1948,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2366,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ schemars = "1"
 # resolves >=1.7 (the `allowed_hosts` DNS-rebinding behavior depends on >=1.7
 # APIs). Future fix: pin an exact/min version (or treat Cargo.lock as the source
 # of truth) and add a minimum-version / deny check so a downgrade can't slip in.
-rmcp = { version = "2.0", features = ["transport-io", "transport-streamable-http-server"], optional = true }
+rmcp = { version = "3.1", features = ["transport-io", "transport-streamable-http-server"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Maintained libyaml-lineage YAML backend. The previous `serde_yml 0.0.13` fork

--- a/specs/025-rmcp-3-migration/plan.md
+++ b/specs/025-rmcp-3-migration/plan.md
@@ -1,0 +1,160 @@
+# Implementation Plan: rmcp 3.x Migration & MCP 2026-07-28 Service
+
+**Feature**: `025-rmcp-3-migration` · **Branch base (binding)**: main containing `114b793`
+(verified: `git merge-base --is-ancestor 114b793 HEAD`) · **Authority**: `spec.md` (Addendum A
+binding; three external review rounds folded; every named API signature source-verified against
+docs.rs/rmcp/3.1.0) · **Change-to-site map**: `research.md` (incl. round-3 source corrections)
+
+## Summary
+
+Move symforge from rmcp 2.2 to **3.1.0 exactly** (manifest `"3.1"`, lockfile pinned and recorded)
+and serve MCP **2026-07-28** alongside every currently supported legacy revision. Blast radius is
+concentrated in four files (`src/protocol/mod.rs`, `src/protocol/result_status.rs`,
+`src/protocol/edit_tools.rs`, `src/server/mcp_http.rs`); the daemon proxy, all 40 `#[tool]`
+handlers, and the IPC layer are untouched. Delivery is **two PRs** with a hard fault boundary:
+
+- **PR-A — mechanical chase at protocol parity.** Compile against 3.1.0 with ZERO intended
+  behavior change; the full existing suite is a pure regression gate.
+- **PR-B — protocol enablement.** Allow-list freeze, cache hints, discover-first lifecycle,
+  FR-319 central evidence attachment, the SC-310…SC-318 test battery, docs.
+
+## Technical Context
+
+- Toolchain: `rust-toolchain.toml` pins 1.96.0 (> rmcp MSRV 1.88); CI installs from the pin.
+- Dependency: `rmcp = { version = "3.1", features = ["transport-io",
+  "transport-streamable-http-server"], optional = true }` — feature names verified to exist on
+  3.1.0 (round 3); `server` is in rmcp's default set. Lockfile must resolve **exactly 3.1.0**
+  (`cargo tree -p rmcp` recorded in the PR).
+- Source-verified API facts the plan RELIES on (no open questions remain):
+  `ToolRouter::call → Result<CallToolResponse, ErrorData>` (no conversion in `call_tool`);
+  `read_resource_uri()` stays on internal `ReadResourceResult` → one
+  `.map(ReadResourceResponse::Complete)` at the trait boundary;
+  `StreamableHttpService::new(factory, Arc<M>, config)` still requires the session manager
+  (`LocalSessionManager` retained); `with_stateless_protocol_metadata_required` defaults `false`
+  (pinned explicitly anyway); default `supported_protocol_versions()` = `KNOWN_VERSIONS`
+  **including** `V_2026_07_28` (override = allow-list freeze, not activation).
+- Gates (repo CLAUDE.md): `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -D
+  warnings`, full serial test suite, `cargo build --release`; plus the spec's named batteries.
+
+## Constitution Check
+
+No `.specify` constitution exists; the binding constraints are: the frozen invariants
+**INV-1…INV-4** (response enums stop at the trait boundary; compact-surface dispatch gate
+survives the 3.x macro; the 023 admission gates stay load-bearing; resource reads never
+shared-cacheable), the owner decisions in the spec header, and the repo verification gates
+above. Any plan step that would touch these is non-conforming by definition.
+
+## Project Structure
+
+### Documentation (this feature)
+`specs/025-rmcp-3-migration/`: `spec.md` · `research.md` · `plan.md` (this) · `tasks.md` ·
+`REVIEW-DISPOSITIONS.md` · `REVIEW-REPORT-2026-08-03.md` ·
+`VERIFICATION-REPORT-owner-agent-2026-08-03.md`. No data-model.md (the feature owns no data
+entities — every type is upstream rmcp's) and no contracts/ dir (the wire contract IS the spec's
+FR set; house precedent 021 likewise has none).
+
+### Source code touched
+- **PR-A**: `Cargo.toml`, `Cargo.lock`, `src/protocol/mod.rs` (`:1529` call_tool signature,
+  `:1505` read_resource signature+map, `:1557` ListToolsResult literal),
+  `src/protocol/result_status.rs` (`:1`, `:142` Meta→MetaObject),
+  `src/protocol/edit_tools.rs` (`:271` same), `src/server/mcp_http.rs` (`:119` legacy-session
+  rename; constructor chase `:42/:110/:126-129`), `CLAUDE.md` (stale "39-tool" → 40; deferred
+  M4 sub-item), CI workflow (mixed-major `cargo metadata` assertion).
+- **PR-B**: `src/protocol/mod.rs` (supported_protocol_versions override; manual `list_prompts`
+  override for cache hints; central evidence attachment seam), `src/protocol/resources.rs`
+  (`:142` read hints), `src/protocol/result_status.rs` (evidence helper),
+  `src/server/mcp_http.rs` (metadata knob pin, module docs), `src/main.rs:236` +
+  `tests/serve_http_attach.rs:23-30` docs, `src/protocol/mod.rs:1570-1576` on_initialized
+  comment, new tests (see tasks).
+
+## Implementation order and rationale
+
+**PR-A (strict order — each step keeps `cargo check` progress monotonic):**
+1. Base gate + mixed-major assertion + Cargo bump (`"3.1"`), lock resolves 3.1.0.
+2. Compiler-driven renames: `Meta`→`MetaObject` (3 sites), `with_stateful_mode`→
+   `with_legacy_session_mode` (1 site).
+3. `ListToolsResult` literal at `mod.rs:1557`: explicit `result_type:
+   Some(ResultType::Complete)` + `..Default::default()` for the two new cache-hint fields
+   (values stay `None` in PR-A — policy is PR-B).
+4. MRTR signatures: `call_tool → Result<CallToolResponse, ErrorData>` (body unchanged — router
+   already returns the enum); `read_resource → Result<ReadResourceResponse, ErrorData>` with
+   `.map(ReadResourceResponse::Complete)`.
+5. `StreamableHttpService` constructor chase, `LocalSessionManager` retained,
+   `with_json_response(true)` re-verified.
+6. Phase-1 closure greps (FR-315: the four unadjudicated change-ids; FR-A2 zero-match baseline).
+7. `CLAUDE.md` tool-count fix (40).
+8. Full gates + full serial suite green ⇒ PR-A opens; squash-merge on green CI.
+
+**PR-B (builds on merged PR-A):**
+1. Pin `.with_stateless_protocol_metadata_required(false)` (FR-309).
+2. `supported_protocol_versions()` allow-list freeze (FR-307) + negotiation/discover tests
+   (SC-310, SC-311 discover-FIRST full-surface, SC-305 legacy pins).
+3. Cache hints via builder style (FR-310/311/312, INV-4; manual `list_prompts` override;
+   deterministic tools/list order test; SC-313).
+4. FR-319 central evidence attachment (design D1 below) + SC-316 five-case battery + SC-316b
+   legacy roots interop.
+5. SC-314 strict-metadata positive/negative battery (behind bearer auth).
+6. Docs (FR-316 list) + version-aware wire fixtures (FR-A6; owner tests 1-2).
+7. Full gates ⇒ PR-B opens; squash-merge on green.
+
+**Why this order**: PR-A steps 2-5 are compiler-forced and independently verifiable; nothing in
+PR-A consults a policy decision, so a red suite in PR-A can only mean a mechanical mistake or an
+upstream behavior surprise — exactly what a pure regression gate can adjudicate. PR-B's steps
+order tests-with-their-features so every policy lands with its tripwire in the same commit.
+
+## Design decisions
+
+### D1 — Central evidence attachment site (FR-319)
+Attach at the **trait-boundary seam, post-router**: in `call_tool`, after
+`self.tool_router.call(tcc)` resolves, merge project evidence into the result's `_meta`
+(creating `_meta` when absent; never overwriting an evidence key already written by
+`ResultStatus::into_call_tool_result` — single-writer wins, seam is fallback). Same pattern in
+`read_resource` on the `ReadResourceResult` before wrapping `Complete`. Rationale: one seam
+covers all 40 handlers including plain-`String` returns, zero per-handler edits, and the
+existing statused path stays byte-identical (its evidence is already attached before the seam
+sees it). The unbound case writes an explicit `{"bound": false}`-shaped marker (exact shape in
+tasks) rather than omitting the key — absence must remain distinguishable from unbound.
+
+### D2 — `_meta` parity exception, stated not silent
+Previously meta-less results (plain-`String` tools) gain a `_meta` carrying only project
+evidence. SC-303's battery key-plucks and tolerates this; the spec's parity exception paragraph
+is the documentation of record. Any golden fixture that asserts full `_meta` equality must be
+updated in the same commit with the evidence key included.
+
+### D3 — Version-aware fixtures
+New transport tests parameterize expected JSON by negotiated version (modern: `resultType`
+present; legacy: stripped). Existing serde-level batteries are NOT converted — they remain
+regression gates for `_meta`/`structuredContent` only (FR-305 three-layer contract).
+
+### D4 — CI mixed-major assertion shape
+A small script step: `cargo metadata --format-version 1` parsed (python one-liner) asserting
+the set of distinct major versions for packages named `rmcp`/`rmcp-macros` == {3}. Lands in
+PR-A alongside the bump so the gate exists from the first migrated commit.
+
+## Risks and mitigations
+
+- **3.x `#[tool_handler]` macro stops deferring to the manual `call_tool` override** → the
+  compact-surface gate silently dies. Mitigation: SC-304 (direct) + SC-315 (real-dispatch
+  tripwire) run in PR-A's regression pass; if the macro contract changed, PR-A goes red before
+  any protocol work starts.
+- **Tool serde grows fields → A-025 ≤1500 B / H1 ≤5000 B byte budgets fail with no code
+  change.** Mitigation: FR-317 decision rule — escalate to owner as a budget decision; never
+  silently weaken.
+- **`serve_http_attach` fixtures drift under 3.1.0's stricter validation.** Mitigation: it runs
+  in PR-A's regression gate at parity (legacy semantics unchanged); strictness posture is pinned
+  explicitly only in PR-B.
+- **Evidence seam double-writes or breaks SFB09 `_meta` wire shape.** Mitigation: single-writer
+  merge rule (D1) + SC-303 byte-level battery in the same PR.
+
+## Out of scope for this plan
+
+MRTR emission, Tasks extension, subscriptions/listen, sampling/logging capabilities, modern
+roots re-trigger machinery, client-side cache behavior (documented, not implemented), startup
+performance (024 backlog).
+
+## Constitution re-check (post-design)
+
+D1-D4 touch no frozen invariant: the response enums still stop at the trait boundary (D1
+operates on `CallToolResult`/`ReadResourceResult` BEFORE wrapping), the compact gate ordering is
+unchanged (`enforce_compact_surface` stays first in `call_tool`), the 023 admission gates are
+not on any touched path, and INV-4's read-hint scope is exactly FR-312. PASS.

--- a/specs/025-rmcp-3-migration/tasks.md
+++ b/specs/025-rmcp-3-migration/tasks.md
@@ -1,0 +1,95 @@
+# Tasks: rmcp 3.x Migration & MCP 2026-07-28 Service
+
+Derived from `plan.md` (order binding) and `spec.md` (FR/SC authority; Addendum A wins).
+Two PRs, hard fault boundary. Every task cites its FR/SC.
+
+## Standing rules for every task
+
+- Worktree `E:\project\symforge-rmcp3`, branch `feat/rmcp-3-migration` (PR-A) then a follow-on
+  branch off merged main for PR-B. Base gate first (T200).
+- Builds/tests through Terminal Commander `run_and_watch`; never `| tail`, never sleep-polling.
+- No behavior change lands in PR-A; anything behavioral discovered mid-chase STOPS the task and
+  gets recorded, not smuggled.
+- Frozen invariants INV-1…INV-4 are non-negotiable; a task that would touch one is a spec bug —
+  stop and surface.
+
+## Phase A0: Preconditions (PR-A)
+
+- [ ] **T200** Base gate: `git merge-base --is-ancestor 114b793 HEAD` (FR-321). STOP on failure.
+- [ ] **T201** Bump `Cargo.toml` to `rmcp = { version = "3.1", ... }` (features UNCHANGED —
+  FR-A5 resolved); `cargo update -p rmcp`; record `cargo tree -p rmcp` showing exactly 3.1.0.
+- [ ] **T202** Mixed-major assertion (FR-A4, D4): `cargo metadata` parse asserting distinct
+  majors of `rmcp`+`rmcp-macros` == {3}; add the same check as a CI step in this PR.
+
+## Phase A1: Mechanical chase (PR-A; compiler-driven, zero behavior change)
+
+- [ ] **T210** `Meta` → `MetaObject`: `src/protocol/result_status.rs:1`, `:142`,
+  `src/protocol/edit_tools.rs:271` (FR-303/meta-split).
+- [ ] **T211** `with_stateful_mode(false)` → `with_legacy_session_mode(false)` at
+  `src/server/mcp_http.rs:119` + module-doc touch-up of that line only (stateful-rename).
+- [ ] **T212** `ListToolsResult` literal `mod.rs:1557`: explicit
+  `result_type: Some(ResultType::Complete)`, cache-hint fields via `..Default::default()`
+  (stay `None` in PR-A) (FR-305 struct layer only).
+- [ ] **T213** `call_tool` signature → `Result<CallToolResponse, ErrorData>`; body UNCHANGED
+  (router already returns the enum — source-verified). `read_resource` →
+  `Result<ReadResourceResponse, ErrorData>` with `.map(ReadResourceResponse::Complete)`;
+  admission-gated delegation untouched (FR-304, INV-1, INV-3).
+- [ ] **T214** `StreamableHttpService` constructor chase (`mcp_http.rs:42/:110/:126-129`):
+  `LocalSessionManager` RETAINED; `with_json_response(true)` re-verified; bearer-auth layering
+  byte-identical (FR-306, SC-308).
+- [ ] **T215** Closure greps (FR-315): tasks-extension, http-headers-2243, event-store,
+  sep2260-association each zero-hit; FR-A2 zero-match baseline for the four response enums.
+  Record outputs in the PR body.
+- [ ] **T216** `CLAUDE.md` "39-tool" → 40 with counting rule (ledger M4 deferred item).
+
+## Phase A2: PR-A gates
+
+- [ ] **T220** `cargo fmt --check`; `cargo clippy --all-targets -- -D warnings`.
+- [ ] **T221** Full serial suite green — pure regression gate (SC-301…SC-309 batteries incl.
+  SC-303 `_meta` byte shape, SC-304 compact rejection, `serve_http_attach`, byte budgets
+  FR-317 rule on any budget failure). `cargo build --release`.
+- [ ] **T222** PR-A: conventional title, body carries T201/T202/T215 evidence; squash-merge on
+  green CI; cleanup (target, worktree keeps for PR-B or re-cut).
+
+## Phase B0: PR-B branch
+
+- [ ] **T230** New branch off merged main (contains PR-A); base gate again.
+
+## Phase B1: Protocol policy (PR-B)
+
+- [ ] **T231** Pin `.with_stateless_protocol_metadata_required(false)` (FR-309).
+- [ ] **T232** `supported_protocol_versions()` override = explicit frozen allow-list (today's
+  `KNOWN_VERSIONS` incl. `V_2026_07_28`) (FR-307 as corrected round 3).
+- [ ] **T233** Cache hints (FR-310/311/312, INV-4): builder style on the four list surfaces
+  (`ttl_ms 3_600_000`, `Public`) + manual `list_prompts` override; `read_resource` `ttl_ms 0`,
+  `Private`; deterministic tools/list ordering.
+- [ ] **T234** FR-319 central evidence attachment per plan D1: post-router `_meta` merge in
+  `call_tool` (single-writer, statused path byte-identical) + same on `read_resource`; explicit
+  unbound marker; `_meta` parity exception documented (D2).
+
+## Phase B2: New test battery (PR-B; each with its feature)
+
+- [ ] **T240** SC-310 negotiation (2026-07-28 and 2025-06-18 both negotiate).
+- [ ] **T241** SC-311 discover-FIRST full surface: authenticated version-headered
+  `server/discover` as literally the first request; then tools/list, tools/call, prompts/list,
+  resources/list, resources/read; explicit asserts: no initialize, no initialized,
+  on_initialized never ran.
+- [ ] **T242** SC-312 modern binding per fallback-chain rung; never solicits roots outside
+  on_initialized; never blocks.
+- [ ] **T243** SC-313 cache-hint conformance on all five surfaces.
+- [ ] **T244** SC-314 strict-metadata battery incl. the four modern NEGATIVE cases (behind
+  bearer auth).
+- [ ] **T245** SC-315 compact gate via REAL dispatch (HTTP harness + in-process call_tool).
+- [ ] **T246** SC-316 evidence disclosure five cases (statused, plain-String `health`,
+  resources/read, foreign-binding negative, unbound marker).
+- [ ] **T247** SC-316b legacy stdio roots interop end-to-end.
+- [ ] **T248** FR-A6 version-aware wire fixtures (owner tests 1-2): modern emits `resultType`,
+  legacy stripped.
+
+## Phase B3: Docs + closure (PR-B)
+
+- [ ] **T250** FR-316 doc list: `mcp_http.rs:11-28`, `serve_http_attach.rs:23-30` comment,
+  `main.rs:236`, `mod.rs:1570-1576` on_initialized scoping.
+- [ ] **T251** Full gates (fmt/clippy/serial suite/release) + SC-317/SC-318 closure.
+- [ ] **T252** PR-B: squash-merge on green; final cleanup (targets, worktrees, branches both
+  ends); update task board + agentmemory.

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -268,7 +268,7 @@ fn statused_edit_tool_result(
     } else {
         rmcp::model::CallToolResult::success(content)
     };
-    Ok(result.with_meta(Some(rmcp::model::Meta(meta))))
+    Ok(result.with_meta(Some(rmcp::model::MetaObject(meta))))
 }
 
 /// Classify one structural-edit tool's output body.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -36,7 +36,7 @@ use rmcp::handler::server::router::prompt::PromptRouter;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::model::{
     ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
-    ReadResourceRequestParams, ReadResourceResult, ServerCapabilities, ServerInfo, Tool,
+    ReadResourceRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ServerHandler, prompt_handler, tool_handler};
@@ -1507,10 +1507,19 @@ impl ServerHandler for SymForgeServer {
         &self,
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> impl std::future::Future<Output = Result<ReadResourceResult, rmcp::ErrorData>> + Send + '_
-    {
+    ) -> impl std::future::Future<
+        Output = Result<rmcp::model::ReadResourceResponse, rmcp::ErrorData>,
+    > + Send
+    + '_ {
         let uri = request.uri;
-        async move { self.read_resource_uri(&uri).await }
+        // INV-1: the response enum exists only at this trait boundary; all
+        // internal resource logic (and the spec-023 admission gating it wraps)
+        // stays on `ReadResourceResult`.
+        async move {
+            self.read_resource_uri(&uri)
+                .await
+                .map(rmcp::model::ReadResourceResponse::Complete)
+        }
     }
 
     /// MCP `tools/call` dispatch with a central compact-surface gate (P1-A).
@@ -1531,7 +1540,7 @@ impl ServerHandler for SymForgeServer {
         &self,
         request: rmcp::model::CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    ) -> Result<rmcp::model::CallToolResponse, rmcp::ErrorData> {
         surface_probe::enforce_compact_surface(request.name.as_ref())?;
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         // Task 7: bind the selected-project evidence slot for this dispatch,
@@ -1557,8 +1566,11 @@ impl ServerHandler for SymForgeServer {
         };
         Ok(ListToolsResult {
             tools,
-            meta: None,
-            next_cursor: None,
+            // FR-305 pinned struct shape: Complete is explicit, matching the
+            // upstream constructor default. Cache-hint fields stay None here
+            // (policy lands in PR-B; spec 025).
+            result_type: Some(rmcp::model::ResultType::COMPLETE),
+            ..Default::default()
         })
     }
 

--- a/src/protocol/result_status.rs
+++ b/src/protocol/result_status.rs
@@ -1,4 +1,4 @@
-use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Meta};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, MetaObject};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 
@@ -139,6 +139,6 @@ impl ResultStatus {
         } else {
             CallToolResult::success(content)
         };
-        result.with_meta(Some(Meta(meta)))
+        result.with_meta(Some(MetaObject(meta)))
     }
 }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -13289,7 +13289,13 @@ mod tests {
     }
 
     fn serialized_tool_result<R: IntoCallToolResult>(result: R) -> serde_json::Value {
-        let result = result.into_call_tool_result().unwrap();
+        // INV-1/INV-5: the response enum stops at the trait boundary; this
+        // server emits Complete only, so the helper unwraps it (wildcard arm
+        // required — the enum is #[non_exhaustive]).
+        let result = match result.into_call_tool_result().unwrap() {
+            rmcp::model::CallToolResponse::Complete(result) => result,
+            other => panic!("server must emit Complete-only results, got {other:?}"),
+        };
         serde_json::to_value(&result).unwrap()
     }
 

--- a/src/server/mcp_http.rs
+++ b/src/server/mcp_http.rs
@@ -116,7 +116,9 @@ fn build_mcp_service(
     // `StreamableHttpServerConfig` is `#[non_exhaustive]`; use its builders.
     let config = StreamableHttpServerConfig::default()
         // Stateless: serve each request directly (no MCP session handshake gate).
-        .with_stateful_mode(false)
+        // rmcp 3.x renamed the knob: it now governs only legacy-protocol
+        // sessions (2026-07-28 HTTP is always sessionless).
+        .with_legacy_session_mode(false)
         // Return application/json (single JSON-RPC response), not SSE framing.
         .with_json_response(true)
         // Preserve loopback DNS-rebinding defaults; additionally permit the


### PR DESCRIPTION
**PR-A of the spec-025 rmcp migration** — the mechanical compile chase at protocol parity. Zero intended behavior change; the full serial suite is the regression gate and passed untouched (**3084 lib + all integration binaries, 0 failures**), plus release build.

Spec: `specs/025-rmcp-3-migration/spec.md` (Addendum A binding; three external review rounds — Cursor, Codex, cloud Codex with rmcp source access — folded before implementation). `plan.md`/`tasks.md` ride in this PR (Phase A tasks T200–T222).

## What moved

| change | site | note |
|---|---|---|
| rmcp `"2.0"` → `"3.1"` | Cargo.toml/lock | lockfile resolves **exactly 3.1.0**; features verified unchanged |
| `Meta` → `MetaObject` | result_status.rs, edit_tools.rs | SFB09 `_meta` wire shape byte-identical (SC-303 green) |
| `with_legacy_session_mode(false)` | mcp_http.rs | rename only; `LocalSessionManager` retained (3.1.0 constructor requires it) |
| `ListToolsResult` literal | mod.rs | explicit `result_type: Some(COMPLETE)`; cache hints stay `None` (PR-B) |
| `call_tool` → `CallToolResponse` | mod.rs | body unchanged — `ToolRouter::call` already returns the enum (source-verified) |
| `read_resource` → `ReadResourceResponse` | mod.rs | one `.map(Complete)` at the trait boundary; 023 admission gating untouched |
| CI: mixed-major assertion | ci.yml | `cargo metadata` parse — `cargo tree -d` can't distinguish majors |
| CLAUDE.md | — | stale "39-tool" → 40 with counting rule |

## Evidence

- Mixed-major: `{'rmcp': ['3'], 'rmcp-macros': ['3']}` ✓
- Closure greps (FR-315): tasks-extension / http-headers-2243 / event-store / sep2260-association all **zero-hit**; zero matches on the four `#[non_exhaustive]` response enums (FR-A2 baseline)
- Only two unplanned fix-ups in the entire chase: one unused import, one test helper unwrapping `Complete` (wildcard arm per the non-exhaustive rule)
- Gates: fmt · clippy `-D warnings` · full serial suite · release build — all green

PR-B (protocol enablement: allow-list freeze, cache hints, discover-first lifecycle, FR-319 evidence attachment, SC-310–318 battery, docs) follows on a fresh branch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)