### PR TITLE
style: cargo fmt for worktree-routing incident changes

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1572,9 +1572,7 @@ impl DaemonState {
 
         match self.open_project_for_session(session_id, &binding) {
             Ok(mut output) => {
-                if activate
-                    && self.set_active_project(session_id, &binding.root_id.0)
-                {
+                if activate && self.set_active_project(session_id, &binding.root_id.0) {
                     output.push_str(&format!(
                         "active_project={} (default index_folder: unqualified reads on this session now target this project)\n",
                         binding.root_id.0
@@ -2480,7 +2478,9 @@ async fn connect_or_spawn_session_at(
     // Capture the daemon's boot epoch for descriptor epoch validation.
     // Unauthenticated /health by design; failure is non-fatal (epoch simply
     // absent, selection falls back to PID+TCP for legacy records).
-    let daemon_started_at = daemon_health(port).await.and_then(|h| h.started_at_unix_secs);
+    let daemon_started_at = daemon_health(port)
+        .await
+        .and_then(|h| h.started_at_unix_secs);
 
     Ok(DaemonSessionClient::new_with_auth_token(
         base_url,
@@ -4242,8 +4242,7 @@ fn guard_session_caller_root(
     runtime: &SessionRuntime,
     query: Option<&str>,
 ) -> Result<(), StatusCode> {
-    if let Some(caller_root) =
-        crate::sidecar::handlers::query_param(query, "caller_root")
+    if let Some(caller_root) = crate::sidecar::handlers::query_param(query, "caller_root")
         && !crate::sidecar::handlers::roots_match(
             std::path::Path::new(&caller_root),
             &runtime.canonical_root,
@@ -11604,11 +11603,7 @@ mod tests {
             "caller_root=B (the active project) must be served"
         );
 
-        let unpinned = client
-            .get(url(""))
-            .send()
-            .await
-            .expect("unpinned request");
+        let unpinned = client.get(url("")).send().await.expect("unpinned request");
         assert!(
             unpinned.status().is_success(),
             "a request without caller_root stays unguarded"

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1125,8 +1125,7 @@ impl SymForgeServer {
         // Reconnect attempt — take a write lock so only one caller does this.
         let reconnected = {
             let mut client = daemon_lock.write().await;
-            self.daemon_degraded.lock().last_reconnect_attempt =
-                Some(std::time::Instant::now());
+            self.daemon_degraded.lock().last_reconnect_attempt = Some(std::time::Instant::now());
             match client.reconnect().await {
                 Ok(new_client) => {
                     tracing::info!("daemon reconnected successfully");
@@ -1228,7 +1227,10 @@ impl SymForgeServer {
             return None;
         }
         Some(DaemonDegradationSnapshot {
-            endpoint: state.last_endpoint.clone().unwrap_or_else(|| "(unknown)".to_string()),
+            endpoint: state
+                .last_endpoint
+                .clone()
+                .unwrap_or_else(|| "(unknown)".to_string()),
             last_failure: state
                 .last_failure
                 .clone()
@@ -1803,9 +1805,7 @@ impl ServerHandler for SymForgeServer {
                         let body = result
                             .content
                             .iter()
-                            .filter_map(|block| {
-                                block.as_text().map(|text| text.text.as_str())
-                            })
+                            .filter_map(|block| block.as_text().map(|text| text.text.as_str()))
                             .collect::<Vec<_>>()
                             .join("\n");
                         if !body.is_empty() && tools::is_error_output(&body) {
@@ -2041,7 +2041,10 @@ mod tests {
             .proxy_tool_call("health", &serde_json::json!({}))
             .await;
 
-        assert!(result.is_none(), "failed rediscovery still falls back local");
+        assert!(
+            result.is_none(),
+            "failed rediscovery still falls back local"
+        );
         let state = server.daemon_degraded.lock();
         let bumped = state
             .last_reconnect_attempt
@@ -2050,7 +2053,10 @@ mod tests {
             bumped > past_attempt,
             "the reconnect attempt marker must advance past the cooldown"
         );
-        assert!(state.degraded, "failed rediscovery keeps the degraded state");
+        assert!(
+            state.degraded,
+            "failed rediscovery keeps the degraded state"
+        );
     }
 
     /// Feature 013 US1 (T021): a daemon-PROXY server with a durable

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -205,8 +205,7 @@ fn is_foreign_project_refusal(text: &str) -> bool {
     // Current shape carries the typed `Error: project_routing:` prefix; the
     // legacy anchor below still classifies pre-10.1 bodies that came back
     // through DISPATCH rather than an early return.
-    (text.starts_with("Error: project_routing: project '")
-        || text.starts_with("project '"))
+    (text.starts_with("Error: project_routing: project '") || text.starts_with("project '"))
         && text.contains("is not available on this connection")
 }
 

--- a/src/sidecar/port_file.rs
+++ b/src/sidecar/port_file.rs
@@ -417,7 +417,11 @@ fn select_descriptor_status(
     if let Some(unprobed) = candidates.get(probed) {
         Some(selected(unprobed, SidecarLiveness::Unknown, epoch_rejected))
     } else {
-        Some(selected(&candidates[0], SidecarLiveness::Dead, epoch_rejected))
+        Some(selected(
+            &candidates[0],
+            SidecarLiveness::Dead,
+            epoch_rejected,
+        ))
     }
 }
 
@@ -949,30 +953,16 @@ mod tests {
         let pid = std::process::id();
 
         // Matching epoch: selected.
-        write_descriptor_for_pid_at(
-            dir,
-            pid,
-            port,
-            Some("session-7"),
-            None,
-            Some(1_700_000_000),
-        )
-        .expect("write matching descriptor");
+        write_descriptor_for_pid_at(dir, pid, port, Some("session-7"), None, Some(1_700_000_000))
+            .expect("write matching descriptor");
         let status = read_sidecar_status_at(dir, "127.0.0.1");
         assert_eq!(status.liveness, SidecarLiveness::Alive);
         assert_eq!(status.port, Some(port), "matching epoch must select");
 
         // Stale epoch (descriptor written against the PREVIOUS daemon boot):
         // rejected even though the port is alive and serves 200.
-        write_descriptor_for_pid_at(
-            dir,
-            pid,
-            port,
-            Some("session-7"),
-            None,
-            Some(1_600_000_000),
-        )
-        .expect("write stale-epoch descriptor");
+        write_descriptor_for_pid_at(dir, pid, port, Some("session-7"), None, Some(1_600_000_000))
+            .expect("write stale-epoch descriptor");
         let status = read_sidecar_status_at(dir, "127.0.0.1");
         assert_ne!(
             status.liveness,
@@ -980,7 +970,11 @@ mod tests {
             "stale epoch must not select: {status:?}"
         );
         assert!(
-            status.detail.as_deref().unwrap_or("").contains("epoch-rejected"),
+            status
+                .detail
+                .as_deref()
+                .unwrap_or("")
+                .contains("epoch-rejected"),
             "rejection must be attributed to the epoch probe: {status:?}"
         );
 


### PR DESCRIPTION
CI `cargo fmt --check` failed after #543 (commits 4c1731b6 / f56ffdd landed unformatted). This PR is the output of `cargo fmt` on origin/main — 4 files, whitespace/line-wrap only, no behavior change. Verified: `cargo fmt --check` passes locally on 1.96.0 (same toolchain CI resolves from rust-toolchain.toml).