### PR TITLE
perf(ci): cache Rust builds and drop the redundant cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install
 
+      # Compile, not test execution, dominates this job (~27 min wall; the suite
+      # itself is ~3.5 min). Nothing was cached, so every run rebuilt the entire
+      # dependency graph -- including the expensive C builds that almost never
+      # change: 25 tree-sitter grammars, vendored libgit2 (cmake), bundled sqlite.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: symforge-rust
+          cache-on-failure: true
+
       - name: Check Rust formatting
         run: cargo fmt --check
 
@@ -89,9 +98,11 @@ jobs:
           print(f"rmcp majors OK: { {k: sorted(v) for k, v in majors.items()} }")
           EOF
 
-      - name: Run cargo check
-        run: cargo check
-
+      # `cargo check` used to run here as its own full dev-profile pass. Clippy
+      # cannot reuse that work (different driver => different fingerprint), and
+      # `clippy --all-targets` is a strict superset: the same rustc checks, more
+      # lints, and more targets (`cargo check` covers lib+bins only). Keeping
+      # both compiled the graph twice to learn the same thing.
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
@@ -135,6 +146,13 @@ jobs:
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install
 
+      # Distinct shared-key: the embed graph is a different feature set, so it
+      # must not share a cache entry with the default-feature `rust` job.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: symforge-embed
+          cache-on-failure: true
+
       # Engine-only build for library embedders (e.g. AAP): no daemon / sidecar /
       # protocol-server / CLI surface. Makes "an embedder can build symforge" a
       # green gate, so a server-only break (e.g. a `#[cfg(unix)]` unsafe block that
@@ -162,6 +180,13 @@ jobs:
       # 1.95.0 -> 1.96.0 bump.
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install && rustup target add x86_64-unknown-linux-musl
+
+      # Separate key again: musl artifacts are target-specific and share nothing
+      # with the host-target builds above.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: symforge-embed-musl
+          cache-on-failure: true
 
       # Cross-compile the engine-only embed build to musl. AAP compiles the
       # SymForge engine inside musl guest-agent VMs, so a musl regression must
@@ -213,6 +238,13 @@ jobs:
       # tautology on Linux and only has teeth here — it just had no Darwin
       # runner. One test binary, not a macOS matrix: this is the narrowest thing
       # that answers the question.
+      # macOS runners bill at a higher multiplier than ubuntu, so an uncached
+      # cold build here is the most expensive minute in the workflow.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: symforge-darwin
+          cache-on-failure: true
+
       - name: Run serve port-binding tests on Darwin
         run: cargo test --test serve_port -- --test-threads=1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,21 @@
 
 ## CI Gates
 
-- PR and push CI run version sync, `cargo fmt --check`, `cargo check`,
+- PR and push CI run version sync, `cargo fmt --check`,
   `cargo clippy --all-targets -- -D warnings`, the full Rust test suite,
   `cargo build --release`, and npm tests.
+- The three Rust jobs (`rust`, `embed-build`, `embed-musl`) each use
+  `Swatinem/rust-cache@v2` under distinct `shared-key`s. This job is
+  compile-dominated (~27 min wall as_of 2026-08-05; the suite itself is
+  ~3.5 min), and it previously cached nothing.
+- CI runs `clippy --all-targets` WITHOUT a preceding `cargo check`: clippy is a
+  strict superset (same rustc checks, more lints, more targets) and cannot reuse
+  a `cargo check` pass, so running both compiled the graph twice for one answer.
+- `cargo build --release` is NOT droppable from PR CI: the tool-correctness
+  harness runs `verify-tools.cjs --bin target/release/symforge`.
+- One CI run per PR (`pull_request`); `push` runs fire only on `main` after a
+  merge. Verified 2026-08-05 against `gh run list` — feature-branch pushes do
+  not double-trigger.
 - Scheduled and manual CI additionally run ignored performance smoke coverage:
   `test_load_perf_1000_files` and `calibrate_current_repo_smoke`.
 - Full real-repo coupling calibration is operator-triggered with


### PR DESCRIPTION
The `rust` job is compile-dominated — **~27 min wall** (measured 27m5s on #509) against a **~3.5 min** test suite — and it **cached nothing**. Every run rebuilt the entire dependency graph from scratch, including the C builds that almost never change: 25 tree-sitter grammars, vendored libgit2 via cmake, bundled sqlite. `embed-build`, `embed-musl`, and `darwin-serve-port` each compiled their own copy of that graph independently, also uncached.

### Changes

- `Swatinem/rust-cache@v2` on all four Rust jobs, under **distinct `shared-key`s** — the default-feature, embed, musl, and Darwin graphs share no artifacts, so one key would thrash.
- Drop the standalone `cargo check` step. Clippy cannot reuse that work (different driver ⇒ different fingerprint), and `clippy --all-targets` is a **strict superset**: same rustc checks, more lints, more targets (`cargo check` covers lib+bins only). Running both compiled the graph twice to learn the same thing.
- CLAUDE.md's CI Gates section updated to match — it claimed `cargo check` runs in CI, which this makes false.

### Two backlog suspicions I checked and disproved rather than acted on

| backlog claim | verdict |
|---|---|
| "drop the release build from PR CI — it gates nothing a PR needs" | **False.** `verify-tools.cjs --bin target/release/symforge` consumes it; the release build feeds the tool-correctness harness. Kept. |
| "every PR pays this twice (push + PR event?)" | **False.** `gh run list` shows one `pull_request` run per feature branch, and `push` runs only on `main` after a merge. No double-trigger exists. |

### Measuring the win

This PR's own `rust` job is the **cold** case (cache seeded, expect no gain or slightly worse from the save step). The honest number comes from the *next* PR that lands on top of this one, which restores the cache. I'll report both rather than claim a win from a seeding run.

Risk worth stating: GitHub's per-repo cache limit is 10 GB. If four keys plus the existing entries exceed it, evictions could make hits inconsistent — visible as a warm run that isn't faster. That's a tuning problem (fewer keys, or `cache-directories` narrowing), not a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)