### PR TITLE
perf(publish): split the index publication phase into named components

### DIFF
--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -1289,6 +1289,10 @@ impl SharedIndexHandle {
         // would otherwise be the silent span between that line and serving.
         let publication_started = Instant::now();
         let manifest = capture_published_manifest(&index, scout_plan.as_deref());
+        info!(
+            "publication/manifest in {:?}",
+            publication_started.elapsed()
+        );
         let source = manifest
             .as_ref()
             .map(|manifest| Arc::new(manifest.source.clone()));
@@ -1320,8 +1324,23 @@ impl SharedIndexHandle {
         } else {
             FreshnessStatus::Current
         };
+        // Publication is the single largest startup phase on BOTH paths --
+        // measured 3.09s/1.88s cold and 2.05s/1.80s warm, against trigram
+        // 452ms and serve runtime construction 43ms on the same warm start.
+        // It was reported only as one aggregate number, so split it: the
+        // knowledge bridge rebuilds thousands of cards and forward links from
+        // scratch every start and is the prime suspect, but three of the four
+        // causes this backlog proposed for other phases turned out wrong, so
+        // name each component rather than assume.
+        let phase = Instant::now();
         let published_state = Arc::new(PublishedIndexState::capture(0, &index));
+        info!("publication/state capture in {:?}", phase.elapsed());
+
+        let phase = Instant::now();
         let published_repo_outline = Arc::new(index.capture_repo_outline_view());
+        info!("publication/repo outline in {:?}", phase.elapsed());
+
+        let phase = Instant::now();
         let bridge = source
             .as_deref()
             .map(|source| {
@@ -1333,6 +1352,13 @@ impl SharedIndexHandle {
                 ))
             })
             .unwrap_or_else(|| Arc::new(KnowledgeBridge::default()));
+        info!(
+            "publication/knowledge bridge ({} cards) in {:?}",
+            bridge.cards.len(),
+            phase.elapsed()
+        );
+
+        let phase = Instant::now();
         let authority = build_published_authority(
             &index,
             source.as_deref(),
@@ -1342,6 +1368,7 @@ impl SharedIndexHandle {
             &code_signals,
             manifest.as_deref(),
         );
+        info!("publication/authority in {:?}", phase.elapsed());
         let live = Arc::new(index);
         let published_generation = Arc::new(PublishedGeneration {
             publication_generation: 0,


### PR DESCRIPTION
`index publication (manifest + bridge + authority)` is the **single largest startup phase on both paths** — 3.09 s/1.88 s cold and 2.05 s/1.80 s warm, against trigram 452 ms and serve runtime construction 43 ms on the same warm start. It was reported as one aggregate number, so it named no culprit.

Measured, release build, warm restore of this repo (919 files):

| component | time | share |
|---|---|---|
| publication/manifest | 659.6887 ms | **35.0%** |
| publication/state capture | 5.7011 ms | — |
| publication/repo outline | 1.2461 ms | — |
| **publication/knowledge bridge (5521 cards)** | **1.060338 s** | **56.3%** |
| publication/authority | 155.2563 ms | 8.2% |
| **total** | **1.8824358 s** | |

### Two results

**The knowledge bridge is confirmed as the lever.** The backlog's *original* item 1 claimed it rebuilds ~5,400 cards from scratch on every start and ranked it best effort-to-win. Measured: **5,521 cards, 56.3%**. It runs even on a warm restore, where the snapshot already carries the files those cards are derived from.

This is the first backlog claim this campaign has **confirmed** rather than corrected — the previous four investigations each found the stated cause wrong (most starkly #3, where the suspected router/schema generation measured 1.77 ms of a 2.78 s phase).

**`publication/manifest` at 659.6887 ms is new information.** It's the second-largest component at 35.0% and appears nowhere in the backlog. Together, bridge + manifest are **91.3%** of publication.

### Scope

Logs only. No behaviour change. 27 insertions, one file.

Not optimising in this PR. The bridge's candidate fixes are persisting it alongside the snapshot — a **format bump**, which carries the same constraint as backlog #4 since AAP bakes snapshots into room images via the semver-public embed facade — or making it incremental against the snapshot generation. Hard constraint either way: published data must stay byte-equivalent, enforced by the suite plus golden replay.

### Gates

`cargo fmt` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · full serial suite running locally in parallel with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)