### PR TITLE
perf(curation): probe the replay dir before computing a curation plan

### DIFF
--- a/src/protocol/knowledge_curation.rs
+++ b/src/protocol/knowledge_curation.rs
@@ -282,6 +282,13 @@ impl KnowledgeCurationCoordinator {
     /// that project begins serving tool calls. Failures remain represented in
     /// the replay store and health surface; callers may keep read-only service
     /// available while curation stays fail-closed.
+    ///
+    /// One deliberate observability change came with the replay-directory probe
+    /// below: on a project with nothing to recover, a plan that WOULD have
+    /// errored is no longer computed, so its warning is no longer logged at
+    /// startup. Nothing consumed that plan on this path, and the same error
+    /// resurfaces on the first `review_knowledge` call, so this trades a
+    /// startup warning nothing acted on for ~3.8s of cold-start latency.
     pub(crate) fn recover_on_project_load(
         &self,
         index: &SharedIndex,
@@ -289,31 +296,63 @@ impl KnowledgeCurationCoordinator {
         state_placement: Option<&StatePlacement>,
         persistence_health: CapabilityStatus,
     ) -> Result<(), String> {
-        // This call is 99.2% of `serve: runtime built` on a genuinely-cold
-        // index (2.76s of 2.78s) yet ~free on a snapshot restore. On a fresh
-        // project `.symforge/` holds no curation dir, so the `replay_dir`
-        // early-return below fires and none of the recovery work runs — which
-        // means the whole cost is in the three calls above it. Name them.
         let phase = std::time::Instant::now();
         let generation = index.published_source_set().current_generation();
         tracing::info!("curation/published source set in {:?}", phase.elapsed());
 
-        let phase = std::time::Instant::now();
-        let plan = curation_plan_current(&generation)?;
-        tracing::info!("curation/plan current in {:?}", phase.elapsed());
+        // A project with no curation replay directory has nothing to recover,
+        // and answering that costs one `is_dir()` off the state placement.
+        //
+        // This used to sit AFTER `curation_plan_current`, which is ~3.8s on a
+        // genuinely-cold index — 99.9% of startup curation recovery, itself
+        // 99.2% of `serve: runtime built` — and whose only contribution here was
+        // `plan.source.location`, feeding a single
+        // `matches!(.., SourceLocation::WorkingTree { .. })` in
+        // `apply_capability`. So a full remediation review ran to completion and
+        // was then discarded because there was no replay directory to apply it
+        // to. Nothing is skipped by probing first: `apply_capability` CREATES
+        // nothing (five capability checks and two `fs::metadata` reads);
+        // directory creation lives in `prepare_mutation` and
+        // `probe_apply_directories`, both of which are still gated behind the
+        // replay-directory check below.
+        //
+        // The plan that actually guards recovery is the one taken INSIDE the
+        // lock, against the generation observed there — it is unchanged.
+        if let Some(directory) = state_placement.and_then(StatePlacement::directory)
+            && !directory
+                .as_path()
+                .join(CURATION_STATE_DIR)
+                .join(REPLAY_DIR)
+                .is_dir()
+        {
+            tracing::info!("curation/no replay dir — early return (probed)");
+            return Ok(());
+        }
+
+        // Identical to what the discarded plan carried: `curation_plan_current`
+        // clones this straight off the generation, and `capability_status`
+        // already resolves it exactly this way. Same absent-source error.
+        let source_location = generation
+            .source
+            .as_ref()
+            .map(|source| &source.location)
+            .ok_or_else(|| "Curation unavailable: source identity is absent.".to_string())?;
 
         let phase = std::time::Instant::now();
         let state_dir = apply_capability(
             repo_root,
             state_placement,
             persistence_health,
-            &plan.source.location,
+            source_location,
         )
         .map_err(unavailable)?;
         tracing::info!("curation/apply capability in {:?}", phase.elapsed());
 
         let curation_dir = state_dir.join(CURATION_STATE_DIR);
         let replay_dir = curation_dir.join(REPLAY_DIR);
+        // Re-checked against the RESOLVED state dir: the probe above is skipped
+        // when the placement carries no directory, and a replay dir can appear
+        // between the two checks.
         if !replay_dir.is_dir() {
             tracing::info!("curation/no replay dir — early return");
             return Ok(());
@@ -326,6 +365,8 @@ impl KnowledgeCurationCoordinator {
             .map_err(|error| durable_state_error(&error))?;
         let result = (|| {
             let generation = index.published_source_set().current_generation();
+            // The fail-closed re-validation, under the lock, against the
+            // generation observed inside it.
             let _plan = curation_plan_current(&generation)?;
             self.recover_pending_records(repo_root, &curation_dir, &replay_dir, &generation)
         })();


### PR DESCRIPTION
## The problem

`recover_on_project_load` computed `curation_plan_current` **first**, and only
then checked whether there was a replay directory to apply anything to.

On a genuinely-cold index that plan is ~3.5 s — effectively all of startup
curation recovery, itself ~98% of `serve: runtime built`. On a fresh project its
only contribution was `plan.source.location`, feeding a single
`matches!(.., SourceLocation::WorkingTree { .. })` inside `apply_capability`. So
a full remediation review ran to completion and was then discarded because there
was nothing to replay.

## The change

Probe the replay directory from `state_placement` first — one `is_dir()` — and
resolve the source location straight off the generation, exactly as
`capability_status` already does (`knowledge_curation.rs:250`).

The outer plan is **deleted, not moved**. The plan that guards recovery is the
one taken *inside* the lock against the generation observed there, and it is
untouched. That means this also reclaims the cost on the **recovery** path,
where the plan was previously computed twice against the same generation.

Safe because `apply_capability` **creates nothing** — five capability checks and
two `fs::metadata` reads. Directory creation lives in `prepare_mutation` and
`probe_apply_directories`, both still gated behind the replay-directory check.
The check against the resolved state dir is kept for the TOCTOU window.

## Measured

Release build, genuinely-cold worktree (no `.symforge/`), **both sides built and
run in the same session on the same fixture**, 3 samples each:

| | before (mean) | after (mean) |
|---|---|---|
| `curation/plan current` | 3.525 s (3.55 / 3.92 / 3.11) | *not called* |
| `recover_on_project_load` | **3.528 s** (3.55 / 3.92 / 3.11) | **68.7 µs** (85.3 / 58.1 / 62.8 µs) |
| `serve: runtime built` | **3.591 s** (3.65 / 3.96 / 3.17) | **42.7 ms** (32.96 / 59.38 / 35.82 ms) |

Baseline spread is 3.11–3.96 s, so single-sample numbers are not meaningful
here; these are means over 3 cold runs per side.

## Behaviour change, stated explicitly

On a project with nothing to recover, a plan that *would* have errored is no
longer computed, so its startup warning is no longer logged. Nothing consumed
that plan on this path, and the same error resurfaces on the first
`review_knowledge` call. This is recorded in the function's doc comment rather
than left to be discovered.

## Review

Reviewed independently by Cursor 2.5, Grok 4.5 and Kimi against a written brief.
All three converged on this same shape without conferring; two additionally
identified the duplicate plan computation on the recovery path. All three
refuted the objection that had blocked this change earlier — that
`apply_capability` might create the state directory.

Findings are in `specs/021-admission-coverage-honesty/` (landed in #530).

## Verification

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
`project_startup_recovers_pending_write_before_serving_tools` — which builds a
crash fixture *with* a replay record and asserts recovery terminalizes it — is
the guard for the dangerous direction, and passes along with the other 22
curation tests. Full serial suite running locally alongside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
