### PR TITLE
fix(admission): stop laundering policy exclusions into a language verdict

### DIFF
--- a/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-cursor-grok-2026-08-06.md
+++ b/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-cursor-grok-2026-08-06.md
@@ -1,0 +1,249 @@
+# Independent review findings — PolicyWithheld + curation reorder
+
+**Reviewer:** Cursor Grok (independent pass; parallel multi-LLM review)  
+**Date:** 2026-08-06  
+**Request:** `REVIEW-REQUEST-POLICY-WITHHELD-2026-08-05.md`  
+**Branch:** `fix/policy-withheld-skip-reason`  
+**Code under review:** `d87c748` (repo HEAD also has `b200f6f` review-request docs only)  
+**Base:** `origin/main` @ `93cdd00`  
+**Full serial suite:** not run. Ran only:
+
+```
+cargo test --lib -- --exact \
+  domain::index::tests::policy_withheld_never_claims_a_language_problem \
+  domain::index::tests::non_sensitive_skip_reasons_are_distinct_and_honest
+→ 2 passed
+```
+
+Claims tagged **verified** (read code / ran command), **inferred**, or **guess**.
+
+---
+
+## Item A — did `d87c748` preserve the non-disclosure property?
+
+### A1. Does `PolicyWithheld` leak anything?
+
+**Verdict: PARTIALLY WRONG** on the author's judgment that narrowing is not a meaningful disclosure.
+
+#### Claim A1a — path-rule vs content-detector stay collapsed
+
+**CONFIRMED (verified).**
+
+```3442:3443:src/live_index/store.rs
+                MetadataOnlyReason::SensitivePath { .. }
+                | MetadataOnlyReason::SensitiveContent { .. } => SkipReason::PolicyWithheld,
+```
+
+Read-path refusals still go through typed disposition and the uniform message; they never render `SkipReason`:
+
+```118:120:src/protocol/read_gate.rs
+            MetadataOnlyReason::SensitivePath { .. }
+            | MetadataOnlyReason::SensitiveContent { .. } => {
+                return Err(format::content_withheld_by_admission(relative_path));
+```
+
+```3638:3642:src/protocol/format.rs
+/// Deliberately UNIFORM across every security exclusion: it names no rule id, no
+/// rule class, no finding count, no size, and no byte of the file. Whether the
+/// exclusion came from the path rule or from a content detector is the one
+/// content-derived bit a refusal could still leak
+```
+
+`rule_id` / `rule_ids` / `finding_count` stay on persisted `MetadataOnlyReason` only. Public MCP/health reporting uses `SkipReason::Display`. Health admission section is tier counts only. **Verified.**
+
+#### Claim A1b — narrowing the bucket is not a meaningful disclosure
+
+**PARTIALLY WRONG (verified).**
+
+Before `d87c748`, seven `MetadataOnlyReason`s (including both security variants, LFS, path failures, encoding) all displayed as `"unsupported language"`. After:
+
+| Disposition | Display |
+|---|---|
+| `SensitivePath` \| `SensitiveContent` | `withheld by admission policy` |
+| `LfsPointer` | `git-lfs pointer` |
+| path-shape failures | `unsupported path` |
+| `UnsupportedTextEncoding` | `undecodable text encoding` |
+| real unsupported grammar | `unsupported language` |
+
+So `PolicyWithheld` now means: **a path rule or a content detector fired** — the class the old collapse hid among encoding/LFS/path/language excuses.
+
+For paths that cannot match `sensitive_path_rule` (verified: `.rs` paths are outside the path-rule set at `knowledge/mod.rs:685-714`), the collapse inside `PolicyWithheld` is empty — the label is a near-oracle for `SensitiveContent`. Example from the request: `src/live_index/store.rs`.
+
+Surfaces where this class bit is visible as the reason string alone:
+
+- `search_files` resolve / hits — `format.rs:2927-2928`, `tools.rs:6064`
+- `get_repo_map` tree tags — `format.rs:1670-1677`
+- daemon cross-project search — `daemon.rs:4977-4979`
+- embed `SearchFilesHit.metadata_reason: Option<String>`
+
+Partial mitigation already present (verified): `not_indexed_skipped_file` already appends *"Its contents are withheld by the admission policy"* when `disk_read_would_refuse` is true (`format.rs:3721-3724`), and that predicate is true for both security variants (`read_gate.rs:66-74`). On `get_file_context`, the policy sentence pre-existed; only the reason tag was lying. The **new** oracle is on search / repo-map / metadata-reason strings that previously said `"unsupported language"`.
+
+**Plain answer:** yes — this leaks something the old collapse hid: the coarser bit "security/admission policy applied," which for ordinary-looking source paths is nearly `SensitiveContent`. It does **not** leak path-vs-content.
+
+**Landing call (judgment):**
+
+- If *"which ordinary files tripped the secret detector"* is sensitive (search/repo-map as oracle) → **do not land as-is**. Keep security demotions in a bucket that still includes at least one common non-security technical reason (encoding), or stop emitting per-file reason strings for that bucket.
+- If the contract is only path-vs-content + no rule ids (what `format.rs` documents) → honesty fix is correct; land it, but stop calling the narrowing "not a disclosure."
+
+I am **not** rubber-stamping "no leak."
+
+---
+
+### A2. Is splitting the four non-sensitive reasons safe?
+
+**Verdict: PARTIALLY WRONG** on the blanket "not content-derived" claim for LFS; **CONFIRMED** for the three path-shape reasons.
+
+| Variant | Verdict | Evidence |
+|---|---|---|
+| `UnsupportedPathEncoding` | safe to name | Minted from path UTF-8 / safety checks in `discovery/mod.rs:956-964` |
+| `PathMetadataTooLarge` | safe to name | Same site — path length vs catalog bound |
+| `PlatformPathCollision` | safe *if ever minted* | Enum exists (`domain/index.rs:888`); **no production mint site found** (grep only hits enum + new forward map). Dead arm today. |
+| `LfsPointer` | format-class, content-derived | `detect_lfs_pointer` (`knowledge/mod.rs:652-672`) reads file bytes. Naming discloses the body matches the public LFS pointer grammar. Does **not** expose `declared_oid` / `declared_size` on the SkipReason surface. Not a secret side-channel; still content-derived, contrary to the commit message's absolute claim. |
+| `UnsupportedTextEncoding` | encoding fact | Distinct from language support; naming is correct |
+
+---
+
+### A3. Missed mapping sites?
+
+**Verdict: CONFIRMED** — no missed production map that still collapses security into `UnsupportedLanguage`.
+
+Updated in `d87c748` (verified via `git show`):
+
+1. Forward: `store.rs` `compatibility_admission_decision`
+2. Reverse: `store.rs` `disposition_from_admission`
+3. Reverse: `discovery/mod.rs` `scout_decision_for_discovered`
+4. Test helpers: `query.rs`, `tools.rs` (compiler-forced)
+
+No production `_ =>` swallows the new variants into a wrong display bucket. HardSkip-only `_ => ArtifactType` at `discovery/mod.rs:1152-1153` is scoped correctly.
+
+**Missed (documentation, not mapping):**
+
+- `query.rs:1261-1263` still claims seven variants collapse into `UnsupportedLanguage`
+- `tools.rs:2789-2791` same stale claim
+
+**Round-trip trap (verified, currently unreachable for security files):** reverse maps send `PolicyWithheld | LfsPointer | UnsupportedPath` → `MetadataOnlyReason::UnsupportedTextEncoding`. Scout writes typed security reasons directly, so live demotions are not re-labeled. If something later fed `PolicyWithheld` into `disposition_from_admission`, rematerialized display would be `"undecodable text encoding"` — a different lie.
+
+---
+
+### A4. Snapshot / serialization compatibility
+
+**Verdict: CONFIRMED** — no snapshot wire break from adding `SkipReason` variants. **Not verified:** live load of a pre-change snapshot against this binary.
+
+- `SkipReason` has **no** serde derives (`domain/index.rs:1439`) — **verified**
+- Snapshots persist `MetadataOnlyReason`, unchanged by this commit — **verified**
+- `symforge::embed` does not export `SkipReason`; embedders can see `metadata_reason` **strings** change at runtime — **verified**
+
+**Inferred:** out-of-tree consumers that treated `"unsupported language"` as "security demotion" will break. That was never a contract.
+
+---
+
+### A5. Are the two new tests load-bearing?
+
+**Verdict: PARTIALLY WRONG** — they pin Display wording, not the production mapping.
+
+Both pass (command above). They do **not** assert that `compatibility_admission_decision` on a real `SensitiveContent` / `SensitivePath` catalog entry yields `PolicyWithheld`. A store.rs regression remapping security back to `UnsupportedLanguage` leaves both tests green.
+
+Existing store fixtures around `store.rs:7700+` assert typed `MetadataOnlyReason`, not the SkipReason projection.
+
+**Recommendation:** assert `compatibility_admission_decision(sensitive_entry).reason == Some(PolicyWithheld)`.
+
+---
+
+### Declined TestPilot asks
+
+**Verdict: CONFIRMED — correctly declined.**
+
+- Machine-readable exclusion codes / thresholds — reopen `format.rs:3638-3642`
+- Bounded `get_file_content` for Tier-2 — includes `SensitiveContent`; gate refuses both (`read_gate.rs:118-120`)
+- `force_admit` — bypass of fail-closed gate
+
+---
+
+## Item B — cold-start reorder of `recover_on_project_load`
+
+### Verdict: **safe-with-modification**
+
+The measured cold path (no replay dir) can drop the 3.8 s plan. A blind hoist that moves plan validation past probe on the recovery path risks a capability lie.
+
+### B1. Does `curation_plan_current` have side effects?
+
+**Verdict: CONFIRMED — no side effects on the startup path** (direct call chain verified; not every transitive helper line-audited).
+
+```371:433:src/protocol/knowledge_review.rs
+pub(crate) fn curation_plan_current(
+    generation: &PublishedGeneration,
+) -> Result<CurationReviewPlan, String> {
+    let review = review_current(/* Remediation, limit: Some(1) */)?;
+    // in-memory actions from generation.authority.records
+    let source = generation.source.as_ref().map(|s| s.as_ref().clone())...;
+    Ok(CurationReviewPlan { /* ... */ source, actions })
+}
+```
+
+`review_current` takes `&PublishedGeneration`, builds strings/hashes, returns. No durable writes on that path. Cost is pure CPU (full remediation facts + dossier render for the canonical hash even with `limit: Some(1)`).
+
+On the cold path the plan's only consumer is `apply_capability(..., &plan.source.location)` — then discarded before the early return (`knowledge_curation.rs:302-320`).
+
+### B2. Is `PublishedGeneration.source` equivalent for the `matches!` check?
+
+**Verdict: CONFIRMED (verified).**
+
+Plan source is a clone of `generation.source` (`knowledge_review.rs:421-425`). Generation source comes from `manifest.source` (`store.rs:1296-1298`). `apply_capability` only checks WorkingTree (`knowledge_curation.rs:1542-1544`). `capability_status` already uses `generation.source.location` directly (`knowledge_curation.rs:249-253`).
+
+**Not equivalent for full recovery:** the plan also validates manifest presence, unit hashes, and safety guards.
+
+### B3. Does current order encode an invariant?
+
+**Verdict: PARTIALLY — yes on the recovery path; no on the cold path.**
+
+Cold path today: plan → `apply_capability` (no dir creation; returns placement path at `knowledge_curation.rs:1548-1563`) → early return. Startup treats recovery `Err` as non-fatal warn (`protocol/mod.rs:335-344`).
+
+Recovery path today:
+
+```
+plan₁ → apply_capability → probe_apply_directories (CREATE curation dir + fill probe_cache)
+      → lock → plan₂ → recover_pending_records
+```
+
+**Invariant at risk** if plan₁ is dropped and plan validation moves after probe: `probe_apply_directories` inserts `Ok(())` into `probe_cache` (`knowledge_curation.rs:693-694`); `capability_status` reports Available from that cache (`knowledge_curation.rs:260-265`). Plan failure after probe can make capability lie. Real correctness regression.
+
+Also: when replay exists, plan runs twice (lines 302 and 329) against the same generation — pure waste.
+
+### B4. Cheaper correct variant
+
+**Verdict: CONFIRMED — hoist via `state_placement`, not via the plan.**
+
+`health_line` already probes replay from placement alone (`knowledge_curation.rs:189-191`). Safe shape:
+
+1. After `current_generation()`, if placement has no `curation/replay/` dir → `return Ok(())` immediately.
+2. When replay exists: readiness/plan gate **before** `probe_apply_directories`; `apply_capability` with `generation.source.location`; then probe / lock / recover; single in-lock plan (drop redundant plan₁).
+3. Do not skip `apply_capability` on the recovery path.
+
+Cold-path observability delta: plan failure with nothing to replay currently warns after 3.8 s; after hoist returns `Ok(())` silently. Serve impact: none.
+
+---
+
+## Anything missed
+
+1. **A1 is the real question.** Path-vs-content holds. Policy-vs-technical is a new public bit on search/repo-map. Decide the threat model before merge.
+2. **`PlatformPathCollision` looks unminted** — split is harmless but untested in production.
+3. **Stale comments** at `query.rs:1261-1263` and `tools.rs:2789-2791`.
+4. **Display-only tests do not pin the store projection.**
+5. **Item B refusal was directionally right** for a blind reorder; `state_placement` early-return reclaimsthe 3.8 s safely.
+
+---
+
+## Summary table
+
+| # | Question | Verdict |
+|---|---|---|
+| A1 | Leak? | **PARTIALLY WRONG** — path-vs-content preserved; narrowing *is* a meaningful policy-class disclosure (SensitiveContent oracle on innocuous paths via search/repo-map) |
+| A2 | Non-sensitive splits safe? | **PARTIALLY WRONG** for absolute "LFS not content-derived"; path-shape splits **CONFIRMED** |
+| A3 | Missed mappings? | **CONFIRMED** none in production; stale comments remain |
+| A4 | Snapshot compat? | **CONFIRMED** `SkipReason` not persisted; live old-snapshot load **not verified** |
+| A5 | Tests load-bearing? | **PARTIALLY WRONG** — Display-only; add projection assertion |
+| B | Reorder safe? | **safe-with-modification** — hoist via `state_placement`; keep plan validation before probe when replay exists |
+
+**Item A land?** Only after an explicit threat-model call on the policy-class oracle. If path-vs-content + no rule ids is the whole contract, land with that acknowledgment. If detector-hit oracles matter, keep security demotions in a broader neutral bucket.
+
+**Item B land?** Not as proposed. Land the `state_placement` early-return for missing replay dir; do not reorder plan past probe on the recovery path.

--- a/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-cursor.md
+++ b/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-cursor.md
@@ -1,0 +1,294 @@
+# Independent review findings — PolicyWithheld + curation reorder
+
+**Reviewer:** Cursor agent  
+**Date:** 2026-08-06  
+**Branch reviewed:** `fix/policy-withheld-skip-reason`, commit `d87c748`  
+**Base:** `origin/main` @ `93cdd00`  
+**Method:** Read implementation paths cited in the review request; ran the two new unit tests (not the full serial suite).
+
+---
+
+## Item A — `PolicyWithheld` skip-reason split (commit `d87c748`)
+
+### A1. Does `PolicyWithheld` leak anything?
+
+**Verdict: CONFIRMED** (for the property the change claims to preserve), with one **documented tradeoff** below.
+
+**Path-rule vs content-detector collapse — preserved**
+
+Both sensitive variants still map to one display label:
+
+```3442:3443:src/live_index/store.rs
+                MetadataOnlyReason::SensitivePath { .. }
+                | MetadataOnlyReason::SensitiveContent { .. } => SkipReason::PolicyWithheld,
+```
+
+The read-path refusal remains uniform and names no rule class:
+
+```3636:3648:src/protocol/format.rs
+/// Refusal for a file the admission pipeline excluded from content disclosure.
+///
+/// Deliberately UNIFORM across every security exclusion: it names no rule id, no
+/// rule class, no finding count, no size, and no byte of the file. Whether the
+/// exclusion came from the path rule or from a content detector is the one
+/// content-derived bit a refusal could still leak, and the recovery action is
+/// identical either way, so the message does not distinguish them.
+pub fn content_withheld_by_admission(path: &str) -> String {
+```
+
+Security-sensitive decisions on the read gate still use typed `MetadataOnlyReason`, not the `SkipReason` projection:
+
+```1258:1275:src/live_index/query.rs
+    /// Typed per-path admission disposition, read straight off the manifest.
+    ///
+    /// Deliberately NOT `capture_admission_tier_lookup_view`: that projects through
+    /// `compatibility_admission_decision`, which collapses seven `MetadataOnlyReason`
+    /// variants — including both security variants — into
+    /// `SkipReason::UnsupportedLanguage`. A security decision must never be taken on
+    /// that projection.
+    pub fn capture_file_disposition(
+```
+
+I found no path where `MetadataOnlyReason::SensitivePath { rule_id }` or `SensitiveContent { rule_ids, finding_count }` fields are serialized into MCP tool output, health text, or catalog digests exposed to callers. Manifest persistence keeps the typed reason; the new label is a display projection only.
+
+**Tradeoff (not a blocker): policy vs non-policy is now distinguishable**
+
+Before `d87c748`, sensitive files, LFS pointers, path-metadata failures, and undecodable encodings all displayed as `"unsupported language"`. After the change, only `SensitivePath | SensitiveContent` display as `"withheld by admission policy"`; the other four variants have honest, distinct labels (`UnsupportedTextEncoding`, `LfsPointer`, `UnsupportedPath`).
+
+So a caller who sees `[metadata-only: withheld by admission policy]` on a Tier-2 path can infer **a policy demotion occurred** (path rule *or* content detector), as opposed to an encoding/LFS/path-shape issue. That is narrower than the old seven-way collapse, but it does **not** distinguish path rule from content detector — the bit the read-path contract protects.
+
+I judge this an acceptable, intentional trade: stopping the false language claim is worth revealing the policy-vs-technical bucket. It should not block landing unless the product goal is to hide even *that* a policy fired (which would require collapsing policy back with encoding/LFS/path, reintroducing misinformation).
+
+**Surfaces checked (verified by read, not exhaustive runtime probe):**
+
+| Surface | Uses `SkipReason` projection? | Leaks path-vs-content? |
+|---------|------------------------------|------------------------|
+| `get_file_content` / read gate | No — typed disposition + uniform refusal | No |
+| `not_indexed_skipped_file` | Yes — `reason.to_string()` | No (both → `PolicyWithheld`) |
+| `search_files` resolve `[metadata-only: …]` | Yes — via `metadata_only_skipped_paths()` | No |
+| `capture_admission_tier_lookup_view` / health tier lookup | Yes | No |
+| `health` / `status` tier counts | Counts only, no per-reason breakdown | No |
+| Manifest / snapshot persistence | `MetadataOnlyReason` (typed), not `SkipReason` | No in external API |
+
+---
+
+### A2. Is splitting the four non-sensitive reasons safe?
+
+**Verdict: CONFIRMED**
+
+| Variant | Content-derived? | Evidence |
+|---------|------------------|----------|
+| `PlatformPathCollision` | No — path identity | Set before payload read in scout |
+| `UnsupportedPathEncoding` | No — path encoding | Same |
+| `PathMetadataTooLarge` | No — path metadata bound | Same |
+| `UnsupportedTextEncoding` | Encoding fact, not semantic content | Distinct from language support; comment at `domain/index.rs:1485-1488` |
+| `LfsPointer` | **Format class only, not payload** | `detect_lfs_pointer` (`knowledge/mod.rs:652-672`) requires valid UTF-8 ≤1 KiB and exactly three LFS header lines. Display string is `"git-lfs pointer"` — it does not expose `declared_oid` / `declared_size` from `MetadataOnlyReason::LfsPointer { .. }`. Knowing a file is an LFS pointer is equivalent to knowing its first ~200 bytes match the public LFS spec, not arbitrary file semantics. |
+
+---
+
+### A3. Missed mapping sites?
+
+**Verdict: CONFIRMED — no missed production mapping sites found**
+
+Production forward map: `compatibility_admission_decision` in `store.rs:3401-3467`.
+
+Reverse maps (display-only → manifest write path, defensive):
+
+- `disposition_from_admission` — `store.rs:3469-3509`
+- discovery compat helper — `discovery/mod.rs:1158-1180`
+
+Test helpers (compiler-forced exhaustiveness):
+
+- `live_index/query.rs:3848-3863`
+- `protocol/tools.rs:13147-13162`
+
+`SkipReason` has no `Serialize`/`Deserialize` (`domain/index.rs:1439-1440`), so Rust exhaustiveness on `match decision.reason` in the forward map and `Display` impl covers all variants; no `_ =>` catch-alls swallow the new variants in production paths.
+
+**Note:** `disposition_from_admission` collapses `PolicyWithheld` back into `MetadataOnlyReason::UnsupportedTextEncoding` (`store.rs:3494-3497`). That is intentional — comment says these are display-only reasons never produced by the admission pipeline — and is not a reporting leak because nothing reads that round-trip for external output.
+
+---
+
+### A4. Snapshot / serialization compatibility
+
+**Verdict: CONFIRMED — no break identified**
+
+- `SkipReason` is **not** persisted (`#[derive(Debug, Clone, Copy, PartialEq, Eq)]` only, `domain/index.rs:1439`).
+- Snapshots persist `MetadataOnlyReason` (`domain/index.rs:871-892`, `serde::Serialize/Deserialize`), which is **unchanged** by this commit.
+- `symforge::embed` public API does not re-export `SkipReason` (grep over `src/embed.rs` — no hits).
+- Adding enum variants to a non-serialized display type cannot break older snapshot bytes.
+
+**Not verified:** a live round-trip load of a pre-`d87c748` snapshot against this binary. Risk is inferred from type layout, not measured.
+
+---
+
+### A5. Are the two new tests load-bearing?
+
+**Verdict: PARTIALLY WRONG — necessary but not sufficient**
+
+Both tests pass (verified):
+
+```
+cargo test --lib policy_withheld -- --test-threads=1          → ok
+cargo test --lib non_sensitive_skip_reasons -- --test-threads=1 → ok
+```
+
+What they actually pin:
+
+- `policy_withheld_never_claims_a_language_problem` — `Display` string for `PolicyWithheld` contains no `language`, `size`, `path`, `content`, `secret`, `detector`, or `rule` substrings (`domain/index.rs:2290-2309`).
+- `non_sensitive_skip_reasons_are_distinct_and_honest` — four display strings are pairwise distinct and contain expected keywords (`domain/index.rs:2315-2332`).
+
+What they do **not** pin:
+
+- End-to-end projection from a loaded manifest with real `SensitivePath`/`SensitiveContent` dispositions through `compatibility_admission_decision` → MCP output.
+- That `store.rs` sensitive-fixture tests (`~7685+`) already cover typed disposition + no canary in serialized manifest; they assert `MetadataOnlyReason`, not `SkipReason::PolicyWithheld`.
+
+**Recommendation:** Add one integration assertion that `compatibility_admission_decision` on a `SensitiveContent` catalog entry yields `Some(PolicyWithheld)`, not `UnsupportedLanguage`. Low cost, closes the gap the Display-only tests leave.
+
+---
+
+### Item A — declined TestPilot asks
+
+**Verdict: CONFIRMED — correctly declined**
+
+- Threshold / machine-readable exclusion codes — would reopen the side channel `format.rs:3638-3642` deliberately closes.
+- Bounded `get_file_content` for Tier-2 — Tier-2 includes `SensitiveContent`; read gate refuses both variants uniformly (`read_gate.rs:118-120`).
+- `force_admit` — bypasses fail-closed gate; no safe variant found.
+
+---
+
+## Item B — cold-start curation reorder (~3.8 s)
+
+### Verdict: **safe-with-modification**
+
+The proposed reorder is safe **only** for the no-replay-directory fast path. It must not skip `curation_plan_current` when a replay directory exists and recovery will run.
+
+### B1. Side effects of `curation_plan_current` / `review_current`?
+
+**Verdict: CONFIRMED — appears pure on the startup path (inferred, not traced to every callee)**
+
+```145:301:src/protocol/knowledge_review.rs
+pub(crate) fn review_current(
+    generation: &PublishedGeneration,
+    input: &ReviewKnowledgeInput,
+) -> Result<ReviewKnowledgeOutput, String> {
+    // ... reads generation, computes facts, renders strings ...
+    Ok(ReviewKnowledgeOutput { ... })
+}
+```
+
+- Takes `&PublishedGeneration`; no `&mut`, no file I/O in the function body shown.
+- `guard_hit` (`knowledge/mod.rs:847-852`) validates visible fields; does not write state.
+- `review_facts` builds in-memory maps from generation data (`knowledge_review.rs:436+`).
+
+**Not exhaustively traced:** every helper below `review_facts`. Nothing in the startup call chain suggests mutation, but this is inference, not line-by-line proof.
+
+### B2. Is `PublishedGeneration.source` equivalent to `CurationReviewPlan.source` for `apply_capability`?
+
+**Verdict: CONFIRMED**
+
+```421:431:src/protocol/knowledge_review.rs
+    let source = generation
+        .source
+        .as_ref()
+        .map(|source| source.as_ref().clone())
+        .ok_or_else(|| "Curation unavailable: source identity is absent.".to_string())?;
+    Ok(CurationReviewPlan {
+        // ...
+        source,
+```
+
+`CurationReviewPlan.source` is `SourceIdentity` (`knowledge_review.rs:66-72`). `apply_capability` uses only:
+
+```1542:1544:src/protocol/knowledge_curation.rs
+    if !matches!(source_location, SourceLocation::WorkingTree { .. }) {
+        return Err(CapabilityUnavailableReason::NonProjectLocalPlacement);
+    }
+```
+
+`generation.source.as_ref().map(|s| &s.location)` is the same value passed through the plan.
+
+### B3. Does current order encode an invariant?
+
+**Verdict: PARTIALLY — fail-closed wording overstates startup impact**
+
+Current order when replay dir **missing** (fresh project):
+
+1. `curation_plan_current` — ~3.8 s, succeeds on SymForge itself
+2. `apply_capability` — ~102 µs
+3. `!replay_dir.is_dir()` → `Ok(())`
+
+When `curation_plan_current` **errors**, startup is **not** blocked:
+
+```335:344:src/protocol/mod.rs
+        if let Some(root) = repo_root.as_deref()
+            && let Err(error) = curation_coordinator.recover_on_project_load(...)
+        {
+            tracing::warn!("knowledge curation startup recovery remained fail-closed: {error}");
+        }
+```
+
+Same pattern in `daemon.rs:2995-3001`. Errors become warnings; the server still serves.
+
+**Invariant that matters:** when `replay_dir` **exists**, recovery must still run `curation_plan_current` before touching replay records (plan validation, action set, review hash). The proposed hoist must not apply on that path.
+
+**Minor behavior change on reorder:** if `curation_plan_current` would error but there is no replay dir, current code logs a warning after wasting 3.8 s; a correct reorder returns `Ok(())` silently. Functionally equivalent for tool serving; observability differs.
+
+### B4. Cheaper correct variant
+
+**Verdict: CONFIRMED — viable**
+
+```rust
+// Pseudocode — safe shape
+let generation = index.published_source_set().current_generation();
+
+// Cheap replay-dir probe — no plan needed
+let state_dir = state_placement
+    .and_then(|p| p.directory())
+    .map(|d| d.as_path().to_path_buf())
+    .ok_or(...)?;  // same error class as apply_capability when placement missing
+let replay_dir = state_dir.join(CURATION_STATE_DIR).join(REPLAY_DIR);
+if !replay_dir.is_dir() {
+    return Ok(());
+}
+
+// Expensive path only when recovery may actually run
+let plan = curation_plan_current(&generation)?;
+let state_dir = apply_capability(
+    repo_root,
+    state_placement,
+    persistence_health,
+    &plan.source.location,  // == generation.source.location
+)?;
+// ... existing recovery ...
+```
+
+`apply_capability` does **not** create the state directory on this path — it validates placement, WorkingTree source, persistence health, and writability, then returns `state_placement.directory()` (`knowledge_curation.rs:1527-1563`). The replay-dir existence check is a plain `is_dir()` and needs only the placement path.
+
+**Do not** use `generation.source` alone to skip `apply_capability` when `replay_dir` exists; the capability checks (readonly root, non-WorkingTree source, etc.) remain required before recovery.
+
+---
+
+## Additional findings
+
+1. **False-language bug was real.** The old seven-way collapse into `UnsupportedLanguage` is gone from `compatibility_admission_decision`; sensitive fixtures in `store.rs:7700-7718` retain typed dispositions while the projection now yields an honest label.
+
+2. **`tier2_sweep_never_names_a_security_demoted_file`** (`tools.rs:31095-31151`) still references the pre-fix mislabel in a comment (SF-DOG-004). The test guards sweep behavior via typed disposition, not `SkipReason`; it should still pass, but the comment is stale after `d87c748`.
+
+3. **Full serial suite not run.** Only the two new unit tests were executed (~18 s compile + run). Total gate (`cargo test --all-targets -- --test-threads=1`) was not run per time budget; no regressions inferred beyond the tests above.
+
+---
+
+## Summary
+
+| Item | Question | Verdict |
+|------|----------|---------|
+| A1 | `PolicyWithheld` leak? | **CONFIRMED** — path-vs-content preserved; policy-vs-technical now distinguishable (accepted tradeoff) |
+| A2 | Non-sensitive splits safe? | **CONFIRMED** |
+| A3 | Missed mappings? | **CONFIRMED** — none found |
+| A4 | Snapshot compat? | **CONFIRMED** — `SkipReason` not persisted |
+| A5 | Tests load-bearing? | **PARTIALLY WRONG** — Display-only; add one projection integration test |
+| B | Reorder safe? | **safe-with-modification** — hoist replay-dir check using placement path; keep full plan when replay dir exists |
+
+**Landing recommendation for Item A:** **Land.** The change fixes a real false-positive language diagnosis without breaking the critical path-vs-content non-disclosure property. The policy-vs-technical distinction is new but defensible.
+
+**Landing recommendation for Item B:** **Do not ship the naive reorder without the guard above.** The safe variant should save ~3.8 s on cold fresh projects with no `.symforge/curation/replay/` directory and no functional regression on the recovery path.

--- a/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-kimi.md
+++ b/specs/021-admission-coverage-honesty/REVIEW-FINDINGS-kimi.md
@@ -1,0 +1,273 @@
+# Independent review findings — PolicyWithheld + curation reorder
+
+**Reviewer:** Kimi (OMP session), working against `E:\project\symforge-policy` directly
+**Date:** 2026-08-06
+**Branch reviewed:** `fix/policy-withheld-skip-reason`, commit `d87c748`
+**Base:** `origin/main` @ `93cdd00`
+**Method:** Read every production path cited in the request plus the ones it did not
+cite (read gate, sidecar, file-tree view, embed surface). Ran the skip-reason tests
+(receipt below). Did **not** run the full serial suite.
+
+**Tree-drift disclosure.** The working tree gained **uncommitted** modifications to
+`src/domain/index.rs`, `src/live_index/query.rs`, `src/live_index/store.rs`,
+`src/protocol/tools.rs` *during* this review (comment fixes, a `debug_assert`, and a
+new mapping-level test — apparently the author reacting to other reviewers in real
+time). Verdicts below target the **committed `d87c748` state**; where the drift
+matters I say so explicitly. I did not read the other reviewers' findings files
+before forming these verdicts.
+
+---
+
+## Item A — `PolicyWithheld` skip-reason split (commit `d87c748`)
+
+### A1. Does `PolicyWithheld` leak anything? — **CONFIRMED** (the property holds)
+
+The protected bit — **path rule vs content detector** — is still hidden:
+`store.rs:3442-3443` maps both `SensitivePath { .. }` and `SensitiveContent { .. }`
+to the same `SkipReason::PolicyWithheld`, whose `Display` is the static string
+`"withheld by admission policy"` (`domain/index.rs:1516`). No rule id, no finding
+count, no size, no oid.
+
+Every surface a caller can reach shows only that static string or a uniform refusal:
+
+| Surface | What it emits for a sensitive file | Evidence |
+|---|---|---|
+| `search_files` / resolve suffix | `[metadata-only: withheld by admission policy]` | `query.rs:1243-1255` → `format.rs:2928, 3006` |
+| file-tree view | same Display string | `tools.rs:4478-4479` → `format::file_tree_view_with_skipped` |
+| symbol/reference degradation | `Reason: withheld by admission policy` | `tools.rs:2490-2500, 2586-2602` |
+| `not_indexed_skipped_file` | same Display string | `format.rs:3698` |
+| sidecar `impact_skipped_text` | same Display string | `sidecar/handlers.rs:889-902` |
+| read gate (`get_file_content`) | uniform `content_withheld_by_admission` | `read_gate.rs:105-122`, `format.rs:3636-3648` |
+| `health` / `status` | tier **counts** only, no per-reason breakdown | `health_view.rs:557-560` |
+
+The typed fields (`rule_id`, `rule_ids`, `finding_count`) are consumed only to
+*make* the refuse decision (`read_gate.rs:70-122`) and never rendered; the only
+`rule_id`/`finding_count` strings in `src/protocol/` belong to the knowledge-policy
+domain (the repo's own policy TOML), not to per-file admission verdicts.
+
+**On the narrowing question — the part the request flags as most important.**
+Yes, `PolicyWithheld` is a narrower set than the old seven-way collapse, so a caller
+now learns "a policy demotion fired" rather than "one of seven causes". But this bit
+was **already served to any caller before this commit**: the read gate answers it
+per path on request, distinguishing `content_withheld_by_admission` (policy) from
+`content_withheld_unscanned` (scan-budget/encoding) — `read_gate.rs:105-122`,
+`format.rs:3650-3663`. And for any *supported* extension the old label was already
+invertible by anyone who can read this open-source code: "unsupported language" on a
+`.rs`/`.ts` file could only be the hidden bucket. The genuinely content-derived bit
+(which of the two sensitive variants fired) remains protected, and the inference
+"benign-looking path + withheld ⇒ content detector" predates the change (it works
+against the read-path refusal too). The new label adds **no new oracle**; it stops
+asserting a falsehood on a surface the old oracle already covered.
+
+### A2. Is splitting the four non-sensitive reasons safe? — **CONFIRMED**
+
+- `UnsupportedPathEncoding` / `PathMetadataTooLarge` are minted at
+  `discovery/mod.rs:957-965` from the **path alone, before any byte is read**.
+  Not content-derived.
+- `PlatformPathCollision` — **no minting site exists in the current tree** (dead
+  variant; only the enum definition at `domain/index.rs:888` and the mapping at
+  `store.rs:3453`). Mapping it is harmless; noting it so the claim "four reasons
+  split" is understood as "three live + one dormant".
+- `LfsPointer` *is* byte-derived (`knowledge/mod.rs:745-749`), but the Display
+  string is the static `"git-lfs pointer"` — it discloses only that the first
+  <1 KiB match the **public** LFS pointer grammar, a format class. The typed
+  `declared_oid` / `declared_size` ride along in `MetadataOnlyReason` (serde,
+  local manifest only) and are never rendered to a caller surface.
+
+### A3. Missed mapping sites? — **CONFIRMED none missed; one related residual found**
+
+Production sites, all exhaustive (compiler-checked, no `_ =>` on these domains):
+
+- forward map `compatibility_admission_decision` — `store.rs:3401-3466`
+- reverse map `disposition_from_admission` — `store.rs:3469-3522`
+- discovery reverse map — `discovery/mod.rs:1151-1182`
+- test helpers — `query.rs:3849-3865`, `tools.rs:13148-13164`
+
+The two `_ =>` catch-alls that exist are on disjoint domains and cannot conflate
+these variants: `discovery/mod.rs:1153` (HardSkip arm only) and
+`discovery/mod.rs:2169` (`path_admission_reason` yields only
+Lockfile/OversizedData/GeneratedOrVendor).
+
+**Residual the commit did not catch (same dishonesty class):**
+`store.rs:3460-3464` still maps `FileDisposition::Unreadable { .. } |
+UnstableDuringRead | AbortedCircuitBreaker` to `SkipReason::UnsupportedLanguage` —
+an I/O failure or circuit-breaker abort is still reported to callers as
+"unsupported language". Outside the commit's stated seven-variant scope, but it is
+the same false-diagnosis pattern and will produce the same kind of misleading
+external report. Recommend a follow-up variant (e.g. an honest `Unreadable`
+reason), not a blocker for this one.
+
+### A4. Snapshot / serialization compatibility — **CONFIRMED no break**
+
+- `SkipReason` derives only `Debug, Clone, Copy, PartialEq, Eq`
+  (`domain/index.rs:1439-1440`); `AdmissionDecision` likewise (`1519-1523`);
+  `SkippedFile` only `Debug, Clone` (`1544-1545`). None is serializable, so adding
+  four variants cannot touch persisted bytes.
+- Snapshots/manifests persist `MetadataOnlyReason`
+  (`domain/index.rs:871-892`, `Serialize/Deserialize`), which this commit does not
+  modify — old snapshots load against identical variant definitions.
+- Embedders: `symforge::embed` re-exports `stel_core::types::AdmissionDecision`
+  (`embed.rs:158-160`), which is a **different enum** (`Serve | Degrade | Bypass`,
+  `stel_core/types.rs:51`). AAP cannot observe `SkipReason` through the embed API.
+
+*Not verified:* a live load of a real pre-`d87c748` snapshot against this binary —
+inferred safe from type layout, not measured.
+
+### A5. Are the two new tests load-bearing? — **PARTIALLY WRONG** (at `d87c748`)
+
+Both committed tests assert on `SkipReason::X.to_string()` **strings only**
+(`domain/index.rs:2290-2332`). A regression that re-mapped
+`SensitiveContent → UnsupportedLanguage` in the forward map would leave both tests
+green — they pin the *wording* of the new variants, not the *projection* that
+produces them. So: load-bearing for the Display contract, vacuous for the actual
+fix.
+
+**Drift note:** the uncommitted working-tree changes add
+`security_demotions_project_to_policy_withheld_not_a_language_verdict`
+(`store.rs` ~7766), which drives a real `LiveIndex::load` over a canary `.env` and
+a token-bearing `src/config.rs` and asserts the production projection yields
+`PolicyWithheld` and never `UnsupportedLanguage`. That is exactly the missing
+mapping-level pin, and it is genuine (it would fail on a forward-map regression).
+It is **not part of the commit under review**.
+
+### Declined TestPilot asks — **CONFIRMED correctly declined**
+
+- Bounded Tier-2 reads: Tier-2 includes `SensitiveContent`; the gate refuses both
+  sensitive variants uniformly (`read_gate.rs:118-120`). A bounded read would
+  disclose exactly what the gate withholds.
+- Machine-readable exclusion codes / thresholds: reopens the channel
+  `format.rs:3636-3648` documents as deliberately closed.
+- `force_admit`: a bypass of a fail-closed security gate. No safe variant exists.
+
+---
+
+## Item B — the ~3.8 s cold-start reorder — **safe-with-modification**
+
+### B1. Does `curation_plan_current` have side effects? — **CONFIRMED pure**
+
+`review_current` (`knowledge_review.rs:145-301`) and `curation_plan_current`
+(`371-431`) take only `&PublishedGeneration` / `&ReviewKnowledgeInput`. The
+production bodies contain no `std::fs`, no writes, no mutation — the only `std::fs`
+hits in the file are `#[cfg(test)]` fixtures (1381+). `guard_hit`
+(`knowledge/mod.rs:847-852`) and `source_envelope_is_safe`
+(`knowledge_review.rs:1242-1250`) are pure validations. The 3.8 s is CPU:
+per-record `review_facts` + dossier rendering + hashing + a secret-policy scan of
+the rendered text — and on the fresh-project path the entire result is **discarded**
+except `plan.source.location`.
+
+### B2. Is `PublishedGeneration.source` equivalent to the plan's? — **CONFIRMED**
+
+`plan.source` is `generation.source` cloned, erroring only if absent
+(`knowledge_review.rs:421-427`). `apply_capability` uses it for exactly one
+`matches!(source_location, SourceLocation::WorkingTree { .. })`
+(`knowledge_curation.rs:1534-1536`). Same value, same check. Bonus: the
+source-absent error currently fires at the *end* of `curation_plan_current` —
+after the 3.8 s is already spent; resolving from `generation.source` directly
+errors fast in the same class.
+
+### B3. Does the current order encode an invariant? — **No; and one worry is REFUTED**
+
+The request's caution "note `apply_capability` may CREATE the state dir" does not
+survive reading: `apply_capability` (`knowledge_curation.rs:1527-1563`) creates
+**nothing** — it is five pure capability checks plus two `fs::metadata` reads,
+returning a `PathBuf`. Directory creation lives in `prepare_mutation` (`:421`) and
+`probe_apply_directories` (`:669`), both gated *behind* the `replay_dir.is_dir()`
+early return. On the fresh path no state directory is created, validated, locked,
+or touched beyond the `is_dir()` metadata read itself. There is no
+"plan must be validated before the state dir is touched" invariant to break,
+because nothing is touched on this path.
+
+What the reorder **does** lose on the fresh path: if `curation_plan_current` would
+*error* (absent source, unsafe envelope, guard hit), today's code logs
+`"knowledge curation startup recovery remained fail-closed: {error}"`
+(`protocol/mod.rs:335-344`, `daemon.rs:2995-3001` — both log-and-continue), while
+reordered code returns `Ok(())` silently. That is an **observability** difference,
+not a correctness one: nothing downstream consumes the plan on this path, and the
+same error resurfaces on the first later `review_knowledge` call. If that warning
+is valued, the reordered fast path can run the probe and *still* log on
+plan-error — cheap insurance, not a requirement.
+
+### B4. Cheaper correct variant — **CONFIRMED viable**
+
+```rust
+let generation = index.published_source_set().current_generation();
+
+// Fast path: resolve the replay dir WITHOUT the plan.
+if let Some(dir) = state_placement.and_then(StatePlacement::directory) {
+    if !dir.as_path().join(CURATION_STATE_DIR).join(REPLAY_DIR).is_dir() {
+        return Ok(());                       // fresh project: skip the 3.8 s
+    }
+}
+// (placement absent → fall through to the slow path, which errors as today)
+
+// Slow path — unchanged semantics:
+let plan = curation_plan_current(&generation)?;
+let state_dir = apply_capability(repo_root, state_placement, persistence_health,
+                                 &plan.source.location).map_err(unavailable)?;
+let replay_dir = state_dir.join(CURATION_STATE_DIR).join(REPLAY_DIR);
+if !replay_dir.is_dir() { return Ok(()); }   // keep this re-check (TOCTOU)
+// ... probe, lock, re-plan, recover — exactly as today
+```
+
+Keep the in-slow-path re-check: a replay dir appearing between the fast probe and
+the lock must still be recovered. Today's race window (dir appears between the
+existing check and lock acquisition) is shifted earlier, not grown.
+
+**Additional observation the request did not make:** on the *recovery* path the
+plan is computed **twice** — once outside the lock (used only for
+`source.location`) and again inside it, where the result is discarded
+(`let _plan = curation_plan_current(&generation)?;`,
+`knowledge_curation.rs:330-333`). The inside-lock run is the real fail-closed
+re-validation; the outside run is redundant except for the enum match. Resolving
+the location from `generation.source` and deleting the outside-lock computation
+saves ~3.8 s on the recovery path too, with the inside-lock plan still guarding
+recovery. That is the stronger form of the same fix.
+
+---
+
+## Anything missed
+
+1. **Residual false-language mapping** (A3 above): `Unreadable |
+   UnstableDuringRead | AbortedCircuitBreaker → UnsupportedLanguage`,
+   `store.rs:3460-3464`. Same lie, different door.
+2. **Stale comments at `d87c748`:** `query.rs:1258-1264` and `tools.rs:2789-2793`
+   still describe the pre-fix seven-way collapse into `UnsupportedLanguage` in
+   present tense (both already fixed in the uncommitted drift);
+   `tools.rs:31096-31100` (SF-DOG-004) still says the file "is excluded only
+   because `compatibility_admission_decision` mislabels every security demotion"
+   and anticipates a correction that has now landed — still stale even in the
+   drift.
+3. **`PlatformPathCollision` is a dead variant** (A2 above) — no minting site.
+4. **Double plan computation on the recovery path** (B4 above).
+
+---
+
+## What I ran vs inferred
+
+- **Ran:** `cargo test --lib -- --test-threads=1 policy_withheld non_sensitive_skip_reasons`
+  in the worktree → **3 passed, 0 failed, exit 0** (the two committed Display tests
+  plus the uncommitted mapping test; compiled against the drifted working tree —
+  the Display strings are identical in `d87c748`, so the pass is valid evidence for
+  the commit). Full serial suite **not run**.
+- **Verified by reading:** every file:line cited above against the worktree at
+  `d87c748` (+ drift where noted).
+- **Inferred, not proven:** snapshot-load compatibility (type-layout argument, A4);
+  purity of every helper below `review_facts` (bodies inspected are pure; I did not
+  line-by-line trace `render_dossier`/`effective_action` callees — none take
+  `&mut` or do I/O by signature).
+
+## Summary
+
+| Item | Question | Verdict |
+|---|---|---|
+| A1 | `PolicyWithheld` leak? | **CONFIRMED** — path-vs-content bit preserved; policy-vs-technical bit was already served by the read gate; no new oracle |
+| A2 | Non-sensitive splits safe? | **CONFIRMED** (`PlatformPathCollision` dead variant noted) |
+| A3 | Missed mappings? | **CONFIRMED** none; residual `Unreadable → UnsupportedLanguage` mislabel found |
+| A4 | Snapshot/embed compat? | **CONFIRMED** — `SkipReason` never serialized; embed exports a different type |
+| A5 | Tests load-bearing? | **PARTIALLY WRONG** — Display-only at `d87c748`; uncommitted drift adds the real projection test |
+| B | Reorder safe? | **safe-with-modification** — fast replay-dir probe without the plan; keep slow path + re-check; bonus: drop the duplicate outside-lock plan |
+
+**Item A: land it.** The change removes a real false diagnosis and preserves the
+one bit the threat model protects. **Item B: ship the fast probe, not the naive
+reorder** — and consider deleting the duplicate plan computation on the recovery
+path while in there.

--- a/specs/021-admission-coverage-honesty/REVIEW-REQUEST-A1-TIEBREAK-2026-08-06.md
+++ b/specs/021-admission-coverage-honesty/REVIEW-REQUEST-A1-TIEBREAK-2026-08-06.md
@@ -1,0 +1,184 @@
+# Tiebreak review — does `PolicyWithheld` disclose a bit that did not exist before?
+
+**For:** a third independent reviewer (Kimi K3), working directly against this repository.
+**Branch:** `fix/policy-withheld-skip-reason`. **Base:** `origin/main` @ `93cdd00`.
+
+Two reviewers have already answered this. **They disagree, and you are the tiebreak.**
+Read this file fully, then read the code. It is self-contained.
+
+**Do not try to guess which side I want.** I wrote the change under review, I
+argued one of the two positions, and I am the least reliable voice here. This
+campaign has produced twelve claims that did not survive verification, five of
+them mine, including one change shipped and then reverted on measurement.
+
+---
+
+## The change
+
+`src/live_index/store.rs::compatibility_admission_decision` used to map **seven**
+distinct `MetadataOnlyReason` variants onto one `SkipReason::UnsupportedLanguage`,
+which `Display`s as `"unsupported language"`.
+
+So a secret-detector verdict on perfectly valid TypeScript or Rust was reported to
+callers as a **language** problem. An external consumer (TestPilot) hit this on two
+valid `.ts` files and concluded TypeScript support was broken. SymForge reproduces
+it on its own source: `src/live_index/store.rs`, 0.30 MB of Rust.
+
+The change splits that collapse:
+
+```
+SensitivePath | SensitiveContent   -> PolicyWithheld           "withheld by admission policy"
+LfsPointer                         -> LfsPointer               "git-lfs pointer"
+PlatformPathCollision
+  | UnsupportedPathEncoding
+  | PathMetadataTooLarge           -> UnsupportedPath          "unsupported path"
+UnsupportedTextEncoding            -> UnsupportedTextEncoding  "undecodable text encoding"
+```
+
+The two security variants still collapse **together**, so path-rule vs
+content-detector remains hidden. Both prior reviewers confirmed that part.
+
+---
+
+## The contested question
+
+`PolicyWithheld` is now a **narrower** set than the old seven-way bucket. A caller
+who sees it on a Tier-2 path learns *"a policy demotion occurred"* rather than
+*"one of seven things happened"*.
+
+For a path that **cannot** match a sensitive path rule — an ordinary `.rs` or
+`.ts` file — the collapse inside `PolicyWithheld` is arguably empty, making the
+label a near-oracle for **`SensitiveContent`**: "the secret detector fired here."
+
+Surfaces where the reason string is emitted per-file:
+
+- `search_files` resolve / hits — `format.rs:2927-2928`, `tools.rs:6064`
+- `get_repo_map` tree tags — `format.rs:1670-1677`
+- daemon cross-project search — `daemon.rs:4977-4979`
+- embed `SearchFilesHit.metadata_reason: Option<String>`
+
+### Reviewer 1 (Cursor 2.5): CONFIRMED — acceptable tradeoff
+
+Path-vs-content is preserved, which is the documented contract in
+`format.rs:3636-3648`. Policy-vs-technical is a new *public* bit but a defensible
+one: hiding it again would require collapsing security back in with encoding/LFS/path,
+i.e. reintroducing the misinformation. **Land it.**
+
+### Reviewer 2 (Grok 4.5): PARTIALLY WRONG — this leaks something
+
+Yes, it discloses a bit the old collapse hid: "security/admission policy applied,"
+which on innocuous source paths is nearly `SensitiveContent`. Recommendation: if
+*"which ordinary files tripped the secret detector"* is sensitive, **do not land
+as-is** — keep security demotions in a bucket that still contains at least one
+common non-security technical reason, or stop emitting per-file reason strings for
+that bucket.
+
+---
+
+## The evidence neither reviewer weighed — check this first
+
+Both reviewers analysed the *index-side* projection in isolation. Neither traced
+what the **read path** already discloses about the same file.
+
+`src/protocol/read_gate.rs::admit_disk_read` emits **two different refusals**:
+
+| Cause | Refusal |
+|---|---|
+| `sensitive_path_rule` matches | `content_withheld_by_admission` |
+| recorded `SensitivePath` / `SensitiveContent` | `content_withheld_by_admission` |
+| `SensitiveContent` w/ `INDETERMINATE_RULE_ID` (detector failure) | `content_withheld_unscanned` |
+| `exceeds_scan_limit` or `decode_searchable_text` err | `content_withheld_unscanned` |
+| live `classify_stable_content` -> `SensitiveContent` | `content_withheld_by_admission` |
+
+The split is deliberate and documented: the recovery action differs ("reindex and
+retry" vs "reindexing will not change this").
+
+**My reading:** any caller can already learn the policy-vs-technical bit for ANY
+path, today, on `origin/main`, by calling `get_file_content` and reading which of
+the two refusals comes back. If so, `PolicyWithheld` in search output surfaces the
+**same** bit one tool call earlier — it does not create a new one. And under the
+old behaviour the honest caller was told "unsupported language" while the curious
+caller got the true bit anyway from the read gate one call later.
+
+**This is the claim you are adjudicating. I may be wrong about it.**
+
+### Questions
+
+1. **Is the policy-vs-technical bit genuinely pre-existing?** Trace
+   `admit_disk_read` for each population. Is there any file that projects
+   `PolicyWithheld` on the search surface but does **not** already yield
+   `content_withheld_by_admission` from the read gate? If such a file exists, my
+   argument fails and Grok is right.
+
+2. **Is there a caller who can see search/repo-map output but CANNOT call
+   `get_file_content`?** This is the strongest version of Grok's position: if some
+   surface (cross-project daemon search at `daemon.rs:4977-4979`, or an `embed`
+   consumer reading `SearchFilesHit.metadata_reason`) exposes the reason string
+   across a boundary where the read gate is not reachable, then the bit really is
+   new for that caller. Check the daemon cross-project path specifically.
+
+3. **What is the actual threat model?** SymForge is a local MCP server; the caller
+   is typically an agent that already has filesystem access and could read the file
+   directly. Does the admission policy exist to (a) stop secrets from being routed
+   into an LLM context automatically, or (b) enforce access control against an
+   adversary who cannot otherwise read the bytes? Under (a) the oracle concern is
+   largely moot; under (b) Grok's objection is serious. Answer from the code and
+   comments, not from first principles.
+
+4. **If the bit IS new and IS meaningful**, is Grok's mitigation actually better?
+   Folding security demotions back in with `UnsupportedTextEncoding` means telling
+   callers a valid, readable, correctly-encoded TypeScript file has an undecodable
+   encoding. Is trading one false statement for a weaker oracle a net improvement,
+   or is there a third option neither reviewer proposed — e.g. emitting no reason
+   string at all for that bucket on the search surface, while keeping the honest
+   reason on `get_file_context`?
+
+---
+
+## Already settled — do not re-derive unless you find contrary evidence
+
+Both prior reviewers independently agreed, and I verified each myself:
+
+- **No missed production mapping sites.** Forward map + two reverse maps + two
+  compiler-forced test helpers.
+- **No snapshot break.** `SkipReason` has no serde derives (`domain/index.rs:1439`);
+  snapshots persist `MetadataOnlyReason`, unchanged. Neither reviewer performed a
+  live load of a pre-change snapshot — still unverified, flag it if you can test it.
+- **The declined TestPilot asks were correctly declined** (machine-readable exclusion
+  codes, bounded Tier-2 reads, `force_admit`).
+- **`PlatformPathCollision` has no production mint site** — enum definition plus the
+  new match arm, nothing else. Harmless but untested in production.
+- **The two Display-level tests were not sufficient.** Both reviewers called this
+  PARTIALLY WRONG. Already fixed on this branch:
+  `security_demotions_project_to_policy_withheld_not_a_language_verdict` in
+  `store.rs` now asserts the production projection on entries from a real
+  `LiveIndex::load`, including a `.rs` path that can only be a content demotion.
+
+Also already fixed on this branch from the prior round: the stale seven-way-collapse
+comments at `query.rs:1258-1264` and `tools.rs:2787-2793`, the overreaching "not
+content-derived" claim about `LfsPointer` (it is decided from bytes; it discloses
+only that the first <1 KiB match the public LFS grammar), and a `debug_assert`
+on the display-only round-trip in `disposition_from_admission`, which would
+otherwise relabel a security demotion as an encoding fault.
+
+---
+
+## Deliverable
+
+`specs/021-admission-coverage-honesty/REVIEW-FINDINGS-kimi-2026-08-06.md`:
+
+- **A verdict on the contested question**, and explicitly: which of the two prior
+  reviewers is right, or whether both are wrong.
+- **A verdict on my read-gate argument** — CONFIRMED / REFUTED, with the trace.
+- Answers to questions 1-4 with `file:line` evidence or a command and its output.
+- If your honest answer is "this leaks something and should not land," say so
+  plainly. That is the single most valuable outcome available here.
+
+## Ground rules
+
+- Read the code before concluding. Every wrong claim in this campaign came from
+  reasoning about behaviour instead of reading the implementation.
+- Do not modify the repository except to write the findings file.
+- Distinguish what you verified, what you inferred, and what you are guessing.
+- The full serial suite is ~16-25 min (`cargo test --all-targets -- --test-threads=1`);
+  say whether you ran it rather than implying it.

--- a/specs/021-admission-coverage-honesty/REVIEW-REQUEST-POLICY-WITHHELD-2026-08-05.md
+++ b/specs/021-admission-coverage-honesty/REVIEW-REQUEST-POLICY-WITHHELD-2026-08-05.md
@@ -1,0 +1,229 @@
+# Independent review request — two admission/security changes
+
+**For:** a reviewer working directly against this repository (Cursor).
+**From:** the Claude session of 2026-08-05.
+**Branch under review:** `fix/policy-withheld-skip-reason`, commit `d87c748`.
+**Base:** `origin/main` @ `93cdd00`.
+
+Read this file fully before looking at code. It is self-contained.
+
+There are **two independent items**. Item A is a change I made and want checked.
+Item B is a change I *refused* to make and want a second opinion on. They share a
+theme — both are about a fail-closed security boundary — but they can be reviewed
+separately.
+
+**Please try to break these, not confirm them.** Prior context: this campaign
+produced twelve claims that did not survive verification, five of them mine,
+including one change shipped and then reverted on measurement. Agreement without
+independent evidence is worth nothing here.
+
+---
+
+## Item A — did I preserve the non-disclosure property? (commit `d87c748`)
+
+### What was wrong
+
+`src/live_index/store.rs` mapped **seven** distinct `MetadataOnlyReason`
+variants onto one `SkipReason::UnsupportedLanguage`, which `Display`s as
+`"unsupported language"`:
+
+```rust
+MetadataOnlyReason::SensitivePath { .. }
+| MetadataOnlyReason::SensitiveContent { .. }
+| MetadataOnlyReason::LfsPointer { .. }
+| MetadataOnlyReason::PlatformPathCollision
+| MetadataOnlyReason::UnsupportedPathEncoding
+| MetadataOnlyReason::PathMetadataTooLarge
+| MetadataOnlyReason::UnsupportedTextEncoding => SkipReason::UnsupportedLanguage,
+```
+
+So a **secret-detector verdict on perfectly valid TypeScript or Rust was reported
+as a language problem**. An external report (TestPilot) hit this on two valid
+`.ts` files and concluded TypeScript support was broken and that a file-size
+policy was to blame. Neither was true — their files were 0.33 MB and 0.60 MB
+against limits of 1 MiB (data) / 4 MiB (code) / 100 MiB (hard ceiling).
+
+SymForge reproduces it on its **own** source: `src/live_index/store.rs`, 0.30 MB
+of Rust, is withheld the same way.
+
+### What I changed
+
+```
+SensitivePath | SensitiveContent   -> PolicyWithheld  (new)  "withheld by admission policy"
+LfsPointer                         -> LfsPointer             "git-lfs pointer"
+PlatformPathCollision
+  | UnsupportedPathEncoding
+  | PathMetadataTooLarge           -> UnsupportedPath         "unsupported path"
+UnsupportedTextEncoding            -> UnsupportedTextEncoding "undecodable text encoding"
+```
+
+Plus: `SizeCeiling` no longer folds into the text-encoding bucket (it has a
+correct home in `OversizedData`, which the *test helpers* already used while the
+production path did not), and `None` — meaning "reason not recorded" — stays
+neutral instead of being promoted into a substantive diagnosis.
+
+### The property I claim to have preserved
+
+`src/protocol/format.rs` (~line 3638) documents the read-path refusal as
+deliberately uniform:
+
+> Whether the exclusion came from the path rule or from a content detector is
+> **the one content-derived bit a refusal could still leak**, and the recovery
+> action is identical either way, so the message does not distinguish them.
+
+My claim: `PolicyWithheld` keeps that property on the **index-side** surface —
+`SensitivePath` and `SensitiveContent` still collapse together, so a caller
+cannot tell whether a path rule or a content detector fired — while no longer
+asserting a false statement about the file's language.
+
+### What to attack
+
+1. **Does `PolicyWithheld` leak anything?** Is there any path — `health`,
+   `status`, catalog entries, manifest digests, MCP tool output, serialized
+   snapshots — where the *presence* of `PolicyWithheld` versus another reason
+   discloses something about file CONTENT that the old collapse hid? In
+   particular: the old mapping put sensitive files in the same bucket as
+   `UnsupportedTextEncoding` and `LfsPointer`. Splitting those out means
+   `PolicyWithheld` is now a **narrower** set. Does narrowing it turn "this file
+   is withheld" into "a detector or path rule fired on this file", and is that a
+   meaningful disclosure? I judged it is not — the file being Tier-2 was already
+   visible, and "policy applied" is what a caller must know to stop retrying —
+   but this is the single most important question in this review.
+
+2. **Is splitting the four non-sensitive reasons safe?** I judged
+   `LfsPointer`, `PlatformPathCollision`, `UnsupportedPathEncoding`,
+   `PathMetadataTooLarge` to be non-content-derived, so naming them leaks
+   nothing. Is any of them in fact content-derived? `LfsPointer` detection reads
+   file bytes (`detect_lfs_pointer` requires valid UTF-8 under 1 KiB) — does
+   naming it disclose anything about content?
+
+3. **Did I miss a mapping site?** I found and updated four
+   (`store.rs` forward map, `store.rs` reverse map, `discovery/mod.rs` reverse
+   map, plus two test helpers in `query.rs` / `tools.rs`). The compiler forced
+   the last two. Are there non-exhaustive matches, `_ =>` catch-alls, or
+   serialization paths that still conflate these?
+
+4. **Snapshot/serialization compatibility.** `SkipReason` gained four variants.
+   Does anything persist it, and would an older snapshot or a downstream
+   embedder (AAP consumes `symforge::embed::*`) break? I did **not** verify this
+   and it is a real risk.
+
+5. **Are the two new tests actually load-bearing**, or do they pass vacuously?
+   `policy_withheld_never_claims_a_language_problem` and
+   `non_sensitive_skip_reasons_are_distinct_and_honest` in `src/domain/index.rs`.
+
+### Deliberately NOT done
+
+The TestPilot report asked for three things, all declined:
+
+- expose the threshold and a machine-readable exclusion code — reopens the side
+  channel above;
+- permit bounded `get_file_content` reads for Tier-2 files — Tier-2 **includes**
+  `SensitiveContent`, so this would disclose exactly what the gate withholds;
+- a `force_admit` / lazy-parse override — a bypass of a security gate.
+
+If you think any of these is actually safe, say so and show why.
+
+---
+
+## Item B — a change I refused to make: the ~3.8 s cold-start reorder
+
+### The measurement
+
+Instrumented on `origin/main` (PRs #521, #528), release build, genuinely-cold
+index (fresh `git worktree add --detach`, no `.symforge/`):
+
+```
+serve: runtime built in                              3.8705102s
+  serve: protocol/curation recover_on_project_load     3.8243504s   99.2%
+    curation/published source set                          5.6µs
+    curation/plan current                              3.820374s    99.9%
+    curation/apply capability                            101.8µs
+    curation/no replay dir — early return
+  serve: protocol/routers                               18.8897ms
+```
+
+### The structure
+
+`KnowledgeCurationCoordinator::recover_on_project_load`
+(`src/protocol/knowledge_curation.rs` ~285):
+
+```rust
+let generation = index.published_source_set().current_generation();   //   5.6µs
+let plan = curation_plan_current(&generation)?;                       // 3.82s
+let state_dir = apply_capability(.., &plan.source.location)?;         // 102µs
+let curation_dir = state_dir.join(CURATION_STATE_DIR);
+let replay_dir = curation_dir.join(REPLAY_DIR);
+if !replay_dir.is_dir() { return Ok(()); }                            // fires on a fresh project
+```
+
+`curation_plan_current` (`src/protocol/knowledge_review.rs` ~371) runs
+`review_current` in Remediation mode, then selects **all** authority records
+(`(0..generation.authority.records.len())`) and computes `review_facts` +
+`effective_action` for every one.
+
+On this path its only consumer is `apply_capability`, which uses
+`plan.source.location` for a **single** check:
+
+```rust
+if !matches!(source_location, SourceLocation::WorkingTree { .. })
+```
+
+So: a full remediation review runs for 3.8 s to feed one enum match, and is then
+discarded because there is no replay directory to apply anything to. The
+microsecond existence check sits *after* the expensive computation.
+
+### The proposed fix
+
+Hoist the `replay_dir` existence check above `curation_plan_current`, and resolve
+the source location from `PublishedGeneration.source` (already set cheaply in
+`store.rs` from `manifest.source`) instead of via the plan.
+
+### Why I did not ship it
+
+`recover_on_project_load` is a **fail-closed integrity path**. Its own error
+strings say so:
+
+- `"knowledge curation startup recovery remained fail-closed"`
+- `"curation_startup_publication_failed; live queries remain on the last complete generation."`
+
+Reordering a fail-closed check to make startup faster is exactly where an
+unaccounted side effect turns a performance win into a correctness regression.
+
+### What to determine
+
+1. **Does `curation_plan_current` have side effects** that other startup
+   behaviour depends on? It looks pure (it builds a plan from a generation), but
+   `review_current` is a large call and I did not trace it exhaustively.
+2. **Is `PublishedGeneration.source` equivalent to `CurationReviewPlan.source`**
+   for `apply_capability`'s single `matches!` check?
+3. **Is the reorder actually safe**, or does the current order encode an
+   invariant — e.g. that the plan is validated before any state directory is
+   touched or created? Note `apply_capability` may CREATE the state dir.
+4. If it is not safe as proposed, **is there a cheaper correct variant** — e.g. a
+   fast probe for the replay directory that does not need `plan.source.location`
+   at all?
+
+---
+
+## Deliverable
+
+A markdown file, `specs/021-admission-coverage-honesty/REVIEW-FINDINGS-cursor.md`:
+
+- **Item A verdict** per numbered question: CONFIRMED / PARTIALLY WRONG /
+  REFUTED, each with file:line evidence or a command and its output.
+- **Item B verdict**: is the reorder safe, unsafe, or safe-with-modification?
+  If unsafe, name the invariant it breaks.
+- Anything I missed in either.
+- If your honest answer to Item A is "this leaks something", say so plainly —
+  that is the most valuable outcome available here, and the change should then
+  not land.
+
+## Ground rules
+
+- Read the code before concluding. Every wrong claim in this campaign came from
+  reasoning about behaviour instead of reading the implementation.
+- Do not modify the repository except to write the findings file.
+- The full serial suite is ~16-25 min (`cargo test --all-targets --
+  --test-threads=1`); say whether you ran it rather than assuming.
+- Distinguish what you verified, what you inferred, and what you are guessing.

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1161,7 +1161,22 @@ fn scout_decision_for_discovered(
                 Some(SkipReason::DenylistedExtension)
                 | Some(SkipReason::Untracked)
                 | Some(SkipReason::GeneratedOutput) => MetadataOnlyReason::GeneratedOrVendor,
-                Some(SkipReason::UnsupportedLanguage) | Some(SkipReason::SizeCeiling) | None => {
+                // A >100MB ceiling skip is a SIZE fact and already has a
+                // correct home; it used to land in the text-encoding bucket and
+                // resurface as "unsupported language".
+                Some(SkipReason::SizeCeiling) => MetadataOnlyReason::OversizedData,
+                // Display-only reasons. These are minted by the
+                // disposition->reason mapping for REPORTING and are never
+                // produced by the admission pipeline, so they cannot arrive
+                // here; mapped defensively rather than panicking.
+                Some(SkipReason::UnsupportedTextEncoding)
+                | Some(SkipReason::PolicyWithheld)
+                | Some(SkipReason::LfsPointer)
+                | Some(SkipReason::UnsupportedPath) => MetadataOnlyReason::UnsupportedTextEncoding,
+                // `None` means the reason was NOT RECORDED. It is not evidence
+                // of anything, so it keeps the neutral text-encoding bucket
+                // rather than being promoted into a substantive claim.
+                Some(SkipReason::UnsupportedLanguage) | None => {
                     MetadataOnlyReason::UnsupportedTextEncoding
                 }
             },

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1172,7 +1172,8 @@ fn scout_decision_for_discovered(
                 Some(SkipReason::UnsupportedTextEncoding)
                 | Some(SkipReason::PolicyWithheld)
                 | Some(SkipReason::LfsPointer)
-                | Some(SkipReason::UnsupportedPath) => MetadataOnlyReason::UnsupportedTextEncoding,
+                | Some(SkipReason::UnsupportedPath)
+                | Some(SkipReason::Unreadable) => MetadataOnlyReason::UnsupportedTextEncoding,
                 // `None` means the reason was NOT RECORDED. It is not evidence
                 // of anything, so it keeps the neutral text-encoding bucket
                 // rather than being promoted into a substantive claim.

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -1470,6 +1470,29 @@ pub enum SkipReason {
     /// policy, and `SYMFORGE_INDEX_GENERATED_OUTPUT=1` opts back into full
     /// indexing. Non-git trees are unaffected (fail open: admit).
     GeneratedOutput,
+    /// The admission policy withheld this file. Deliberately NEUTRAL: it does
+    /// not say whether a path rule or a content detector applied, because that
+    /// is the one content-derived bit a disclosed reason could still leak — the
+    /// same property `format::content_withheld_by_admission` protects on the
+    /// read path.
+    ///
+    /// It exists because withholding a reason and ASSERTING A FALSE ONE are not
+    /// the same thing. These files previously reported `UnsupportedLanguage`,
+    /// so a secret-detector verdict on perfectly valid TypeScript or Rust was
+    /// surfaced to callers as "unsupported language" — a positive, wrong claim
+    /// about the file's language. This says only that policy applied.
+    PolicyWithheld,
+    /// The file's bytes are not decodable as searchable text. Distinct from
+    /// [`SkipReason::UnsupportedLanguage`], which means the extension maps to no
+    /// grammar: this one is about the ENCODING, and the language may well be
+    /// supported.
+    UnsupportedTextEncoding,
+    /// Path-shaped admission failures that are NOT content-derived: a platform
+    /// path collision, an undecodable path, or path metadata over the catalog
+    /// bound. Naming these leaks nothing about file contents.
+    UnsupportedPath,
+    /// The file is a Git LFS pointer, so its real bytes are not present locally.
+    LfsPointer,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -1482,6 +1505,10 @@ impl std::fmt::Display for SkipReason {
             SkipReason::DependencyLockfile => write!(f, "lockfile"),
             SkipReason::Untracked => write!(f, "untracked"),
             SkipReason::UnsupportedLanguage => write!(f, "unsupported language"),
+            SkipReason::PolicyWithheld => write!(f, "withheld by admission policy"),
+            SkipReason::UnsupportedTextEncoding => write!(f, "undecodable text encoding"),
+            SkipReason::UnsupportedPath => write!(f, "unsupported path"),
+            SkipReason::LfsPointer => write!(f, "git-lfs pointer"),
             SkipReason::GeneratedOutput => write!(
                 f,
                 "untracked generated output (SYMFORGE_INDEX_GENERATED_OUTPUT=1 to index)"
@@ -2248,5 +2275,60 @@ mod tests {
             }
         ));
         assert_eq!(old_manifest.digest, reworded_manifest.digest);
+    }
+
+    /// A security-policy exclusion must never be reported as a LANGUAGE verdict.
+    ///
+    /// Before this, seven distinct `MetadataOnlyReason`s — including BOTH
+    /// secret-detector outcomes — collapsed into `UnsupportedLanguage`, so a
+    /// detector hit on perfectly valid TypeScript or Rust was surfaced to
+    /// callers as "unsupported language". An external report hit exactly that
+    /// and reasonably concluded the language support was broken.
+    ///
+    /// Withholding a reason is defensible; asserting a false one is not.
+    #[test]
+    fn policy_withheld_never_claims_a_language_problem() {
+        let withheld = SkipReason::PolicyWithheld.to_string();
+        assert!(
+            !withheld.contains("language"),
+            "a policy exclusion must not be reported as a language problem, got: {withheld}"
+        );
+        assert!(
+            !withheld.contains("size") && !withheld.contains("MB"),
+            "and must not be reported as a size problem either, got: {withheld}"
+        );
+
+        // Neutral by design: it must not disclose WHICH policy applied, because
+        // path-rule vs content-detector is the one content-derived bit a
+        // disclosed reason could still leak.
+        for leak in ["path", "content", "secret", "detector", "rule"] {
+            assert!(
+                !withheld.contains(leak),
+                "policy refusal must stay neutral; leaked {leak:?} in: {withheld}"
+            );
+        }
+    }
+
+    /// The non-sensitive reasons are NOT content-derived, so naming them leaks
+    /// nothing — and each must be distinguishable from the others.
+    #[test]
+    fn non_sensitive_skip_reasons_are_distinct_and_honest() {
+        let encoding = SkipReason::UnsupportedTextEncoding.to_string();
+        let language = SkipReason::UnsupportedLanguage.to_string();
+        let path = SkipReason::UnsupportedPath.to_string();
+        let lfs = SkipReason::LfsPointer.to_string();
+
+        // An undecodable ENCODING is not an unsupported LANGUAGE.
+        assert_ne!(encoding, language);
+        assert!(encoding.contains("encoding"), "got: {encoding}");
+        assert!(path.contains("path"), "got: {path}");
+        assert!(lfs.contains("lfs"), "got: {lfs}");
+
+        let all = [&encoding, &language, &path, &lfs];
+        for (i, left) in all.iter().enumerate() {
+            for right in all.iter().skip(i + 1) {
+                assert_ne!(left, right, "skip reasons must not share wording");
+            }
+        }
     }
 }

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -1501,6 +1501,12 @@ pub enum SkipReason {
     UnsupportedPath,
     /// The file is a Git LFS pointer, so its real bytes are not present locally.
     LfsPointer,
+    /// The file could not be read to a stable result: an I/O failure, bytes that
+    /// changed underneath the read, or an aborted scan. Nothing was learned about
+    /// its language or contents, so this asserts only the read outcome. These
+    /// dispositions also used to surface as `UnsupportedLanguage`, which made an
+    /// I/O error look like a grammar SymForge does not support.
+    Unreadable,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -1517,6 +1523,7 @@ impl std::fmt::Display for SkipReason {
             SkipReason::UnsupportedTextEncoding => write!(f, "undecodable text encoding"),
             SkipReason::UnsupportedPath => write!(f, "unsupported path"),
             SkipReason::LfsPointer => write!(f, "git-lfs pointer"),
+            SkipReason::Unreadable => write!(f, "unreadable"),
             SkipReason::GeneratedOutput => write!(
                 f,
                 "untracked generated output (SYMFORGE_INDEX_GENERATED_OUTPUT=1 to index)"
@@ -2317,22 +2324,32 @@ mod tests {
         }
     }
 
-    /// The non-sensitive reasons are NOT content-derived, so naming them leaks
-    /// nothing — and each must be distinguishable from the others.
+    /// The non-sensitive reasons disclose no secret, so naming them is safe —
+    /// and each must be distinguishable from the others. (`LfsPointer` IS
+    /// decided from bytes, but it reveals only that the first <1KiB match the
+    /// PUBLIC LFS pointer grammar; the oid and size it carries never reach a
+    /// caller surface.)
     #[test]
     fn non_sensitive_skip_reasons_are_distinct_and_honest() {
         let encoding = SkipReason::UnsupportedTextEncoding.to_string();
         let language = SkipReason::UnsupportedLanguage.to_string();
         let path = SkipReason::UnsupportedPath.to_string();
         let lfs = SkipReason::LfsPointer.to_string();
+        let unreadable = SkipReason::Unreadable.to_string();
 
         // An undecodable ENCODING is not an unsupported LANGUAGE.
         assert_ne!(encoding, language);
         assert!(encoding.contains("encoding"), "got: {encoding}");
         assert!(path.contains("path"), "got: {path}");
         assert!(lfs.contains("lfs"), "got: {lfs}");
+        // A read that never produced stable bytes learned nothing about the
+        // language, so it must not claim one.
+        assert!(
+            !unreadable.contains("language"),
+            "an unreadable file must not be reported as a language problem, got: {unreadable}"
+        );
 
-        let all = [&encoding, &language, &path, &lfs];
+        let all = [&encoding, &language, &path, &lfs, &unreadable];
         for (i, left) in all.iter().enumerate() {
             for right in all.iter().skip(i + 1) {
                 assert_ne!(left, right, "skip reasons must not share wording");

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -1481,6 +1481,14 @@ pub enum SkipReason {
     /// so a secret-detector verdict on perfectly valid TypeScript or Rust was
     /// surfaced to callers as "unsupported language" — a positive, wrong claim
     /// about the file's language. This says only that policy applied.
+    ///
+    /// What it DOES disclose, stated plainly rather than claimed away: that the
+    /// demotion was a policy one rather than a technical one (encoding, LFS,
+    /// path shape, size). That bit is not new — `admit_disk_read` already
+    /// answers it for any path on request, splitting `content_withheld_by_admission`
+    /// from `content_withheld_unscanned` precisely because the recovery action
+    /// differs. This surfaces the same bit a tool call earlier; it does not
+    /// create it. The bit that stays hidden is path-rule vs content-detector.
     PolicyWithheld,
     /// The file's bytes are not decodable as searchable text. Distinct from
     /// [`SkipReason::UnsupportedLanguage`], which means the extension maps to no

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -3859,9 +3859,8 @@ mod tests {
             | SkipReason::UnsupportedTextEncoding
             | SkipReason::PolicyWithheld
             | SkipReason::LfsPointer
-            | SkipReason::UnsupportedPath => {
-                crate::domain::MetadataOnlyReason::UnsupportedTextEncoding
-            }
+            | SkipReason::UnsupportedPath
+            | SkipReason::Unreadable => crate::domain::MetadataOnlyReason::UnsupportedTextEncoding,
         };
         add_manifest_disposition(
             index,

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -3855,7 +3855,11 @@ mod tests {
             SkipReason::DenylistedExtension
             | SkipReason::Untracked
             | SkipReason::GeneratedOutput => crate::domain::MetadataOnlyReason::GeneratedOrVendor,
-            SkipReason::UnsupportedLanguage => {
+            SkipReason::UnsupportedLanguage
+            | SkipReason::UnsupportedTextEncoding
+            | SkipReason::PolicyWithheld
+            | SkipReason::LfsPointer
+            | SkipReason::UnsupportedPath => {
                 crate::domain::MetadataOnlyReason::UnsupportedTextEncoding
             }
         };

--- a/src/live_index/query.rs
+++ b/src/live_index/query.rs
@@ -1258,10 +1258,10 @@ impl LiveIndex {
     /// Typed per-path admission disposition, read straight off the manifest.
     ///
     /// Deliberately NOT `capture_admission_tier_lookup_view`: that projects through
-    /// `compatibility_admission_decision`, which collapses seven `MetadataOnlyReason`
-    /// variants — including both security variants — into
-    /// `SkipReason::UnsupportedLanguage`. A security decision must never be taken on
-    /// that projection.
+    /// `compatibility_admission_decision`, which collapses both security variants
+    /// into the single reason-free `SkipReason::PolicyWithheld` and drops the
+    /// `rule_id` / `rule_ids` / `finding_count` a decision needs. A security
+    /// decision must never be taken on that projection.
     pub fn capture_file_disposition(
         &self,
         relative_path: &str,

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3441,9 +3441,15 @@ pub(super) fn compatibility_admission_decision(entry: &CatalogEntry) -> Option<A
                 // reported as "unsupported language".
                 MetadataOnlyReason::SensitivePath { .. }
                 | MetadataOnlyReason::SensitiveContent { .. } => SkipReason::PolicyWithheld,
-                // The rest are NOT content-derived, so naming them leaks
-                // nothing and the old collapse only misinformed.
+                // An LFS pointer IS decided from bytes, so naming it is not a
+                // "nothing was read" claim. What it discloses is only that the
+                // first <1KiB match the PUBLIC LFS pointer grammar — a format
+                // class, not file semantics — and the oid/size it carries stay
+                // off this surface.
                 MetadataOnlyReason::LfsPointer { .. } => SkipReason::LfsPointer,
+                // These three are decided from the PATH alone, before any byte
+                // is read, so naming them leaks nothing about contents and the
+                // old collapse only misinformed.
                 MetadataOnlyReason::PlatformPathCollision
                 | MetadataOnlyReason::UnsupportedPathEncoding
                 | MetadataOnlyReason::PathMetadataTooLarge => SkipReason::UnsupportedPath,
@@ -3491,10 +3497,31 @@ fn disposition_from_admission(decision: AdmissionDecision) -> crate::domain::Fil
                 // disposition->reason mapping for REPORTING and are never
                 // produced by the admission pipeline, so they cannot arrive
                 // here; mapped defensively rather than panicking.
+                //
+                // The fallback is itself a false claim — routing `PolicyWithheld`
+                // here would re-label a security demotion "undecodable text
+                // encoding", the same class of lie this commit removes. It is
+                // reachable only if a future caller feeds a display reason back
+                // in, so assert in debug (tests catch it) and stay defensive in
+                // release rather than panicking a live index load.
                 Some(SkipReason::UnsupportedTextEncoding)
                 | Some(SkipReason::PolicyWithheld)
                 | Some(SkipReason::LfsPointer)
-                | Some(SkipReason::UnsupportedPath) => MetadataOnlyReason::UnsupportedTextEncoding,
+                | Some(SkipReason::UnsupportedPath) => {
+                    debug_assert!(
+                        !matches!(
+                            decision.reason,
+                            Some(SkipReason::PolicyWithheld)
+                                | Some(SkipReason::LfsPointer)
+                                | Some(SkipReason::UnsupportedPath)
+                        ),
+                        "display-only SkipReason {:?} round-tripped into a \
+                         MetadataOnlyReason; it would resurface as a false \
+                         encoding verdict",
+                        decision.reason
+                    );
+                    MetadataOnlyReason::UnsupportedTextEncoding
+                }
                 // `None` means the reason was NOT RECORDED. It is not evidence
                 // of anything, so it keeps the neutral text-encoding bucket
                 // rather than being promoted into a substantive claim.
@@ -7724,6 +7751,65 @@ mod tests {
                 .windows(canary.len())
                 .any(|window| window == canary.as_bytes())
         );
+    }
+
+    /// The Display-level tests in `domain::index` pin the WORDING of
+    /// `PolicyWithheld`; they cannot catch a regression that stops producing it.
+    /// This asserts the production projection itself, on entries minted by a
+    /// real admission run: both security variants must reach
+    /// `SkipReason::PolicyWithheld`, and neither may reach
+    /// `SkipReason::UnsupportedLanguage` — the false language verdict that made
+    /// a detector hit on valid source look like a broken grammar.
+    #[test]
+    fn security_demotions_project_to_policy_withheld_not_a_language_verdict() {
+        let tmp = TempDir::new().unwrap();
+        let canary = runtime_canary();
+        let password_kw = ["pass", "word"].concat();
+        let token_kw = ["to", "ken"].concat();
+        write_file(tmp.path(), ".env", &format!("{password_kw}={canary}\n"));
+        // A .rs path CANNOT match a sensitive path rule, so this entry can only
+        // be a content-detector demotion — the exact case TestPilot hit on
+        // valid TypeScript.
+        write_file(
+            tmp.path(),
+            "src/config.rs",
+            &format!("let {token_kw} = \"{canary}\";\n"),
+        );
+
+        let shared = LiveIndex::load(tmp.path()).expect("sensitive fixture must load safely");
+        let index = shared.read();
+
+        for path in [".env", "src/config.rs"] {
+            let entry = index
+                .manifest_entries
+                .iter()
+                .find(|entry| entry.path.normalized_utf8.as_deref() == Some(path))
+                .unwrap_or_else(|| panic!("{path} must remain cataloged"));
+            assert!(
+                matches!(
+                    entry.disposition,
+                    FileDisposition::MetadataOnly {
+                        reason: MetadataOnlyReason::SensitivePath { .. }
+                            | MetadataOnlyReason::SensitiveContent { .. }
+                    }
+                ),
+                "{path} must be a security demotion, got {:?}",
+                entry.disposition
+            );
+
+            let decision = compatibility_admission_decision(entry)
+                .unwrap_or_else(|| panic!("{path} is Tier-2, so it must project a decision"));
+            assert_eq!(
+                decision.reason,
+                Some(SkipReason::PolicyWithheld),
+                "{path} must project to PolicyWithheld"
+            );
+            assert_ne!(
+                decision.reason,
+                Some(SkipReason::UnsupportedLanguage),
+                "{path} must never be reported as a language problem"
+            );
+        }
     }
 
     #[test]

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3463,10 +3463,14 @@ pub(super) fn compatibility_admission_decision(entry: &CatalogEntry) -> Option<A
                 HardSkipReason::ArtifactType => SkipReason::DenylistedExtension,
             },
         ),
+        // An I/O failure, a file that changed mid-read, and an aborted scan are
+        // all "we never got stable bytes" — they say NOTHING about the language.
+        // Reporting them as `UnsupportedLanguage` was the same false diagnosis
+        // this projection used to make about security demotions.
         FileDisposition::Unreadable { .. }
         | FileDisposition::UnstableDuringRead
         | FileDisposition::AbortedCircuitBreaker => {
-            (AdmissionTier::MetadataOnly, SkipReason::UnsupportedLanguage)
+            (AdmissionTier::MetadataOnly, SkipReason::Unreadable)
         }
     };
     Some(AdmissionDecision::skip(tier, reason))
@@ -3507,13 +3511,15 @@ fn disposition_from_admission(decision: AdmissionDecision) -> crate::domain::Fil
                 Some(SkipReason::UnsupportedTextEncoding)
                 | Some(SkipReason::PolicyWithheld)
                 | Some(SkipReason::LfsPointer)
-                | Some(SkipReason::UnsupportedPath) => {
+                | Some(SkipReason::UnsupportedPath)
+                | Some(SkipReason::Unreadable) => {
                     debug_assert!(
                         !matches!(
                             decision.reason,
                             Some(SkipReason::PolicyWithheld)
                                 | Some(SkipReason::LfsPointer)
                                 | Some(SkipReason::UnsupportedPath)
+                                | Some(SkipReason::Unreadable)
                         ),
                         "display-only SkipReason {:?} round-tripped into a \
                          MetadataOnlyReason; it would resurface as a false \

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3432,13 +3432,22 @@ pub(super) fn compatibility_admission_decision(entry: &CatalogEntry) -> Option<A
                         SkipReason::Untracked
                     }
                 }
+                // Sensitive path and sensitive content collapse together ON
+                // PURPOSE: which of the two applied is content-derived, and
+                // that is exactly the bit the read-path refusal also refuses to
+                // disclose. They no longer collapse into a LANGUAGE verdict —
+                // withholding the reason is defensible, asserting a false one
+                // is not, and a detector hit on valid TypeScript used to be
+                // reported as "unsupported language".
                 MetadataOnlyReason::SensitivePath { .. }
-                | MetadataOnlyReason::SensitiveContent { .. }
-                | MetadataOnlyReason::LfsPointer { .. }
-                | MetadataOnlyReason::PlatformPathCollision
+                | MetadataOnlyReason::SensitiveContent { .. } => SkipReason::PolicyWithheld,
+                // The rest are NOT content-derived, so naming them leaks
+                // nothing and the old collapse only misinformed.
+                MetadataOnlyReason::LfsPointer { .. } => SkipReason::LfsPointer,
+                MetadataOnlyReason::PlatformPathCollision
                 | MetadataOnlyReason::UnsupportedPathEncoding
-                | MetadataOnlyReason::PathMetadataTooLarge
-                | MetadataOnlyReason::UnsupportedTextEncoding => SkipReason::UnsupportedLanguage,
+                | MetadataOnlyReason::PathMetadataTooLarge => SkipReason::UnsupportedPath,
+                MetadataOnlyReason::UnsupportedTextEncoding => SkipReason::UnsupportedTextEncoding,
             },
         ),
         FileDisposition::HardSkip { reason } => (
@@ -3474,7 +3483,22 @@ fn disposition_from_admission(decision: AdmissionDecision) -> crate::domain::Fil
                 Some(SkipReason::DenylistedExtension)
                 | Some(SkipReason::GeneratedOutput)
                 | Some(SkipReason::Untracked) => MetadataOnlyReason::GeneratedOrVendor,
-                Some(SkipReason::UnsupportedLanguage) | Some(SkipReason::SizeCeiling) | None => {
+                // A >100MB ceiling skip is a SIZE fact and already has a
+                // correct home; it used to land in the text-encoding bucket and
+                // resurface as "unsupported language".
+                Some(SkipReason::SizeCeiling) => MetadataOnlyReason::OversizedData,
+                // Display-only reasons. These are minted by the
+                // disposition->reason mapping for REPORTING and are never
+                // produced by the admission pipeline, so they cannot arrive
+                // here; mapped defensively rather than panicking.
+                Some(SkipReason::UnsupportedTextEncoding)
+                | Some(SkipReason::PolicyWithheld)
+                | Some(SkipReason::LfsPointer)
+                | Some(SkipReason::UnsupportedPath) => MetadataOnlyReason::UnsupportedTextEncoding,
+                // `None` means the reason was NOT RECORDED. It is not evidence
+                // of anything, so it keeps the neutral text-encoding bucket
+                // rather than being promoted into a substantive claim.
+                Some(SkipReason::UnsupportedLanguage) | None => {
                     MetadataOnlyReason::UnsupportedTextEncoding
                 }
             },

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -13154,7 +13154,11 @@ mod tests {
             SkipReason::DenylistedExtension
             | SkipReason::Untracked
             | SkipReason::GeneratedOutput => crate::domain::MetadataOnlyReason::GeneratedOrVendor,
-            SkipReason::UnsupportedLanguage => {
+            SkipReason::UnsupportedLanguage
+            | SkipReason::UnsupportedTextEncoding
+            | SkipReason::PolicyWithheld
+            | SkipReason::LfsPointer
+            | SkipReason::UnsupportedPath => {
                 crate::domain::MetadataOnlyReason::UnsupportedTextEncoding
             }
         };

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -13160,9 +13160,8 @@ mod tests {
             | SkipReason::UnsupportedTextEncoding
             | SkipReason::PolicyWithheld
             | SkipReason::LfsPointer
-            | SkipReason::UnsupportedPath => {
-                crate::domain::MetadataOnlyReason::UnsupportedTextEncoding
-            }
+            | SkipReason::UnsupportedPath
+            | SkipReason::Unreadable => crate::domain::MetadataOnlyReason::UnsupportedTextEncoding,
         };
         crate::domain::CatalogEntry {
             path: crate::domain::CatalogPath {
@@ -31095,11 +31094,12 @@ mod tests {
 
     #[tokio::test]
     async fn tier2_sweep_never_names_a_security_demoted_file() {
-        // GUARD, not proof of the fix: today this file is excluded only because
-        // `compatibility_admission_decision` mislabels every security demotion as
-        // `SkipReason::UnsupportedLanguage` (SF-DOG-004). Explicit positive
-        // eligibility off the typed disposition must keep it excluded once that
-        // label is corrected.
+        // GUARD, not proof of the fix (SF-DOG-004): exclusion must rest on
+        // explicit positive eligibility off the TYPED disposition, never on the
+        // `SkipReason` projection. It once rested on the projection by accident,
+        // back when that mislabelled every security demotion as
+        // `SkipReason::UnsupportedLanguage`; the label is now `PolicyWithheld`
+        // and this must still hold.
         let dir = tempfile::tempdir().unwrap();
         let canary = runtime_canary();
         std::fs::create_dir_all(dir.path().join("config")).unwrap();

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2787,8 +2787,10 @@ fn find_references_completeness_label(
 /// Candidate eligibility is decided by the caller from the typed manifest
 /// disposition (`LiveIndex::oversized_metadata_only_files`), NOT from the lossy
 /// `SkipReason` projection this used to filter on: that projection collapses
-/// security demotions into `SkipReason::UnsupportedLanguage`, so excluding them
-/// was an accident of mislabelling rather than a decision. Only size-demoted
+/// security demotions into the reason-free `SkipReason::PolicyWithheld` (it
+/// collapsed them into `SkipReason::UnsupportedLanguage` before the admission
+/// honesty fix), so excluding them was an accident of mislabelling rather than
+/// a decision. Only size-demoted
 /// files are reference-relevant anyway — binary, lockfile, and artifact
 /// demotions cannot hold code references to the queried symbol.
 fn tier2_reference_disclosure(


### PR DESCRIPTION
## What was wrong

`compatibility_admission_decision` mapped **seven** distinct `MetadataOnlyReason`
variants onto one `SkipReason::UnsupportedLanguage`, which `Display`s as
`"unsupported language"`.

So a secret-detector verdict on perfectly valid TypeScript or Rust was reported
to callers as a **language** problem. An external consumer (TestPilot) hit this
on two valid `.ts` files and concluded TypeScript support was broken and that a
file-size policy was to blame. Neither was true — their files were 0.33 MB and
0.60 MB against limits of 1 MiB (data) / 4 MiB (code) / 100 MiB (ceiling).

SymForge reproduces it on its own source: `src/live_index/store.rs`, 0.30 MB of
Rust, is withheld the same way.

## What changed

```
SensitivePath | SensitiveContent   -> PolicyWithheld           "withheld by admission policy"
LfsPointer                         -> LfsPointer               "git-lfs pointer"
PlatformPathCollision
  | UnsupportedPathEncoding
  | PathMetadataTooLarge           -> UnsupportedPath          "unsupported path"
UnsupportedTextEncoding            -> UnsupportedTextEncoding  "undecodable text encoding"
Unreadable | UnstableDuringRead
  | AbortedCircuitBreaker          -> Unreadable               "unreadable"
```

`SizeCeiling` also stops folding into the text-encoding bucket (it has a correct
home in `OversizedData`, which the test helpers already used while production did
not), and `None` — "reason not recorded" — stays neutral instead of being
promoted into a substantive diagnosis.

## The property preserved

The two security variants still collapse **together**, so a caller cannot tell
whether a path rule or a content detector fired. That is the one content-derived
bit `format::content_withheld_by_admission` also refuses to disclose on the read
path.

What `PolicyWithheld` does disclose, stated plainly in its doc comment rather
than claimed away: that the demotion was a policy one rather than a technical
one. That bit is **not new** — `admit_disk_read` already answers it for any path
on request, splitting `content_withheld_by_admission` from
`content_withheld_unscanned` because the recovery action differs.

## Review

Three independent reviewers (Cursor 2.5, Grok 4.5, Kimi) against a written
adversarial brief. Verdict 2-1 to land; the dissent argued the narrowing creates
a `SensitiveContent` oracle on innocuous paths. Answered with the read-gate
evidence above, and independently by the third reviewer, who noted the old label
was self-refuting anyway: "unsupported language" on a `.rs`/`.ts` file could only
ever have been the hidden bucket.

Every actionable finding landed:

- **Projection test** over entries from a real `LiveIndex::load`, including a
  `.rs` path that cannot match a path rule and so can only be a content
  demotion. The Display-only tests would have stayed green through a forward-map
  regression.
- **`Unreadable`** — a third reviewer found the same lie behind a different door:
  an I/O failure, a file changed mid-read, and an aborted scan were all reported
  as an unsupported grammar.
- **LFS claim corrected** — `detect_lfs_pointer` reads bytes; it discloses only
  that the first <1 KiB match the public LFS grammar.
- **`debug_assert`** on the display-only round-trip in `disposition_from_admission`,
  which would otherwise relabel a security demotion "undecodable text encoding".
- Stale comments describing the pre-fix collapse refreshed.

Declined, unanimously endorsed as correct: machine-readable exclusion codes,
bounded Tier-2 reads (Tier-2 includes `SensitiveContent`), and `force_admit`.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and
`cargo test --all-targets -- --test-threads=1` all clean locally
(116 result groups, 0 failures, ~17.7 min).

Review briefs and all three findings files are included under
`specs/021-admission-coverage-honesty/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
