### PR TITLE
feat(embed): engine_info, runtime guarantees, and an indexing-pool cap

### DIFF
--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 pub enum LanguageId {
     Rust,
@@ -33,6 +33,66 @@ pub enum LanguageId {
 }
 
 impl LanguageId {
+    /// Every supported grammar, in declaration order (embed `engine_info`).
+    pub const ALL: [Self; 25] = [
+        Self::Rust,
+        Self::Python,
+        Self::JavaScript,
+        Self::TypeScript,
+        Self::Go,
+        Self::Java,
+        Self::C,
+        Self::Cpp,
+        Self::CSharp,
+        Self::Ruby,
+        Self::Php,
+        Self::Swift,
+        Self::Kotlin,
+        Self::Dart,
+        Self::Perl,
+        Self::Elixir,
+        Self::Json,
+        Self::Toml,
+        Self::Yaml,
+        Self::Markdown,
+        Self::Text,
+        Self::Env,
+        Self::Html,
+        Self::Css,
+        Self::Scss,
+    ];
+
+    /// Stable lowercase grammar name (embed `engine_info` reporting).
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            Self::JavaScript => "javascript",
+            Self::TypeScript => "typescript",
+            Self::Go => "go",
+            Self::Java => "java",
+            Self::C => "c",
+            Self::Cpp => "cpp",
+            Self::CSharp => "csharp",
+            Self::Ruby => "ruby",
+            Self::Php => "php",
+            Self::Swift => "swift",
+            Self::Kotlin => "kotlin",
+            Self::Dart => "dart",
+            Self::Perl => "perl",
+            Self::Elixir => "elixir",
+            Self::Json => "json",
+            Self::Toml => "toml",
+            Self::Yaml => "yaml",
+            Self::Markdown => "markdown",
+            Self::Text => "text",
+            Self::Env => "env",
+            Self::Html => "html",
+            Self::Css => "css",
+            Self::Scss => "scss",
+        }
+    }
+
     pub fn from_extension(ext: &str) -> Option<Self> {
         match ext.to_ascii_lowercase().as_str() {
             "rs" => Some(Self::Rust),

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -41,6 +41,58 @@ pub use crate::live_index::search::{
     SymbolSearchResult, TextSearchError, TextSearchResult, search_symbols, search_text,
 };
 pub use crate::live_index::single_file::{ReindexResult, remove_file, update_file_from_disk};
+
+// ---------------------------------------------------------------------------
+// Engine identity + runtime guarantees (task #25 / AAP asks 4-6).
+//
+// NO IMPLICIT BACKGROUND MACHINERY: constructing or loading an index under
+// the embed feature spawns no watchers, timers, or async runtimes — the file
+// watcher is server-only and caller-started, never by `LiveIndex::load`. The
+// one lazily created resource is the rayon indexing pool (persistent COMPUTE
+// workers, first parse), cappable via `SYMFORGE_INDEXING_THREADS` for
+// tight-RAM PID-1 embedders.
+//
+// SEARCH BOUNDS: `search_symbols`/`search_text` results are bounded by their
+// limit parameters; the scan itself is bounded by the in-memory candidate set
+// (trigram-prefiltered for literal text queries) with a worst case linear in
+// indexed files — measured p95 well under 1 ms on a ~900-file repo. There is
+// no in-engine cancellation token today; an embedder enforcing `timeout_ms`
+// should wrap the call (a budget parameter is a compatible future addition
+// and will land here if a real workload needs it).
+// ---------------------------------------------------------------------------
+
+/// Engine identity for embedder readiness evidence: one call, no I/O.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EngineInfo {
+    /// The symforge crate version compiled into this engine.
+    pub version: &'static str,
+    /// On-disk snapshot format version written/restored by this engine.
+    pub snapshot_format_version: u32,
+    /// Secret-detector policy version enforced at admission and raw reads.
+    pub secret_policy_version: u32,
+    /// Stable lowercase names of every supported grammar.
+    pub grammars: &'static [&'static str],
+}
+
+/// The [`EngineInfo`] for this build. Values are compile-time constants.
+pub fn engine_info() -> EngineInfo {
+    const GRAMMAR_NAMES: [&str; crate::domain::LanguageId::ALL.len()] = {
+        let mut names = [""; crate::domain::LanguageId::ALL.len()];
+        let mut i = 0;
+        while i < crate::domain::LanguageId::ALL.len() {
+            names[i] = crate::domain::LanguageId::ALL[i].name();
+            i += 1;
+        }
+        names
+    };
+    EngineInfo {
+        version: env!("CARGO_PKG_VERSION"),
+        snapshot_format_version: crate::live_index::persist::SNAPSHOT_FORMAT_VERSION,
+        secret_policy_version: crate::knowledge::SECRET_POLICY_VERSION,
+        grammars: &GRAMMAR_NAMES,
+    }
+}
 pub use crate::live_index::store::{
     IndexLoadSource, IndexedFile, ParseStatus, PublishedIndexState, PublishedIndexStatus,
     SharedIndex, SnapshotVerifyState,
@@ -166,6 +218,10 @@ mod contract {
     #[allow(unused_imports)]
     use crate::embed::{ReindexResult, remove_file, update_file_from_disk};
 
+    // Task #25: engine identity is semver-public.
+    #[allow(unused_imports)]
+    use crate::embed::{EngineInfo, engine_info};
+
     // Also name the back-compat MODULE re-exports so their removal trips too.
     #[allow(unused_imports)]
     use crate::embed::{domain, git, live_index, parsing};
@@ -242,6 +298,7 @@ mod contract {
         let _update_file_from_disk: fn(&SharedIndex, &Path, &str) -> ReindexResult =
             crate::embed::update_file_from_disk;
         let _remove_file: fn(&SharedIndex, &str) -> bool = crate::embed::remove_file;
+        let _engine_info: fn() -> EngineInfo = crate::embed::engine_info;
 
         // Associated functions (no `&self`).
         let _load: fn(&Path) -> anyhow::Result<SharedIndex> = LiveIndex::load;
@@ -280,7 +337,19 @@ mod contract {
             _import_portable_snapshot,
             _update_file_from_disk,
             _remove_file,
+            _engine_info,
         );
+
+        // Task #25: engine identity is real data, not just a signature.
+        let info = crate::embed::engine_info();
+        assert!(!info.version.is_empty());
+        assert_eq!(
+            info.grammars.len(),
+            crate::domain::LanguageId::ALL.len(),
+            "every grammar is reported"
+        );
+        assert!(info.grammars.contains(&"rust"));
+        assert!(info.snapshot_format_version >= 7);
 
         // Back-compat module paths still resolve (deep-path imports AAP uses).
         let _deep_process_file: fn(&str, &[u8], LanguageId) -> FileProcessingResult =

--- a/src/live_index/health_view.rs
+++ b/src/live_index/health_view.rs
@@ -290,7 +290,7 @@ impl LiveIndex {
                     .extension()
                     .and_then(|extension| extension.to_str())
                     .map(ToOwned::to_owned),
-                language: entry.language.clone(),
+                language: entry.language,
                 reason: decision.reason,
             });
         }
@@ -300,7 +300,7 @@ impl LiveIndex {
                 path: file.relative_path.clone(),
                 size: Some(file.byte_len),
                 extension: None,
-                language: Some(file.language.clone()),
+                language: Some(file.language),
                 reason: None,
             });
         }

--- a/src/live_index/local_ref_scout.rs
+++ b/src/live_index/local_ref_scout.rs
@@ -331,7 +331,7 @@ fn classify_ref_blob(entry: &RefBlobEntry, bytes: &[u8]) -> RefBlobRoute {
         StableContentAdmission::Admitted => {
             let classification =
                 FileClassification::for_indexed_path(&entry.relative_path, targets);
-            let language = entry.language.clone().unwrap_or(LanguageId::Text);
+            let language = entry.language.unwrap_or(LanguageId::Text);
             RefBlobRoute::Parse {
                 targets,
                 language,
@@ -444,7 +444,7 @@ fn route_catalog_files(catalog: &LocalRefCatalog, blobs: &RefBlobBytes) -> RefRo
         let key = (
             entry.object_id.clone(),
             classification,
-            language.clone(),
+            language,
             is_tsx,
             is_c_header,
         );

--- a/src/live_index/persist.rs
+++ b/src/live_index/persist.rs
@@ -29,6 +29,11 @@ use crate::paths;
 use crate::domain::ParseDiagnostic;
 
 const CURRENT_VERSION: u32 = 7;
+
+/// The on-disk snapshot format version this engine writes and restores
+/// (embed `engine_info` reporting; a mismatched snapshot fails soft to a
+/// cold index, never a panic).
+pub const SNAPSHOT_FORMAT_VERSION: u32 = CURRENT_VERSION;
 const INDEX_FILENAME: &str = "index.bin";
 const INDEX_TMP_FILENAME: &str = "index.bin.tmp";
 const INDEX_TMP_PREFIX: &str = "index.bin.tmp.";
@@ -2217,7 +2222,7 @@ fn build_snapshot(
             path.clone(),
             IndexedFileSnapshot {
                 relative_path: file.relative_path.clone(),
-                language: file.language.clone(),
+                language: file.language,
                 classification: file.classification,
                 content: file.content.clone(),
                 symbols: file.symbols.clone(),

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -2607,7 +2607,7 @@ impl LiveIndex {
             .map(|(relative_path, file)| RepoOutlineFileView {
                 noise_class: NoisePolicy::classify_path(relative_path, gi_ref),
                 relative_path: relative_path.clone(),
-                language: file.language.clone(),
+                language: file.language,
                 symbol_count: file.symbols.len(),
             })
             .collect();
@@ -2958,7 +2958,7 @@ impl LiveIndex {
         // Resolve the logical module path for the target file.
         let module_path = resolve_module_path(target_path, &target_file.language);
 
-        let target_language = target_file.language.clone();
+        let target_language = target_file.language;
         let target_scope = declared_scope(target_file);
         let target_symbol_names: HashSet<&str> = target_file
             .symbols

--- a/src/live_index/search.rs
+++ b/src/live_index/search.rs
@@ -1182,7 +1182,7 @@ pub fn search_text_with_options(
             case_sensitive: options.case_sensitive,
             whole_word: options.whole_word,
             path_scope: options.path_scope.clone(),
-            language_filter: options.language_filter.clone(),
+            language_filter: options.language_filter,
             glob: options.glob.clone(),
             exclude_glob: options.exclude_glob.clone(),
             search_scope: options.search_scope,
@@ -1399,7 +1399,7 @@ fn search_structural_with_compiler(
         .filter(|(path, file)| {
             file_matches_text_options(path, file, options, &compiled_globs, &targets_by_path)
         })
-        .map(|(path, file)| (path.clone(), file.language.clone()))
+        .map(|(path, file)| (path.clone(), file.language))
         .collect();
     candidates.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -1417,7 +1417,7 @@ fn search_structural_with_compiler(
 
         let is_tsx = LanguageId::is_tsx_path(path);
         let compiled = compiled_patterns
-            .entry((lang.clone(), is_tsx, pattern.to_string()))
+            .entry((*lang, is_tsx, pattern.to_string()))
             .or_insert_with(|| compile_pattern(pattern, lang, is_tsx));
         let structural_matches = match compiled {
             Ok(compiled_pattern) => {
@@ -3991,7 +3991,7 @@ mod tests {
             pattern,
             &TextSearchOptions::default(),
             |pattern, lang, is_tsx| {
-                *compile_calls_by_language.entry(lang.clone()).or_default() += 1;
+                *compile_calls_by_language.entry(*lang).or_default() += 1;
                 crate::parsing::ast_grep::compile_structural_pattern(pattern, lang, is_tsx)
             },
         )

--- a/src/live_index/single_file.rs
+++ b/src/live_index/single_file.rs
@@ -63,13 +63,7 @@ where
     L: Into<Option<LanguageId>>,
 {
     let language = language.into();
-    match read_and_index(
-        relative_path,
-        abs_path,
-        shared,
-        language.clone(),
-        expected_gen,
-    ) {
+    match read_and_index(relative_path, abs_path, shared, language, expected_gen) {
         ReindexResult::NotFound => {}
         other => return other,
     }
@@ -77,13 +71,7 @@ where
     let delays_ms = [50u64, 200, 500];
     for delay_ms in delays_ms {
         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-        match read_and_index(
-            relative_path,
-            abs_path,
-            shared,
-            language.clone(),
-            expected_gen,
-        ) {
+        match read_and_index(relative_path, abs_path, shared, language, expected_gen) {
             ReindexResult::NotFound => continue,
             other => return other,
         }
@@ -286,10 +274,7 @@ where
             _ => unreachable!("terminal scout decisions return before content ingestion"),
         };
 
-        let language = language
-            .clone()
-            .or_else(|| scouted.language.clone())
-            .unwrap_or(LanguageId::Text);
+        let language = language.or(scouted.language).unwrap_or(LanguageId::Text);
 
         let bytes = match stable_read(abs_path, &scouted.stamp) {
             crate::live_index::store::StableReadOutcome::Accepted { bytes, .. } => bytes,

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -86,10 +86,42 @@ fn indexing_thread_stack_size() -> usize {
     }
 }
 
+/// Env override for the indexing pool's worker count. The pool is the ONLY
+/// background machinery an embed-feature index load creates (lazy, compute
+/// only — no watchers/timers/runtimes), so a tight-RAM PID-1 embedder can cap
+/// it explicitly. Invalid or zero values fall back to rayon's default.
+const INDEXING_THREADS_ENV: &str = "SYMFORGE_INDEXING_THREADS";
+
+fn indexing_thread_count() -> Option<usize> {
+    let raw = std::env::var(INDEXING_THREADS_ENV).ok()?;
+    match raw.trim().parse::<usize>() {
+        Ok(count) if count >= 1 => Some(count),
+        _ => {
+            warn!(
+                env = INDEXING_THREADS_ENV,
+                value = %raw,
+                "ignoring invalid indexing thread count; using rayon default"
+            );
+            None
+        }
+    }
+}
+
 fn indexing_thread_pool() -> &'static rayon::ThreadPool {
     INDEXING_THREAD_POOL.get_or_init(|| {
         let builder = rayon::ThreadPoolBuilder::new()
             .thread_name(|index| format!("symforge-index-{}", index));
+        let builder = match indexing_thread_count() {
+            Some(count) => {
+                info!(
+                    count,
+                    env = INDEXING_THREADS_ENV,
+                    "initializing indexing thread pool with explicit worker count"
+                );
+                builder.num_threads(count)
+            }
+            None => builder,
+        };
 
         #[cfg(windows)]
         let builder = {
@@ -3286,7 +3318,7 @@ fn catalog_entry_from_scout(
     CatalogEntry {
         path: scouted.path.clone(),
         size: scouted.stamp.size,
-        language: scouted.language.clone(),
+        language: scouted.language,
         classification: scouted.classification,
         disposition,
         content_hash,
@@ -3594,7 +3626,7 @@ fn project_scout_for_legacy_execution(plan: &discovery::ScoutPlan) -> LegacyExec
                     relative_path,
                     absolute_path,
                     file_size: entry.stamp.size,
-                    language: entry.language.clone(),
+                    language: entry.language,
                     classification: entry.classification,
                 });
             }
@@ -3808,7 +3840,7 @@ fn admit_and_parse_entries(
                         crate::domain::FileDisposition::MetadataOnly { reason },
                     );
                 }
-                let language = entry.language.clone().unwrap_or(LanguageId::Text);
+                let language = entry.language.unwrap_or(LanguageId::Text);
 
                 let mtime_secs = planned
                     .stamp
@@ -4489,7 +4521,7 @@ impl LiveIndex {
         let manifest_entry = CatalogEntry {
             path: catalog_path,
             size: file.byte_len,
-            language: Some(file.language.clone()),
+            language: Some(file.language),
             classification: file.classification,
             disposition: FileDisposition::Indexed {
                 targets,

--- a/src/live_index/view.rs
+++ b/src/live_index/view.rs
@@ -1518,7 +1518,7 @@ mod tests {
         let mut map: HashMap<String, Arc<IndexedFile>> = HashMap::new();
         for (path, lang, sym) in files {
             let mut file = make_file_with_symbol(path, sym, &format!("fn {sym}() {{}}"));
-            file.language = lang.clone();
+            file.language = *lang;
             map.insert((*path).to_string(), Arc::new(file));
         }
         idx.trigram_index = crate::live_index::trigram::TrigramIndex::build_from_files(&map);

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1892,7 +1892,7 @@ export function App() {
         ];
 
         for &(source, path, ref lang) in cases {
-            let result = process_file(path, source, lang.clone());
+            let result = process_file(path, source, *lang);
             assert_eq!(result.relative_path, path);
             assert_eq!(result.byte_len, source.len() as u64);
             assert!(!result.content_hash.is_empty());
@@ -1966,9 +1966,9 @@ export function App() {
         ];
 
         for &(source, path, ref lang) in cases {
-            let first = process_file(path, source, lang.clone());
-            let second = process_file(path, source, lang.clone());
-            let third = process_file(path, source, lang.clone());
+            let first = process_file(path, source, *lang);
+            let second = process_file(path, source, *lang);
+            let third = process_file(path, source, *lang);
             assert_eq!(
                 first, second,
                 "{path}: identical bytes must yield identical FileProcessingResult (run 1 vs 2)"

--- a/src/parsing/xref.rs
+++ b/src/parsing/xref.rs
@@ -2980,7 +2980,7 @@ export const Table = ({ rows }) => (\n\
         ];
 
         for (source, lang) in cases {
-            let (refs, _) = parse_and_extract(source, lang.clone());
+            let (refs, _) = parse_and_extract(source, *lang);
             assert!(
                 !refs.is_empty(),
                 "language {:?} should produce refs from non-trivial source, got none",
@@ -3007,7 +3007,7 @@ export const Table = ({ rows }) => (\n\
             LanguageId::Elixir,
         ];
         for lang in languages {
-            let (refs, alias_map) = parse_and_extract("", lang.clone());
+            let (refs, alias_map) = parse_and_extract("", lang);
             assert!(
                 refs.is_empty(),
                 "language {:?} should produce no refs from empty source",

--- a/src/protocol/edit.rs
+++ b/src/protocol/edit.rs
@@ -520,8 +520,7 @@ pub(crate) fn rebase_edit_base_for_reroute(
             rebased: false,
         });
     }
-    let result =
-        crate::parsing::process_file(&file.relative_path, &target_bytes, file.language.clone());
+    let result = crate::parsing::process_file(&file.relative_path, &target_bytes, file.language);
     Ok(EditBase {
         file: std::sync::Arc::new(IndexedFile::from_parse_result(result, target_bytes)),
         rebased: true,
@@ -1896,7 +1895,7 @@ pub(crate) fn execute_batch_edit(
                 path: edit.path.clone(),
                 sym,
                 operation: i,
-                language: file.language.clone(),
+                language: file.language,
             });
         }
     }
@@ -1988,7 +1987,7 @@ pub(crate) fn execute_batch_edit(
             }
         }
 
-        let language = resolved[indices[0]].language.clone();
+        let language = resolved[indices[0]].language;
         let line_ending = detect_line_ending(&content);
         let mut file_summaries: Vec<String> = Vec::new();
 
@@ -2161,7 +2160,7 @@ pub(crate) fn execute_batch_edit(
                         &staged_file.abs_path,
                         &staged_file.path,
                         &on_disk,
-                        staged_file.language.clone(),
+                        staged_file.language,
                     );
                 }
                 Err(rb_err) => {
@@ -2200,7 +2199,7 @@ pub(crate) fn execute_batch_edit(
             &staged_file.abs_path,
             &staged_file.path,
             &staged_file.new_content,
-            staged_file.language.clone(),
+            staged_file.language,
         );
         let hook_ctx = super::edit_hooks::EditContext {
             relative_path: &staged_file.path,
@@ -2340,7 +2339,7 @@ pub(crate) fn execute_batch_rename(
         let abs_start = sym.byte_range.0 + name_offset as u32;
         let abs_end = abs_start + input.name.len() as u32;
         let owner = crate::live_index::enclosing_impl_owner(&file.symbols, sym.line_range.0);
-        ((abs_start, abs_end), file.language.clone(), owner)
+        ((abs_start, abs_end), file.language, owner)
     };
 
     // Phase 2: Find all references across the project. Carry each ref's
@@ -2695,9 +2694,9 @@ pub(crate) fn execute_batch_rename(
             last_start = Some(range.0);
         }
         let lang = if path == &input.path {
-            language.clone()
+            language
         } else {
-            file.language.clone()
+            file.language
         };
         let indexed_abs = match safe_repo_path(repo_root, path) {
             Ok(p) => p,
@@ -2761,13 +2760,7 @@ pub(crate) fn execute_batch_rename(
             // Re-read from disk and reindex to ensure index matches disk.
             match std::fs::read(&sf.abs_path) {
                 Ok(on_disk) => {
-                    reindex_after_write(
-                        index,
-                        &sf.abs_path,
-                        &sf.path,
-                        &on_disk,
-                        sf.language.clone(),
-                    );
+                    reindex_after_write(index, &sf.abs_path, &sf.path, &on_disk, sf.language);
                 }
                 Err(rb_err) => {
                     rollback_failures
@@ -2801,13 +2794,7 @@ pub(crate) fn execute_batch_rename(
     let mut files_updated = 0;
     let mut refs_updated = 0;
     for sf in &staged {
-        reindex_after_write(
-            index,
-            &sf.abs_path,
-            &sf.path,
-            &sf.new_content,
-            sf.language.clone(),
-        );
+        reindex_after_write(index, &sf.abs_path, &sf.path, &sf.new_content, sf.language);
         let hook_ctx = super::edit_hooks::EditContext {
             relative_path: &sf.path,
             indexed_absolute_path: &sf.resolved_target.indexed_path,
@@ -3009,7 +2996,7 @@ pub(crate) fn execute_batch_insert(
                 path: target.path.clone(),
                 sym,
                 operation: i,
-                language: file.language.clone(),
+                language: file.language,
             });
         }
     }
@@ -3136,7 +3123,7 @@ pub(crate) fn execute_batch_insert(
             abs_path: resolved_target.target_path.clone(),
             original: file.content.clone(),
             new_content: content,
-            language: resolved[indices[0]].language.clone(),
+            language: resolved[indices[0]].language,
             summaries: file_summaries,
             working_directory: per_file_working_directory,
             resolved_target,
@@ -3188,7 +3175,7 @@ pub(crate) fn execute_batch_insert(
                         &staged_file.abs_path,
                         &staged_file.path,
                         &on_disk,
-                        staged_file.language.clone(),
+                        staged_file.language,
                     );
                 }
                 Err(rb_err) => {
@@ -3226,7 +3213,7 @@ pub(crate) fn execute_batch_insert(
             &staged_file.abs_path,
             &staged_file.path,
             &staged_file.new_content,
-            staged_file.language.clone(),
+            staged_file.language,
         );
         let hook_ctx = super::edit_hooks::EditContext {
             relative_path: &staged_file.path,

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -963,7 +963,7 @@ impl SymForgeServer {
                 &resolved_path,
                 &params.0.path,
                 &new_content,
-                file.language.clone(),
+                file.language,
             );
         }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
@@ -1179,7 +1179,7 @@ impl SymForgeServer {
                 &resolved_path,
                 &params.0.path,
                 &new_content,
-                file.language.clone(),
+                file.language,
             );
         }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
@@ -1370,7 +1370,7 @@ impl SymForgeServer {
                 &resolved_path,
                 &params.0.path,
                 &new_content,
-                file.language.clone(),
+                file.language,
             );
         }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);
@@ -1745,7 +1745,7 @@ impl SymForgeServer {
                 &resolved_path,
                 &params.0.path,
                 &new_content,
-                file.language.clone(),
+                file.language,
             );
         }
         edit_hooks::after_commit(&hook_ctx, &resolved_path);

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -5385,7 +5385,7 @@ impl SymForgeServer {
                 text_options.path_scope = options.path_scope.clone();
                 text_options.noise_policy = options.noise_policy;
                 text_options.include_personal_tooling = options.include_personal_tooling;
-                text_options.language_filter = options.language_filter.clone();
+                text_options.language_filter = options.language_filter;
                 text_options.total_limit = 15;
                 text_options.max_per_file = 1;
                 search::search_text_with_options(
@@ -9892,7 +9892,7 @@ impl SymForgeServer {
                 options.path_scope = search::PathScope::Prefix(prefix.clone());
             }
             if let Some(ref lang) = lang_filter {
-                options.language_filter = Some(lang.clone());
+                options.language_filter = Some(*lang);
             }
             let result = search::search_text_with_options(&guard, Some(tq), None, false, &options);
             if let Ok(r) = result {
@@ -9973,7 +9973,7 @@ impl SymForgeServer {
                     options.path_scope = search::PathScope::Prefix(prefix.clone());
                 }
                 if let Some(ref lang) = lang_filter {
-                    options.language_filter = Some(lang.clone());
+                    options.language_filter = Some(*lang);
                 }
 
                 if let Ok(result) = search::search_text_with_options(

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -986,7 +986,7 @@ async fn handle_new_file_impact(
         for symbol in &file.symbols {
             *kind_counts.entry(symbol.kind.to_string()).or_insert(0) += 1;
         }
-        file.language.clone()
+        file.language
     };
 
     let mut kind_parts: Vec<String> = kind_counts

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -374,11 +374,7 @@ where
                 {
                     return None;
                 }
-                Some((
-                    relative_path,
-                    entry.absolute_path.clone()?,
-                    entry.language.clone(),
-                ))
+                Some((relative_path, entry.absolute_path.clone()?, entry.language))
             })
             .collect();
         let removed_paths: Vec<(String, crate::domain::ScoutedEntry)> =


### PR DESCRIPTION
Task-board #25 — AAP asks 4–6, closing out the embed brief.

## What lands
- **`embed::engine_info()`** (ask 6): version, snapshot-format version, secret-policy version, and the full 25-grammar list — compile-time constants, one call, no I/O. New `LanguageId::ALL`/`name()` back it; `LanguageId` gains `Copy` (fieldless enum, purely additive) with the resulting `clone_on_copy` sweep applied via clippy --fix.
- **No-implicit-background guarantee** (ask 4), documented on the facade: no watchers/timers/runtimes from index construction — the watcher is server-only and caller-started. The one lazy resource (rayon indexing pool) is now cappable via **`SYMFORGE_INDEXING_THREADS`** for tight-RAM PID-1 embedders; invalid values fall back to the rayon default with a logged warning.
- **Search bounds** (ask 5), documented on the facade: limit-bounded results, candidate-set-bounded scans (trigram prefilter; measured p95 0.2 ms on ~900 files), honest statement that no in-engine cancellation exists today — wrap with your `timeout_ms`; a budget parameter is a compatible future addition if a real workload needs it.

## Acceptance mapping
- Ask 6 "one call, no I/O, stable fields" — met, contract-pinned with runtime assertions.
- Ask 4 "no watcher threads/timers unless asked" — true by construction (server-only watcher), documented, pool cappable.
- Ask 5 "budget/cancellation OR documented hard bounds" — documented-bounds branch taken, with the escape hatch named.

## Gates
fmt ✓ · clippy -D warnings (full + embed) ✓ · embed lib suite 1295 ✓ · full serial suite all targets ✓ · release build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)