### PR TITLE
perf(curation): name the sub-phases of startup curation recovery

### DIFF
--- a/src/protocol/knowledge_curation.rs
+++ b/src/protocol/knowledge_curation.rs
@@ -289,8 +289,20 @@ impl KnowledgeCurationCoordinator {
         state_placement: Option<&StatePlacement>,
         persistence_health: CapabilityStatus,
     ) -> Result<(), String> {
+        // This call is 99.2% of `serve: runtime built` on a genuinely-cold
+        // index (2.76s of 2.78s) yet ~free on a snapshot restore. On a fresh
+        // project `.symforge/` holds no curation dir, so the `replay_dir`
+        // early-return below fires and none of the recovery work runs — which
+        // means the whole cost is in the three calls above it. Name them.
+        let phase = std::time::Instant::now();
         let generation = index.published_source_set().current_generation();
+        tracing::info!("curation/published source set in {:?}", phase.elapsed());
+
+        let phase = std::time::Instant::now();
         let plan = curation_plan_current(&generation)?;
+        tracing::info!("curation/plan current in {:?}", phase.elapsed());
+
+        let phase = std::time::Instant::now();
         let state_dir = apply_capability(
             repo_root,
             state_placement,
@@ -298,9 +310,12 @@ impl KnowledgeCurationCoordinator {
             &plan.source.location,
         )
         .map_err(unavailable)?;
+        tracing::info!("curation/apply capability in {:?}", phase.elapsed());
+
         let curation_dir = state_dir.join(CURATION_STATE_DIR);
         let replay_dir = curation_dir.join(REPLAY_DIR);
         if !replay_dir.is_dir() {
+            tracing::info!("curation/no replay dir — early return");
             return Ok(());
         }
         self.probe_apply_directories(repo_root, &curation_dir)


### PR DESCRIPTION
PR #521 showed `serve: runtime built` is **99.2%** `KnowledgeCurationCoordinator::recover_on_project_load` on a cold index. This splits that call, and the answer is **structural, not algorithmic**.

Measured, release build, genuinely-cold index (fresh worktree, no `.symforge/`):

```
curation/published source set in    5.6µs
curation/plan current in        3.820374s   ← 99.9%
curation/apply capability in     101.8µs
curation/no replay dir — early return
recover_on_project_load TOTAL   3.8243504s
serve: protocol/routers in       18.8897ms
serve: runtime built in          3.8705102s
```

### The waste is ordering

The `no replay dir` line fires **immediately after** the 3.8 s computation. On a fresh project there is no curation/replay directory, so **none of the recovery work the plan exists for can run** — the plan is computed and then discarded, because the microsecond existence check sits *after* the expensive computation rather than before it.

`curation_plan_current` runs a full remediation review over **every** authority record (`review_current`, then `review_facts` + `effective_action` across `(0..generation.authority.records.len())`). Its only consumer on this path is `apply_capability`, which uses `plan.source.location` for a single enum match:

```rust
if !matches!(source_location, SourceLocation::WorkingTree { .. })
```

### Why this PR does not include the fix

`recover_on_project_load` is a **fail-closed integrity path** — its own errors say so: *"knowledge curation startup recovery remained fail-closed"*, *"curation_startup_publication_failed; live queries remain on the last complete generation."*

Reordering a fail-closed check to make startup faster is exactly where an unaccounted side effect turns a performance win into a correctness regression. I have not established that nothing else depends on the plan computation having run. Two things to verify first: that `PublishedGeneration.source` is equivalent to `CurationReviewPlan.source` for `apply_capability`'s purposes, and that `curation_plan_current` has no side effects other startup behaviour relies on.

The measurement is landed so that work starts at the fix instead of the search. Expected saving once verified: **~3.8 s off every genuinely-cold serve start.**

### Track record on this one function

Five hypotheses, all wrong, each killed by measurement:

| hypothesis | source | measured |
|---|---|---|
| concurrent snapshot write | mine | no `background_verify` on the cold path |
| first-time sqlite creation | mine | 11 ms + 9 ms |
| schema generation | **backlog's** | 1.77–18.9 ms |
| `published_source_set()` | mine | **5.6 µs** |
| router construction (3.59 s) | backlog's | — |

Logs only. No behaviour change. 15 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)