### PR TITLE
perf(serve): name the sub-phases of serve runtime construction

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -325,8 +325,13 @@ impl SymForgeServer {
                 reason: CapabilityUnavailableReason::PersistentStateUnavailable,
             }
         };
+        // This constructor is 99.1% of `serve: runtime built` on a cold index
+        // (2.91s of 2.94s) but is ~free when the index came from a snapshot
+        // restore. Only ONE thing in here takes the index, so name it: the
+        // routers below are static and would cost the same on both paths.
         let curation_coordinator =
             Arc::new(knowledge_curation::KnowledgeCurationCoordinator::default());
+        let phase = std::time::Instant::now();
         if let Some(root) = repo_root.as_deref()
             && let Err(error) = curation_coordinator.recover_on_project_load(
                 &index,
@@ -337,10 +342,19 @@ impl SymForgeServer {
         {
             tracing::warn!("knowledge curation startup recovery remained fail-closed: {error}");
         }
+        tracing::info!(
+            "serve: protocol/curation recover_on_project_load in {:?}",
+            phase.elapsed()
+        );
+
+        let phase = std::time::Instant::now();
+        let tool_router = Self::tool_router();
+        let prompt_router = Self::prompt_router();
+        tracing::info!("serve: protocol/routers in {:?}", phase.elapsed());
         Self {
             index,
-            tool_router: Self::tool_router(),
-            prompt_router: Self::prompt_router(),
+            tool_router,
+            prompt_router,
             project_name,
             watcher_info,
             watcher_handle: Arc::new(Mutex::new(None)),

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -458,19 +458,33 @@ fn build_serve_runtime(
     let project_state_dir = state_placement
         .as_ref()
         .and_then(|placement| placement.directory());
+    // Sub-phase timings. `serve: runtime built in` measures 2.8s on a
+    // genuinely-cold index but only ~22ms when the index came from a snapshot
+    // restore — a ~126x gap for what should be identical work. Two plausible
+    // causes were measured and REFUTED: it is not a concurrent snapshot write
+    // (the cold path spawns no background_verify at all), and it is not
+    // first-time sqlite creation (a second cold start with the databases
+    // already present still took 2.798s). Schema generation cannot explain it
+    // either, being byte-identical on both paths. Name each sub-phase so the
+    // next measurement points at the culprit instead of guessing again.
+    let phase = std::time::Instant::now();
     let ledger_store: Option<Arc<StelLedgerStore>> = project_state_dir.map(|state_dir| {
         Arc::new(StelLedgerStore::open(
             state_dir,
             format!("serve-{}", std::process::id()),
         ))
     });
+    tracing::info!("serve: runtime/ledger store in {:?}", phase.elapsed());
 
     // 006 G-039: the hashed product API-key store shares the exact same typed
     // project state owner. It cannot reconstruct placement from the source root.
+    let phase = std::time::Instant::now();
     let key_store: Option<Arc<ApiKeyStore>> =
         project_state_dir.map(|state_dir| Arc::new(ApiKeyStore::open(state_dir)));
+    tracing::info!("serve: runtime/key store in {:?}", phase.elapsed());
 
     let watcher_info = Arc::new(Mutex::new(WatcherInfo::default()));
+    let phase = std::time::Instant::now();
     let mut protocol = SymForgeServer::new_with_state_placement(
         Arc::clone(&index),
         project_name,
@@ -479,6 +493,7 @@ fn build_serve_runtime(
         state_placement,
         None,
     );
+    tracing::info!("serve: runtime/protocol server in {:?}", phase.elapsed());
     // Share the SAME store allocation with the dispatcher so durable
     // write-through (T028) and the runtime summary read (T029) use one path.
     if let Some(store) = ledger_store.as_ref() {
@@ -497,10 +512,12 @@ fn build_serve_runtime(
     // observes exactly the rows the dispatcher wrote — surviving restart.
     let runtime_store = ledger_store.map(|store| (*store).clone());
 
+    let phase = std::time::Instant::now();
     let mut runtime = ServerRuntime::build_runtime(index, protocol, governor, auth, runtime_store);
     if let Some(store) = key_store {
         runtime = runtime.with_key_store(store);
     }
+    tracing::info!("serve: runtime/server runtime in {:?}", phase.elapsed());
     runtime
 }
 


### PR DESCRIPTION
`serve: runtime built` measures **~2.8 s on a genuinely-cold index** but **~22 ms** when the index came from a snapshot restore. Backlog item #3 blamed the 40-tool router and schema generation, and proposed a lazy/once-per-process router with precomputed schemas.

**That is wrong by roughly three orders of magnitude.** Measured, release build, cold index (924 files):

```
serve: runtime/ledger store in                       11.182ms
serve: runtime/key store in                           8.9855ms
serve: protocol/curation recover_on_project_load in   2.7627229s   ← 99.2%
serve: protocol/routers in                            1.7702ms     ← the proposed target
serve: runtime/server runtime in                        800ns
serve: runtime built in                               2.7848727s
```

The routers cost **1.77 ms — 0.06% of the phase**. Optimising them would have delivered ~1.8 ms of a 2.78 s problem, after a full campaign.

The real cost is `KnowledgeCurationCoordinator::recover_on_project_load` at **99.2%**.

### Causes measured and refuted along the way

| hypothesis | how it died |
|---|---|
| concurrent snapshot write | the cold path spawns no `background_verify` at all |
| first-time sqlite creation | 2nd cold start with both DBs already present was unchanged; stores now measure 11 ms + 9 ms directly |
| schema generation *(the backlog's)* | measured 1.77 ms |

### Scope

Phase logs only. No behaviour change — the routers move into locals purely so they can be timed, constructed in the same order. 2 files, 33 insertions.

### Deliberately not optimising

Four causes have now been guessed wrong on this item. The next step is to instrument *inside* `recover_on_project_load`, and to establish why it is ~free on the warm path, **before** anyone chooses a fix. Shipping a fix now would be a fifth guess.

This is the same move PR #488 made for the index build — and it's why #2 and #4 have usable numbers today while #3 did not.

### Gates

`cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · full serial suite running locally in parallel with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)