### PR TITLE
feat(embed): export the snapshot-restore fast path on the facade

### DIFF
--- a/src/embed.rs
+++ b/src/embed.rs
@@ -47,6 +47,27 @@ pub use crate::live_index::store::{
 pub use crate::parsing::process_file;
 
 // ---------------------------------------------------------------------------
+// Snapshot restore (task #22 / AAP ask 2a): the warm-start fast path.
+//
+// `load_snapshot_for_root` (or the explicit-placement `load_snapshot`)
+// rehydrates a persisted `.symforge/index.bin` WITHOUT re-parsing; the loader
+// fails soft — `None` on a missing/corrupt/version-mismatched/foreign
+// snapshot, never a panic — so the embedder's fallback is always a cold
+// `LiveIndex::load`. `snapshot_compatible` is the readiness probe.
+//
+// NOTE (portability): a snapshot is bound to the canonical absolute root it
+// was written from (anti-foreign-state identity check). Restoring at a
+// DIFFERENT root or platform returns `None` today; the sanctioned opt-in
+// portable-import lane is tracked as task #23 and is NOT yet part of this
+// contract.
+// ---------------------------------------------------------------------------
+pub use crate::domain::StatePlacement;
+pub use crate::live_index::persist::{
+    IndexSnapshot, load_snapshot, load_snapshot_for_root, project_local_state_placement,
+    snapshot_compatible, snapshot_to_live_index,
+};
+
+// ---------------------------------------------------------------------------
 // STEL durable economics ledger + calibration (FR-001 embed durability).
 //
 // D3-ROOT extract-up: the durable per-project ledger store and the calibration
@@ -117,6 +138,14 @@ mod contract {
         StelLedgerEvent, StelLedgerStore, StoredLedgerRecord,
     };
 
+    // Task #22: the snapshot-restore fast path is semver-public. Name every
+    // contracted item so rename/removal/signature-drift trips compilation.
+    #[allow(unused_imports)]
+    use crate::embed::{
+        IndexSnapshot, StatePlacement, load_snapshot, load_snapshot_for_root,
+        project_local_state_placement, snapshot_compatible, snapshot_to_live_index,
+    };
+
     // Also name the back-compat MODULE re-exports so their removal trips too.
     #[allow(unused_imports)]
     use crate::embed::{domain, git, live_index, parsing};
@@ -153,6 +182,8 @@ mod contract {
         _assert_named::<SnapshotVerifyState>();
         _assert_named::<LiveIndex>();
         _assert_named::<GitRepo>();
+        _assert_named::<IndexSnapshot>();
+        _assert_named::<StatePlacement>();
 
         // --- Function / method contract: FULL-signature fn-pointer bindings. ---
         // A signature change (param type, arity, or return type) makes these
@@ -172,6 +203,17 @@ mod contract {
         ) -> Result<TextSearchResult, TextSearchError> = crate::embed::search_text;
         let _process_file: fn(&str, &[u8], LanguageId) -> FileProcessingResult =
             crate::embed::process_file;
+
+        // Snapshot restore (task #22) — full-signature bindings.
+        let _load_snapshot: fn(&Path, &StatePlacement) -> Option<IndexSnapshot> =
+            crate::embed::load_snapshot;
+        let _load_snapshot_for_root: fn(&Path) -> Option<IndexSnapshot> =
+            crate::embed::load_snapshot_for_root;
+        let _project_local_state_placement: fn(&Path) -> anyhow::Result<StatePlacement> =
+            crate::embed::project_local_state_placement;
+        let _snapshot_compatible: fn(&Path) -> bool = crate::embed::snapshot_compatible;
+        let _snapshot_to_live_index: fn(IndexSnapshot, &Path) -> LiveIndex =
+            crate::embed::snapshot_to_live_index;
 
         // Associated functions (no `&self`).
         let _load: fn(&Path) -> anyhow::Result<SharedIndex> = LiveIndex::load;
@@ -202,6 +244,11 @@ mod contract {
             _git_open,
             _git_file_at_ref,
             _git_changed_paths,
+            _load_snapshot,
+            _load_snapshot_for_root,
+            _project_local_state_placement,
+            _snapshot_compatible,
+            _snapshot_to_live_index,
         );
 
         // Back-compat module paths still resolve (deep-path imports AAP uses).

--- a/src/live_index/persist.rs
+++ b/src/live_index/persist.rs
@@ -1698,6 +1698,49 @@ pub fn load_snapshot(
     Some(snapshot)
 }
 
+/// The project-local state placement for `project_root`
+/// (`<canonical root>/.symforge`) — the placement every default single-project
+/// deployment writes its `index.bin` under.
+///
+/// Embedder-facing (spec: task #22, AAP ask 2a): an embedder holds only a
+/// project root; constructing a [`StatePlacement`] otherwise requires the
+/// discovery `RootBinding` machinery the embed surface deliberately omits.
+/// Errors only when the root cannot be canonicalized (missing directory).
+pub fn project_local_state_placement(project_root: &Path) -> anyhow::Result<StatePlacement> {
+    let canonical = dunce::canonicalize(project_root).map_err(|error| {
+        anyhow::anyhow!(
+            "canonicalizing project root {}: {}",
+            project_root.display(),
+            error
+        )
+    })?;
+    Ok(StatePlacement::ProjectLocal {
+        directory: crate::domain::ProjectStateDir::new(crate::paths::resolve_symforge_dir(
+            &canonical,
+        )),
+    })
+}
+
+/// [`load_snapshot`] against `project_root`'s project-local placement — the
+/// one-argument embedder entry point.
+pub fn load_snapshot_for_root(project_root: &Path) -> Option<IndexSnapshot> {
+    let placement = project_local_state_placement(project_root).ok()?;
+    load_snapshot(project_root, &placement)
+}
+
+/// Whether a usable snapshot exists for `project_root` (project-local
+/// placement): present, current format + secret-policy version, and matching
+/// project/source identity.
+///
+/// AAP ask 2a's fallback probe. This performs the FULL [`load_snapshot`]
+/// validation (a `true` here means the subsequent restore will succeed against
+/// unchanged disk state), so a caller about to restore should just call
+/// [`load_snapshot_for_root`] once and keep the snapshot instead of probing
+/// first — this probe is for readiness reporting, not a fast pre-check.
+pub fn snapshot_compatible(project_root: &Path) -> bool {
+    load_snapshot_for_root(project_root).is_some()
+}
+
 /// Rehydrate a `LiveIndex` from a persisted snapshot.
 ///
 /// `project_root` is the filesystem root the snapshot was taken from; it is
@@ -2257,6 +2300,31 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/src/git/test_helpers.rs"
         ));
+    }
+
+    /// Task #22 (embed snapshot export): the one-argument embedder entry
+    /// points round-trip — checkpoint, probe, restore, rehydrate — and the
+    /// probe is honest about absence.
+    #[test]
+    fn embedder_snapshot_helpers_round_trip() {
+        let dir = tempfile::TempDir::new().expect("fixture root");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn seeded() {}\n").expect("seed file");
+
+        // No snapshot yet: probe says incompatible, restore says None.
+        assert!(!super::snapshot_compatible(dir.path()));
+        assert!(super::load_snapshot_for_root(dir.path()).is_none());
+
+        let placement =
+            super::project_local_state_placement(dir.path()).expect("placement resolves");
+        let shared = crate::live_index::LiveIndex::load_for_state_placement(dir.path(), &placement)
+            .expect("cold load");
+        super::checkpoint_shared_index(&shared, dir.path(), &placement).expect("checkpoint");
+
+        assert!(super::snapshot_compatible(dir.path()));
+        let snapshot = super::load_snapshot_for_root(dir.path()).expect("snapshot restores");
+        let live = super::snapshot_to_live_index(snapshot, dir.path());
+        assert_eq!(live.file_count(), 1);
+        assert_eq!(live.load_source(), IndexLoadSource::SnapshotRestore);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Task-board #22 — AAP ask 2a from `docs/solutions/symforge-embed-upstream-asks.md` (AAP repo).

## What lands
- One-argument embedder entry points in `live_index::persist`: `project_local_state_placement`, `load_snapshot_for_root`, `snapshot_compatible` — thin, dependency-free wrappers over the existing staleness-gated `load_snapshot`.
- `symforge::embed` re-exports the full restore lane (`load_snapshot`, `load_snapshot_for_root`, `project_local_state_placement`, `snapshot_compatible`, `snapshot_to_live_index`, `IndexSnapshot`, `StatePlacement`), each pinned in the facade's semver contract test with full-signature fn-pointer bindings.
- Facade docs state the portability boundary explicitly: snapshots remain bound to their canonical absolute root (the anti-foreign-state identity check); the opt-in cross-root import is #23 and NOT part of this contract.

## AAP acceptance criteria
- "Restore of an older-format snapshot either succeeds or returns typed incompatibility, never a panic/wrong index" — met by the existing loader (version/policy/identity/digest all fail soft to `None` + quarantine); `snapshot_compatible` is the readiness probe, documented as a full-validation probe (callers about to restore should call `load_snapshot_for_root` once instead).
- "Keep it inside embed's dependency footprint" — zero new deps; embed clippy + 1292 embed lib tests green.

## Gates
fmt ✓ · clippy -D warnings (full + embed graphs) ✓ · embed lib suite 1292 passed ✓ · full serial suite (all targets) ✓ · release build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)