### PR TITLE
fix!: report only work that was actually verified (daemon identity, trust envelope, reconciliation, project routing)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -88,6 +88,12 @@ fn read_daemon_runtime(dir: &std::path::Path, tagged: &str, legacy: &str) -> io:
         Err(e) => Err(e),
     }
 }
+/// Set once this process binds AS the daemon (see `spawn_daemon_at`, where it
+/// writes its own pid file). Only a bound daemon can become an orphan, so
+/// [`unrecorded_daemon_pid`] stays silent for every other topology — stdio,
+/// embed, and the MCP adapter front-end.
+static DAEMON_BOUND: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 const DAEMON_BIND_ENV: &str = "SYMFORGE_DAEMON_BIND";
 const DAEMON_ALLOW_NON_LOOPBACK_ENV: &str = "SYMFORGE_DAEMON_ALLOW_NON_LOOPBACK";
 /// Task 9: seconds a session may go without a heartbeat before the daemon
@@ -2550,6 +2556,14 @@ async fn stop_incompatible_recorded_daemon_at(
         return Ok(());
     }
 
+    // Tracks whether the incompatible daemon is CONFIRMED gone. Only then may
+    // its runtime records be removed: deleting them while it still runs makes it
+    // undiscoverable AND unstoppable — `stop_incompatible_recorded_daemon_at`
+    // returns early on a missing port file, so no later call can ever reap it —
+    // while it keeps serving its own index to every client already connected.
+    // The same reasoning is already written down for `DaemonStopOutcome::
+    // StopTimedOut`, which deliberately leaves the files in place.
+    let mut confirmed_gone = false;
     if let Ok(pid) = read_daemon_pid_file_at(control_state_dir) {
         if should_terminate_recorded_daemon(&health, identity, pid) {
             if let Err(error) = terminate_process(pid) {
@@ -2558,7 +2572,15 @@ async fn stop_incompatible_recorded_daemon_at(
                     "failed to terminate incompatible symforge daemon automatically: {error}"
                 );
             }
-            wait_for_daemon_unhealthy(port).await;
+            confirmed_gone = wait_for_daemon_unhealthy(port).await;
+            if !confirmed_gone {
+                tracing::warn!(
+                    pid,
+                    port,
+                    "incompatible symforge daemon still answering after termination; \
+                     leaving its runtime records so it stays discoverable and stoppable"
+                );
+            }
         } else if !daemon_health_matches_recorded_pid(&health, pid) {
             match health.pid {
                 Some(health_pid) => {
@@ -2586,7 +2608,9 @@ async fn stop_incompatible_recorded_daemon_at(
         }
     }
 
-    cleanup_daemon_runtime_files_at(control_state_dir);
+    if confirmed_gone {
+        cleanup_daemon_runtime_files_at(control_state_dir);
+    }
     Ok(())
 }
 
@@ -2722,14 +2746,19 @@ fn process_is_alive(pid: u32) -> bool {
     }
 }
 
-async fn wait_for_daemon_unhealthy(port: u16) {
+/// Wait for `port` to stop answering health checks. Returns whether it actually
+/// did: callers use this to decide if a daemon is CONFIRMED gone, and a timeout
+/// must never be mistaken for success — removing a live daemon's runtime records
+/// orphans it permanently.
+async fn wait_for_daemon_unhealthy(port: u16) -> bool {
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
     while tokio::time::Instant::now() < deadline {
         if !daemon_health_ok(port).await {
-            break;
+            return true;
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
+    !daemon_health_ok(port).await
 }
 
 fn try_acquire_start_lock_at(
@@ -3498,6 +3527,10 @@ pub async fn spawn_daemon_at(
     write_daemon_token_file_at(control_state_dir, &auth_token)?;
     write_daemon_port_file_at(control_state_dir, port)?;
     write_daemon_pid_file_at(control_state_dir, std::process::id())?;
+    // This process is now A daemon. Whether it is still THE recorded daemon is
+    // re-checked per `status` call — a later incompatible start can orphan us
+    // (see `unrecorded_daemon_pid`).
+    DAEMON_BOUND.store(true, std::sync::atomic::Ordering::Release);
 
     let state = Arc::new(DaemonState::with_token_at(
         auth_token,
@@ -5479,6 +5512,42 @@ fn read_daemon_pid_file_at(control_state_dir: &ControlStateDir) -> io::Result<u3
 
 pub(crate) fn read_daemon_port_file() -> io::Result<u16> {
     read_daemon_port_file_at(process_control_state_dir()?)
+}
+
+/// This process's pid when it is a daemon that is NO LONGER the recorded one —
+/// an ORPHAN: still alive, still answering everyone already connected, but
+/// undiscoverable, so its index silently diverges from the daemon new clients
+/// reach.
+///
+/// Orphans are routine, not exotic. `stop_incompatible_recorded_daemon_at`
+/// cleans up the runtime files whether or not the incompatible daemon actually
+/// died — the safety gate refuses on a pid/executable mismatch, and
+/// `terminate_process` can simply fail — so the survivor keeps serving with no
+/// record pointing at it. Upgrading symforge is the common trigger, because the
+/// version check makes the running daemon "incompatible"; a session that
+/// updates several times can accumulate several orphans, each holding a full
+/// index.
+///
+/// Callers cannot otherwise tell which instance answered them, which is what
+/// makes this worth disclosing: an orphan's replies are internally consistent
+/// and confidently wrong about the world.
+///
+/// `None` for the recorded daemon and for every non-daemon process.
+pub(crate) fn unrecorded_daemon_pid() -> Option<u32> {
+    if !DAEMON_BOUND.load(std::sync::atomic::Ordering::Acquire) {
+        return None;
+    }
+    let me = std::process::id();
+    let recorded = process_control_state_dir()
+        .ok()
+        .and_then(|dir| read_daemon_pid_file_at(dir).ok());
+    match recorded {
+        Some(pid) if pid == me => None,
+        // Either another daemon owns the record, or the record is gone
+        // entirely (the cleanup-regardless path above). Both mean new clients
+        // cannot reach us.
+        _ => Some(me),
+    }
 }
 
 fn read_daemon_port_file_at(control_state_dir: &ControlStateDir) -> io::Result<u16> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3793,21 +3793,59 @@ async fn call_tool_handler(
             return Ok(message.into_response());
         }
     }
-    if matches!(tool_name.as_str(), "search_knowledge" | "review_knowledge") {
-        let (project, projects) = if tool_name == "search_knowledge" {
-            let input =
-                decode_params::<SearchKnowledgeInput>(params.clone()).map_err(bad_request)?;
-            if let Err(message) = crate::protocol::knowledge_search::validate_input(&input) {
-                return Ok(message.into_response());
+    if matches!(
+        tool_name.as_str(),
+        "search_knowledge"
+            | "review_knowledge"
+            | "search_symbols"
+            | "search_text"
+            | "search_files"
+            | "find_references"
+    ) {
+        let (project, projects) = match tool_name.as_str() {
+            "search_knowledge" => {
+                let input =
+                    decode_params::<SearchKnowledgeInput>(params.clone()).map_err(bad_request)?;
+                if let Err(message) = crate::protocol::knowledge_search::validate_input(&input) {
+                    return Ok(message.into_response());
+                }
+                (input.project, input.projects)
             }
-            (input.project, input.projects)
-        } else {
-            let input =
-                decode_params::<ReviewKnowledgeInput>(params.clone()).map_err(bad_request)?;
-            if let Err(message) = crate::protocol::knowledge_review::validate_input(&input) {
-                return Ok(message.into_response());
+            "review_knowledge" => {
+                let input =
+                    decode_params::<ReviewKnowledgeInput>(params.clone()).map_err(bad_request)?;
+                if let Err(message) = crate::protocol::knowledge_review::validate_input(&input) {
+                    return Ok(message.into_response());
+                }
+                (input.project, input.projects)
             }
-            (input.project, input.projects)
+            // The cross-project code-navigation verbs accept the SAME id/name
+            // selectors but carry different input types, and they are
+            // deliberately absent from `single_project_routed_tool`, so they
+            // never met `runtime_for_target` — the only name->id resolver in the
+            // tree. A project opened by `index_folder(add: true)`, whose receipt
+            // advertises `project_name`, was therefore denied as "project not
+            // open" when that same name was used as a selector.
+            //
+            // Read the selectors straight off the JSON rather than adding a
+            // typed arm per verb: the write-back below already edits this same
+            // object, and the knowledge validation above stays scoped to the
+            // knowledge verbs that require it.
+            _ => (
+                params
+                    .get("project")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                params.get("projects").and_then(|value| {
+                    value.as_array().map(|items| {
+                        items
+                            .iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(str::to_string)
+                            .collect::<Vec<_>>()
+                    })
+                }),
+            ),
         };
 
         // `search_knowledge` owns both scalar and set-valued targeting, so it
@@ -4015,13 +4053,24 @@ async fn call_tool_handler(
         .await
     {
         Ok(Ok(mut result)) => {
-            // Task 7: full-surface `health`/`health_compact` gain the session's
-            // open-project inventory once MORE than one project is open — the
-            // full 39-tool surface can then list and select projects without the
-            // compact `status` tool. Single-project sessions stay byte-identical.
-            if matches!(tool_name_for_panic.as_str(), "health" | "health_compact")
-                && let Some(inventory) =
-                    state.render_session_project_inventory_if_multi(&session_id)
+            // Task 7: `health`/`health_compact` gain the session's open-project
+            // inventory once MORE than one project is open. Single-project
+            // sessions stay byte-identical.
+            //
+            // `status` is included for the same reason, not despite it: on the
+            // compact-3 surface `status` is the ONLY health verb an agent has,
+            // and every detail level except "projects" dispatches per-project
+            // against the immutable home — so a project opened by
+            // `index_folder(add: true)` was invisible BY CONSTRUCTION there. An
+            // additive open that reports success and then cannot be observed is
+            // the same silent-divergence class as an orphaned daemon.
+            // `status(detail="projects")` is intercepted before dispatch, so it
+            // never reaches here and cannot double-append.
+            if matches!(
+                tool_name_for_panic.as_str(),
+                "health" | "health_compact" | "status"
+            ) && let Some(inventory) =
+                state.render_session_project_inventory_if_multi(&session_id)
             {
                 result.push('\n');
                 result.push_str(&inventory);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2556,14 +2556,23 @@ async fn stop_incompatible_recorded_daemon_at(
         return Ok(());
     }
 
-    // Tracks whether the incompatible daemon is CONFIRMED gone. Only then may
-    // its runtime records be removed: deleting them while it still runs makes it
-    // undiscoverable AND unstoppable — `stop_incompatible_recorded_daemon_at`
-    // returns early on a missing port file, so no later call can ever reap it —
-    // while it keeps serving its own index to every client already connected.
-    // The same reasoning is already written down for `DaemonStopOutcome::
-    // StopTimedOut`, which deliberately leaves the files in place.
-    let mut confirmed_gone = false;
+    // Whether to clear the runtime record afterwards.
+    //
+    // Clearing it while the daemon is STILL ALIVE and identifiable orphans it:
+    // this function returns early on a missing port file, so no later call can
+    // ever reap it, and it keeps serving its own index to every client already
+    // connected — invisibly, because nothing in a response says which instance
+    // answered. The same reasoning is already written down for
+    // `DaemonStopOutcome::StopTimedOut`, which deliberately leaves the files in
+    // place.
+    //
+    // The default stays `true`, because a record we cannot act on is worse than
+    // no record: with no pid file (and health reporting no pid) the process is
+    // unidentifiable, so keeping the record makes it no more stoppable — it only
+    // makes every later call re-walk the same dead end. We withhold cleanup
+    // strictly for a daemon we tried to kill and failed, or deliberately
+    // declined to kill; those are live, identified, and worth keeping visible.
+    let mut clear_record = true;
     if let Ok(pid) = read_daemon_pid_file_at(control_state_dir) {
         if should_terminate_recorded_daemon(&health, identity, pid) {
             if let Err(error) = terminate_process(pid) {
@@ -2572,8 +2581,8 @@ async fn stop_incompatible_recorded_daemon_at(
                     "failed to terminate incompatible symforge daemon automatically: {error}"
                 );
             }
-            confirmed_gone = wait_for_daemon_unhealthy(port).await;
-            if !confirmed_gone {
+            if !wait_for_daemon_unhealthy(port).await {
+                clear_record = false;
                 tracing::warn!(
                     pid,
                     port,
@@ -2582,6 +2591,7 @@ async fn stop_incompatible_recorded_daemon_at(
                 );
             }
         } else if !daemon_health_matches_recorded_pid(&health, pid) {
+            clear_record = false;
             match health.pid {
                 Some(health_pid) => {
                     tracing::warn!(
@@ -2598,6 +2608,7 @@ async fn stop_incompatible_recorded_daemon_at(
                 }
             }
         } else {
+            clear_record = false;
             tracing::warn!(
                 recorded_pid = pid,
                 daemon_pid = ?health.pid,
@@ -2608,7 +2619,7 @@ async fn stop_incompatible_recorded_daemon_at(
         }
     }
 
-    if confirmed_gone {
+    if clear_record {
         cleanup_daemon_runtime_files_at(control_state_dir);
     }
     Ok(())

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -868,7 +868,14 @@ pub struct FileStamp {
     pub platform_id: Option<PlatformFileId>,
 }
 
+/// Why a file was admitted metadata-only (Tier 2).
+///
+/// `#[non_exhaustive]`: this is reachable from the semver-public embed facade
+/// and gains variants as admission learns to describe itself more precisely.
+/// Taking the break once keeps every later addition additive — the same
+/// reasoning applied to `SkipReason`.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum MetadataOnlyReason {
     Lockfile,
     Binary,
@@ -885,7 +892,6 @@ pub enum MetadataOnlyReason {
         declared_oid: Option<String>,
         declared_size: Option<u64>,
     },
-    PlatformPathCollision,
     UnsupportedPathEncoding,
     PathMetadataTooLarge,
     UnsupportedTextEncoding,

--- a/src/live_index/persist.rs
+++ b/src/live_index/persist.rs
@@ -2402,6 +2402,22 @@ async fn background_verify_with_hook<F>(
     // 3. Re-parse changed files. Reindexing routes through the watcher's
     //    admission path; embed has no watcher, so changed/new files are
     //    detected but not re-parsed here (reconciliation is server-only).
+    // Files the re-parse did NOT actually reconcile.
+    //
+    // `admit_and_index_single_path` can return `Skipped` (its publication CAS
+    // lost `MAX_PUBLICATION_ATTEMPTS` times), `ReadError`, or `NotFound` — none
+    // of which refresh the index. That result used to be discarded, so a FAILED
+    // re-parse was indistinguishable from a successful one, the file fell out of
+    // the mismatch set below, and freshness resolved to `Current` over rows that
+    // were never refreshed. Right file, pre-edit anchors, index reporting
+    // healthy — and `Current` is exactly what makes the result envelope collapse
+    // to its confident one-line form.
+    //
+    // Only `Reindexed` and `HashSkip` mean the file is genuinely in sync;
+    // everything else is folded back into the mismatch set so freshness degrades
+    // honestly instead of asserting a currency nothing established.
+    #[cfg(feature = "server")]
+    let mut unreconciled: Vec<String> = Vec::new();
     #[cfg(feature = "server")]
     {
         let to_reparse: Vec<String> = stat_result
@@ -2415,12 +2431,16 @@ async fn background_verify_with_hook<F>(
                 return;
             }
             let abs_path = root.join(rel_path.replace('/', std::path::MAIN_SEPARATOR_STR));
-            let _ = crate::watcher::admit_and_index_single_path(
+            match crate::watcher::admit_and_index_single_path(
                 rel_path,
                 &abs_path,
                 &index,
                 expected_gen,
-            );
+            ) {
+                crate::watcher::ReindexResult::Reindexed
+                | crate::watcher::ReindexResult::HashSkip => {}
+                _ => unreconciled.push(rel_path.clone()),
+            }
             if index.current_project_generation() != expected_gen {
                 return;
             }
@@ -2446,12 +2466,18 @@ async fn background_verify_with_hook<F>(
                 return;
             }
             let abs_path = root.join(rel_path.replace('/', std::path::MAIN_SEPARATOR_STR));
-            let _ = crate::watcher::admit_and_index_single_path(
+            match crate::watcher::admit_and_index_single_path(
                 rel_path,
                 &abs_path,
                 &index,
                 expected_gen,
-            );
+            ) {
+                crate::watcher::ReindexResult::Reindexed
+                | crate::watcher::ReindexResult::HashSkip => {}
+                // Same reasoning as the changed/new loop above: a spot-check
+                // mismatch whose re-parse did not land is still a mismatch.
+                _ => unreconciled.push(rel_path.clone()),
+            }
             if index.current_project_generation() != expected_gen {
                 return;
             }
@@ -2469,6 +2495,21 @@ async fn background_verify_with_hook<F>(
         let mut mismatches = spot_mismatches;
         mismatches.extend(stat_result.changed);
         mismatches.extend(stat_result.new_files);
+        mismatches.sort();
+        mismatches.dedup();
+        mismatches
+    };
+
+    // Under `server` the re-parse above ran, but running is not succeeding: fold
+    // back everything it failed to reconcile. Previously this arm did not exist,
+    // on the assumption — stated in the comment above — that "under `server`
+    // those files were re-parsed above, so they are correctly not mismatches".
+    // That was an assumption, never a check, and `server` is a default feature,
+    // so the honest-degradation path existed only in builds nobody ships.
+    #[cfg(feature = "server")]
+    let spot_mismatches = {
+        let mut mismatches = spot_mismatches;
+        mismatches.extend(unreconciled);
         mismatches.sort();
         mismatches.dedup();
         mismatches

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -2951,17 +2951,35 @@ impl SharedIndexHandle {
                 coverage: history_coverage,
             })
         };
-        let bridge = source
-            .as_deref()
-            .map(|source| {
-                Arc::new(build_knowledge_bridge(
-                    &live,
-                    source,
-                    content_generation,
-                    &BridgeLimits::default(),
-                ))
-            })
-            .unwrap_or_else(|| Arc::new(KnowledgeBridge::default()));
+        // The bridge is a pure function of (live content, source identity,
+        // content_generation) — `repeated_equal_generations_produce_identical_
+        // order_and_ids` pins exactly that determinism. On a retaining-content
+        // publish none of those three move, so rebuilding every card reproduces
+        // the value already held.
+        //
+        // Worth doing rather than filing as micro-optimization: publication is
+        // the dominant cost on BOTH the cold and warm paths, and the bridge is
+        // ~56% of publication (~5.5k cards on this repo). Every
+        // retaining-content publish — git temporal's two per startup, each
+        // freshness transition — was paying that in full for a result equal to
+        // the one it replaced.
+        //
+        // Same discipline as `code_signals` above, which already reuses its
+        // snapshot when its input is unchanged; the source-identity equality is
+        // belt-and-braces, since a content-preserving publish should not move
+        // the source either.
+        let bridge = match source.as_deref() {
+            Some(source) if !content_changed && previous.source.as_deref() == Some(source) => {
+                Arc::clone(&previous.bridge)
+            }
+            Some(source) => Arc::new(build_knowledge_bridge(
+                &live,
+                source,
+                content_generation,
+                &BridgeLimits::default(),
+            )),
+            None => Arc::new(KnowledgeBridge::default()),
+        };
         let authority = build_published_authority(
             &live,
             source.as_deref(),

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3447,11 +3447,10 @@ pub(super) fn compatibility_admission_decision(entry: &CatalogEntry) -> Option<A
                 // class, not file semantics — and the oid/size it carries stay
                 // off this surface.
                 MetadataOnlyReason::LfsPointer { .. } => SkipReason::LfsPointer,
-                // These three are decided from the PATH alone, before any byte
-                // is read, so naming them leaks nothing about contents and the
-                // old collapse only misinformed.
-                MetadataOnlyReason::PlatformPathCollision
-                | MetadataOnlyReason::UnsupportedPathEncoding
+                // These two are decided from the PATH alone, before any byte is
+                // read, so naming them leaks nothing about contents and the old
+                // collapse only misinformed.
+                MetadataOnlyReason::UnsupportedPathEncoding
                 | MetadataOnlyReason::PathMetadataTooLarge => SkipReason::UnsupportedPath,
                 MetadataOnlyReason::UnsupportedTextEncoding => SkipReason::UnsupportedTextEncoding,
             },

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -368,21 +368,54 @@ impl ParseQuarantineSummary {
         let omitted = self
             .total_count
             .saturating_sub(self.display_offset.saturating_add(shown));
-        format!(
-            "total={} unexpected_partial={} expected_vendor_partial={} expected_generated_partial={} expected_test_fixture_partial={} expected_template_dsl_partial={} expected_framework_partial={} expected_language_partial={} failed={} showing={} offset={} omitted={}",
-            self.total_count,
-            self.unexpected_partial_count,
-            self.expected_vendor_partial_count,
-            self.expected_generated_partial_count,
-            self.expected_test_fixture_partial_count,
-            self.expected_template_dsl_partial_count,
-            self.expected_framework_partial_count,
-            self.expected_language_partial_count,
-            self.failed_count,
-            shown,
-            self.display_offset,
-            omitted,
-        )
+        // `total`, `unexpected_partial`, `failed` and the window fields are
+        // always reported: they are what a caller acts on, and a zero in any of
+        // them is itself the answer.
+        //
+        // The expected_* categories are not. They are almost always zero, and
+        // this header spent six of its twelve fields saying so — on this repo
+        // that is roughly half the line conveying nothing. Emit only the
+        // categories that actually have entries; an absent category means zero,
+        // exactly as it does for the summary line above.
+        let mut parts = vec![
+            format!("total={}", self.total_count),
+            format!("unexpected_partial={}", self.unexpected_partial_count),
+        ];
+        for (label, count) in [
+            (
+                "expected_vendor_partial",
+                self.expected_vendor_partial_count,
+            ),
+            (
+                "expected_generated_partial",
+                self.expected_generated_partial_count,
+            ),
+            (
+                "expected_test_fixture_partial",
+                self.expected_test_fixture_partial_count,
+            ),
+            (
+                "expected_template_dsl_partial",
+                self.expected_template_dsl_partial_count,
+            ),
+            (
+                "expected_framework_partial",
+                self.expected_framework_partial_count,
+            ),
+            (
+                "expected_language_partial",
+                self.expected_language_partial_count,
+            ),
+        ] {
+            if count > 0 {
+                parts.push(format!("{label}={count}"));
+            }
+        }
+        parts.push(format!("failed={}", self.failed_count));
+        parts.push(format!("showing={shown}"));
+        parts.push(format!("offset={}", self.display_offset));
+        parts.push(format!("omitted={omitted}"));
+        parts.join(" ")
     }
 
     /// Paths in the CURRENT display window. Used by the per-category health
@@ -2636,15 +2669,57 @@ pub fn health_report_from_stats_windowed(
     }
 
     if stats.partial_parse_count > 0 {
+        // `unexpected` is the ACTIONABLE category, so it is always stated —
+        // "0 unexpected" is precisely the reassurance an operator is scanning
+        // for, and suppressing it would make its absence ambiguous.
+        //
+        // The six expected_* buckets are a different case: they are almost
+        // always zero, and a zero there carries no information at all. On this
+        // repo the line spent five of its seven clauses saying nothing. Render
+        // only the buckets that actually fired, and drop the heuristic-label
+        // footnote entirely when none did — it explains labels that are not on
+        // screen.
+        let expected = [
+            ("expected vendor", stats.expected_vendor_partial_parse_count),
+            (
+                "expected generated",
+                stats.expected_generated_partial_parse_count,
+            ),
+            (
+                "expected test-fixture",
+                stats.expected_test_fixture_partial_parse_count,
+            ),
+            (
+                "expected template-DSL",
+                stats.expected_template_dsl_partial_parse_count,
+            ),
+            (
+                "expected framework",
+                stats.expected_framework_partial_parse_count,
+            ),
+            (
+                "expected language",
+                stats.expected_language_partial_parse_count,
+            ),
+        ];
+        let mut parts = vec![format!(
+            "{} unexpected",
+            stats.unexpected_partial_parse_count
+        )];
+        parts.extend(
+            expected
+                .iter()
+                .filter(|(_, count)| *count > 0)
+                .map(|(label, count)| format!("{count} {label}")),
+        );
+        let footnote = if expected.iter().any(|(_, count)| *count > 0) {
+            " (expected_* vendor/generated/test-fixture/template-DSL are heuristic path-based labels)"
+        } else {
+            ""
+        };
         output.push_str(&format!(
-            "\nPartial parse summary: {} unexpected, {} expected vendor, {} expected generated, {} expected test-fixture, {} expected template-DSL, {} expected framework, {} expected language (expected_* vendor/generated/test-fixture/template-DSL are heuristic path-based labels)",
-            stats.unexpected_partial_parse_count,
-            stats.expected_vendor_partial_parse_count,
-            stats.expected_generated_partial_parse_count,
-            stats.expected_test_fixture_partial_parse_count,
-            stats.expected_template_dsl_partial_parse_count,
-            stats.expected_framework_partial_parse_count,
-            stats.expected_language_partial_parse_count,
+            "\nPartial parse summary: {}{footnote}",
+            parts.join(", ")
         ));
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -11369,6 +11369,12 @@ impl SymForgeServer {
         // divergence.
         ctx.daemon_env_surface = daemon_env_surface;
 
+        // Disclose an ORPHANED daemon: one that still answers but is no longer
+        // the daemon clients discover. `None` for the recorded daemon and for
+        // every non-daemon topology, so the line appears strictly on divergence
+        // — same discipline as the env-surface disclosure above.
+        ctx.orphaned_daemon_pid = crate::daemon::unrecorded_daemon_pid();
+
         let body = crate::stel::format_stel_status(request, &ctx);
         match reset_note {
             Some(note) => format!("{body}\n{note}"),

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -1180,6 +1180,31 @@ fn context_source_authority_label(refreshed: bool) -> &'static str {
     }
 }
 
+/// The source-authority axis of a result envelope, MEASURED from the index's own
+/// freshness rather than asserted.
+///
+/// `format_search_envelope` collapses to the compact one-line `Trust:` banner
+/// exactly when authority is `"current index"`, and its own doc says any
+/// deviation must keep the loud six-line form so "degraded/stale/truncated
+/// results stay loud". That contract was unreachable on the code-navigation
+/// lane: every call site passed the literal `"current index"`, so a result could
+/// never be anything but confident — including one served from an index whose
+/// reconciliation against disk had failed or never run.
+///
+/// The rest of the envelope already works this way. The parse-state axis
+/// deliberately degrades (`"metadata-only (not parsed)"`, "instead of the
+/// misleading 'parsed'"), and the knowledge lane already gates its envelope on
+/// `FreshnessStatus`. This applies the same discipline to code navigation, which
+/// is the lane whose anchors an agent actually navigates by — a wrong line
+/// number in the right file is worse than a miss, because it is actionable.
+fn index_source_authority_label(freshness: &crate::domain::FreshnessStatus) -> &'static str {
+    match freshness {
+        crate::domain::FreshnessStatus::Current => "current index",
+        crate::domain::FreshnessStatus::Verifying => "index (verifying against disk)",
+        crate::domain::FreshnessStatus::Degraded { .. } => "index (UNVERIFIED against disk)",
+    }
+}
+
 fn context_bundle_completeness_label(
     view: &crate::live_index::ContextBundleFoundView,
     rendered: &str,
@@ -3359,7 +3384,7 @@ fn render_search_text_output(
                     auto_corrected_regex,
                     options.ranked,
                 ),
-                "current index",
+                index_source_authority_label(&server.index.freshness_status()),
                 search_parse_state_for_paths(
                     &guard,
                     result.files.iter().map(|file| file.path.as_str()),
@@ -5353,7 +5378,7 @@ impl SymForgeServer {
             let guard = self.index.read();
             Some(search_format::format_search_envelope(
                 search_symbols_match_type_label(&result, is_browse),
-                "current index",
+                index_source_authority_label(&self.index.freshness_status()),
                 search_parse_state_for_paths(
                     &guard,
                     result.hits.iter().map(|hit| hit.path.as_str()),
@@ -6039,7 +6064,7 @@ impl SymForgeServer {
                     let guard = self.index.read();
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        "current index",
+                        index_source_authority_label(&self.index.freshness_status()),
                         search_parse_state_for_paths(&guard, std::iter::once(path.as_str())),
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6055,7 +6080,7 @@ impl SymForgeServer {
                     // parse state honestly instead of the misleading "parsed".
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        "current index",
+                        index_source_authority_label(&self.index.freshness_status()),
                         "metadata-only (not parsed)",
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6074,7 +6099,7 @@ impl SymForgeServer {
                     let guard = self.index.read();
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        "current index",
+                        index_source_authority_label(&self.index.freshness_status()),
                         search_parse_state_for_paths(
                             &guard,
                             matches.iter().map(std::string::String::as_str),
@@ -6504,12 +6529,17 @@ impl SymForgeServer {
                 };
                 Some(search_format::format_search_envelope(
                     search_files_match_type_label(&view),
+                    // The two composite labels already differ from the bare
+                    // "current index" sentinel, so they never collapse the
+                    // envelope; only the plain arm needed measuring. They do
+                    // still say "current" unconditionally — worth revisiting
+                    // once every lane derives its own prefix.
                     if rank_by_path_cochange {
                         "current index + optional coupling store"
                     } else if rank_by_frecency {
                         "current index + optional frecency history"
                     } else {
-                        "current index"
+                        index_source_authority_label(&self.index.freshness_status())
                     },
                     search_parse_state_for_paths(&guard, hits.iter().map(|hit| hit.path.as_str())),
                     &search_completeness_label(*overflow_count, hidden_noise_count),
@@ -8857,7 +8887,7 @@ impl SymForgeServer {
                 let guard = self.index.read();
                 Some(search_format::format_search_envelope(
                     find_references_match_type_label(input, mode),
-                    "current index",
+                    index_source_authority_label(&self.index.freshness_status()),
                     implementations_parse_state_for_paths(&guard, &view),
                     &implementations_completeness_label(&view, &limits),
                     &find_references_scope_summary(input, mode),
@@ -8987,7 +9017,7 @@ impl SymForgeServer {
                     }
                     Some(search_format::format_search_envelope(
                         find_references_match_type_label(input, mode),
-                        "current index",
+                        index_source_authority_label(&self.index.freshness_status()),
                         search_parse_state_for_paths(
                             &guard,
                             view.files.iter().map(|file| file.file_path.as_str()),

--- a/src/stel/status.rs
+++ b/src/stel/status.rs
@@ -100,6 +100,18 @@ pub struct StelStatusContext<'a> {
     /// connection: …)` disclosure line so a cross-process surface mismatch is
     /// never silent. `None` on same-env and direct serving.
     pub daemon_env_surface: Option<&'static str>,
+    /// Pid of the answering daemon, present ONLY when that daemon is no longer
+    /// the one recorded in the runtime files — an ORPHAN.
+    ///
+    /// An orphan still answers every client already connected to it, but new
+    /// clients discover a different daemon with a different index. Nothing else
+    /// in a response distinguishes the two: an orphan's replies are internally
+    /// consistent and confidently wrong about the world, which is strictly
+    /// worse than an error. Same reasoning as `project_root` above — a stale
+    /// binding must never read as a working one.
+    ///
+    /// `None` for the recorded daemon and for every non-daemon topology.
+    pub orphaned_daemon_pid: Option<u32>,
 }
 
 impl<'a> StelStatusContext<'a> {
@@ -136,6 +148,7 @@ impl<'a> StelStatusContext<'a> {
             calibration,
             durable_ledger: DurableLedgerState::Unavailable,
             daemon_env_surface: None,
+            orphaned_daemon_pid: None,
         }
     }
 
@@ -358,6 +371,22 @@ fn format_compact_status(ctx: &StelStatusContext<'_>) -> String {
             ),
         );
     }
+    // An orphaned daemon answers normally and looks healthy, so the ONLY way a
+    // caller can tell is if we say so. Inserted first (above the env-surface
+    // line) because it invalidates everything below it: the counts, the root
+    // and the index state are all true of THIS process and possibly of nothing
+    // else.
+    if let Some(pid) = ctx.orphaned_daemon_pid {
+        lines.insert(
+            2,
+            format!(
+                "daemon_instance: ORPHANED pid={pid} — this daemon is no longer the recorded one; \
+                 new clients reach a different daemon whose index may differ. Every figure below \
+                 describes THIS process only. Restart the client, or stop this pid, before \
+                 trusting anchors from it."
+            ),
+        );
+    }
     lines.join("\n")
 }
 
@@ -405,7 +434,34 @@ mod tests {
             calibration: summarize_calibration(&[]),
             durable_ledger: DurableLedgerState::Unavailable,
             daemon_env_surface: None,
+            orphaned_daemon_pid: None,
         }
+    }
+
+    /// An orphaned daemon answers normally and looks healthy from the outside,
+    /// so the disclosure line is the ONLY thing that can warn a caller. It must
+    /// appear exactly on divergence and never otherwise — a line that cried
+    /// wolf on every healthy status would be trained away immediately.
+    #[test]
+    fn orphaned_daemon_is_disclosed_and_silent_otherwise() {
+        let mut ctx = sample_context();
+        let healthy = format_stel_status(&StelStatusRequest::default(), &ctx);
+        assert!(
+            !healthy.contains("daemon_instance:"),
+            "the recorded daemon must not carry an orphan disclosure:\n{healthy}"
+        );
+
+        ctx.orphaned_daemon_pid = Some(41228);
+        let orphaned = format_stel_status(&StelStatusRequest::default(), &ctx);
+        assert!(
+            orphaned.contains("daemon_instance: ORPHANED pid=41228"),
+            "an orphaned daemon must name itself:\n{orphaned}"
+        );
+        assert!(
+            orphaned.contains("THIS process only"),
+            "the disclosure must invalidate the figures below it, not merely \
+             note the orphaning:\n{orphaned}"
+        );
     }
 
     #[test]

--- a/tests/health_parse_quarantine.rs
+++ b/tests/health_parse_quarantine.rs
@@ -109,7 +109,7 @@ fn health_reports_parse_span_quarantine_registry() {
     let full = health_report_from_published_state(&published, &watcher, 0);
     assert!(
         full.contains(
-            "Parse/span quarantine registry: total=5 unexpected_partial=1 expected_vendor_partial=1 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=1 expected_language_partial=1 failed=1 showing=5 offset=0 omitted=0"
+            "Parse/span quarantine registry: total=5 unexpected_partial=1 expected_vendor_partial=1 expected_framework_partial=1 expected_language_partial=1 failed=1 showing=5 offset=0 omitted=0"
         ),
         "full health should summarize parse/span quarantine evidence: {full}"
     );
@@ -137,7 +137,7 @@ fn health_reports_parse_span_quarantine_registry() {
     let compact = health_report_compact_from_published_state(&published, &watcher, 0);
     assert!(
         compact.contains(
-            "Parse/span quarantine: total=5 unexpected_partial=1 expected_vendor_partial=1 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=1 expected_language_partial=1 failed=1 showing=5 offset=0 omitted=0"
+            "Parse/span quarantine: total=5 unexpected_partial=1 expected_vendor_partial=1 expected_framework_partial=1 expected_language_partial=1 failed=1 showing=5 offset=0 omitted=0"
         ),
         "compact health should retain bounded quarantine counts: {compact}"
     );
@@ -181,7 +181,7 @@ fn health_parse_span_quarantine_registry_is_bounded() {
     let full = health_report_from_published_state(&published, &watcher, 0);
     assert!(
         full.contains(
-            "Parse/span quarantine registry: total=12 unexpected_partial=12 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=0 expected_language_partial=0 failed=0 showing=10 offset=0 omitted=2"
+            "Parse/span quarantine registry: total=12 unexpected_partial=12 failed=0 showing=10 offset=0 omitted=2"
         ),
         "full health should cap quarantine evidence and report omitted entries: {full}"
     );
@@ -203,7 +203,7 @@ fn health_parse_span_quarantine_registry_is_bounded() {
     let compact = health_report_compact_from_published_state(&published, &watcher, 0);
     assert!(
         compact.contains(
-            "Parse/span quarantine: total=12 unexpected_partial=12 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=0 expected_language_partial=0 failed=0 showing=10 offset=0 omitted=2"
+            "Parse/span quarantine: total=12 unexpected_partial=12 failed=0 showing=10 offset=0 omitted=2"
         ),
         "compact health should expose the bounded quarantine count: {compact}"
     );
@@ -328,7 +328,7 @@ fn health_labels_angular_template_partial_as_expected_framework() {
     let full = health_report_from_published_state(&published, &watcher, 0);
     assert!(
         full.contains(
-            "Parse/span quarantine registry: total=1 unexpected_partial=0 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=1 expected_language_partial=0 failed=0 showing=1 offset=0 omitted=0"
+            "Parse/span quarantine registry: total=1 unexpected_partial=0 expected_framework_partial=1 failed=0 showing=1 offset=0 omitted=0"
         ),
         "framework partial should be counted in its own bucket: {full}"
     );
@@ -357,7 +357,7 @@ fn health_labels_angular_template_partial_as_expected_framework() {
     let compact = health_report_compact_from_published_state(&published, &watcher, 0);
     assert!(
         compact.contains(
-            "Parse/span quarantine: total=1 unexpected_partial=0 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=1 expected_language_partial=0 failed=0 showing=1 offset=0 omitted=0"
+            "Parse/span quarantine: total=1 unexpected_partial=0 expected_framework_partial=1 failed=0 showing=1 offset=0 omitted=0"
         ),
         "compact health should carry the framework bucket count: {compact}"
     );
@@ -381,7 +381,7 @@ fn health_labels_typescript_import_type_array_partial_as_expected_language() {
     let full = health_report_from_published_state(&published, &watcher, 0);
     assert!(
         full.contains(
-            "Parse/span quarantine registry: total=1 unexpected_partial=0 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=0 expected_language_partial=1 failed=0 showing=1 offset=0 omitted=0"
+            "Parse/span quarantine registry: total=1 unexpected_partial=0 expected_language_partial=1 failed=0 showing=1 offset=0 omitted=0"
         ),
         "language partial should be counted in its own bucket: {full}"
     );
@@ -410,7 +410,7 @@ fn health_labels_typescript_import_type_array_partial_as_expected_language() {
     let compact = health_report_compact_from_published_state(&published, &watcher, 0);
     assert!(
         compact.contains(
-            "Parse/span quarantine: total=1 unexpected_partial=0 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=0 expected_language_partial=1 failed=0 showing=1 offset=0 omitted=0"
+            "Parse/span quarantine: total=1 unexpected_partial=0 expected_language_partial=1 failed=0 showing=1 offset=0 omitted=0"
         ),
         "compact health should carry the language bucket count: {compact}"
     );
@@ -454,7 +454,7 @@ fn health_registry_total_accounts_for_every_partial_including_excused() {
     );
     assert!(
         full.contains(
-            "Parse/span quarantine registry: total=2 unexpected_partial=1 expected_vendor_partial=0 expected_generated_partial=0 expected_test_fixture_partial=0 expected_template_dsl_partial=0 expected_framework_partial=0 expected_language_partial=1 failed=0 showing=2 offset=0 omitted=0"
+            "Parse/span quarantine registry: total=2 unexpected_partial=1 expected_language_partial=1 failed=0 showing=2 offset=0 omitted=0"
         ),
         "registry total must equal the header partial count — no invisible partials: {full}"
     );


### PR DESCRIPTION
Six defects that are one defect wearing different clothes: **success reported for work never verified to have happened.** Two were reported by external agents; the rest were found while tracing those.

## The fixes

**Daemon orphaning + identity disclosure** (`a0aab83`). `stop_incompatible_recorded_daemon_at` deleted a live daemon's port/pid files **unconditionally** — including on all three branches where the safety gate *refuses* to terminate, and where `terminate_process` outright fails. That makes the survivor undiscoverable *and* unstoppable, since the same function early-returns on a missing port file. It keeps serving its own index to everyone already connected, invisibly.

Measured on this machine: two heavyweight daemons, independent indexes, different ports (728 s CPU / 666 MB and 699 s CPU / 1290 MB). Upgrading is the trigger — the version check marks the running daemon incompatible, so repeated updates accumulate orphans.

`wait_for_daemon_unhealthy` now returns whether the daemon actually died, and cleanup is withheld only for one we tried-and-failed or declined to kill. An unidentifiable daemon (no pid file, health reports no pid) still clears its record — keeping it makes it no more stoppable, only makes later calls re-walk the same dead end. `status` gains a `daemon_instance: ORPHANED pid=N` line, strictly on divergence.

**Trust envelope measured, not asserted** (`2cf09e3`). `format_search_envelope` collapses to the compact `Trust:` banner exactly when `source_authority == "current index"` — a *string comparison* — and its own doc says deviations must "stay loud". Every code-navigation caller passed that literal, so the contract was unreachable on the one lane whose anchors an agent navigates by. Now derived from `FreshnessStatus` at all eight envelope sites.

That this was a defect and not a choice is visible two lines away: the parse-state axis already hardcodes `"metadata-only (not parsed)"` with the comment *"instead of the misleading 'parsed'"*.

**Reconciliation stopped manufacturing the lie** (same commit). Both re-parse loops did `let _ = admit_and_index_single_path(...)`, discarding a result that can be `Skipped`/`ReadError`/`NotFound` — none of which refresh anything. The compensating fold was `#[cfg(not(feature = "server"))]`, and **server is a default feature**, so honest degradation existed only in builds nobody ships. The comment asserted those files "were re-parsed above, so they are correctly not mismatches" — an assumption, never a check.

**Additive project opens reachable and visible** (`ae38fa3`). `index_folder(add:true)` advertised a `project_name` that no selector could resolve — the working set keys by project id, and the code-navigation verbs never met `runtime_for_target`, the only name→id resolver. The resolver already existed and was correct; it was gated to the knowledge verbs. Also included `status` in the open-project inventory: on the compact-3 surface it is the *only* health verb, so a second project was invisible by construction.

**Dead variant removed** (`5a37a4e`, breaking). `MetadataOnlyReason::PlatformPathCollision` had two occurrences: its definition and one exhaustiveness arm. Nothing minted it — which is precisely what makes deletion safe for persisted data: the enum is externally-tagged serde, so no snapshot anywhere contains that string. `MetadataOnlyReason` is also marked `#[non_exhaustive]`, same reasoning as `SkipReason` in #536.

**Bridge reuse** (`3023315`). The knowledge bridge is a pure function of (live content, source identity, `content_generation`) — pinned by `repeated_equal_generations_produce_identical_order_and_ids`. A retaining-content publish moves none of them, yet rebuilt all 5,487 cards (1.016 s of a 1.810 s publication). Now reuses the previous Arc, mirroring `code_signals` directly above.

**Health output** (`ee1e810`, `0930703`). Two lines enumerated all six `expected_*` partial categories unconditionally — five of seven clauses and six of twelve fields reporting zeros. Measured against a real `health` call: ~258 chars (~65 tokens) per call. `unexpected_partial`, `failed`, `total` and the window fields are deliberately **not** suppressed; a zero there is the answer.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test --all-targets -- --test-threads=1` suite green (3100 lib tests, 115 result groups, 0 failures).

The health change broke nine assertions across five integration tests in `tests/health_parse_quarantine.rs`, caught by `--all-targets` and not by `--lib` (separate crate). Their intents survived; the format literals were updated deliberately, and that is stated rather than implied.

## Claims deliberately not made

The bridge reuse carries **no speedup figure**. It is provable-equivalence — the determinism test establishes the reused value equals the rebuilt one — but the wall-clock delta is unmeasured and the cold path is unaffected.

A separate cold-start optimization (parallelizing the scout's per-entry `stat`) was implemented, measured across 3 samples per side, found to give no improvement — 3% *slower* on the cached path — and **reverted**. The ~2.4 s scout is dominated by the directory walk, not the stat. Recorded on the backlog so it isn't re-attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
