### PR TITLE
perf(surface): drop inert schema bytes from tools/list

### DIFF
--- a/src/protocol/surface_probe.rs
+++ b/src/protocol/surface_probe.rs
@@ -171,6 +171,15 @@ pub fn list_tools_for_profile(profile: SurfaceProfile) -> Vec<Tool> {
             .list_all()
             .into_iter()
             .filter(|tool| tool.name.as_ref() != "symforge")
+            .map(|mut tool| {
+                // The `#[tool]` macro builds these schemas via schemars, so they
+                // carry the same inert `$schema` / `"default": null` bytes the
+                // compact surface strips in `schema_object`.
+                let mut schema = (*tool.input_schema).clone();
+                crate::stel::surface_list::strip_schema_noise(&mut schema);
+                tool.input_schema = Arc::new(schema);
+                tool
+            })
             .collect(),
         SurfaceProfile::Compact => compact_probe_tools(),
         SurfaceProfile::Meta => meta_probe_tools(),

--- a/src/stel/surface_list.rs
+++ b/src/stel/surface_list.rs
@@ -10,15 +10,43 @@ use serde_json::{Map, Value, json};
 use super::surface::CompactSurfaceTool;
 use super::types::{StelEditRequest, StelRequest, StelStatusRequest};
 
+/// Drop serialized bytes no MCP client needs: the per-tool `$schema`
+/// declaration and the `"default": null` schemars emits for every optional
+/// field. Both are inert for routing and for validation, and together they are
+/// ~8% of the `tools/list` payload on the full surface.
+pub(crate) fn strip_schema_noise(root: &mut Map<String, Value>) {
+    // Root-only: a nested `$schema` key would be a struct FIELD name under
+    // `properties`, not the JSON Schema keyword.
+    root.remove("$schema");
+    for value in root.values_mut() {
+        strip_null_defaults(value);
+    }
+}
+
+fn strip_null_defaults(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            // Safe against a field literally named `default`: under
+            // `properties` that entry's value is a schema object, never null.
+            map.retain(|key, val| !(key == "default" && val.is_null()));
+            for child in map.values_mut() {
+                strip_null_defaults(child);
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(strip_null_defaults),
+        _ => {}
+    }
+}
+
 fn schema_object<T: JsonSchema>() -> Arc<Map<String, Value>> {
     let schema = schema_for!(T);
     let value = serde_json::to_value(schema).expect("STEL input schema must serialize");
-    Arc::new(
-        value
-            .as_object()
-            .expect("STEL input schema root must be a JSON object")
-            .clone(),
-    )
+    let mut root = value
+        .as_object()
+        .expect("STEL input schema root must be a JSON object")
+        .clone();
+    strip_schema_noise(&mut root);
+    Arc::new(root)
 }
 
 fn surface_tool(
@@ -164,5 +192,79 @@ mod tests {
             bytes <= 1500,
             "symforge_edit input_schema must be <= 1500 B (A-025); got {bytes} B"
         );
+    }
+
+    /// The stripper must take the two inert keywords and NOTHING else. A struct
+    /// field may legitimately be named `default` or `$schema`; under
+    /// `properties` those are field names, not keywords, and must survive.
+    #[test]
+    fn strip_schema_noise_drops_keywords_but_spares_field_names() {
+        let mut root = match serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "default": null },
+                "depth": { "type": "integer", "default": 3 },
+                "default": { "type": "string" },
+                "$schema": { "type": "string" }
+            }
+        }) {
+            Value::Object(map) => map,
+            other => panic!("fixture must be an object, got {other:?}"),
+        };
+
+        strip_schema_noise(&mut root);
+
+        assert!(
+            !root.contains_key("$schema"),
+            "root $schema keyword must go"
+        );
+        let props = root["properties"]
+            .as_object()
+            .expect("properties survives stripping");
+        assert!(
+            !props["path"].as_object().unwrap().contains_key("default"),
+            "`default: null` is schemars boilerplate and must go"
+        );
+        assert_eq!(
+            props["depth"]["default"], 3,
+            "a REAL default value must survive"
+        );
+        assert!(
+            props.contains_key("default") && props.contains_key("$schema"),
+            "fields NAMED `default`/`$schema` are not keywords and must survive"
+        );
+    }
+
+    /// Guards the win: if schemars (or a future rmcp) starts re-emitting these,
+    /// the payload silently regrows and this fails instead.
+    #[test]
+    fn compact_surface_carries_no_inert_schema_bytes() {
+        fn assert_no_null_default(value: &Value, tool: &str) {
+            match value {
+                Value::Object(map) => {
+                    for (key, child) in map {
+                        assert!(
+                            !(key == "default" && child.is_null()),
+                            "{tool}: `default: null` survived stripping"
+                        );
+                        assert_no_null_default(child, tool);
+                    }
+                }
+                Value::Array(items) => items.iter().for_each(|v| assert_no_null_default(v, tool)),
+                _ => {}
+            }
+        }
+
+        for tool in compact_surface_tools() {
+            let name = tool.name.as_ref();
+            assert!(
+                !tool.input_schema.contains_key("$schema"),
+                "{name}: root $schema survived stripping"
+            );
+            for value in tool.input_schema.values() {
+                assert_no_null_default(value, name);
+            }
+        }
     }
 }


### PR DESCRIPTION
schemars emits a `$schema` declaration per tool and a `"default": null` for every optional field. Neither is used for routing or validation by an MCP client, and together they are **5,127 B of the full surface's 90,476 B** `tools/list` payload — paid by every client that lists tools.

Stripped at the two points where input schemas are built: `schema_object` for the compact surface, and the `#[tool]`-macro schemas in `list_tools_for_profile`'s `Full` branch.

### Measured

Against the installed 8.22.0 release vs this build, over real JSON-RPC stdio:

| surface | before | after | saved |
|---|---|---|---|
| full (39 tools) | 90,476 B | 85,349 B | **−5,127 B (−5.7%)** |
| compact-3 | 4,971 B | 4,800 B | −171 B (−3.4%) |

Tool counts and names verified unchanged on both surfaces; no `$schema` root or `default: null` survives anywhere in the emitted payloads.

### It also un-wedges two nearly-exhausted frozen contracts

| contract | before | after | headroom |
|---|---|---|---|
| A-025 `symforge_edit` schema ≤ 1500 B | 1,498 B | 1,441 B | 2 B → **59 B** |
| H1 compact `tools/list` ≤ 5000 B | 4,971 B | 4,800 B | 29 B → **200 B** |

A-025 sitting **2 bytes** under its ceiling meant any doc-comment edit on `StelEditRequest` would have failed the build, with nothing pointing at why.

### Why the stripper is narrow

`$schema` is removed only at a schema **root** — a nested one would be a struct *field name* under `properties`, not the keyword. `default` is removed only when its value is `null`, which a field named `default` never is (its value is a schema object). `strip_schema_noise_drops_keywords_but_spares_field_names` pins both cases, and `compact_surface_carries_no_inert_schema_bytes` fails if the inert bytes ever come back.

### Gates

`cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · `cargo test --all-targets --no-fail-fast -- --test-threads=1` exit 0 (3,094 lib tests + all integration binaries, 0 failed, 18.9 min). `cargo build --release` not run locally — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)