### PR TITLE
perf(ci): drop rust-cache, it measured slower than no cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,6 @@ jobs:
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install
 
-      # Compile, not test execution, dominates this job (~27 min wall; the suite
-      # itself is ~3.5 min). Nothing was cached, so every run rebuilt the entire
-      # dependency graph -- including the expensive C builds that almost never
-      # change: 25 tree-sitter grammars, vendored libgit2 (cmake), bundled sqlite.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: symforge-rust
-          cache-on-failure: true
 
       - name: Check Rust formatting
         run: cargo fmt --check
@@ -146,12 +138,6 @@ jobs:
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install
 
-      # Distinct shared-key: the embed graph is a different feature set, so it
-      # must not share a cache entry with the default-feature `rust` job.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: symforge-embed
-          cache-on-failure: true
 
       # Engine-only build for library embedders (e.g. AAP): no daemon / sidecar /
       # protocol-server / CLI surface. Makes "an embedder can build symforge" a
@@ -181,12 +167,6 @@ jobs:
       - name: Install Rust toolchain (rust-toolchain.toml)
         run: rustup toolchain install && rustup target add x86_64-unknown-linux-musl
 
-      # Separate key again: musl artifacts are target-specific and share nothing
-      # with the host-target builds above.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: symforge-embed-musl
-          cache-on-failure: true
 
       # Cross-compile the engine-only embed build to musl. AAP compiles the
       # SymForge engine inside musl guest-agent VMs, so a musl regression must
@@ -238,12 +218,6 @@ jobs:
       # tautology on Linux and only has teeth here — it just had no Darwin
       # runner. One test binary, not a macOS matrix: this is the narrowest thing
       # that answers the question.
-      # macOS runners bill at a higher multiplier than ubuntu, so an uncached
-      # cold build here is the most expensive minute in the workflow.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: symforge-darwin
-          cache-on-failure: true
 
       - name: Run serve port-binding tests on Darwin
         run: cargo test --test serve_port -- --test-threads=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,13 @@
 - PR and push CI run version sync, `cargo fmt --check`,
   `cargo clippy --all-targets -- -D warnings`, the full Rust test suite,
   `cargo build --release`, and npm tests.
-- The three Rust jobs (`rust`, `embed-build`, `embed-musl`) each use
-  `Swatinem/rust-cache@v2` under distinct `shared-key`s. This job is
-  compile-dominated (~27 min wall as_of 2026-08-05; the suite itself is
-  ~3.5 min), and it previously cached nothing.
+- The `rust` job is compile-dominated (~25 min wall as_of 2026-08-05; the suite
+  itself is ~3.5 min). **Do not add `Swatinem/rust-cache` back** — it was tried
+  and MEASURED SLOWER, then reverted. Warm restore: `rust` 24m57s → 25m36s,
+  `darwin-serve-port` 2m59s → 4m13s, `embed-build` 2m43s → 2m52s, `embed-musl`
+  flat. Four jobs, all neutral-to-worse. Restoring and re-saving this target
+  tree (25 tree-sitter C grammars, vendored libgit2, bundled sqlite) costs more
+  wall time on a disk-constrained runner than the compilation it avoids.
 - CI runs `clippy --all-targets` WITHOUT a preceding `cargo check`: clippy is a
   strict superset (same rustc checks, more lints, more targets) and cannot reuse
   a `cargo check` pass, so running both compiled the graph twice for one answer.


### PR DESCRIPTION
#512 added `Swatinem/rust-cache` to four jobs. The warm run has now landed, and **the caching half of that change is a net negative.** Reverting it; keeping the part that worked.

| run | cache | `cargo check` | `rust` job |
|---|---|---|---|
| #509 | none | present | 27m05s |
| #510 | none | present | 27m21s |
| #512 | miss + save | **removed** | **24m57s** |
| #513 | **hit + save** | removed | **25m36s** |

**Kept:** removing the redundant `cargo check` is worth **−2m16s (−8.3%)**. #512 was a cache *miss*, so the cache could only have cost time there — which makes that gain attributable to the check removal alone.

**Reverted:** the restore made `rust` **39s slower**, and every other cached job regressed or held flat on the same warm run:

| job | before | warm |
|---|---|---|
| darwin-serve-port | 2m59s | **4m13s** |
| embed-build | 2m43s | 2m52s |
| embed-musl | 2m01s | 2m01s |

Four jobs, consistent direction — not single-sample noise.

### Why it doesn't pay here

This target tree is unusually large: 25 tree-sitter C grammars, vendored libgit2 built via cmake, bundled sqlite. The `rust` job runs `free_runner_disk.sh` as its *first* step precisely because the runner is disk-constrained. Restoring and re-saving an archive that big costs more wall time than the compilation it avoids — and the effect is worst on the short jobs, where cache I/O is a large fraction of total runtime.

CLAUDE.md now records the measurement with a "do not add this back" note, so it isn't re-attempted blind.

I'd rather revert my own change on the evidence than defend it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)