### PR TITLE
perf(026): restore the persisted snapshot on serve startup

### DIFF
--- a/specs/026-serve-snapshot-restore/spec.md
+++ b/specs/026-serve-snapshot-restore/spec.md
@@ -1,0 +1,47 @@
+# Spec 026 — serve snapshot restore
+
+**Status**: implemented in the same PR (one-campaign-one-PR, per
+`specs/024-optimization-backlog/BACKLOG.md` protocol).
+**Origin**: 024 backlog items 8/9 research pass (2026-08-04), recorded in
+BACKLOG.md §"Research result — serve snapshot restore".
+
+## Problem
+
+`symforge serve` never consulted the persisted `.symforge/index.bin`
+snapshot: every serve start paid the full cold pipeline (release, this repo:
+parse 4.60 s + runtime 3.59 s + publication 2.67 s + trigram 0.61 s ≈ 9.9 s
+to listening), while the stdio local path already restores the same snapshot
+in well under a second and reconciles in the background. The gap made serve
+starts fragile against the 60 s daemon/admin start deadline and re-parsed
+work that was already durably persisted.
+
+## Requirements
+
+- **FR-026-1**: `load_serve_index` MUST try `persist::load_snapshot` (the
+  staleness-gated loader every other consumer uses) before the synchronous
+  cold `LiveIndex::load_for_state_placement`. A usable snapshot is rehydrated
+  via `snapshot_to_live_index_with_code_signals` and published through the
+  same `SharedIndexHandle` path the stdio restore uses.
+- **FR-026-2**: A snapshot-restored serve index MUST spawn
+  `persist::background_verify` with the snapshot's mtime map — identical to
+  the stdio flow — so disk drift is reconciled without blocking startup, and
+  the index carries the honest `SnapshotRestore` / `Pending` trust labels
+  until verification completes.
+- **FR-026-3**: No snapshot (absent, stale, wrong root) keeps the exact prior
+  behavior: synchronous cold load, same error surface (`ServeError::IndexLoad`),
+  no verify task. Unbound roots keep serving the empty index.
+- **FR-026-4**: No new staleness policy is introduced — the gate lives solely
+  inside `load_snapshot`, shared with stdio/daemon (single decision point).
+
+## Success criteria
+
+- **SC-026-1**: `load_serve_index_restores_snapshot_when_present`
+  (`src/server/serve.rs` tests) — cold path with no snapshot returns no
+  verify map; after `checkpoint_shared_index`, the warm path returns a
+  `SnapshotRestore`-labeled index with the mtime map.
+- **SC-026-2**: full serial suite green (regression gate — serve HTTP attach,
+  auth, port batteries unchanged).
+- **SC-026-3**: measured claim: warm serve start reaches "index ready" without
+  a parse phase (log line `serve: loaded serialized index from
+  .symforge/index.bin`); cold-parse timing applies only to genuinely cold
+  first indexes.

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -335,21 +335,29 @@ pub enum ServeError {
 
 /// Build the in-process [`SharedIndex`] for serving.
 ///
-/// Resolves the project root (`discovery::find_project_root`) and loads it
-/// synchronously (the same `LiveIndex::load` the stdio local path uses). When no
-/// safe root is found, serves over an empty index — `tools/list` still responds,
-/// and the operator can `index_folder` after attaching. Returns the index and
-/// the resolved root (for the STEL ledger store location and the project name).
+/// Resolves the project root (`discovery::find_project_root`) and loads it —
+/// snapshot-first, exactly like the stdio local path (spec 026): a fresh
+/// `.symforge/index.bin` rehydrates in well under a second (no re-parsing),
+/// with the SAME staleness gate `persist::load_snapshot` applies everywhere
+/// and a background verification pass reconciling against current disk state.
+/// Only when no usable snapshot exists does serve pay the synchronous cold
+/// `LiveIndex::load` it always paid. When no safe root is found, serves over
+/// an empty index — `tools/list` still responds, and the operator can
+/// `index_folder` after attaching.
+///
+/// The fourth tuple element carries the snapshot's mtime map when the fast
+/// path was taken; the caller spawns `persist::background_verify` with it
+/// (this function is sync — it cannot spawn).
+type LoadedServeIndex = (
+    SharedIndex,
+    Option<std::path::PathBuf>,
+    Option<StatePlacement>,
+    Option<std::collections::HashMap<String, u64>>,
+);
+
 fn load_serve_index(
     workspace_root: Option<&std::path::Path>,
-) -> Result<
-    (
-        SharedIndex,
-        Option<std::path::PathBuf>,
-        Option<StatePlacement>,
-    ),
-    ServeError,
-> {
+) -> Result<LoadedServeIndex, ServeError> {
     // An explicit root answers the same question CWD discovery does — "which
     // tree does this launch serve?" — so it is resolved through the SAME guard
     // and binding path, never trusted blindly.
@@ -364,15 +372,51 @@ fn load_serve_index(
                 RootCandidateSource::LaunchCwd,
                 RootRequestMode::Automatic,
             ) else {
-                return Ok((LiveIndex::empty(), None, None));
+                return Ok((LiveIndex::empty(), None, None, None));
             };
             let state_placement = crate::discovery::resolve_state_placement(&binding);
             let root = binding.canonical_root;
+
+            // Fast path: rehydrate the persisted snapshot (staleness-gated
+            // inside `load_snapshot`) instead of re-parsing the tree.
+            if let Some(snapshot) =
+                crate::live_index::persist::load_snapshot(&root, &state_placement)
+            {
+                let file_count = snapshot.files.len();
+                let snapshot_mtimes: std::collections::HashMap<String, u64> = snapshot
+                    .files
+                    .iter()
+                    .map(|(path, file)| (path.clone(), file.mtime_secs))
+                    .collect();
+                let (live, code_signals) =
+                    crate::live_index::persist::snapshot_to_live_index_with_code_signals(
+                        snapshot, &root,
+                    );
+                tracing::info!(
+                    files = file_count,
+                    load_source = ?live.load_source(),
+                    snapshot_verify_state = ?live.snapshot_verify_state(),
+                    "serve: loaded serialized index from .symforge/index.bin"
+                );
+                let shared = crate::live_index::SharedIndexHandle::shared_for_state_placement_with_code_signals(
+                    live,
+                    &root,
+                    &state_placement,
+                    code_signals,
+                );
+                return Ok((
+                    shared,
+                    Some(root),
+                    Some(state_placement),
+                    Some(snapshot_mtimes),
+                ));
+            }
+
             let index = LiveIndex::load_for_state_placement(&root, &state_placement)
                 .map_err(|source| ServeError::IndexLoad { source })?;
-            Ok((index, Some(root), Some(state_placement)))
+            Ok((index, Some(root), Some(state_placement), None))
         }
-        None => Ok((LiveIndex::empty(), None, None)),
+        None => Ok((LiveIndex::empty(), None, None, None)),
     }
 }
 
@@ -497,8 +541,18 @@ pub async fn run(args: ServeArgs) -> Result<(), ServeError> {
     // the load itself on this repo, and an unattributed slow phase is exactly
     // what let the load-duration under-report go unnoticed.
     let phase = std::time::Instant::now();
-    let (index, repo_root, state_placement) = load_serve_index(args.workspace_root.as_deref())?;
+    let (index, repo_root, state_placement, snapshot_mtimes) =
+        load_serve_index(args.workspace_root.as_deref())?;
     tracing::info!("serve: index ready in {:?}", phase.elapsed());
+    // Spec 026: a snapshot-restored index reconciles against current disk
+    // state in the background (same verify pass the stdio path spawns); tools
+    // serve immediately with the honest SnapshotRestore/Pending trust labels.
+    if let (Some(mtimes), Some(root)) = (snapshot_mtimes, repo_root.clone()) {
+        let bg_index = index.clone();
+        tokio::spawn(async move {
+            crate::live_index::persist::background_verify(bg_index, root, mtimes).await;
+        });
+    }
     let control_state_dir: Option<ControlStateDir> =
         crate::paths::process_control_state_placement()
             .directory()
@@ -672,6 +726,40 @@ mod tests {
     /// Serializes process-env mutation across the env-dependent tests in this
     /// module (in addition to the suite-wide `--test-threads=1`).
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Spec 026: serve restores from a fresh `.symforge/index.bin` instead of
+    /// re-parsing — the fast path returns a SnapshotRestore-labeled index plus
+    /// the mtime map the caller hands to `background_verify`. Without a
+    /// snapshot the cold path still loads (and returns no mtime map).
+    #[test]
+    fn load_serve_index_restores_snapshot_when_present() {
+        let dir = tempfile::TempDir::new().expect("fixture root");
+        std::fs::create_dir(dir.path().join(".git")).expect("plant .git");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn seeded() {}\n").expect("seed file");
+
+        // Cold path first: no snapshot on disk yet.
+        let (cold, root, placement, mtimes) =
+            load_serve_index(Some(dir.path())).expect("cold load");
+        assert!(mtimes.is_none(), "no snapshot => no verify map");
+        let root = root.expect("root bound");
+        let placement = placement.expect("state placement resolved");
+        assert_eq!(cold.read().file_count(), 1);
+
+        // Persist the checkpoint the daemon/stdio paths write.
+        crate::live_index::persist::checkpoint_shared_index(&cold, &root, &placement)
+            .expect("write snapshot");
+
+        // Warm path: the snapshot must be restored, not re-parsed.
+        let (warm, _, _, mtimes) = load_serve_index(Some(dir.path())).expect("warm load");
+        assert_eq!(
+            warm.read().load_source(),
+            crate::live_index::store::IndexLoadSource::SnapshotRestore,
+            "serve must rehydrate a fresh snapshot"
+        );
+        assert_eq!(warm.read().file_count(), 1);
+        let mtimes = mtimes.expect("snapshot restore returns the verify map");
+        assert!(mtimes.contains_key("lib.rs"), "mtime map keys: {mtimes:?}");
+    }
 
     #[test]
     fn resolve_api_key_prefers_inline_over_env() {


### PR DESCRIPTION
Task-board items #8/#9 (first tranche) — spec `specs/026-serve-snapshot-restore/spec.md`, from the 024 backlog research pass recorded in `specs/024-optimization-backlog/BACKLOG.md`.

## What changes
`load_serve_index` tries `persist::load_snapshot` (the staleness-gated loader the stdio/daemon paths already use) before the synchronous cold `LiveIndex::load_for_state_placement`. A usable snapshot rehydrates through `snapshot_to_live_index_with_code_signals` + the shared `SharedIndexHandle` publish path, and `run` spawns the same `persist::background_verify` reconciliation the stdio restore spawns.

## Measured basis
- Cold serve (release, this repo): ~9.9 s to listening (parse 4.60 s + runtime 3.59 s + publication 2.67 s + trigram 0.61 s — #488 phase logs).
- stdio snapshot restore of the same 916-file/20 MB snapshot: listening ~3 s, with background verification carrying the honest `SnapshotRestore`/`Pending` trust labels.

## Behavior guarantees
- No snapshot (absent/stale/wrong root): byte-identical prior cold path, same `ServeError::IndexLoad` surface, no verify task.
- No new staleness policy — the gate lives solely inside `load_snapshot` (single decision point, shared with stdio/daemon).
- Unbound roots keep serving the empty index.

## Tests / gates
`load_serve_index_restores_snapshot_when_present` (cold→checkpoint→warm round trip asserting `SnapshotRestore` + verify map). fmt ✓ clippy -D warnings ✓ full serial suite (all targets) ✓ release build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)