### PR TITLE
perf(persist): name the warm-restore derived-index phases

### DIFF
--- a/src/live_index/persist.rs
+++ b/src/live_index/persist.rs
@@ -1946,6 +1946,13 @@ pub fn snapshot_to_live_index_with_code_signals(
     let manifest_entries = manifest.entries;
     let mut files: HashMap<String, Arc<IndexedFile>> = HashMap::with_capacity(snapshot_files.len());
 
+    // Warm-restore phase timings. Spec 026 made snapshot restore the COMMON
+    // start path, but every derived index below is still rebuilt from scratch
+    // on it, and none of it was logged — so a warm start's ~1.1s (2.90s to
+    // index-ready minus 1.80s publication) was entirely unattributed. Name each
+    // phase, exactly as #488 did for the cold path and #521 for serve runtime
+    // construction, so the next decision targets a measurement.
+    let phase = Instant::now();
     for (path, snap_file) in snapshot_files {
         let indexed_file = IndexedFile {
             relative_path: snap_file.relative_path,
@@ -1964,7 +1971,15 @@ pub fn snapshot_to_live_index_with_code_signals(
         files.insert(path, Arc::new(indexed_file));
     }
 
+    tracing::info!(
+        "warm restore: file map rebuilt ({} files) in {:?}",
+        files.len(),
+        phase.elapsed()
+    );
+
+    let phase = Instant::now();
     let trigram_index = super::trigram::TrigramIndex::build_from_files(&files);
+    tracing::info!("warm restore: trigram index built in {:?}", phase.elapsed());
 
     let mut index = LiveIndex {
         files,
@@ -1987,8 +2002,20 @@ pub fn snapshot_to_live_index_with_code_signals(
         // project switch invalidates it the same way a freshly loaded one does.
         indexed_root: Some(normalize_root(project_root)),
     };
+    let phase = Instant::now();
     index.rebuild_reverse_index();
+    tracing::info!(
+        "warm restore: reverse index rebuilt in {:?}",
+        phase.elapsed()
+    );
+
+    let phase = Instant::now();
     index.rebuild_path_indices();
+    tracing::info!(
+        "warm restore: path indices rebuilt in {:?}",
+        phase.elapsed()
+    );
+
     (index, code_signals.into_published())
 }
 


### PR DESCRIPTION
Spec 026 made snapshot restore the **common** start path, but every derived index is still rebuilt from scratch on it and **none of it was logged** — so a warm start's time was entirely unattributed. This names each phase.

Measured, release build, warm restore of this repo (918 files):

```
warm restore: file map rebuilt (918 files) in    515µs
warm restore: trigram index built in           452.0169ms
warm restore: reverse index rebuilt in          19.2339ms
warm restore: path indices rebuilt in            1.3862ms
```

### This settles two things

**1. Backlog item #4 is under-ranked.** It ranks the trigram build last and suggests closing it as not-worth-it, on the grounds that 0.61 s is the smallest *cold* number. But the rebuild also runs on the warm path — `persist.rs` documents it at *"Reverse index and trigram index are rebuilt from snapshot on load"* — so it is paid on **every start**, and at 452 ms it is **95.5%** of all derived-rebuild work. Within that group it is the right target.

**2. It is not the biggest warm lever.** The same start measured:

```
index publication (manifest + bridge + authority) in 2.0520435s
serve: index ready in                               4.9228275s
```

Publication is **4.5×** the trigram and dominates warm startup. The backlog treats publication as a cold-path residual folded into item #2; measured, it is also the dominant **warm** phase and deserves its own item.

### Scope

Logs only. No behaviour change. 27 insertions, one file.

Deliberately not optimising: the two candidate fixes for the trigram are (a) persisting derived indices in the snapshot — a **format bump** that AAP's baked images depend on, needing coordination through the embed facade — or (b) a lazy/background build, which touches the honesty label on the first `search_text`. Neither is worth doing before publication is addressed.

This is the third instrumentation-first result in this campaign, after #488 (cold path) and #521 (serve runtime, where the backlog's suspected cause turned out to be 0.06% of the real cost).

### Gates

`cargo fmt` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · full serial suite running locally in parallel with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)