### PR TITLE
fix(embed)!: mark SkipReason non_exhaustive before more variants land

### DIFF
--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -1436,7 +1436,21 @@ pub enum AdmissionTier {
 }
 
 /// Reason a file was placed in Tier 2 or Tier 3.
+///
+/// `#[non_exhaustive]`: this enum is reachable from the semver-public embed
+/// facade (`symforge::embed` re-exports the `domain` module wholesale), and it
+/// gains variants whenever admission learns to be more honest about WHY a file
+/// was demoted — five were added in one change alone. Without this, every such
+/// addition is a breaking change for any downstream crate that matches on it
+/// exhaustively. Adding it is a one-time break so that later additions are not.
+///
+/// Callers inside this crate are unaffected: `#[non_exhaustive]` constrains
+/// downstream crates only, so the exhaustive matches in `store.rs`,
+/// `discovery/mod.rs` and the test helpers still compile — and still fail the
+/// build when a new variant is added, which is exactly the guard that has
+/// caught missed mapping sites twice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SkipReason {
     SizeCeiling,
     DenylistedExtension,


### PR DESCRIPTION
## The problem

`SkipReason` is reachable from the **semver-public** embed facade — `src/embed.rs` re-exports the `domain` module wholesale, so `symforge::embed::domain::index::SkipReason` is nameable and, until now, **exhaustively matchable** by downstream crates.

That made the five variants added by #530 (`PolicyWithheld`, `UnsupportedTextEncoding`, `UnsupportedPath`, `LfsPointer`, `Unreadable`) a latent **semver-major**.

This enum exists to describe *why* admission demoted a file. It will keep gaining variants every time that story gets more honest — and each addition silently breaks any consumer matching exhaustively. Better to take the break once, deliberately, so later additions are additive.

## Why internal code is unaffected

`#[non_exhaustive]` constrains **downstream** crates only. The exhaustive matches in `store.rs`, `discovery/mod.rs` and the test helpers still compile — and still fail the build when a variant is added, which is exactly the guard that caught missed mapping sites twice during #530.

## Verification

`cargo clippy --all-targets -- -D warnings` clean. That is the load-bearing check here: `--all-targets` compiles `tests/` as **separate crates**, so any integration test matching the enum exhaustively would have broken. None do.

`cargo fmt --check` clean.

## Provenance

Found by an embed-surface reach audit tracing what a library consumer can actually observe. The reach chain is real and every hop was read:

```
SkipReason Display            domain/index.rs:1512
  <- compatibility_admission_decision   store.rs:3401
  <- metadata_only_skipped_paths        query.rs:1243   (.map(|r| r.to_string()))
  <- SearchFilesHit.metadata_reason     query.rs:949    (pub field)
  <- SearchFilesView::Found{hits}       query.rs:952-964
  <- capture_search_files_view          query.rs:1549   (pub, ungated)
  <- embed.rs:38-39
```

The same audit cleared the sibling question: #532''s curation change lives under `#[cfg(feature = "server")] pub mod protocol;` (`lib.rs:59-60`), so it does not exist in an embed build at all — structural non-reach, not inference.

## Not addressed here

`SearchFilesView` and `SearchFilesHit` have the same exposure (public enum with a public `Vec<SearchFilesHit>` variant field; public struct fields) and no `#[non_exhaustive]`. Adding fields or variants there is equally breaking. Left alone deliberately — that is a pre-existing surface decision rather than a hazard this change introduced, and it deserves its own call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)