### PR TITLE
fix(live-index): refuse Ready on a bootstrap placeholder with no bound root

### DIFF
--- a/docs/reviews/REVIEW-FINDINGS-cursor-composer-cold-start-ready-2026-08-07.md
+++ b/docs/reviews/REVIEW-FINDINGS-cursor-composer-cold-start-ready-2026-08-07.md
@@ -1,0 +1,205 @@
+# Composer review — cold-start Ready before rooted
+
+**Branch:** `fix/cold-start-ready-before-rooted` (off `main`)  
+**Reviewer:** Cursor Composer (adversarial, code-backed)  
+**Date:** 2026-08-07  
+**Scope:** Inline diff from `symforge-review.md` + repo inspection
+
+Ground rules applied: comments are not behaviour; existence is not invocation; claims cite `file:line`; confidence labels used throughout.
+
+---
+
+## Executive summary
+
+The fix is **directionally correct**. Gating `index_state()` on `load_source == EmptyBootstrap` (not `indexed_root.is_none()`) matches the measured defect and preserves the local-ref lane. Pairing `(a)` with `(c)` is **mandatory** — without the harness change, CI would go red deterministically.
+
+**Merge recommendation:** Do not block on logic alone. Add one **rooted load + mutation → Ready** regression test before merge; consider fixing `sidecar_contract`’s `build_shared_index` to use a rooted index so the golden documents a genuinely healthy sidecar.
+
+---
+
+## Q1 — Can the fix deadlock the index at `Loading` forever?
+
+**Cannot rule out “Loading forever” from the diff alone, but the catastrophic case — successful reload that never clears `EmptyBootstrap` — is ruled out by code structure.**
+
+| Claim | Confidence | Evidence |
+|-------|------------|----------|
+| Successful reload replaces placeholder, sets `FreshLoad` | **Proven** | `main.rs:423-430` → `reload_for_state_placement` → `swap_and_publish` (`store.rs:2096-2121`); `apply_reload_data` sets `load_source = FreshLoad`, `indexed_root = Some(...)` (`store.rs:4354-4365`) |
+| In-place mutation without updating `load_source` on success | **Proven false** | Reload builds new `LiveIndex` via `from_reload_data`, does not mutate placeholder |
+| Failed reload leaves stuck `Loading` after freshen | **Likely** | Placeholder remains; `is_empty == false` + `EmptyBootstrap` → `Loading`; tools refuse via `loading_guard!` |
+
+**To fully rule out production “forever Loading”:** integration trace showing `"background cold-start indexing complete"` (`main.rs:428`) and next `published_state().load_source == FreshLoad`. Diff does not add that test.
+
+**Verdict:** No deadlock on **successful** load. Permanent `Loading` on **failed** load after freshen is a visible degraded state, not silent wrong answers.
+
+---
+
+## Q2 — Is `EmptyBootstrap` sufficient?
+
+**Covers the reported bug path. Not a complete proxy for “populated + rootless”.**
+
+| Route | Guarded? | Confidence | Location |
+|-------|----------|------------|----------|
+| Cold-start placeholder + targeted freshen | Yes | **Proven** | `empty_live_index()` `4084-4097`; `update_file` `4472` |
+| `from_source_files` (local-ref lane) | No (`FreshLoad`, rootless) | **Proven** | `store.rs:4110-4130` |
+| Snapshot restore | N/A (`SnapshotRestore` + rooted) | **Proven** | `persist.rs:1752-1764` |
+| `remove_file` leaves `is_empty == false` on bootstrap | Yes → `Loading` | **Proven** | `store.rs:4513+` |
+
+Local-ref lane intentionally uses `publish_ref_source`, not `capture_published_manifest` (`store.rs:978`). A populated rootless index with `FreshLoad` can still report `Ready` with unbound manifest if ref-source publish is skipped — **different lane**, not the measured cold-start flake.
+
+**Verdict:** Sufficient for the **measured** defect. Incomplete as a general “never serve rootless populated as Ready” invariant.
+
+---
+
+## Q3 — Is flipping `health.json` legitimate?
+
+**Legitimate given how the test is built. Does not model a healthy production index.**
+
+**Proven:** `test_health_contract_golden` (`sidecar_contract.rs:296-313`) uses `build_shared_index` → `LiveIndex::empty()` + `add_file` (`196-206`). That is the defect scenario: `EmptyBootstrap`, files present, no `indexed_root`. Golden `"Ready"` was false once honesty guard exists.
+
+**Settles (ii) vs (i):**
+
+- **(i) Bootstrap placeholder model** — flip to `"Loading"` is **correct**.
+- **(ii) Healthy index model** — test never modeled one. Positive Ready coverage exists in `handlers.rs:2792-2816` (`FreshLoad` manual index → Ready).
+
+**Concern:** External readers may treat `health.json` as normative “healthy = Ready”. After flip: 2 files, 2 symbols, `Loading`. Honest for the test; misleading as exemplar.
+
+**Recommendation:** Change contract test `build_shared_index` to rooted `FreshLoad` and restore golden `"Ready"`.
+
+---
+
+## Q4 — Is the positive case still tested?
+
+**Partially. Gap on “rooted index + mutation → still Ready”.**
+
+**Still covered:**
+
+- `unbound_bootstrap_rebinds_writable_project_without_restart` — `reload()` → `Ready` (`store.rs:6078-6098`)
+- Snapshot verify → Ready (`persist.rs:2689-2792`)
+- Sidecar handler test → Ready (`handlers.rs:2792-2816`)
+
+**Gap (proven):** Four flipped tests were the only `empty()` → `add_file` → `PublishedIndexStatus::Ready` assertions. No replacement test: `LiveIndex::load(root)` → `add_file` → `Ready`.
+
+A future change pinning everything at `Loading` would **not** be caught by the four flipped tests.
+
+**Recommendation:**
+
+```rust
+// store.rs — suggested regression
+#[test]
+fn rooted_index_mutation_after_load_stays_ready() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "a.rs", "fn alpha() {}");
+    let shared = LiveIndex::load(tmp.path()).unwrap();
+    shared.add_file("b.rs".into(), make_indexed_file_for_mutation("b.rs"));
+    assert_eq!(shared.published_state().status, PublishedIndexStatus::Ready);
+}
+```
+
+---
+
+## Q5 — Does `is_ready()` delegating to `index_state()` change behaviour beyond the fix?
+
+**Yes, only where `EmptyBootstrap` + `is_empty == false` — aligns previously divergent surfaces.**
+
+| Call site | Effect | Confidence |
+|-----------|--------|------------|
+| `tools.rs:11242` — `StelStatusContext::from_server(..., guard.is_ready(), ...)` | `index_ready` false during bootstrap-with-admitted-file | **Proven** |
+| `tools.rs:6674` — `ground_plan_economics` | Skips grounding while not Ready | **Proven** |
+| Tool/edit guards (`tools.rs:3794-3804`) | Use `index_state()` directly; unchanged for Empty/Ready | **Proven** |
+
+Truly empty bootstrap (`is_empty == true`): `index_state()` → `Empty`; `is_ready()` → false. **No change.**
+
+**Verdict:** In-scope, desirable alignment. No proven hang loop.
+
+---
+
+## Q6 — Is the 20-second harness ceiling enough?
+
+**Likely yes for current fixtures; not proven under worst CI contention.**
+
+| Fact | Value |
+|------|-------|
+| `verify-tools` fixture | ~4 src files |
+| `verify-tools-real` fixture | 3 modules |
+| Old ceiling | 30 × 250 ms ≈ 7.5 s (file-count gate — wrong signal) |
+| New ceiling | 80 × 250 ms ≈ 20 s sleep + RPC time |
+| Gate condition | `_meta` evidence: `Ready`, `load_source != EmptyBootstrap`, `index_files > 0` |
+
+**Verdict:** **Defensible** for tiny fixtures. If CI flakes at exit 2, bump to 120×250 ms (30 s) or env-configurable ceiling.
+
+---
+
+## Q7 — Is `process.exit(2)` handled correctly?
+
+**Proven: CI fails correctly.**
+
+- `.github/workflows/ci.yml:104-105` — direct `node scripts/verify-tools.cjs`; any non-zero fails job
+- Exit 2 = harness abort; exit 1 = regression — useful local distinction
+- Abort path: `proc.kill()` then `process.exit(2)` — **likely** fine; **speculative** orphan-child race on kill-before-exit (low severity on CI)
+
+---
+
+## Q8 — Is the `_meta` gate contract-safe?
+
+**Mostly stable, with one format fragility.**
+
+**Stable (proven):**
+
+- Key: `symforge/project_evidence` — `result_status.rs:46`
+- Fields: `result_status.rs:58-67`
+- Attached via `with_project_evidence_scope` — `mod.rs:1540-1544`
+- Harness: `SYMFORGE_NO_DAEMON=1` — local seed path
+
+**Fragility (likely):** Evidence `load_source` uses `format!("{:?}", ...)` → `"EmptyBootstrap"` (`tools.rs:7305`). Status text uses snake_case `"empty_bootstrap"` (`format.rs:468`). Harness checks `!== "EmptyBootstrap"` — works today, breaks if evidence format changes without harness update.
+
+**Recommendation:** Use `index_load_source_label()` in evidence construction, or document Debug-format coupling.
+
+---
+
+## Q9 — Anything else actually wrong
+
+1. **Freshen-before-guard still mutates placeholder on same call** (`tools.rs:4466-4469`). After fix, `get_file_context` returns loading message after admit. Real load `swap_and_publish` discards placeholder — no lasting corruption (**proven**), but unnecessary work.
+
+2. **`validate_file_syntax` skips loading guard** (`tools.rs:8672-8673`) and freshens first (`8668`). Same bootstrap mutation path — **bug survives in rarer form** for that tool during cold start.
+
+3. **`Empty` vs `Loading` on true-empty bootstrap:** Before first freshen, state is `Empty`. First targeted read can freshen; tools that skip guard remain exposed.
+
+4. **Failed background reload → permanent Loading** — operational regression vs silently wrong Ready. Consider surfacing reload failure as Degraded with reason (not in diff).
+
+5. **No mutation-after-load → Ready test** (Q4) — suite cannot fail on broken positive mutation path.
+
+---
+
+## Summary table
+
+| Q | Answer | Confidence |
+|---|--------|------------|
+| 1 | No deadlock on successful reload; stuck Loading if reload fails after freshen | Proven / Likely |
+| 2 | Sufficient for cold-start bug; not for all rootless populated indexes | Likely |
+| 3 | Golden flip correct for test setup; test does not model healthy index | Proven |
+| 4 | Positive Ready on load exists; gap on mutation-after-load → Ready | Proven |
+| 5 | `is_ready()` change is intentional alignment; low external risk | Proven |
+| 6 | 20 s defensible for tiny fixtures | Likely |
+| 7 | exit(2) fails CI correctly | Proven |
+| 8 | Stable with Debug-format coupling risk | Likely |
+| 9 | Guard-only leaves freshen ordering + validate_file_syntax hole | Proven |
+
+---
+
+## Pre-merge checklist
+
+- [ ] Add `rooted_index_mutation_after_load_stays_ready` (or equivalent)
+- [ ] (Optional) Fix `sidecar_contract` `build_shared_index` to use rooted `FreshLoad` + restore golden `Ready`
+- [ ] (Optional) Use `index_load_source_label()` in `ProjectEvidence.load_source`
+- [ ] Confirm full gate green: `cargo fmt --check`, clippy, tests, release build, both verify-tools fixtures
+
+---
+
+## Files touched by fix (reference)
+
+| File | Change |
+|------|--------|
+| `src/live_index/health_view.rs` | `EmptyBootstrap` → `Loading`; `is_ready()` delegates to `index_state()` |
+| `src/live_index/store.rs` | `capture_published_manifest` warnings; regression test; four assertion flips |
+| `tests/fixtures/sidecar_contract/health.json` | `Ready` → `Loading` |
+| `scripts/verify-tools.cjs` | `_meta` evidence gate; stderr inherit; `RUST_LOG=warn`; 80 polls; exit 2 abort |

--- a/docs/reviews/REVIEW-FINDINGS-cursor-grok-cold-start-ready-2026-08-07.md
+++ b/docs/reviews/REVIEW-FINDINGS-cursor-grok-cold-start-ready-2026-08-07.md
@@ -1,0 +1,203 @@
+# Independent review findings — cold-start Ready before rooted
+
+**Reviewer:** Cursor Grok (independent adversarial pass)  
+**Date:** 2026-08-07  
+**Request:** `C:\Users\rakovnik\Downloads\symforge-review.md`  
+**Branch:** `fix/cold-start-ready-before-rooted`  
+**Code under review:** `904b2c2` (`fix(live-index): refuse Ready on a bootstrap placeholder with no bound root`)  
+**Worktree:** `E:/project/symforge-policy`  
+**Base:** `main` (diff: 4 files, +134/−33)  
+**Full serial suite:** not run. Claims tagged **proven** / **likely** / **speculative** from code reading only.
+
+**Intent under review:** Stop an EmptyBootstrap placeholder that admitted a file from reporting `Ready` (and unbound knowledge / `source=unknown`) before the detached initial load binds a root; make harness readiness gate on source-bound evidence.
+
+Ground rules applied: comments are claims, not evidence; existence ≠ invocation; cite `file:line`.
+
+---
+
+## Lead judgment
+
+Core guard is sound and does **not** deadlock on a successful cold start. Merge-blocking only if you require (a) a rooted Ready `/health` golden, or (b) an explicit mutation→Ready positive test, before land. Do not treat the `health.json` flip as proof the sidecar happy path was re-validated — the contract helper still builds EmptyBootstrap.
+
+---
+
+## Q1 — Can the fix deadlock the index at `Loading` forever?
+
+**Verdict: No for successful cold start. Yes if background load fails after a file was admitted.**
+
+**Confidence:** proven (success) / likely (failure)
+
+### What must be true to escape Loading
+
+`index_state()` returns `Loading` when `load_source == EmptyBootstrap` (`health_view.rs:347–348`). Escape requires something to set `load_source` to another variant.
+
+### Success path — ruled out from code (not from comments)
+
+Cold start (`main.rs:422–433`):
+
+1. Publishes `LiveIndex::empty()` (EmptyBootstrap).
+2. `spawn_blocking` → `reload_for_state_placement`.
+3. That builds a **new** index via `from_reload_data` → `apply_reload_data` (`store.rs:4564–4575`), which sets:
+   - `load_source = IndexLoadSource::FreshLoad`
+   - `indexed_root = Some(data.indexed_root)`
+4. Then `swap_and_publish(live)` (`store.rs:2203–2218`).
+
+It does **not** mutate the placeholder in place without updating `load_source`. The unverified claim in the review packet (“real load replaces via FreshLoad”) is **proven**.
+
+### Failure path — residual hang-shaped availability loss
+
+If background reload errors (`main.rs:428–429`), an EmptyBootstrap generation that already admitted a file (`is_empty == false`) stays `Loading` until a successful reload (`index_folder` / restart). Before the fix that state lied as `Ready`; after, tools refuse. Not a process deadlock; permanent tool refusal until recovery.
+
+**Diff alone is insufficient; worktree code rules out the success-path deadlock.**
+
+---
+
+## Q2 — Is `EmptyBootstrap` sufficient to cover the bug?
+
+**Verdict: Yes for the reported cold-start race. No for the broader class “populated + no `indexed_root`”.**
+
+**Confidence:** proven
+
+### Covered
+
+- Only `empty_live_index` / `reset_to_empty` set `EmptyBootstrap` (`store.rs:4286`, `2250`).
+- `update_file` / `add_file` set `is_empty = false` and never touch `load_source` (`store.rs:4682`) — the race this fix targets.
+- `remove_file` never restoring `is_empty` does **not** evade the guard: load_source stays EmptyBootstrap → still Loading.
+
+### Not covered by the guard
+
+- `LiveIndex::from_source_files` → `FreshLoad` + `indexed_root: None` (`store.rs:4312–4332`). Intentionally excluded; local-ref publishes identity on a separate path (`store.rs:1513–1575`).
+- Default `swap_and_publish` of a FreshLoad/rootless index still hits `capture_published_manifest` early-return (`store.rs:1010–1021`, now `warn!`) while `index_state()` is **Ready**. Sidecar handlers’ test helper builds exactly that shape (`handlers.rs:2769–2787`) and still expects Ready (`handlers.rs:2871–2873`).
+
+No other production writer of `load_source = FreshLoad` besides `apply_reload_data` / constructors; snapshot restore always binds a root (`persist.rs:1991–2003`).
+
+---
+
+## Q3 — Is flipping `tests/fixtures/sidecar_contract/health.json` legitimate?
+
+**Verdict: (i) for what the contract test builds — not (ii).**
+
+**Confidence:** proven
+
+`tests/sidecar_contract.rs:196–205` builds via `LiveIndex::empty()` + `add_file`. That is EmptyBootstrap-with-files — the buggy shape. Previously the golden advertised `Ready` for that lie; `Loading` matches the new honesty rule.
+
+It does **not** model a normal rooted healthy index. Contrast: `handlers.rs` builds FreshLoad fixtures and still asserts Ready (`handlers.rs:2871–2873`).
+
+Nobody updated the contract helper to `from_source_files` / a real load, so the golden now documents “2 files + Loading” as the contract fixture’s answer — correct for the helper, misleading as “healthy sidecar” documentation.
+
+**What would settle it:** change `build_shared_index` in `sidecar_contract.rs` to a FreshLoad (or loaded) index and keep `Ready`, **or** keep the flip and add a second golden for a rooted Ready health response.
+
+---
+
+## Q4 — Is the positive case still tested?
+
+**Verdict: Partially. Reload → Ready yes; mutation → Ready on a rooted index no.**
+
+**Confidence:** proven
+
+Still asserts Ready:
+
+- `unbound_bootstrap_rebinds_writable_project_without_restart` — empty → `reload` → `Ready` + `FreshLoad` (`store.rs:6327–6329`)
+- `test_is_ready_true_when_not_tripped` / `test_index_state_ready` — FreshLoad constructors (`query.rs:5634–5676`)
+- Snapshot verify → `is_ready()` (`persist.rs:3109`)
+
+The four flipped assertions were never a true positive: they asserted Ready on EmptyBootstrap mutations. A change that pins **everything** at Loading would still fail the reload/FreshLoad tests. A change that makes **publication after mutation** always Loading on a previously Ready index would not be caught by those four.
+
+Hole is real but narrower than “suite can’t fail positive.”
+
+---
+
+## Q5 — Does `is_ready()` delegating to `index_state()` change behaviour beyond the fix?
+
+**Verdict: Yes, one intentional external change; no hang found in-repo.**
+
+**Confidence:** proven (behaviour) / likely (no hang)
+
+Previously `is_ready()` ignored EmptyBootstrap and returned true once `is_empty == false`. Now it is false for that state — same as `index_state() == Ready` (`health_view.rs:327–328`).
+
+Call sites:
+
+- Tool `loading_guard!` uses `index_state()`, not `is_ready()` (`tools.rs:3885–3895`) — already covered by (a).
+- `status` / STEL: `guard.is_ready()` → `index_ready` (`tools.rs:11376`, `stel/status.rs:352`). After premature freshen, `index_ready` flips from true → false. That is the honesty fix on the status surface.
+- `ground_plan_economics` early-returns when not ready (`tools.rs:6759`) — skips grounding during bootstrap; no loop.
+
+No in-repo startup loop waits on `is_ready()`. External clients polling `index_ready` will wait longer / see false during bootstrap — correct, not a deadlock.
+
+---
+
+## Q6 — Is the 20-second harness ceiling enough?
+
+**Verdict: Yes for these fixtures; 20s is defensible. Prefer ~40s if CI flakes.**
+
+**Confidence:** likely
+
+Harness fixtures are tiny (`verify-tools` ~34 files, `verify-tools-real` ~13). The ~10s full-repo cold-load figure does not apply here. Ceiling is sleep budget (80×250ms); work can finish earlier. Risk is only a heavily contended runner where even a small fixture’s load exceeds 20s — then exit 2 aborts every run.
+
+---
+
+## Q7 — Is `process.exit(2)` handled correctly?
+
+**Verdict: Yes for CI failure. Child cleanup is good enough.**
+
+**Confidence:** proven (CI) / likely (orphan)
+
+Invoked directly in CI:
+
+```yaml
+node scripts/verify-tools.cjs --bin target/release/symforge
+```
+
+(`.github/workflows/ci.yml:127–128`, same in `release.yml`). Any non-zero fails the step. Exit 2 matches “missing binary” (`verify-tools.cjs:334`).
+
+Abort path: `proc.kill()` then `process.exit(2)` (`verify-tools.cjs:244–245`) — does not return into the case loop, so no half-loaded snapshot compare. Residual: if `kill` fails, parent still exits and the job tears down; brief orphan possible on Windows, not a silent green.
+
+---
+
+## Q8 — Is the `_meta` gate contract-safe?
+
+**Verdict: Stable enough to gate on; abort text overclaims “absent.”**
+
+**Confidence:** proven
+
+`ProjectEvidence` is a documented meta surface (`result_status.rs:45–67`) with tests (`tools.rs:20841–20866`). Harness fields exist. `load_source` is `format!("{:?}", ...)` → `"EmptyBootstrap"` (`tools.rs:7390`), matching the JS check — **not** the snake_case health label `empty_bootstrap` (`format.rs:468`). Renaming Debug or switching evidence to the label form would break the gate until timeout.
+
+Attachment always writes the key: unbound → `{"bound": false}` (`result_status.rs:120–126`), not omission. Abort copy saying `null/absent evidence` is wrong for that case; you’d see `{"bound":false}`. Distinction “still loading” vs “contract changed” still works if you read `index_state` / `load_source` vs `bound:false`.
+
+---
+
+## Q9 — Anything else that is actually wrong
+
+| # | Finding | Confidence |
+|---|---------|------------|
+| 1 | Contract helper left on buggy construction (`sidecar_contract.rs:196–205`): golden flip is honest, but suite never goldens a rooted Ready `/health`. Prefer fix the helper, not only the golden. | proven |
+| 2 | Failed cold-start after admission → permanent Loading until reload (Q1). Worse availability than the old lie; `index_folder` is the recovery path (not loading-guarded at entry — `tools.rs:7538+`). | likely |
+| 3 | Harness couples to Debug enum spelling of `load_source` (Q8). | proven |
+| 4 | No test: rooted Ready → mutate → still Ready (Q4). | proven |
+| 5 | Freshen-before-guard ordering still unfixed (acknowledged in request). Guard is the choke point — acceptable if the state machine stays honest. Not a new defect in this diff. | — |
+
+Not findings (per request §5): verbose comments; `RUST_LOG=warn` + inherited stderr noise; unreleased status.
+
+---
+
+## Files reviewed
+
+| Path | Role |
+|------|------|
+| `src/live_index/health_view.rs` | `is_ready` / `index_state` guard |
+| `src/live_index/store.rs` | manifest capture warns; reload/FreshLoad; tests |
+| `src/main.rs` | cold-start empty + background reload |
+| `scripts/verify-tools.cjs` | harness gate + exit 2 |
+| `tests/fixtures/sidecar_contract/health.json` | golden flip |
+| `tests/sidecar_contract.rs` | EmptyBootstrap helper (not in diff) |
+| `src/sidecar/handlers.rs` | FreshLoad Ready health unit test (not in diff) |
+| `src/protocol/result_status.rs` | `_meta` evidence contract |
+| `.github/workflows/ci.yml` | direct `node` invocation |
+
+---
+
+## Recommended follow-ups (non-blocking unless noted)
+
+1. **(optional block)** Fix `sidecar_contract::build_shared_index` to FreshLoad/rooted and restore a Ready golden, *or* add a second Ready golden.
+2. Add `rooted_index_stays_ready_after_mutation` next to the new EmptyBootstrap regression.
+3. Soften harness abort text: distinguish `{bound:false}` from missing key; optionally accept both Debug and label forms of `load_source`, or document Debug as the contract.
+4. If cold-start reload failure + admitted files becomes operator-visible: surface it in health/status beyond perpetual Loading.

--- a/docs/reviews/REVIEW-FINDINGS-kimi-cold-start-ready-2026-08-07.md
+++ b/docs/reviews/REVIEW-FINDINGS-kimi-cold-start-ready-2026-08-07.md
@@ -1,0 +1,213 @@
+# Review findings — SymForge "index reports Ready before it is rooted"
+
+**Date:** 2026-08-07
+**Reviewer:** kimi-code/k3 (OMP session, `E:/project/symforge`)
+**Subject:** Proposed fix on `fix/cold-start-ready-before-rooted` (diff packet in
+`~/Downloads/symforge-review.md`). Review performed **against the repository**,
+pre-fix working tree — every claim in the packet was verified against code.
+**Verdict:** Correct; ship (a)+(c) together as planned. Two non-blocking additions
+recommended (Q4 test, Q3 golden setup).
+
+Confidence labels: **proven / likely / speculative**. All citations `file:line`
+against the pre-fix tree.
+
+---
+
+## Q1 — Deadlock at `Loading`? Ruled out on the success path (proven); one caveat on the failure path
+
+The claim "the real load replaces the index via a path that sets `FreshLoad`" is
+verifiable and holds, with a refinement: the real load does not mutate the
+placeholder in place — it **replaces** it:
+
+- `src/main.rs:419-433` — cold start publishes `LiveIndex::empty()` and spawns
+  `bg_index.reload_for_state_placement(&bg_root, …)`.
+- `src/live_index/store.rs:2090-2121` (`reload_for_binding_with_exclusions`) —
+  builds a **new** `LiveIndex` via `from_reload_data`, then `swap_and_publish(live)`.
+- `src/live_index/store.rs:4348-4367` (`apply_reload_data`) — sets
+  `load_source = IndexLoadSource::FreshLoad` (4356) **and**
+  `indexed_root = Some(data.indexed_root)` (4366), unconditionally, in the only
+  reload-application path.
+
+The escape from `Loading` is guaranteed by the same swap that binds the root. No
+path mutates the placeholder in place without updating `load_source`.
+**Deadlock ruled out — proven.**
+
+Caveat (failure path, **likely**): if `build_reload_data_for_binding_with_exclusions`
+returns `Err` *after* a freshen already admitted a file, `main.rs:429` logs and
+nothing retries. The placeholder then sits at `is_empty=false,
+load_source=EmptyBootstrap` → `Loading` forever, every tool refusing. Recovery
+requires explicit re-index (`index_folder`/reset), which does reach
+`apply_reload_data`. A real liveness tradeoff the diff doesn't mention — but
+strictly more honest than the old behavior (same failure previously reported
+`Ready` with `source=unknown`), diagnosable via the new `warn!` plus health lines,
+and the no-admission failure case reports `Empty` (the `is_empty` check precedes
+the new guard), not `Loading`. Related static case: `src/daemon.rs:3359-3367`
+deliberately keeps an `EmptyBootstrap` placeholder when cold load is refused by
+catalog capacity — if that placeholder ever admits a file it too pins at `Loading`
+with no automatic retry. Acceptable, but should be a conscious decision.
+
+## Q2 — `EmptyBootstrap` sufficiency: covers every current route (proven); gap is future constructors (speculative)
+
+Every route to a populated index:
+
+| Route | `load_source` | `indexed_root` | Guard verdict |
+|---|---|---|---|
+| Placeholder + freshen mutation (the bug) | `EmptyBootstrap` | `None` | caught |
+| `apply_reload_data` / `load_with_project_state` | `FreshLoad` | `Some` (store.rs:4366, store.rs:4054) | correctly Ready |
+| Snapshot restore | `SnapshotRestore` | `Some` (persist.rs:1764; wire format carries no root, caller always supplies it — persist.rs:1706) | n/a |
+| `from_source_files` (P1 local-ref lane) | `FreshLoad` | `None` (store.rs:4132) | **deliberately not caught** — correct |
+| `reset_to_empty` | `EmptyBootstrap` | `None` | caught |
+
+The local-ref lane's legitimacy claim checks out: generations publish via
+`publish_ref_source`, which `expect`s a source identity built from the git ref
+(store.rs:1521-1525); `build_ref_source_generation` never consults
+`indexed_root`. A root-based guard would pin it at `Loading` forever. Also: the
+local-ref lane does **not** pass through `capture_published_manifest` (only
+callers: store.rs:1247, 1982, 2853, 2965 — all P0-lane publications), so the new
+`warn!` does not false-positive on the legitimate rootless lane. **Proven.**
+
+No code path clears `indexed_root` on a populated index — assignments are
+constructor/reload-only. The `remove_file`-never-restores-`is_empty` hint resolves
+consistently: placeholder that admitted then removed a file stays `Loading`, the
+honest state for a still-unbound index.
+
+Residual risk: the guard keys on *provenance* (`load_source`), not on the defect
+(`root None` ∧ `no independently published identity`). A **future** constructor
+building populated + rootless + non-`EmptyBootstrap` without its own identity
+slips through. None exists today. Belt-and-braces alternative: "non-empty ∧
+`capture_published_manifest` returns None ⇒ not Ready", but that couples state to
+manifest capture. The provenance guard is the pragmatic 95% fix — ship it.
+
+## Q3 — `health.json` flip: legitimate, option (i), but the test setup deserves a look (proven)
+
+The test builds its index at `tests/sidecar_contract.rs:196-199`:
+`LiveIndex::empty()` plus write-guard `add_file`s — the fixture **always modeled
+an EmptyBootstrap placeholder that admitted two files**, never a healthy rooted
+index. `/health` renders `published.status_label()` (`src/sidecar/handlers.rs:410`),
+post-fix `Loading` for exactly that state. The flip records the honest output of
+what the test actually constructs. **Not a hidden regression.**
+
+Caveats:
+
+1. **Intent mismatch.** A file named `health.json` in a contract suite now
+   documents `Loading` with `file_count: 2`, and the suite no longer contains any
+   golden showing a healthy index saying `Ready`. Better: make
+   `build_shared_index` produce a rooted index (reload from temp dir) so this
+   golden keeps modeling "healthy ⇒ `Ready`", and add a second golden for the
+   placeholder state.
+2. Neighboring assertion `src/sidecar/handlers.rs:2815`
+   (`index_state.contains("Ready")`) builds a `FreshLoad` index
+   (handlers.rs:2718) — survives the fix. No unflipped casualty.
+
+## Q4 — Positive-case coverage: the specific hole exists, but the suite can still fail positively (proven)
+
+The four flipped assertions (store.rs:5677, 5688, 5852, 5863 — all
+`LiveIndex::empty()` + mutate) were the **only** mutation→status assertions in
+the crate. After the flip, **no test asserts that mutating a rooted, loaded index
+publishes `Ready`**. Remaining positive coverage:
+
+- store.rs:6096-6098 — `reload` → `is_ready()` ∧ `index_state() == Ready` ∧
+  `load_source == FreshLoad` (load path, not mutation);
+- persist.rs:2792 — snapshot verify completion → `is_ready()`;
+- daemon/tool health integration tests (tools.rs:16226, 19132, …) asserting
+  `index_state=fresh_process` after real `index_folder` operations.
+
+A future change pinning everything at `Loading` **would** fail 6096-6098 and the
+health tests — the suite is not blind in the positive direction. But the exact
+contract "mutation on a rooted index stays `Ready`" is untested — precisely the
+contract the flips vacated. Recommended in this PR: reload from tempdir,
+`add_file`, assert `published_state().status == Ready`. Cheap.
+
+## Q5 — `is_ready()` delegation: two production consumers, both safe (proven)
+
+Non-test callers, exactly two:
+
+1. `src/protocol/tools.rs:6673-6675` (`ground_plan_economics`) — newly returns
+   early during the bootstrap-admitted window; grounding skipped, steps keep the
+   plan-only floor. Temporary, self-correcting on load completion, conservative
+   direction for the economics layer. Benign.
+2. `src/protocol/tools.rs:11242` → `src/stel/status.rs:339` — status body
+   `index_ready:` line now reads `false` during the window. An externally visible
+   contract change beyond the guard's core purpose — the intended one. Explains
+   the harness comment "do NOT gate on `index_ready`": on a pre-fix binary that
+   line is `true` while unbound, and in a proxied topology the front-end renders
+   the *worker's* index lines, possibly from an older daemon. Gating on `_meta`
+   evidence is right.
+
+No startup gate, poll loop, or health endpoint consumes `is_ready()` in a way
+that could hang; sidecar `/health` uses `status_label()` (handlers.rs:410).
+
+## Q6 — 20 s ceiling: defensible (proven)
+
+The "10 s cold load" number is a red herring: the harness spawns with
+`cwd = tests/fixtures/verify-tools` and pins `SYMFORGE_WORKSPACE_ROOT` to it.
+That fixture is **14 files / 47 KB**; `verify-tools-real` is 13 files / 61 KB.
+Sub-second-to-few-seconds even on a contended runner. 80×250 ms is ~an order of
+magnitude of headroom, and the abort path dumps the last evidence. Do not raise.
+Revisit only if the harness is ever pointed at a real-repo fixture.
+
+## Q7 — `process.exit(2)`: correctly wired; actually fixes a process leak (proven)
+
+Invoked directly — `.github/workflows/ci.yml:104-105`,
+`.github/workflows/release.yml:94-95` run `node scripts/verify-tools.cjs --bin …`
+as bare `run:` steps; any non-zero fails the step, no wrapper swallows it. The
+abort branch `proc.kill()`s before `process.exit(2)` — child not orphaned. This
+**improves** on the old path: pre-fix `throw` inside `startSession` before the
+session handle existed, leaving the spawned child to be reaped only by node exit.
+Exit-code semantics (2 = harness couldn't run, 1 = real regression) now
+distinguishable in CI logs. No dangling-child path in the new code.
+
+## Q8 — `_meta` gate: holds for this topology, fails safe, one fragility (proven/likely)
+
+Chain is complete: every `tools/call` dispatch is wrapped in
+`with_project_evidence_scope(self.local_project_evidence(), …)`
+(`src/protocol/mod.rs:1539-1543`); `local_project_evidence` always returns `Some`
+with all three fields (tools.rs:7300-7321); `status` returns via
+`statused_tool_result` → `ResultStatus::into_call_tool_result`, which attaches
+`_meta["symforge/project_evidence"]` in scope (result_status.rs:129-134). With
+`SYMFORGE_NO_DAEMON=1` the local seed is attached. `index_state` renders
+`status_label()` → `"Ready"`/`"Loading"` (store.rs:3142-3144), matching the
+harness compare. **Proven present and correctly shaped.**
+
+Fragilities, both failing **safe** (abort, not false-pass):
+
+- `load_source` is `format!("{:?}")` of the Rust enum (tools.rs:7305) — renaming
+  `EmptyBootstrap` silently breaks the gate into permanent abort. Visible in CI
+  immediately, but a named-serde string would be sturdier.
+- "Absent evidence vs still loading": in-process evidence is effectively never
+  absent for a statused result, so "absent" in practice means version skew or a
+  non-statused render path — a topology/version signal, not a state signal.
+
+Contract stability: the evidence key has no `contract_version` (unlike
+`RESULT_STATUS_META_KEY`), but harness and binary ship in the same repo/PR, so
+drift is caught atomically. Acceptable.
+
+## Q9 — Anything else actually wrong
+
+Nothing blocking. Two items:
+
+1. **`warn!` repetition (low).** `capture_published_manifest` runs on **every**
+   publication (store.rs:1982, 2853, 2965). While the placeholder-admitted state
+   persists, every watcher/freshen mutation republishes and re-warns — dozens of
+   identical warnings possible during a cold start with an active watcher.
+   Bounded by mutation rate, self-limiting once the real load lands, arguably the
+   evidence you want — but if CI logs spam, gate to once per generation or
+   downgrade repeats to `debug!`.
+2. **Unbound-state consumers during the window.** Between admission and load
+   completion, tools are refused — correct — but anything reading
+   `published_state()` directly (status bodies, evidence `index_files > 0`, repo
+   outline) still reports placeholder contents. External consumers polling
+   `status` during cold start will see `index_ready: false` with
+   `index_files: 1` — odd but honest. No action; don't be surprised in support
+   questions.
+
+---
+
+## Verdict
+
+The fix is correct; every comment-claim sampled verified against the code. Ship
+(a)+(c) together as planned. Recommended additions, neither blocking:
+
+1. Mutation-on-rooted-index → `Ready` test (Q4).
+2. Flip `build_shared_index` to a rooted index so `health.json` keeps a
+   healthy-`Ready` exemplar, plus a second golden for the placeholder state (Q3).

--- a/scripts/verify-tools.cjs
+++ b/scripts/verify-tools.cjs
@@ -204,9 +204,18 @@ async function startSession(READINESS_PROBE) {
   // it needed). Gate on the per-call trust evidence in `_meta` instead: the real load
   // must have PUBLISHED (load_source != EmptyBootstrap) and the published state must
   // be Ready — then confirm a known symbol actually answers.
-  // Do NOT gate on the status body's `index_ready:` — that renders LiveIndex::is_ready().
+  // Gate on `_meta`, not the status body's `index_ready:`. Since the cold-start fix
+  // `is_ready()` delegates to `index_state()`, so it is no longer DISHONEST here — but
+  // it is still the weaker signal: it is a rendered string, it does not carry
+  // `load_source`/`index_files`, and it is not what the daemon proxy forwards. The
+  // `_meta` evidence carries all three from whichever process actually served.
   // ponytail: fixed 80-poll x 250ms ceiling (~20s of sleep); raise if a bigger fixture needs it.
   const EVIDENCE_KEY = "symforge/project_evidence";
+  // Must match `IndexLoadSource::label()` (src/live_index/store.rs) exactly. That
+  // method is the ONE spelling shared by this gate, the `health` runtime line, and
+  // the `_meta` evidence. It used to be `format!("{:?}", ..)` here and snake_case in
+  // `health`, i.e. two spellings of one value compared against each other.
+  const EMPTY_BOOTSTRAP = "empty_bootstrap";
   let ready = false;
   let evidence = null;
   for (let i = 0; i < 80 && !ready; i++) {
@@ -215,7 +224,7 @@ async function startSession(READINESS_PROBE) {
     const sourceBound =
       !!evidence &&
       evidence.index_state === "Ready" &&
-      evidence.load_source !== "EmptyBootstrap" &&
+      evidence.load_source !== EMPTY_BOOTSTRAP &&
       Number(evidence.index_files) > 0;
     if (sourceBound) {
       if (!READINESS_PROBE) {
@@ -237,9 +246,12 @@ async function startSession(READINESS_PROBE) {
       "\n  HARNESS ABORT — the index never reached a source-bound Ready generation " +
         "(80 polls x 250ms, ~20s of sleep).\n" +
         `  last ${EVIDENCE_KEY}: ${JSON.stringify(evidence)}\n` +
-        '  Wanted index_state="Ready" with load_source!="EmptyBootstrap" and index_files>0.\n' +
-        '  load_source="EmptyBootstrap" => the real load never published (placeholder index).\n' +
-        "  null/absent evidence => the _meta contract changed; fix the gate, not the snapshots.\n"
+        `  Wanted index_state="Ready" with load_source!="${EMPTY_BOOTSTRAP}" and index_files>0.\n` +
+        `  load_source="${EMPTY_BOOTSTRAP}" => the real load never published (placeholder index).\n` +
+        '  {"bound":false} => no workspace bound; check SYMFORGE_WORKSPACE_ROOT / the fixture path.\n' +
+        "  null/absent evidence => the _meta key was NOT written at all. The server always writes\n" +
+        "    it (unbound emits {\"bound\":false}, never omission), so this means the _meta contract\n" +
+        "    changed; fix the gate, not the snapshots.\n"
     );
     proc.kill();
     process.exit(2);

--- a/scripts/verify-tools.cjs
+++ b/scripts/verify-tools.cjs
@@ -124,14 +124,19 @@ function writeSnapshot(name, text) {
 async function startSession(READINESS_PROBE) {
   const proc = spawn(BIN, [], {
     cwd: FIXTURE,
-    stdio: ["pipe", "pipe", "ignore"],
+    // stderr INHERITED, not dropped: the daemon's own warnings are the evidence that
+    // explains a readiness/cold-start failure. Safe — tracing writes to stderr
+    // (src/observability.rs), and the JSON-RPC stream this harness parses is stdout-only.
+    stdio: ["pipe", "pipe", "inherit"],
     // symforge_edit REQUIRES the compact surface; read tools reached via probe relay.
     // Pin the root to the fixture (else find_project_root walks up to the parent
     // symforge repo and indexes 620 files, making every oracle mismatch). NO_DAEMON=1
     // keeps the index in-process so the pin holds.
     env: {
       ...process.env,
-      RUST_LOG: "off",
+      // "warn", not "off": a silenced index-publish warning is precisely what made the
+      // source-binding bug cost two days. Measured cost on a healthy run: one line.
+      RUST_LOG: "warn",
       SYMFORGE_SURFACE: "compact",
       SYMFORGE_NO_DAEMON: "1",
       SYMFORGE_WORKSPACE_ROOT: FIXTURE,
@@ -189,18 +194,32 @@ async function startSession(READINESS_PROBE) {
   proc.stdin.write(
     JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) + "\n"
   );
-  // Compact auto-indexes SYMFORGE_WORKSPACE_ROOT on startup (async). Poll until the
-  // index reports a NON-ZERO file count AND a known symbol is actually queryable —
-  // `index_files: 0` matches the loose old check but the fixture isn't searchable yet,
-  // which is the cold-start flake. Requiring a real hit makes readiness deterministic.
-  // ponytail: fixed 30-poll x 250ms ceiling (~7.5s); raise if a bigger fixture needs it.
+  // Compact auto-indexes SYMFORGE_WORKSPACE_ROOT on startup (async), and the
+  // PLACEHOLDER index it serves meanwhile can ALREADY report files: a targeted read
+  // admits files into the EmptyBootstrap index before the initial load has bound a
+  // source root. So `index_files > 0` opens the gate on an index with no source
+  // identity — measured on this fixture, 4 of 12 cold starts reported
+  // index_files>0 / index_state=Ready / load_source=EmptyBootstrap / generation=0 at
+  // poll 0, with the search probe hitting (the targeted read admitted the very file
+  // it needed). Gate on the per-call trust evidence in `_meta` instead: the real load
+  // must have PUBLISHED (load_source != EmptyBootstrap) and the published state must
+  // be Ready — then confirm a known symbol actually answers.
+  // Do NOT gate on the status body's `index_ready:` — that renders LiveIndex::is_ready().
+  // ponytail: fixed 80-poll x 250ms ceiling (~20s of sleep); raise if a bigger fixture needs it.
+  const EVIDENCE_KEY = "symforge/project_evidence";
   let ready = false;
-  for (let i = 0; i < 30 && !ready; i++) {
-    const status = (await callTool("status", {})).text;
-    const files = (status.match(/index_files"?\s*:?\s*(\d+)/) || [])[1];
-    if (files && Number(files) > 0) {
+  let evidence = null;
+  for (let i = 0; i < 80 && !ready; i++) {
+    const status = await callTool("status", {});
+    evidence = (status.result && status.result._meta && status.result._meta[EVIDENCE_KEY]) || null;
+    const sourceBound =
+      !!evidence &&
+      evidence.index_state === "Ready" &&
+      evidence.load_source !== "EmptyBootstrap" &&
+      Number(evidence.index_files) > 0;
+    if (sourceBound) {
       if (!READINESS_PROBE) {
-        ready = true; // no known symbol to probe; non-zero count is the best signal
+        ready = true; // no known symbol to probe; a source-bound Ready generation is the signal
       } else {
         // Confirm the index actually answers before we trust it. Empty/error → wait.
         const probe = await callTool("search_symbols", { query: READINESS_PROBE });
@@ -209,7 +228,22 @@ async function startSession(READINESS_PROBE) {
     }
     if (!ready) await new Promise((r) => setTimeout(r, 250));
   }
-  if (!ready) throw new Error("index never became queryable (cold-start timeout)");
+  if (!ready) {
+    // LOUD and specific. Never fall through to a snapshot comparison against a
+    // half-loaded index: that renders as a content regression and sends the next
+    // session hunting the wrong bug. Exit 2 = the harness could not run (same code as
+    // a missing binary); exit 1 stays reserved for a REAL regression.
+    console.error(
+      "\n  HARNESS ABORT — the index never reached a source-bound Ready generation " +
+        "(80 polls x 250ms, ~20s of sleep).\n" +
+        `  last ${EVIDENCE_KEY}: ${JSON.stringify(evidence)}\n` +
+        '  Wanted index_state="Ready" with load_source!="EmptyBootstrap" and index_files>0.\n' +
+        '  load_source="EmptyBootstrap" => the real load never published (placeholder index).\n' +
+        "  null/absent evidence => the _meta contract changed; fix the gate, not the snapshots.\n"
+    );
+    proc.kill();
+    process.exit(2);
+  }
   return { callTool, close: () => proc.kill() };
 }
 
@@ -271,13 +305,27 @@ async function runCase(session, c) {
   return { verdict: "FAIL", reason: `unknown judge '${c.judge}'`, text };
 }
 
+// First N differing lines, not just one: a formatter change shifts a whole block and
+// the single first line rarely says which. The trailing count carries the real signal:
+// "5 of 137 differing" reads wholesale rewrite, a bare 1-line diff reads one value moved.
+// ponytail: N=5 is the knee — raise it only if a real failure needed more.
+const DIFF_LINES = 5;
 function firstDiff(a, b) {
   const al = (a || "").split("\n");
   const bl = (b || "").split("\n");
+  const shown = [];
+  let differing = 0;
   for (let i = 0; i < Math.max(al.length, bl.length); i++) {
-    if (al[i] !== bl[i]) return `  L${i + 1}\n   expected: ${JSON.stringify(bl[i])}\n   actual:   ${JSON.stringify(al[i])}`;
+    if (al[i] === bl[i]) continue;
+    differing++;
+    if (shown.length < DIFF_LINES) {
+      shown.push(`  L${i + 1}\n   expected: ${JSON.stringify(bl[i])}\n   actual:   ${JSON.stringify(al[i])}`);
+    }
   }
-  return "";
+  if (!differing) return "";
+  const more =
+    differing > shown.length ? `\n  ... ${shown.length} of ${differing} differing line(s) shown` : "";
+  return shown.join("\n") + more;
 }
 
 (async () => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4005,7 +4005,7 @@ async fn call_tool_handler(
             canonical_root: Some(normalized_path_string(&runtime.canonical_root)),
             generation: runtime.index.current_project_generation(),
             index_state: published.status_label().to_string(),
-            load_source: format!("{:?}", runtime.index.read().load_source()),
+            load_source: runtime.index.read().load_source().label().to_string(),
             index_files: published.file_count,
             index_symbols: published.symbol_count,
         })

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -109,6 +109,18 @@ pub use crate::parsing::process_file;
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// In-memory construction (F7): `LiveIndex::from_indexed_files(root, files)` is
+// the route for an embedder whose `IndexedFile`s came from `process_file` +
+// `IndexedFile::from_parse_result` rather than from this process's filesystem
+// walk. It yields a Ready, source-BOUND index.
+//
+// `LiveIndex::empty()` + `add_file` is NOT that route and never was: the
+// resulting index has no `indexed_root`, so it never reports Ready and it
+// publishes knowledge unbound (`source=unknown`). Use `empty()` only as a
+// placeholder you will later `reload(root)`.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // Snapshot restore (task #22 / AAP ask 2a): the warm-start fast path.
 //
 // `load_snapshot_for_root` (or the explicit-placement `load_snapshot`)
@@ -302,6 +314,10 @@ mod contract {
 
         // Associated functions (no `&self`).
         let _load: fn(&Path) -> anyhow::Result<SharedIndex> = LiveIndex::load;
+        let _from_indexed_files: fn(
+            &Path,
+            Vec<(String, IndexedFile)>,
+        ) -> anyhow::Result<SharedIndex> = LiveIndex::from_indexed_files;
         let _from_parse_result: fn(FileProcessingResult, Vec<u8>) -> IndexedFile =
             IndexedFile::from_parse_result;
         let _from_extension: fn(&str) -> Option<LanguageId> = LanguageId::from_extension;
@@ -323,6 +339,7 @@ mod contract {
             _search_text,
             _process_file,
             _load,
+            _from_indexed_files,
             _from_parse_result,
             _from_extension,
             _for_code_path,

--- a/src/live_index/health_view.rs
+++ b/src/live_index/health_view.rs
@@ -345,7 +345,24 @@ impl LiveIndex {
         // unconditionally (store.rs:1568), so a root-based guard would pin that
         // lane at Loading forever.
         if self.load_source == IndexLoadSource::EmptyBootstrap {
-            return IndexState::Loading;
+            // Two different placeholders share `EmptyBootstrap`, and only one of
+            // them has a load coming. The cold-start lane (main.rs:421-433)
+            // spawns a detached `reload_for_state_placement`, so Loading is true
+            // and transient. The no-root lane (main.rs:469-474) spawns NOTHING:
+            // `watcher_root` is None, so neither the watcher (main.rs:479) nor
+            // any reload ever runs, and `load_source` can never leave
+            // `EmptyBootstrap`. Reporting Loading there tells the agent to retry
+            // something that never lands AND hides
+            // `format::empty_index_recovery_hint` — the only message naming the
+            // real recovery. `local_empty_reason` is set exactly in that lane
+            // (main.rs:472) and cleared exactly where a real load arrives
+            // (`apply_reload_data`, store.rs:4565, adjacent to the `load_source`
+            // assignment at :4566), so it is the discriminator.
+            return if self.local_empty_reason().is_some() {
+                IndexState::Empty
+            } else {
+                IndexState::Loading
+            };
         }
         if matches!(
             self.snapshot_verify_state,

--- a/src/live_index/health_view.rs
+++ b/src/live_index/health_view.rs
@@ -6,7 +6,9 @@ use crate::watcher_state::{WatcherInfo, WatcherState};
 
 use super::query::normalize_path_query;
 use super::search::{NoiseClass, NoisePolicy};
-use super::store::{IndexState, IndexedFile, LiveIndex, ParseStatus, SnapshotVerifyState};
+use super::store::{
+    IndexLoadSource, IndexState, IndexedFile, LiveIndex, ParseStatus, SnapshotVerifyState,
+};
 pub struct HealthStats {
     pub file_count: usize,
     pub symbol_count: usize,
@@ -319,23 +321,31 @@ impl LiveIndex {
     }
 
     /// `true` when the index has been loaded and the circuit breaker has NOT tripped.
+    ///
+    /// Delegates to [`Self::index_state`] so the two never disagree — an index the
+    /// tool guards refuse must not report itself ready in `status`.
     pub fn is_ready(&self) -> bool {
-        if self.is_empty {
-            return false;
-        }
-        if matches!(
-            self.snapshot_verify_state,
-            SnapshotVerifyState::Pending | SnapshotVerifyState::Running
-        ) {
-            return false;
-        }
-        !self.cb_state.is_tripped()
+        matches!(self.index_state(), IndexState::Ready)
     }
 
     /// Returns the current index state.
     pub fn index_state(&self) -> IndexState {
         if self.is_empty {
             return IndexState::Empty;
+        }
+        // A bootstrap placeholder that acquired files — targeted-retrieval
+        // freshening admits one before the detached initial load binds a root —
+        // has no `indexed_root`, so `capture_published_manifest` returns None,
+        // publication captures no source identity, and knowledge publishes
+        // unbound (`source=unknown`). It is not Ready; it is still loading.
+        //
+        // Gate on `load_source`, NOT on `indexed_root.is_none()`: the P1
+        // local-ref lane (`LiveIndex::from_source_files`, store.rs:4290) is
+        // legitimately rootless and publishes its own source identity
+        // unconditionally (store.rs:1568), so a root-based guard would pin that
+        // lane at Loading forever.
+        if self.load_source == IndexLoadSource::EmptyBootstrap {
+            return IndexState::Loading;
         }
         if matches!(
             self.snapshot_verify_state,

--- a/src/live_index/health_view.rs
+++ b/src/live_index/health_view.rs
@@ -340,24 +340,29 @@ impl LiveIndex {
         // unbound (`source=unknown`). It is not Ready; it is still loading.
         //
         // Gate on `load_source`, NOT on `indexed_root.is_none()`: the P1
-        // local-ref lane (`LiveIndex::from_source_files`, store.rs:4290) is
-        // legitimately rootless and publishes its own source identity
-        // unconditionally (store.rs:1568), so a root-based guard would pin that
+        // local-ref lane (`LiveIndex::from_source_files`) is legitimately
+        // rootless and builds its own source identity unconditionally
+        // (`build_ref_source_generation`), so a root-based guard would pin that
         // lane at Loading forever.
         if self.load_source == IndexLoadSource::EmptyBootstrap {
             // Two different placeholders share `EmptyBootstrap`, and only one of
-            // them has a load coming. The cold-start lane (main.rs:421-433)
-            // spawns a detached `reload_for_state_placement`, so Loading is true
-            // and transient. The no-root lane (main.rs:469-474) spawns NOTHING:
-            // `watcher_root` is None, so neither the watcher (main.rs:479) nor
-            // any reload ever runs, and `load_source` can never leave
+            // them has a load coming. The cold-start lane in `main` spawns a
+            // detached `reload_for_state_placement`, so Loading is true and
+            // transient. The no-root lane — `main`'s `else` arm, the one that
+            // calls `set_local_empty_reason` — spawns NOTHING: `watcher_root` is
+            // None, so the `if let Some(ref root) = watcher_root` guard never
+            // fires and no reload ever runs, so `load_source` can never leave
             // `EmptyBootstrap`. Reporting Loading there tells the agent to retry
             // something that never lands AND hides
             // `format::empty_index_recovery_hint` — the only message naming the
-            // real recovery. `local_empty_reason` is set exactly in that lane
-            // (main.rs:472) and cleared exactly where a real load arrives
-            // (`apply_reload_data`, store.rs:4565, adjacent to the `load_source`
-            // assignment at :4566), so it is the discriminator.
+            // real recovery. `local_empty_reason` is set exactly in that lane and
+            // cleared by `apply_reload_data` beside its `load_source` and
+            // `indexed_root` assignments, so it is the discriminator.
+            //
+            // Cited by NAME, not line number: the original versions of these
+            // comments were 50+ lines stale within one edit of being written. A
+            // citation that rots on the next insertion is decoration, not
+            // evidence. Symbol names survive edits and are greppable.
             return if self.local_empty_reason().is_some() {
                 IndexState::Empty
             } else {

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -9,7 +9,7 @@ use parking_lot::{Mutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime};
 
 use rayon::prelude::*;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::knowledge_authority::{
     AuthorityLimits, AuthorityTemporalIndex, KnowledgeAuthorityView, build_knowledge_authority,
@@ -755,6 +755,22 @@ pub enum IndexLoadSource {
     SnapshotRestore,
 }
 
+impl IndexLoadSource {
+    /// Stable wire spelling, shared by the `health` runtime line, the
+    /// `symforge/project_evidence` `_meta` block, and `scripts/verify-tools.cjs`.
+    ///
+    /// Do NOT reintroduce `format!("{:?}", ..)` at any of those sites: the Debug
+    /// spelling (`EmptyBootstrap`) and this one (`empty_bootstrap`) then drift
+    /// apart across surfaces that are compared against each other.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::EmptyBootstrap => "empty_bootstrap",
+            Self::FreshLoad => "fresh_load",
+            Self::SnapshotRestore => "snapshot_restore",
+        }
+    }
+}
+
 const SNAPSHOT_VERIFY_MISMATCH_PATH_LIMIT: usize = 10;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1013,10 +1029,24 @@ fn capture_published_manifest(
         // source identity, source version and knowledge bridge are all silently
         // dropped downstream, and the receipt prints `source=unknown`.
         if !live.is_empty {
-            warn!(
-                files = live.files.len(),
-                "publishing a non-empty index with no indexed_root; source identity unbound"
-            );
+            if live.load_source() == IndexLoadSource::EmptyBootstrap {
+                // The bootstrap placeholder admitting a file before its detached
+                // load binds a root is the EXPECTED transient this branch's
+                // `index_state()` guard already models (health_view.rs). It fires
+                // on every publication during that window — measured at ~10 per
+                // healthy cold start — so warning here would train the reader to
+                // ignore the level that carries the real defect below.
+                debug!(
+                    files = live.files.len(),
+                    "bootstrap placeholder published with no indexed_root; guarded as not-Ready"
+                );
+            } else {
+                warn!(
+                    files = live.files.len(),
+                    load_source = live.load_source().label(),
+                    "publishing a non-empty index with no indexed_root; source identity unbound"
+                );
+            }
         }
         return None;
     };
@@ -4336,10 +4366,42 @@ impl LiveIndex {
         index
     }
 
+    /// Build a Ready, source-BOUND `SharedIndex` from already-parsed files held
+    /// in memory — the embedder route for `process_file` +
+    /// `IndexedFile::from_parse_result` output that never touched this process's
+    /// filesystem walk.
+    ///
+    /// `root` is mandatory and must resolve. `LiveIndex::empty()` + `add_file`
+    /// cannot serve this purpose: it leaves `load_source == EmptyBootstrap` and
+    /// `indexed_root == None`, so `index_state()` never reaches Ready and
+    /// `capture_published_manifest` drops source identity. Canonicalizing here
+    /// fails CLOSED rather than publishing a `Ready` index whose knowledge would
+    /// publish unbound.
+    pub fn from_indexed_files(
+        root: &Path,
+        files: Vec<(String, IndexedFile)>,
+    ) -> anyhow::Result<SharedIndex> {
+        let canonical = dunce::canonicalize(root).map_err(|error| {
+            anyhow::anyhow!("index root {} does not resolve: {error}", root.display())
+        })?;
+        let mut index = Self::from_source_files(
+            files
+                .into_iter()
+                .map(|(path, file)| (path, Arc::new(file)))
+                .collect(),
+        );
+        index.indexed_root = Some(canonical);
+        Ok(SharedIndexHandle::shared(index))
+    }
+
     /// Create an empty `SharedIndex` with no files loaded.
     ///
     /// Used when `SYMFORGE_AUTO_INDEX=false`. The caller must call `reload()` to populate it.
     /// Returns `IndexState::Empty` and `is_ready() == false` until reloaded.
+    ///
+    /// NOT a construction route for an embedder holding parsed files: admitting
+    /// files into this placeholder leaves it `EmptyBootstrap` and rootless
+    /// forever. Use [`Self::from_indexed_files`] or `reload(root)` for that.
     pub fn empty() -> SharedIndex {
         SharedIndexHandle::shared(Self::empty_live_index())
     }
@@ -6304,6 +6366,90 @@ mod tests {
             make_indexed_file_for_mutation("src/admitted_before_load.rs"),
         );
         assert_eq!(shared.read().index_state(), IndexState::Loading);
+    }
+
+    /// F7: the embed facade's in-memory construction path must yield an index
+    /// that is BOTH Ready and source-bound. Pinning both matters — a Ready but
+    /// rootless index is the unbound-knowledge defect wearing a green label, so
+    /// a fix that only relabels the placeholder must fail this test.
+    #[test]
+    fn from_indexed_files_is_ready_and_source_bound() {
+        let tmp = TempDir::new().unwrap();
+        let shared = LiveIndex::from_indexed_files(
+            tmp.path(),
+            vec![(
+                "src/lib.rs".to_string(),
+                make_indexed_file_for_mutation("src/lib.rs"),
+            )],
+        )
+        .expect("existing root");
+
+        assert_eq!(shared.read().index_state(), IndexState::Ready);
+        assert_eq!(shared.read().load_source(), IndexLoadSource::FreshLoad);
+        assert!(
+            shared.published_state().indexed_root.is_some(),
+            "an in-memory index built at a root records that root"
+        );
+        assert!(
+            shared.published_generation().source.is_some(),
+            "a rooted in-memory index publishes a bound source identity"
+        );
+
+        // The old construction is still not Ready and still unbound: this is a
+        // new route, not a weakening of the placeholder guard above.
+        let placeholder = LiveIndex::empty();
+        placeholder.update_file(
+            "src/lib.rs".to_string(),
+            make_indexed_file_for_mutation("src/lib.rs"),
+        );
+        assert_eq!(placeholder.read().index_state(), IndexState::Loading);
+        assert!(placeholder.published_generation().source.is_none());
+
+        // A root that does not resolve is refused, not published as Ready.
+        assert!(LiveIndex::from_indexed_files(&tmp.path().join("nope"), Vec::new()).is_err());
+    }
+
+    /// Counterpart to the test above: the no-root lane (main.rs:469-474) spawns
+    /// neither watcher nor reload, so its placeholder can never leave
+    /// `EmptyBootstrap`. The sidecar can still populate it — `/impact` resolves
+    /// its root from the process CWD when the sidecar has none — and reporting
+    /// Loading there would pin every tool at "try again shortly" FOREVER and
+    /// hide `format::empty_index_recovery_hint`, the only message naming the
+    /// real recovery. `local_empty_reason` is the discriminator.
+    #[test]
+    fn unbound_no_root_placeholder_that_admitted_a_file_stays_empty_not_loading() {
+        let shared = LiveIndex::empty();
+        shared.set_local_empty_reason(Some("workspace is not bound".to_string()));
+        shared.update_file(
+            "src/admitted_via_sidecar.rs".to_string(),
+            make_indexed_file_for_mutation("src/admitted_via_sidecar.rs"),
+        );
+        assert_eq!(shared.read().index_state(), IndexState::Empty);
+    }
+
+    /// Q4: the assertions this branch flipped were the crate's only
+    /// mutation->status coverage, and flipping them vacated the contract they
+    /// also carried — that a mutation on a REAL rooted index leaves Ready alone.
+    /// Pinned explicitly so a future widening of the `EmptyBootstrap` guard
+    /// cannot pass by pinning everything to Loading.
+    #[test]
+    fn mutation_on_a_rooted_loaded_index_stays_ready() {
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "a.rs", "fn alpha() {}");
+
+        let shared = LiveIndex::empty();
+        {
+            let mut index = shared.write();
+            index.reload(tmp.path()).expect("reload should succeed");
+        }
+        assert_eq!(shared.published_state().status, PublishedIndexStatus::Ready);
+
+        shared.update_file(
+            "src/added_after_load.rs".to_string(),
+            make_indexed_file_for_mutation("src/added_after_load.rs"),
+        );
+        assert_eq!(shared.published_state().status, PublishedIndexStatus::Ready);
+        assert_eq!(shared.read().index_state(), IndexState::Ready);
     }
 
     #[test]

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -1030,14 +1030,23 @@ fn capture_published_manifest(
         // dropped downstream, and the receipt prints `source=unknown`.
         if !live.is_empty {
             if live.load_source() == IndexLoadSource::EmptyBootstrap {
-                // The bootstrap placeholder admitting a file before its detached
-                // load binds a root is the EXPECTED transient this branch's
-                // `index_state()` guard already models (health_view.rs). It fires
-                // on every publication during that window — measured at ~10 per
-                // healthy cold start — so warning here would train the reader to
-                // ignore the level that carries the real defect below.
+                // A bootstrap placeholder admitting a file before a root is bound
+                // is already modelled by `index_state()` (health_view.rs), which
+                // reports Loading or Empty rather than Ready, so no answer is
+                // served off this generation. It fires on every publication in
+                // that window — measured at ~10 per healthy cold start — so
+                // warning here would train the reader to ignore the level that
+                // carries the real defect below.
+                //
+                // Deliberately NOT called "transient": `EmptyBootstrap` alone
+                // cannot tell a load that is coming from one that already failed
+                // (`main`'s cold-start reload logs that failure on its error
+                // branch; this site cannot see it).
+                // Claiming transience here would assert something this function
+                // never observed.
                 debug!(
                     files = live.files.len(),
+                    local_empty_reason = live.local_empty_reason().is_some(),
                     "bootstrap placeholder published with no indexed_root; guarded as not-Ready"
                 );
             } else {
@@ -4366,10 +4375,15 @@ impl LiveIndex {
         index
     }
 
-    /// Build a Ready, source-BOUND `SharedIndex` from already-parsed files held
-    /// in memory — the embedder route for `process_file` +
+    /// Build a source-BOUND `SharedIndex` from already-parsed files held in
+    /// memory — the embedder route for `process_file` +
     /// `IndexedFile::from_parse_result` output that never touched this process's
     /// filesystem walk.
+    ///
+    /// Reaches `Ready` when `files` is non-empty. An empty `files` yields
+    /// `Empty`, which is correct and not a failure: `is_empty` is checked before
+    /// the bound-root logic in `index_state()`. Say "bound", not "Ready" — the
+    /// state depends on the argument.
     ///
     /// `root` is mandatory and must resolve. `LiveIndex::empty()` + `add_file`
     /// cannot serve this purpose: it leaves `load_source == EmptyBootstrap` and
@@ -6409,8 +6423,9 @@ mod tests {
         assert!(LiveIndex::from_indexed_files(&tmp.path().join("nope"), Vec::new()).is_err());
     }
 
-    /// Counterpart to the test above: the no-root lane (main.rs:469-474) spawns
-    /// neither watcher nor reload, so its placeholder can never leave
+    /// Counterpart to the test above: the no-root lane in `main` — the `else`
+    /// arm that calls `set_local_empty_reason` — spawns neither watcher nor
+    /// reload, so its placeholder can never leave
     /// `EmptyBootstrap`. The sidecar can still populate it — `/impact` resolves
     /// its root from the process CWD when the sidecar has none — and reporting
     /// Loading there would pin every tool at "try again shortly" FOREVER and

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -1007,8 +1007,30 @@ fn capture_published_manifest(
     live: &LiveIndex,
     scout_plan: Option<&discovery::ScoutPlan>,
 ) -> Option<Arc<RepositoryManifest>> {
-    let root = live.indexed_root.as_deref()?;
-    let canonical_root = dunce::canonicalize(root).ok()?;
+    let Some(root) = live.indexed_root.as_deref() else {
+        // An empty bootstrap index legitimately has no root yet. A POPULATED one
+        // publishing without a root is the unbound-knowledge defect: the manifest,
+        // source identity, source version and knowledge bridge are all silently
+        // dropped downstream, and the receipt prints `source=unknown`.
+        if !live.is_empty {
+            warn!(
+                files = live.files.len(),
+                "publishing a non-empty index with no indexed_root; source identity unbound"
+            );
+        }
+        return None;
+    };
+    let canonical_root = match dunce::canonicalize(root) {
+        Ok(canonical_root) => canonical_root,
+        Err(error) => {
+            warn!(
+                root = %root.display(),
+                %error,
+                "failed to canonicalize the indexed root; publishing without source identity"
+            );
+            return None;
+        }
+    };
     let project_id = crate::discovery::project_id_for_canonical_root(&canonical_root);
     let captured = match super::persist::capture_repository_source(&canonical_root, &project_id) {
         Ok(captured) => captured,
@@ -5862,7 +5884,9 @@ mod tests {
         );
         let after_add = shared.published_state();
         assert_eq!(after_add.generation, 1);
-        assert_eq!(after_add.status, PublishedIndexStatus::Ready);
+        // Still an EmptyBootstrap index with no bound root: mutating it does not
+        // make it Ready, it makes it a placeholder that is still loading.
+        assert_eq!(after_add.status, PublishedIndexStatus::Loading);
         assert_eq!(after_add.degraded_summary, None);
         assert_eq!(after_add.file_count, 1);
         assert_eq!(after_add.parsed_count, 1);
@@ -5873,7 +5897,9 @@ mod tests {
         shared.remove_file("src/new.rs");
         let after_remove = shared.published_state();
         assert_eq!(after_remove.generation, 2);
-        assert_eq!(after_remove.status, PublishedIndexStatus::Ready);
+        // `remove_file` never restores `is_empty`, so the index stays a
+        // non-empty-flagged, still-unbound bootstrap.
+        assert_eq!(after_remove.status, PublishedIndexStatus::Loading);
         assert_eq!(after_remove.degraded_summary, None);
         assert_eq!(after_remove.file_count, 0);
         assert_eq!(after_remove.symbol_count, 0);
@@ -6037,7 +6063,9 @@ mod tests {
 
         let after_add = shared.published_state();
         assert_eq!(after_add.generation, 1);
-        assert_eq!(after_add.status, PublishedIndexStatus::Ready);
+        // Write-guard drop publishes, but an unbound EmptyBootstrap index that
+        // gained a file is Loading, not Ready (see index_state's guard).
+        assert_eq!(after_add.status, PublishedIndexStatus::Loading);
         assert_eq!(after_add.degraded_summary, None);
         assert_eq!(after_add.file_count, 1);
 
@@ -6048,7 +6076,7 @@ mod tests {
 
         let after_remove = shared.published_state();
         assert_eq!(after_remove.generation, 2);
-        assert_eq!(after_remove.status, PublishedIndexStatus::Ready);
+        assert_eq!(after_remove.status, PublishedIndexStatus::Loading);
         assert_eq!(after_remove.degraded_summary, None);
         assert_eq!(after_remove.file_count, 0);
     }
@@ -6261,6 +6289,21 @@ mod tests {
         let shared = LiveIndex::empty();
         let index = shared.read();
         assert!(!index.is_ready(), "empty index should not be ready");
+    }
+
+    /// Regression: a file admitted into the empty bootstrap placeholder before the
+    /// initial load bound a root must NOT publish as Ready. Such an index has no
+    /// `indexed_root`, so `capture_published_manifest` returns None and knowledge
+    /// publishes unbound with `source=unknown`, while the tool guards wave the
+    /// request through.
+    #[test]
+    fn bootstrap_placeholder_that_admitted_a_file_is_loading_not_ready() {
+        let shared = LiveIndex::empty();
+        shared.update_file(
+            "src/admitted_before_load.rs".to_string(),
+            make_indexed_file_for_mutation("src/admitted_before_load.rs"),
+        );
+        assert_eq!(shared.read().index_state(), IndexState::Loading);
     }
 
     #[test]

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -497,11 +497,7 @@ pub struct RuntimeStatus {
 }
 
 fn index_load_source_label(load_source: IndexLoadSource) -> &'static str {
-    match load_source {
-        IndexLoadSource::EmptyBootstrap => "empty_bootstrap",
-        IndexLoadSource::FreshLoad => "fresh_load",
-        IndexLoadSource::SnapshotRestore => "snapshot_restore",
-    }
+    load_source.label()
 }
 
 fn index_state_label(status: &RuntimeStatus) -> &'static str {

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -7387,7 +7387,7 @@ impl SymForgeServer {
     ) -> Option<crate::protocol::result_status::ProjectEvidence> {
         let root = self.capture_repo_root();
         let published = self.index.published_state();
-        let load_source = format!("{:?}", self.index.read().load_source());
+        let load_source = self.index.read().load_source().label().to_string();
         Some(crate::protocol::result_status::ProjectEvidence {
             project_id: root
                 .as_deref()
@@ -8760,13 +8760,25 @@ impl SymForgeServer {
         let path_scope = search::PathScope::exact(&input.path);
         freshen_exact_path_for_targeted_retrieval(self, &path_scope);
 
-        // Held across the fallback so the gate reads the recorded disposition off
-        // the SAME publication that produced the index miss. `SharedIndexHandle::read`
-        // is an `ArcSwap` load, not a lock, and nothing below awaits.
-        let index = self.index.read();
-        // Skip loading_guard here — the disk-read fallback below does not
-        // need the index, so we should not block when the index is still loading.
-        let indexed_file = index.capture_shared_file(&input.path);
+        // One publication for the whole handler: the gate below reads the recorded
+        // disposition off the SAME publication that produced the index miss, and
+        // the trust decision here is taken on that same publication rather than a
+        // second, possibly newer, read.
+        let published = self.index.published_generation();
+        // No blanket loading_guard: the disk-read fallback below parses from disk
+        // and does not need the index, so a not-Ready index must not block this
+        // tool outright. But the indexed hit must not be TRUSTED either — the
+        // freshen above admits the requested file into a cold-start bootstrap
+        // placeholder with no bound root, so a "hit" here can be an entry this
+        // very call just created inside an index that is not yet a view of the
+        // repository. While not Ready, ignore the indexed entry and answer from
+        // the authoritative disk parse below.
+        let not_ready = loading_guard_message_from_published(&published.health);
+        let indexed_file = if not_ready.is_some() {
+            None
+        } else {
+            published.live.capture_shared_file(&input.path)
+        };
         if let Some(file) = indexed_file {
             let output = format::validate_file_syntax_result(&input.path, file.as_ref());
             self.session_context.record_summary_output(
@@ -8781,6 +8793,15 @@ impl SymForgeServer {
             .and_then(|ext| ext.to_str())
             .unwrap_or("");
         let Some(language) = LanguageId::from_extension(extension) else {
+            // A not-Ready index is why the indexed lane was skipped for a file the
+            // index may well know: `from_extension` is strictly weaker than the
+            // indexer's own `LanguageId::from_path`, which additionally classifies
+            // extensionless entry points such as README / LICENSE / .env. Blaming
+            // the extension here would be the misleading half of the same defect
+            // this fix exists to remove.
+            if let Some(message) = not_ready {
+                return message;
+            }
             return format!(
                 "Syntax validation unavailable for {}: unsupported or unknown file extension.",
                 input.path
@@ -8802,10 +8823,11 @@ impl SymForgeServer {
         // for the fallback decision, so it gates the CURRENT bytes even when the
         // manifest says `Indexed` (D3: the exemption is about where bytes come
         // from). The gate owns the read; nothing below reopens the path.
-        let bytes = match read_gate::admit_disk_read(index.as_ref(), &input.path, &canon_path) {
-            Ok(bytes) => bytes,
-            Err(refusal) => return refusal,
-        };
+        let bytes =
+            match read_gate::admit_disk_read(published.live.as_ref(), &input.path, &canon_path) {
+                Ok(bytes) => bytes,
+                Err(refusal) => return refusal,
+            };
         let classification = crate::domain::FileClassification::for_code_path(&input.path);
         let result = crate::parsing::process_file_with_classification(
             &input.path,
@@ -12831,6 +12853,43 @@ mod tests {
         );
     }
 
+    /// F4: `status`'s `index_ready` is protocol-visible and comes straight from
+    /// `LiveIndex::is_ready()`. The cold-start fix made `is_ready()` delegate to
+    /// `index_state()`, which changed this rendered line for the bootstrap
+    /// placeholder — and NOTHING pinned it.
+    ///
+    /// The pairing is the whole point: `index_files` > 0 next to
+    /// `index_ready: false`. That looks contradictory and is exactly right — the
+    /// placeholder HAS files (a targeted read admitted one) but has no bound
+    /// root, so it cannot answer as a view of the repository. A regression that
+    /// re-decouples `is_ready()` from `index_state()` re-reports `true` here and
+    /// fails this test.
+    #[test]
+    fn status_reports_index_not_ready_for_a_bootstrap_placeholder_that_admitted_a_file() {
+        let (key, file) = make_file("src/admitted_before_load.rs", b"fn core() {}", vec![]);
+        let mut index = make_live_index_ready(vec![(key, file)]);
+        // The placeholder shape: files present, but the detached initial load has
+        // not published, so no root is bound.
+        index.load_source = crate::live_index::store::IndexLoadSource::EmptyBootstrap;
+        index.indexed_root = None;
+
+        let body = make_server(index).render_stel_status_body(&crate::stel::StelStatusRequest {
+            detail: Some(crate::stel::StelStatusDetail::Full),
+            reset_calibration: None,
+            connection_surface: None,
+        });
+
+        assert!(
+            body.contains("index_ready: false"),
+            "a rootless bootstrap placeholder must not advertise index_ready: true:\n{body}"
+        );
+        assert!(
+            body.contains("index_files: 1"),
+            "the placeholder really does hold the admitted file; that is what makes \
+             index_ready: false load-bearing rather than a trivial empty-index case:\n{body}"
+        );
+    }
+
     #[tokio::test]
     async fn status_serves_on_full_surface_without_corpus() {
         // Wave 1 Fix 4 (corpus-free proof): with SYMFORGE_SURFACE=full active,
@@ -14599,6 +14658,98 @@ mod tests {
         assert!(
             result.contains("Byte span: 28..41"),
             "file context should include the diagnostic byte span; got: {result}"
+        );
+    }
+
+    /// Build a repo with one clean-parsing file on disk, plus an index entry for
+    /// that same path carrying a DELIBERATELY WRONG `parse_status: Failed`.
+    ///
+    /// The wrongness is the instrument: it is the only way to observe WHICH lane
+    /// answered `validate_file_syntax`. `mtime_secs` is pinned to the real disk
+    /// mtime so the handler's own freshen (`freshen_file_if_stale` compares
+    /// exactly that, watcher/mod.rs:203-205) reports Fresh and leaves the planted
+    /// entry alone — otherwise the freshen would silently repair it and the test
+    /// would pass under either lane.
+    fn repo_with_disagreeing_index_entry(
+        load_source: crate::live_index::store::IndexLoadSource,
+    ) -> (TempDir, SymForgeServer) {
+        let repo = TempDir::new().expect("temp repo");
+        let src = repo.path().join("src");
+        fs::create_dir_all(&src).expect("create src");
+        let file_path = src.join("clean.rs");
+        fs::write(&file_path, b"pub fn clean() {}\n").expect("write clean rust");
+
+        let disk_mtime = fs::metadata(&file_path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .expect("disk mtime");
+
+        let (key, mut file) = make_file("src/clean.rs", b"pub fn clean() {}\n", vec![]);
+        file.parse_status = ParseStatus::Failed {
+            error: "planted disagreement: the index says this file does not parse".to_string(),
+        };
+        file.mtime_secs = disk_mtime;
+
+        let mut index = make_live_index_ready(vec![(key, file)]);
+        index.load_source = load_source;
+
+        let server = make_server_with_root(index, Some(repo.path().to_path_buf()));
+        (repo, server)
+    }
+
+    /// The guard-sweep hole: `validate_file_syntax` freshens and then rendered
+    /// from the index with NO readiness gate, so it was the one read tool that
+    /// still answered off an index every other tool had just refused.
+    ///
+    /// A blanket `loading_guard!` would be the wrong fix — it would kill this
+    /// tool's documented ability to validate a config file from disk during a
+    /// cold start. The right fix is to distrust the INDEXED entry while not
+    /// Ready and answer from the authoritative disk parse.
+    #[tokio::test]
+    async fn validate_file_syntax_answers_from_disk_when_the_index_is_not_ready() {
+        let (_repo, server) = repo_with_disagreeing_index_entry(
+            crate::live_index::store::IndexLoadSource::EmptyBootstrap,
+        );
+
+        let result = server
+            .validate_file_syntax(Parameters(super::ValidateFileSyntaxInput {
+                project: None,
+                path: "src/clean.rs".to_string(),
+            }))
+            .await;
+
+        assert!(
+            !result.contains("Status: failed"),
+            "a not-Ready index must not be trusted for the parse verdict; the disk parse \
+             is authoritative here. got: {result}"
+        );
+        assert!(
+            result.contains("Status: ok"),
+            "the disk fallback must still answer (NOT refuse) — this tool validates \
+             config files during a cold start by design. got: {result}"
+        );
+    }
+
+    /// Control for the test above: on a Ready index the indexed entry is still
+    /// authoritative, so the planted verdict comes back. Without this, the fix
+    /// could silently have made the tool ignore the index entirely.
+    #[tokio::test]
+    async fn validate_file_syntax_still_trusts_the_index_when_ready() {
+        let (_repo, server) =
+            repo_with_disagreeing_index_entry(crate::live_index::store::IndexLoadSource::FreshLoad);
+
+        let result = server
+            .validate_file_syntax(Parameters(super::ValidateFileSyntaxInput {
+                project: None,
+                path: "src/clean.rs".to_string(),
+            }))
+            .await;
+
+        assert!(
+            result.contains("Status: failed"),
+            "a Ready index stays authoritative; the indexed lane must be unchanged. got: {result}"
         );
     }
 

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -14667,7 +14667,7 @@ mod tests {
     /// The wrongness is the instrument: it is the only way to observe WHICH lane
     /// answered `validate_file_syntax`. `mtime_secs` is pinned to the real disk
     /// mtime so the handler's own freshen (`freshen_file_if_stale` compares
-    /// exactly that, watcher/mod.rs:203-205) reports Fresh and leaves the planted
+    /// exactly that) reports Fresh and leaves the planted
     /// entry alone — otherwise the freshen would silently repair it and the test
     /// would pass under either lane.
     fn repo_with_disagreeing_index_entry(

--- a/tests/fixtures/sidecar_contract/health.json
+++ b/tests/fixtures/sidecar_contract/health.json
@@ -1,6 +1,6 @@
 {
   "file_count": 2,
-  "index_state": "Ready",
+  "index_state": "Loading",
   "symbol_count": 2,
   "uptime_secs": 0
 }

--- a/tests/fixtures/sidecar_contract/health_bootstrap_placeholder.json
+++ b/tests/fixtures/sidecar_contract/health_bootstrap_placeholder.json
@@ -1,6 +1,6 @@
 {
   "file_count": 2,
-  "index_state": "Ready",
+  "index_state": "Loading",
   "symbol_count": 2,
   "uptime_secs": 0
 }

--- a/tests/sidecar_contract.rs
+++ b/tests/sidecar_contract.rs
@@ -193,7 +193,29 @@ fn make_rust_file_with_refs(
     file
 }
 
-fn build_shared_index(files: Vec<IndexedFile>) -> SharedIndex {
+/// Build a Ready, source-BOUND `SharedIndex` at `root` — the shape a real
+/// serving index has.
+///
+/// Deliberately NOT `LiveIndex::empty()` + `add_file`: that construction leaves
+/// the index an unrooted bootstrap placeholder, which is the cold-start DEFECT
+/// shape, not a healthy index. Modelling every contract golden on it meant the
+/// goldens could not tell the two apart. `build_bootstrap_placeholder_index`
+/// below still builds that shape, for the one golden that is about it.
+fn build_shared_index(root: &Path, files: Vec<IndexedFile>) -> SharedIndex {
+    LiveIndex::from_indexed_files(
+        root,
+        files
+            .into_iter()
+            .map(|file| (file.relative_path.clone(), file))
+            .collect(),
+    )
+    .expect("tempdir root resolves")
+}
+
+/// The cold-start placeholder: an empty bootstrap index that admitted files
+/// before any load bound a root. Kept so one golden pins what the sidecar
+/// reports in exactly that state.
+fn build_bootstrap_placeholder_index(files: Vec<IndexedFile>) -> SharedIndex {
     let shared = LiveIndex::empty();
     {
         let mut guard = shared.write();
@@ -293,10 +315,13 @@ async fn test_health_contract_golden() {
     let original = stable_cwd();
     std::env::set_current_dir(tmp.path()).unwrap();
 
-    let index = build_shared_index(vec![
-        make_rust_file_with_symbols("src/alpha.rs", vec![("alpha", SymbolKind::Function)]),
-        make_rust_file_with_symbols("src/beta.rs", vec![("beta", SymbolKind::Function)]),
-    ]);
+    let index = build_shared_index(
+        tmp.path(),
+        vec![
+            make_rust_file_with_symbols("src/alpha.rs", vec![("alpha", SymbolKind::Function)]),
+            make_rust_file_with_symbols("src/beta.rs", vec![("beta", SymbolKind::Function)]),
+        ],
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -316,6 +341,42 @@ async fn test_health_contract_golden() {
     restore_cwd(&original);
 }
 
+/// Second `/health` golden: the cold-start bootstrap placeholder that admitted
+/// files before any load bound a root.
+///
+/// This is the state the whole cold-start fix is about, and it must stay
+/// DISTINGUISHABLE from the healthy golden above. A regression that reports it
+/// `Ready` — the original defect — changes this golden, not the other one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_health_contract_golden_bootstrap_placeholder() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = CWD_LOCK.lock().await;
+    let original = stable_cwd();
+    std::env::set_current_dir(tmp.path()).unwrap();
+
+    let index = build_bootstrap_placeholder_index(vec![
+        make_rust_file_with_symbols("src/alpha.rs", vec![("alpha", SymbolKind::Function)]),
+        make_rust_file_with_symbols("src/beta.rs", vec![("beta", SymbolKind::Function)]),
+    ]);
+    let handle = spawn_sidecar(
+        Arc::clone(&index),
+        "127.0.0.1",
+        Some(tmp.path().to_path_buf()),
+        Some(control_state(tmp.path())),
+    )
+    .await
+    .expect("spawn_sidecar");
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let body = raw_http_get(handle.port, "/health", "").expect("GET /health");
+    let normalized = normalize_health_json(&body);
+    assert_golden("health_bootstrap_placeholder.json", &normalized);
+
+    handle.shutdown_and_join().await;
+    restore_cwd(&original);
+}
+
 // ---------------------------------------------------------------------------
 // /stats — JSON contract (fresh-spawn zero state)
 // ---------------------------------------------------------------------------
@@ -328,7 +389,7 @@ async fn test_stats_contract_golden() {
     std::env::set_current_dir(tmp.path()).unwrap();
 
     // Empty index is fine — /stats is independent of index contents.
-    let index = build_shared_index(vec![]);
+    let index = build_shared_index(tmp.path(), vec![]);
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -360,13 +421,16 @@ async fn test_outline_contract_golden() {
     let original = stable_cwd();
     std::env::set_current_dir(tmp.path()).unwrap();
 
-    let index = build_shared_index(vec![make_rust_file_with_symbols(
-        "src/lib.rs",
-        vec![
-            ("hello", SymbolKind::Function),
-            ("Config", SymbolKind::Struct),
-        ],
-    )]);
+    let index = build_shared_index(
+        tmp.path(),
+        vec![make_rust_file_with_symbols(
+            "src/lib.rs",
+            vec![
+                ("hello", SymbolKind::Function),
+                ("Config", SymbolKind::Struct),
+            ],
+        )],
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -410,10 +474,13 @@ async fn test_impact_edit_contract_golden() {
     std::fs::create_dir_all(&src_dir).unwrap();
     std::fs::write(src_dir.join("edit.rs"), medium_fixture_content()).unwrap();
 
-    let index = build_shared_index(vec![make_rust_file_with_symbols(
-        "src/edit.rs",
-        vec![("edited", SymbolKind::Function)],
-    )]);
+    let index = build_shared_index(
+        tmp.path(),
+        vec![make_rust_file_with_symbols(
+            "src/edit.rs",
+            vec![("edited", SymbolKind::Function)],
+        )],
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -472,7 +539,7 @@ async fn test_impact_new_file_contract_golden() {
     )
     .unwrap();
 
-    let index = build_shared_index(vec![]);
+    let index = build_shared_index(tmp.path(), vec![]);
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -510,7 +577,7 @@ async fn test_symbol_context_contract_golden() {
         vec![("caller", SymbolKind::Function)],
         vec![("do_thing", ReferenceKind::Call, 1)],
     );
-    let index = build_shared_index(vec![definer, caller]);
+    let index = build_shared_index(tmp.path(), vec![definer, caller]);
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -553,11 +620,14 @@ async fn test_repo_map_contract_golden() {
     let original = stable_cwd();
     std::env::set_current_dir(tmp.path()).unwrap();
 
-    let index = build_shared_index(vec![
-        make_rust_file_with_symbols("src/alpha.rs", vec![("alpha", SymbolKind::Function)]),
-        make_rust_file_with_symbols("src/beta.rs", vec![("beta", SymbolKind::Function)]),
-        make_rust_file_with_symbols("src/gamma.rs", vec![("gamma", SymbolKind::Function)]),
-    ]);
+    let index = build_shared_index(
+        tmp.path(),
+        vec![
+            make_rust_file_with_symbols("src/alpha.rs", vec![("alpha", SymbolKind::Function)]),
+            make_rust_file_with_symbols("src/beta.rs", vec![("beta", SymbolKind::Function)]),
+            make_rust_file_with_symbols("src/gamma.rs", vec![("gamma", SymbolKind::Function)]),
+        ],
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -595,10 +665,13 @@ async fn test_prompt_context_contract_golden() {
     let original = stable_cwd();
     std::env::set_current_dir(tmp.path()).unwrap();
 
-    let index = build_shared_index(vec![make_rust_file_with_symbols(
-        "src/lib.rs",
-        vec![("hello", SymbolKind::Function)],
-    )]);
+    let index = build_shared_index(
+        tmp.path(),
+        vec![make_rust_file_with_symbols(
+            "src/lib.rs",
+            vec![("hello", SymbolKind::Function)],
+        )],
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",

--- a/tests/sidecar_integration.rs
+++ b/tests/sidecar_integration.rs
@@ -76,7 +76,14 @@ fn make_rust_file(path: &str, fn_name: &str) -> IndexedFile {
     }
 }
 
-/// Build a `SharedIndex` using the public API (`LiveIndex::empty()` + `add_file`).
+/// Build a `SharedIndex` as an unrooted bootstrap placeholder
+/// (`LiveIndex::empty()` + `add_file`).
+///
+/// NOT the embedder construction route — that is `LiveIndex::from_indexed_files`
+/// (rooted, Ready). This shape is retained here only because these tests assert
+/// sidecar ENDPOINT behaviour, which does not consult index readiness. Anything
+/// asserting on index state must build a rooted index instead; see
+/// `tests/sidecar_contract.rs::build_shared_index`.
 fn build_shared_index(files: Vec<IndexedFile>) -> SharedIndex {
     let shared = LiveIndex::empty();
     {


### PR DESCRIPTION
An index could report `Ready` before it had bound a repository root, publishing knowledge with no source identity. The receipt printed `source=unknown` beside `counts total=0`.

## The defect

On cold start with no snapshot, a placeholder empty index is published (`indexed_root: None`, `is_empty: true`, `load_source: EmptyBootstrap`) and the real load runs detached. `get_file_context` freshens the requested path **before** it consults the loading guard. The file is absent from the placeholder, so its recorded mtime never matches disk, so it looks stale and is indexed on the spot — and that path sets `is_empty = false` while never setting `indexed_root`.

`index_state()` consulted only `is_empty`, so it returned `Ready`. `capture_published_manifest` then hit its silent `?` on `indexed_root`: no manifest, no source identity, knowledge published unbound.

**A file was admitted into the index before the index knew what repository it was.** Ready without being rooted.

Reproduced at ~12% of cold starts, and once in CI as a `snap-file_context` snapshot mismatch.

## The fix

`index_state()` refuses `Ready` for a bootstrap placeholder. Gated on `load_source`, **not** on `indexed_root.is_none()` — the P1 local-ref lane (`LiveIndex::from_source_files`) is legitimately rootless and builds its own identity via `build_ref_source_generation`; a root-based guard would pin it at `Loading` forever.

The guard has **two** conditions, and the second one is the interesting half. `EmptyBootstrap` covers two lanes. The cold-start lane spawns a detached reload, so `Loading` is true and transient. The **no-root lane** — `main`'s `else` arm that calls `set_local_empty_reason` — spawns neither watcher nor reload, so `load_source` can never leave `EmptyBootstrap`. Reporting `Loading` there would tell an agent to retry something that never lands, and would hide `format::empty_index_recovery_hint`, the only message naming the real recovery.

A single-condition guard traded "reports Ready when it cannot answer" for "reports Loading when it will never load" — the same defect class, pointed the other way. `local_empty_reason` discriminates: set exactly in that lane, cleared by `apply_reload_data`. That lane reports `Empty`.

## Also in this PR

- **A guard sweep of 14 freshen sites.** One hole fixed: `validate_file_syntax` was both a *cause* (calling it first could flip the server to Ready) and the last *victim* (still answering from an index every other tool had just declared untrustworthy). It now answers from disk while the index is unready, preserving its genuine ability to validate a config file during startup.
- **An embed API break, fixed additively.** `LiveIndex::empty()` + `add_file` is the documented public route for embedders and would have yielded a permanently-`Loading` index. New `LiveIndex::from_indexed_files(root, files)` requires a root, so the broken shape cannot be built by accident. Contract-pinned in `src/embed.rs`.
- **Harness readiness gate** now requires a source-bound `Ready` generation rather than `index_files > 0` — file count is reported regardless of state, so the old signal opened the gate on a placeholder. Aborts loudly with exit 2 (harness-couldn't-run) instead of falling through to a snapshot comparison against a half-loaded index.
- **Evidence preservation in the harness:** stderr was `ignore`, `RUST_LOG` was `off`, and diffs printed one line. Those three settings are why this bug was undiagnosable for two days.
- **Log gating**, because the new `warn!` fired ~10x per healthy cold start.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo clippy --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test --all-targets -- --test-threads=1` | exit 0, 661s |
| `cargo build --release` | exit 0, 7m30s |
| `verify-tools` | **8 PASS, 0 REVIEW, 0 FAIL** |
| `verify-tools-real` | **11 PASS, 0 REVIEW, 0 FAIL** |

`snap-file_context` — the test that originally failed with `source=unknown` — is byte-identical to snapshot. Three prior `REVIEW` verdicts ("expected substrings absent: auth.rs") are now `PASS`, because the readiness gate waits for a genuinely source-bound index.

**Race probe: 0 hits in 200 cold starts** — with a working positive control. The defect *condition* still fires on every cold start (12/12 starts, 99 occurrences, mean 8.3, log line `bootstrap placeholder published with no indexed_root; guarded as not-Ready files=1`). The window did not close; the guard refuses to let it be observed. A race number without a positive control proves nothing, because a probe that silently stopped working also scores zero.

**The no-root lane was driven live** (`SYMFORGE_AUTO_INDEX=false`), the defect state forced (index holding one file, no bound root), and the read returned the **recovery hint** — not "try again shortly", not a fabricated answer.

## Claims deliberately not made

- **200 clean runs bounds the residual near 1.5%, not zero**, and only on one machine under one load profile. Every run gated in 316–383 ms on a near-identical polling pattern.
- **The daemon lane was never exercised.** All runs used `SYMFORGE_NO_DAEMON=1`.
- Only `get_file_context` was driven end to end; the other guarded verbs share the guard by construction, not by observation.

## Reviewed

Three independent adversarial reviews are included in `docs/reviews/`. Each found something the other two missed: the `validate_file_syntax` hole, an abort message describing an impossible state, and the `warn!` spam — the last predicted from code alone and later confirmed by measurement.

A follow-up commit converts every citation in the new comments from line numbers to symbol names. The originals were 50+ lines stale, and the corrections rotted again within one edit. A citation that shifts on the next insertion is decoration, not evidence.

## Known-open, deliberately out of scope

- Three HTTP sidecar sites (`/outline`, `/symbol-context`, the prompt hint) have **no readiness check at all** — a separate surface.
- `daemon.rs` keeps an `EmptyBootstrap` placeholder when catalog capacity refuses a cold load; if it ever admits a file it pins the same way.
- A failed cold-start reload could surface as `Degraded`-with-reason rather than perpetual `Loading`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FewzAkBXbPjjwh6ER7Lvkz
