### PR TITLE
fix: make Tier-2 advice and resolve-mode honest about withheld content

### DIFF
--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -1471,6 +1471,59 @@ impl LiveIndex {
         });
         candidates.dedup();
 
+        // Coverage honesty (spec 021): when NO parsed file matches, sweep the
+        // Tier-2 metadata-only catalog with the same basename/substring rules
+        // before declaring absence. A Tier-2 path is real and addressable —
+        // "does not exist in indexed source paths" for one is a false denial
+        // (testpilot receipt: a 532 KB Tier-2 service file resolved by
+        // basename was reported nonexistent). Parsed candidates keep
+        // precedence; this fallback fires only when they are empty.
+        if candidates.is_empty() {
+            let basename_lower = basename.to_ascii_lowercase();
+            let mut tier2: Vec<(String, String)> = self
+                .metadata_only_skipped_paths()
+                .filter(|(path, _)| path_allowed(path))
+                .filter(|(path, _)| {
+                    let path_lower = path.to_ascii_lowercase();
+                    let path_basename = path_lower.rsplit('/').next().unwrap_or(&path_lower);
+                    path_basename == basename_lower
+                        || path_lower.ends_with(&normalized_hint_lower)
+                        || path_lower.contains(&normalized_hint_lower)
+                })
+                .map(|(path, reason)| (path.to_string(), reason))
+                .collect();
+            for component in dir_components {
+                let component_lower = component.to_ascii_lowercase();
+                tier2.retain(|(path, _)| {
+                    path.to_ascii_lowercase()
+                        .split('/')
+                        .any(|part| part == component_lower)
+                });
+            }
+            tier2.sort_by(|(left, _), (right, _)| {
+                left.len().cmp(&right.len()).then(left.cmp(right))
+            });
+            match tier2.len() {
+                0 => {}
+                1 => {
+                    let (path, reason) = tier2.pop().expect("single tier-2 candidate");
+                    return SearchFilesResolveView::ResolvedMetadataOnly { path, reason };
+                }
+                len => {
+                    let overflow_count = len.saturating_sub(RESOLVE_PATH_AMBIGUOUS_CAP);
+                    return SearchFilesResolveView::Ambiguous {
+                        hint: normalized_hint,
+                        matches: tier2
+                            .into_iter()
+                            .take(RESOLVE_PATH_AMBIGUOUS_CAP)
+                            .map(|(path, _)| path)
+                            .collect(),
+                        overflow_count,
+                    };
+                }
+            }
+        }
+
         match candidates.len() {
             0 => SearchFilesResolveView::NotFound {
                 hint: normalized_hint,
@@ -3960,6 +4013,54 @@ mod tests {
             SearchFilesResolveView::ResolvedMetadataOnly {
                 path: "backend/package-lock.json".to_string(),
                 reason: "lockfile".to_string(),
+            }
+        );
+    }
+
+    // Coverage honesty (spec 021 / testpilot receipt): resolve=true by BASENAME
+    // must also find a Tier-2 path when no parsed file matches — a real,
+    // addressable file must never be reported nonexistent just because the hint
+    // was not the full relative path.
+    #[test]
+    fn test_capture_search_files_resolve_view_resolves_tier2_by_basename() {
+        let mut index = make_index(vec![], false);
+        add_metadata_only_skip(
+            &mut index,
+            "src/app/services/recorder.service.ts",
+            SkipReason::SizeThreshold,
+        );
+
+        let view = index.capture_search_files_resolve_view("recorder.service.ts");
+
+        assert_eq!(
+            view,
+            SearchFilesResolveView::ResolvedMetadataOnly {
+                path: "src/app/services/recorder.service.ts".to_string(),
+                reason: SkipReason::SizeThreshold.to_string(),
+            }
+        );
+    }
+
+    // Parsed candidates keep precedence: a Tier-1 basename match wins over a
+    // Tier-2 path with the same basename (the fallback fires only when the
+    // parsed candidate set is empty).
+    #[test]
+    fn test_resolve_tier2_fallback_never_shadows_parsed_candidates() {
+        let mut index = make_index(
+            vec![(
+                "src/util.ts",
+                make_indexed_file("src/util.ts", vec![], ParseStatus::Parsed),
+            )],
+            false,
+        );
+        add_metadata_only_skip(&mut index, "dist/util.ts", SkipReason::GeneratedOutput);
+
+        let view = index.capture_search_files_resolve_view("util.ts");
+
+        assert_eq!(
+            view,
+            SearchFilesResolveView::Resolved {
+                path: "src/util.ts".to_string(),
             }
         );
     }

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -3682,10 +3682,16 @@ pub fn not_found_file_with_suggestions(path: &str, suggestions: &[String]) -> St
 /// admitted as Tier-2 (metadata-only) or Tier-3 (hard-skipped) rather than
 /// parsed. Distinct from `not_found_file`: the file is present on disk, so a
 /// bare "File not found" is wrong and confusing. This message names the tier,
-/// the skip reason, and the size, and points the caller at the documented
-/// escape hatch (`get_file_content` reads Tier-2 files raw from disk).
+/// the skip reason, and the size.
 ///
-/// Example (Tier 2):
+/// The recovery sentence is keyed on `raw_read_available` — whether the
+/// spec-023 read gate would PERMIT a `get_file_content` raw read of this path.
+/// Advising "Use get_file_content" for a path the gate refuses sends the
+/// caller into a guaranteed refusal loop (the Tier-2 UX contradiction,
+/// testpilot receipt 2026-08-03), so a gated path gets the honest withheld
+/// sentence instead.
+///
+/// Example (Tier 2, raw read available):
 ///   `Not indexed: package-lock.json is Tier 2 (metadata only) — reason:
 ///    lockfile, size 406 KB. Use get_file_content for raw reads if you need
 ///    the contents.`
@@ -3694,6 +3700,7 @@ pub fn not_indexed_skipped_file(
     tier: AdmissionTier,
     reason: Option<SkipReason>,
     size: Option<u64>,
+    raw_read_available: bool,
 ) -> String {
     let reason_str = reason
         .map(|r| r.to_string())
@@ -3707,14 +3714,25 @@ pub fn not_indexed_skipped_file(
             // but degrade gracefully rather than assert.
             not_found_file(path)
         }
-        AdmissionTier::MetadataOnly => format!(
+        AdmissionTier::MetadataOnly if raw_read_available => format!(
             "Not indexed: {path} is Tier 2 (metadata only) — reason: {reason_str}, size {size_str}. \
              Use get_file_content for raw reads if you need the contents."
         ),
-        AdmissionTier::HardSkip => format!(
+        AdmissionTier::MetadataOnly => format!(
+            "Not indexed: {path} is Tier 2 (metadata only) — reason: {reason_str}, size {size_str}. \
+             Its contents are withheld by the admission policy — get_file_content will refuse this \
+             file, so read it outside SymForge if you need the raw text."
+        ),
+        AdmissionTier::HardSkip if raw_read_available => format!(
             "Not indexed: {path} is Tier 3 (hard-skipped) — reason: {reason_str}, size {size_str}. \
              This file is not parsed or read; get_file_content may still read it raw if it is a \
              text file within the repository."
+        ),
+        AdmissionTier::HardSkip => format!(
+            "Not indexed: {path} is Tier 3 (hard-skipped) — reason: {reason_str}, size {size_str}. \
+             This file is not parsed or read, and its contents are withheld by the admission \
+             policy — get_file_content will refuse this file, so read it outside SymForge if you \
+             need the raw text."
         ),
     }
 }

--- a/src/protocol/format/tests.rs
+++ b/src/protocol/format/tests.rs
@@ -2802,6 +2802,7 @@ fn test_not_indexed_skipped_file_tier2_message() {
         AdmissionTier::MetadataOnly,
         Some(SkipReason::DependencyLockfile),
         Some(406 * 1024),
+        true,
     );
     assert_eq!(
         result,
@@ -2817,17 +2818,56 @@ fn test_not_indexed_skipped_file_tier3_message() {
         AdmissionTier::HardSkip,
         Some(SkipReason::SizeCeiling),
         Some(200 * 1024 * 1024),
+        false,
     );
     assert!(
         result.starts_with("Not indexed: big.bin is Tier 3 (hard-skipped) — reason: >100MB"),
         "Tier-3 message should name tier and reason; got: {result}"
+    );
+    // 200 MB exceeds the read gate's scan limit: the advice must be the honest
+    // withheld sentence, never a pointer at a read the gate will refuse.
+    assert!(
+        result.contains("get_file_content will refuse"),
+        "gated Tier-3 advice must be honest; got: {result}"
+    );
+    assert!(
+        !result.contains("may still read it raw"),
+        "gated Tier-3 advice must not promise a refused read; got: {result}"
+    );
+}
+
+#[test]
+fn test_not_indexed_skipped_file_tier2_withheld_advice() {
+    // A Tier-2 file the read gate would refuse (e.g. recorded sensitive-content
+    // demotion) must NOT be pointed at get_file_content — that advice loops the
+    // caller into a guaranteed refusal (the testpilot Tier-2 UX contradiction).
+    let result = not_indexed_skipped_file(
+        "src/app/recorder.service.ts",
+        AdmissionTier::MetadataOnly,
+        Some(SkipReason::SizeThreshold),
+        Some(532 * 1024),
+        false,
+    );
+    assert!(
+        result.contains("get_file_content will refuse"),
+        "gated Tier-2 advice must be honest; got: {result}"
+    );
+    assert!(
+        !result.contains("Use get_file_content for raw reads"),
+        "gated Tier-2 advice must not point at a refused read; got: {result}"
     );
 }
 
 #[test]
 fn test_not_indexed_skipped_file_handles_missing_metadata() {
     // Defensive: unknown reason/size must not panic and must render placeholders.
-    let result = not_indexed_skipped_file("vendor/x.lock", AdmissionTier::MetadataOnly, None, None);
+    let result = not_indexed_skipped_file(
+        "vendor/x.lock",
+        AdmissionTier::MetadataOnly,
+        None,
+        None,
+        true,
+    );
     assert!(result.contains("reason: skipped"), "got: {result}");
     assert!(result.contains("size unknown"), "got: {result}");
 }

--- a/src/protocol/read_gate.rs
+++ b/src/protocol/read_gate.rs
@@ -48,6 +48,34 @@ pub(crate) fn admit_worktree_text(
     Ok(String::from_utf8(bytes).ok())
 }
 
+/// Predict — WITHOUT reading any bytes — whether [`admit_disk_read`] would
+/// refuse `relative_path`, from the same signals the gate checks before its
+/// read: the current path rule, the recorded disposition on the live
+/// publication, and (when known) the size against the scan limit.
+///
+/// Used to key advice text ("Use get_file_content for raw reads") on the
+/// gate's actual verdict, so no message ever points the caller at a read the
+/// gate is certain to refuse. Conservative by construction: it cannot see
+/// content that changed after publication, so a `false` here is advice, not
+/// authorization — the gate itself still decides on the exact bytes.
+pub(crate) fn disk_read_would_refuse(
+    live: &LiveIndex,
+    relative_path: &str,
+    size: Option<u64>,
+) -> bool {
+    if crate::knowledge::sensitive_path_rule(relative_path).is_some() {
+        return true;
+    }
+    if let Some(FileDisposition::MetadataOnly {
+        reason:
+            MetadataOnlyReason::SensitivePath { .. } | MetadataOnlyReason::SensitiveContent { .. },
+    }) = live.capture_file_disposition(relative_path)
+    {
+        return true;
+    }
+    size.is_some_and(|size| crate::knowledge::exceeds_scan_limit(size as usize))
+}
+
 /// Read `canon_path` and return its bytes only if the file is admissible for
 /// content disclosure.
 ///

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2663,6 +2663,7 @@ fn admission_tier_file_degradation_for_path(
         view.tier,
         view.reason,
         view.size,
+        !crate::protocol::read_gate::disk_read_would_refuse(index, &view.path, view.size),
     ))
 }
 

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -915,11 +915,22 @@ fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
     // demoted one keeps the oversize refusal; `.bin` still reads as non-parser.
     let has_code_parser = crate::domain::LanguageId::from_path(path).is_some();
 
+    // Key the recovery sentence on the read gate's predicted verdict (spec-023):
+    // "Use get_file_content" must never point at a read the gate will refuse.
+    let raw_read_advice =
+        if crate::protocol::read_gate::disk_read_would_refuse(&state.index.read(), path, view.size)
+        {
+            "Its contents are withheld by the admission policy — get_file_content will refuse \
+         this file."
+        } else {
+            "Use get_file_content for raw reads."
+        };
+
     if has_code_parser {
         return format!(
             "Not indexed: {path} is {tier_label} — reason: {reason}, size {size_mb:.1} MB. \
              The admission gate applies to analyze_file_impact the same as bulk load \
-             and the watcher (no force-admit). Use get_file_content for raw reads."
+             and the watcher (no force-admit). {raw_read_advice}"
         );
     }
 
@@ -934,7 +945,7 @@ fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
          Tier: {tier_label} — reason: {reason}, size {size_mb:.1} MB\n\
          Generation: {generation}\n\
          The file IS tracked (metadata only), not absent; impact/symbol analysis is \
-         unsupported for this file type. Use get_file_content for raw reads."
+         unsupported for this file type. {raw_read_advice}"
     )
 }
 


### PR DESCRIPTION
Task-board #21 — the testpilot Tier-2 UX contradiction (receipt: a 532 KB Tier-2 `recorder.service.ts`).

## Defects fixed
1. **Advice → refusal loop**: `not_indexed_skipped_file` (format.rs) and the sidecar `impact_skipped_text` said "Use get_file_content for raw reads" unconditionally — including for paths the spec-023 read gate is certain to refuse. New `read_gate::disk_read_would_refuse` predicts the verdict from the gate's own pre-read signals (path rule, recorded sensitive disposition, size vs scan limit); both messages now key the recovery sentence on it. Conservative: prediction is advice only — the gate still decides on the exact bytes.
2. **Resolve denies existence**: `search_files(resolve=true, query="<basename>")` reported a real Tier-2 path nonexistent (exact-path Tier-2 rule needed the full relative path; the fuzzy fallback swept parsed files only). The fallback now sweeps the metadata-only catalog with the same basename/substring/dir-component rules when no parsed file matches — parsed candidates keep precedence, so no existing resolution changes.
3. **Unbound bootstrap**: investigated, no code change — global MCP registration carries no cwd/workspace pin, so binding rides on harness launch CWD; `startup_plan` handles a resolved root correctly. Recorded for RUST_LOG capture on recurrence.

## Tests
- Tier-2/Tier-3 gated-advice batteries (withheld sentence asserted, refused-read pointer banned)
- Tier-2 basename resolve → `ResolvedMetadataOnly`; parsed-precedence guard
- Full serial suite green; one pre-existing cwd-guard flake (`test_index_folder_rebinds_repo_root_for_local_impact_analysis`) failed once in-suite and passes 3087/0 on a deterministic full-lib rerun — untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)