### PR TITLE
fix: gate sidecar enrichment on trusted index state

### DIFF
--- a/docs/reviews/REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-2026-08-10.md
+++ b/docs/reviews/REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-2026-08-10.md
@@ -1,0 +1,451 @@
+# Review findings — claude-fable — HTTP sidecar readiness and publication fencing
+
+Reviewer: Claude Fable (adversarial correctness review per
+`REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md`).
+
+## 0. Snapshot identity — the reviewed tree was a MOVING TARGET
+
+Base commit: `71fb88429134462cc8bdf1022ee3037bcec5f65d` (= `origin/main`, 10.0.3).
+All review targets were uncommitted working-tree diffs. Four distinct diff
+states were observed during this single review pass
+(`git diff --binary | git hash-object --stdin`):
+
+| # | Diff blob hash | What happened at this state |
+|---|---|---|
+| S1 | `1fccccd9163df964384db5d01423b6b429035c62` | Full deep-read of the diff (2,974 insertions). `cargo fmt --check` FAIL; `cargo clippy -D warnings` FAIL (dead code); full test suite run: one failure (`batch_rename_perf`). |
+| S2 | `86a94b5a68f60c235346b206aec187bbc0fadf39` | Re-read via interdiff (+334 net lines). Several S1 findings had been fixed in-flight by the implementer. |
+| S3 | `59b6e82ec25e1b77097fe5b29dba68660da20fb0` | Second strict-gate run started here. `cargo fmt --check` still FAIL (9+ locations); `cargo clippy -D warnings` PASS. |
+| S4 | `263c2aee7e353a87d7656497fe38c288b05c983a` | Tree had moved again while S3's gate was still running. |
+
+Every finding below is stamped with the snapshot it was verified against.
+Line numbers are from the stamped snapshot and will drift. **The strict gate
+has never been observed green on any single frozen state of this diff.**
+
+Baseline for comparative measurements: detached worktree at `71fb8842`
+(`../symforge-baseline-review`), same machine, isolated runs.
+
+## 1. Findings (P0/P1/P2/P3)
+
+### P0 — none found.
+
+### P1-1 — `batch_rename` dry-run wall clock regressed ~4x; H.7 perf gate fails (S1: proven, measured; S3 re-measure noted in §3)
+
+1. **Confidence:** proven at S1 by direct A/B measurement on the same machine.
+2. **Location:** entry point `src/protocol/edit_tools.rs:1965 batch_rename` →
+   `prepare_project_wide_rename` (`edit_tools.rs:501`) →
+   `watcher::reconcile_stale_files` (whole-repo freshen sweep inside the timed
+   window), plus every receipt-bearing publish seam in
+   `src/live_index/store.rs` / `src/live_index/single_file.rs` that the sweep
+   drives.
+3. **Sequence:** `cargo test --test batch_rename_perf -- --test-threads=1`.
+   Diff'd tree (S1-era): best-of-3 **20,663 ms** (20,674 / 21,186 / 20,663 —
+   consistent, not load spikes). Baseline `origin/main`, same machine, isolated
+   worktree: **passes the 5,000 ms budget** (suite completed in 40.1 s
+   including the ~35 s cold load; the test short-circuits when an attempt is
+   under budget). The test asserts best-of-N precisely so machine load cannot
+   explain a consistent 4x elevation.
+4. **Consequence:** `cargo test --all-targets` (PR CI gate) fails; and every
+   real `batch_rename`/project-wide-rename call pays the same multi-second
+   regression in production.
+5. **Smallest remediation:** profile the dry-run timed window on the diff vs
+   main before landing. The only whole-repo loop inside the window is
+   `reconcile_stale_files` (per-file `freshen_file_if_stale`, now returning
+   through the receipt-bearing `read_and_index_with_receipt` machinery);
+   suspicion also falls on the added per-publication work
+   (`pre_update_snapshot` clone + `record_pre_update_snapshot_for_publication`
+   + `published_generation()` re-loads) if the sweep publishes. This review
+   measured and localized the window but did not isolate the exact line;
+   per the repo's reporting invariant I am not claiming a root cause I did not
+   observe.
+6. **Regression test:** already exists and is the failing gate —
+   `tests/batch_rename_perf.rs::batch_rename_health_dry_run_stays_under_h7_budget`.
+
+### P1-2 — disk-absence ABA guard existed but was DEAD CODE; production removals fenced only by publication equality (S1: proven; **fixed in-flight by S2** — verify it stays wired)
+
+1. **Confidence:** proven at S1 (clippy `-D warnings` failed the build:
+   ``method `remove_file_if_absent_at_publication_fence_with_receipt` is never
+   used`` at `store.rs:2775`); `finalize_missing_file` (S1
+   `single_file.rs:637`) called fence-only `remove_file_at_publication_fence`,
+   and the watcher event lane called plain `remove_file_at_generation`.
+2. **Location (S2+, fixed):** `src/live_index/single_file.rs:171
+   finalize_missing_file`, `src/watcher/mod.rs:785,818 process_events`,
+   `remove_file_if_scout_entry_at_generation` (now passes
+   `expected_entry.absolute_path`).
+3. **Sequence (S1):** delete `f.rs` → watcher `maybe_reindex` retries observe
+   NotFound → recreate `f.rs` on disk after the last retry, before
+   `finalize_missing_file`, with no intervening publication → publication
+   fence still matches → entry removed while the file exists on disk (until a
+   later create event heals it). This is exactly known-finding #7: an exact
+   index-publication fence does not prove continued filesystem absence.
+4. **Consequence (S1):** transient false-absence for a recreated file; plus a
+   hard CI red (clippy) proving the guard was unreachable.
+5. **Remediation:** already applied in S2 — `symlink_metadata` absence
+   re-confirmation under the writer lock on all three removal paths. Keep it;
+   the S2 tests (`stale_not_found_fence_preserves_recreated_file_and_reports_rejection`,
+   `scout_reconciliation_removal_refuses_a_recreated_disk_path`) pin it: each
+   fails if the disk recheck is removed, because the publication fence alone
+   would admit the removal.
+6. **Regression tests:** the two named above, present at S2+.
+
+### P2-1 — impact 503-after-commit: a retried request reports "no structural changes" for an edit that changed symbols (S3/S4: proven by code reading; open)
+
+1. **Confidence:** proven reachable by code reading; requires a same-project
+   freshness flip mid-request.
+2. **Location:** `src/sidecar/handlers.rs` `impact_handler` — the trailing
+   `capture_queryable_sidecar_generation(&state, &fence)?` executed AFTER
+   `impact_hook_text` has fully committed (S3 numbering ~line 999); the new
+   freshness conjunct in `published_sidecar_index_is_queryable`
+   (`handlers.rs:418-441`) makes the trailing check fail on freshness alone.
+3. **Interleaving:** (A) `/impact?path=f.rs` passes `require_queryable`
+   (freshness `Current`), takes the impact lock, `handle_edit_impact` commits:
+   publishes v1→v2, drains the pre-update snapshot bound to its receipt,
+   seeds the symbol cache with post-edit (v2) symbols, records write stats.
+   (B) snapshot verification starts (or the watcher dies) → published
+   freshness becomes `Verifying`/`Degraded`. (A) trailing capture fails →
+   **503, empty body**, computed response discarded. Hook fails open; the
+   caller retries once the index is `Current` again. The retry's baseline is
+   now v2 (snapshot gone, cache = v2, index = v2), disk = v2 → the response
+   claims **no symbol changes** for an edit that changed/added/removed
+   symbols.
+4. **Consequence:** invented un-change delivered to the caller — wrong output,
+   not a refusal. All mutation side effects also stand behind a 503 the caller
+   is invited to retry (the exact hazard Q3 names).
+5. **Smallest remediation:** do not refuse an impact whose response is derived
+   entirely from its own fenced immutable receipt. Either delete the trailing
+   capture on the impact route (the pre-lock `require`, the in-handler
+   `expected_generation` checks, and the receipt fencing already pin project
+   identity), or restrict the trailing check to project-generation/source/root
+   equality and exclude the freshness conjunct.
+6. **Regression test:** rooted real-index fixture; run `impact_handler`
+   through the public route; force freshness to `Verifying`
+   (`mark_snapshot_verify_running`) after the publish seam (e.g. via a stable-read
+   test seam or by invoking `handle_edit_impact`'s components around a direct
+   freshness mark); assert the response is 200 with the correct diff — and
+   that a follow-up impact does not report an empty diff. Fails on current
+   code (503, then empty diff on retry).
+
+### P2-2 — confirmed-absent removal is dropped forever on fence contention: deleted files linger in global answers (S2+: proven by code reading; open)
+
+1. **Confidence:** proven by code reading (interleaving is ordinary watcher
+   traffic); severity depends on write concurrency.
+2. **Location:** `src/live_index/single_file.rs:171-197 finalize_missing_file`
+   (fence captured at the last NotFound observation), and the silent drops:
+   `watcher/mod.rs process_events` (`ReindexResult::PublicationRejected => {}`)
+   and the event lane's one-shot
+   `remove_file_if_absent_at_publication_fence_with_receipt` calls
+   (`watcher/mod.rs:785,818` — no retry on `None`).
+3. **Interleaving:** delete `a.rs` → `maybe_reindex` retries (~750 ms) observe
+   absence, fence F captured → any concurrent publication of unrelated `b.rs`
+   advances the publication fence → `remove_file_with_fences` rejects (exact
+   fence mismatch) → `PublicationRejected` is discarded; the delete event is
+   consumed and no further events will ever fire for `a.rs`.
+4. **Consequence:** `repo-map`, search, symbol-context and every global-absence
+   claim keep serving the deleted file until something else touches that path
+   (freshen-on-read heals it only if someone reads it). `origin/main` removed
+   at the project-generation fence and was immune to concurrent publishes —
+   this is a staleness-convergence regression, worst in write-heavy repos
+   (where concurrent publications are the norm, making rejection likely).
+5. **Smallest remediation:** on exact-fence rejection in the absence path,
+   recapture the fence and retry the removal a bounded number of times — the
+   `symlink_metadata` re-confirmation under the writer lock is what makes this
+   safe. Equivalently: for the disk-confirmed-absent path, fence on
+   project-generation + disk absence and drop the exact publication-equality
+   conjunct (the disk check is the authority known-finding #7 asked for).
+6. **Regression test:** index `a.rs` and `b.rs`; simulate: delete `a.rs`,
+   capture `publication_fence()`, publish an update to `b.rs`, then call
+   `finalize_missing_file(shared, "a.rs", abs, gen, stale_fence)`; assert the
+   file is (eventually) removed. Fails today: returns `PublicationRejected`
+   and `a.rs` remains indexed with no retry scheduled.
+
+### P2-3 — empty/whitespace legacy session id suppressed the daemon fallback for a local sidecar (S1: proven; **fixed in-flight by S2** — keep the normalization)
+
+At S1, `read_sidecar_endpoint`'s legacy lane returned `Some("")`
+(`port_file.rs:716-719`), `proxy_path` routed that as LOCAL, but
+`initial_endpoint_is_daemon = effective_session_id.is_some()` said daemon →
+on any failure from a local sidecar the daemon fallback was suppressed, and
+outcomes were attributed to a phantom session. Exactly known-finding #4
+("normalize once, one predicate"), which was NOT closed at S1. S2 added
+`normalize_session_id` at descriptor read plus trimming/filtering in
+`try_daemon_fallback`. Verify it survives to the final diff; Q5's
+"empty legacy session ID" row depends on it.
+
+### P2-4 — 404/500 from a live sidecar produced `sidecar_port_stale` + `restart_sidecar` (S1: proven; **fixed in-flight by S3** — one matrix cell still untested)
+
+At S1, `classify_enrichment_response` mapped every non-2xx/409/503 status to
+`Unavailable`, so a live sidecar answering 404 (routine for a not-indexed
+path) or 500 fell into the dead-transport lane: `NoSidecar`,
+`sidecar_port_stale`, `restart_sidecar` hint — calling a live sidecar dead
+(Q5's 404/500 column). S3 added `EnrichmentHttpResult::HttpFailure(status)`
+with its own live-refusal arms (`hook.rs:589-598`), reserving the stale lane
+for transport failure only. **Gap:** as of S3 I found no subprocess test
+pinning the 404/500 lane (the new tests cover 503/409); add one mirroring
+`run_hook_index_not_ready_fails_open_as_sidecar_error` with a 500 mock —
+without it, the smallest reversion (dropping the `HttpFailure` arm) goes
+green.
+
+### P3 — smaller items
+
+- **P3-1 (S3: proven).** `cargo fmt --check` is STILL red at S3 — 9+
+  locations (`hook.rs:1193`, `tools.rs:4878/8725/27700`,
+  `handlers.rs:14/3486/3494`, both hook test files). CI's first job fails.
+- **P3-2 (S3).** Every routine 404 read (unindexed path) now records
+  `SidecarError` in the adoption log and burns one daemon-fallback round-trip
+  (≤500 ms) before failing open. Honest, but it pollutes the error-rate signal
+  with an expected condition; consider a distinct outcome for request-level
+  404 vs 5xx.
+- **P3-3 (S2+, design consequence to confirm).** The new freshness conjunct
+  means `Degraded { WatcherUnavailable }` blacks out ALL sidecar enrichment
+  indefinitely, even though freshen-on-read exists precisely to serve
+  per-file-current answers without a watcher. This is what Q2/invariant 1
+  demand (Degraded must refuse), so it is spec-conformant — but it is a
+  meaningful availability tradeoff the author should confirm was intended for
+  the watcher-dead steady state, not only for transient verification.
+- **P3-4 (S2+).** `SYMBOL_CACHE_GENERATIONS` (`handlers.rs:501`) is a
+  process-global mutex + map keyed by `Arc::as_ptr as usize`. The Weak
+  upgrade + `ptr_eq` guard does defeat address-reuse, and dead entries are
+  purged — correct, but it serializes all sidecars' cache ops on one lock and
+  is a lot of machinery for "cache is scoped to one project generation".
+  Note only; no defect found.
+- **P3-5 (process).** Four diff states in one review pass. Findings and gate
+  results above are snapshot-stamped; nothing here should be assumed true of
+  the final diff until the strict gate runs green on a frozen state.
+
+## 2. Required questions
+
+### Q1 — Complete route sweep
+
+Local Axum router (`src/sidecar/router.rs:23-56`), all behind
+`caller_root_guard` middleware except the two diagnostics:
+
+| Route | Class | Verdict |
+|---|---|---|
+| `/health`, `/stats` | diagnostic | deliberately unguarded (root-agnostic, no index reads that assert global truth); `/stats` counters shown not to advance on refusals (matrix test). |
+| `/outline`, `/workflows/source-read` | read + freshen | guarded — `require_queryable_sidecar_index` → fence-pinned freshen → `capture_queryable_sidecar_generation`. |
+| `/impact`, `/workflows/post-edit-impact` | read + freshen + admit + cache + stats | guarded + single-flighted (`lock_impact_analysis`); P2-1 applies to its trailing capture. |
+| `/symbol-context`, `/workflows/search-hit-expansion` | read + freshen | guarded. |
+| `/repo-map`, `/workflows/repo-start` | global read | guarded. |
+| `/prompt-context`, `/workflows/prompt-context` | global read + freshen | guarded (hints, nested symbol-context, and repo-map body all pinned to the captured generation). |
+
+All five workflow aliases are verified thin delegations to the canonical
+handlers (`workflow_source_read_handler` → `outline_handler`, etc.) — no
+duplicated logic to drift.
+
+Daemon proxy (`src/daemon.rs:3584-3628`): 12 `/v1/sessions/{id}/sidecar/*`
+routes; each authorizes, resolves the session runtime,
+`guard_session_caller_root` (409 parity), then `block_on`s the SAME canonical
+handlers with `repo_root = runtime.canonical_root` — behaviorally identical
+to local routes. Verified `SessionSummary` serializes `project_id` =
+`active_project_id` (`daemon.rs:705-712`, `1484-1491`), so the hook's new
+active-project session filter works against the real daemon, not just the
+mock.
+
+One non-identical entry point, deliberately outside the sidecar fence: MCP
+`analyze_file_impact` (`tools.rs:5306`) → `impact_tool_text` — guarded by
+`loading_guard!` (health only) + generation checks + the shared impact lock,
+but NOT by source-binding/root/freshness. Under `Degraded` freshness the MCP
+tool still mutates/serves while the sidecar refuses. Consistent with the MCP
+surface's trust-banner philosophy, but it is the one lane where invariant-1
+symmetry does not hold; flagging for an explicit decision.
+
+### Q2 — Readiness and root fence
+
+No unqueryable state passes: `published_sidecar_index_is_queryable`
+(`handlers.rs:418-441`) requires status ∈ {Ready, Empty} ∧ `source.is_some()`
+∧ `indexed_root.is_some()` ∧ freshness `Current` (or Empty ∧ `Verifying`).
+Loading, Degraded, source-unbound Ready (`from_source_files` shape), and
+rootless Empty all 503 — each conjunct pinned independently by
+`sidecar_queryability_requires_status_source_and_root_independently` (+
+freshness variants) and `ready_but_source_unbound_index_is_not_queryable_by_sidecar`.
+A rooted, source-bound Empty serves `/repo-map` and admits its first file —
+pinned end-to-end by `test_write_hook_confirms_index`, which now also proves
+the first post-admission edit diffs against the seeded baseline instead of
+reporting every symbol `[Added]`.
+
+Validate-A-serve-B after rebind: prevented twice — `require_queryable`
+compares `state.repo_root` to the fence's `indexed_root` (409 on mismatch),
+and every render re-captures against the fence (project generation + source
+identity value + root), while all mutations CAS on the captured
+project generation. The residual failure mode is fail-closed (P2-1), not
+wrong-project data. Cross-project mutation is additionally pinned by
+`stale_project_generation_cannot_remove_from_rebound_project` and
+`stale_impact_generation_cannot_consume_or_overwrite_rebound_project_state`.
+
+### Q3 — Mutation and receipt linearizability
+
+Linearization point: the winning store publication
+(`publish_indexed_file_at_generation` / `publish_hash_skip_at_generation` /
+terminal-disposition seams), CAS'd under `write_mutex` on
+(project generation, `published_state().generation`) and returning the exact
+`Arc<PublishedGeneration>` while the writer lock still owns it. The impact
+response (symbols, skipped-text, callers) is rendered from
+`receipt.published` — a later watcher publication cannot alter it
+(`reindex_receipt_remains_exact_after_later_publication`). A rejected
+publication is typed (`PublicationRejected`) and maps to 503, never success.
+Concurrent impacts are serialized by the shared `impact_mutex` across the
+HTTP route, workflow alias, daemon proxy, and MCP lane (all reach one of the
+two locking entry points; `impact_entry_points_share_the_index_single_flight_lock`
+pins both). Snapshot consumption is publication-bound
+(`take_pre_update_snapshot_for_publication_at_generation`): an older receipt
+cannot drain a newer publication's baseline even when content hashes collide
+(`publication_bound_snapshot_take_preserves_same_hash_aba_update`), the
+project retarget clears the side table under the writer lock, and the S2
+`SharedIndexWriteGuard::drop` change invalidates path tokens after arbitrary
+guard mutations. **Defect found:** the one remaining Q3 item is P2-1 —
+side effects committed before a trailing 503 whose retry produces a wrong
+"no changes" answer.
+
+### Q4 — Single-file publication semantics
+
+Audited every branch of `read_and_index_with_stable_read_receipt` (S1 diff,
+re-verified S2): exclusion-eviction, metadata-terminal, unavailable-scout,
+generated-output, hard-skip, unreadable, unstable-read, content-policy,
+hash-skip, full index, NotFound, and the 4-attempt CAS loop. All publish
+seams take `expected_index_state_generation = base.health.generation` — the
+health/live domain — and compare against `published_state.load().generation`;
+bridge-/authority-only publications advance only the full
+`publication_generation` and no longer poison the CAS
+(`bridge_only_publication_does_not_invalidate_live_index_reindex_cas` — the
+deterministic 4-loss failure from known-finding #3 is closed). Project
+generation is checked first and independently in every seam. Winning
+publications are returned as receipts under the writer lock. `Removed` is
+reported only when `remove_file_if_absent_at_publication_fence_with_receipt`
+actually published (project gen + exact fence + `symlink_metadata` absence
+under the lock — S2), `Skipped`/`HashSkip` always carry the publication that
+occurred, and every no-publication outcome is `PublicationRejected`.
+Delete→recreate cannot authorize removal of the recreated path (disk
+re-confirmation; pinned). Residuals: P2-2 (rejected removals never retried)
+and a pre-existing (unchanged by this diff) quirk where an excluded-path
+eviction with no prior record still clones-and-publishes.
+
+### Q5 — Hook behavior matrix
+
+Traced at S3 (all lanes end in valid fail-open JSON; request counts bounded;
+`outcome_session_id` is the endpoint that actually answered):
+
+| Endpoint | Response | Behavior |
+|---|---|---|
+| local descriptor | 200 | `Routed`, 1 request. |
+| local descriptor | 503 | one daemon fallback: 200→`DaemonFallback`@daemon-session; 503/409/4xx/5xx→`SidecarError` (`index_not_ready`/`root_conflict`/`http_failure`)@daemon-session; none/transport→`SidecarError index_not_ready`@initial session. No probe, no stale hint. |
+| local descriptor | 409 | same shape, `root_conflict`. Fallback re-resolves BY ROOT and filters sessions to `project_id == matching.project_id`, so it cannot loop back into the retargeted session. |
+| local descriptor | 404/500 | `HttpFailure` lane (S3): fallback attempt, then `SidecarError http_failure`; never `sidecar_port_stale`. (Untested cell — see P2-4.) |
+| local descriptor | transport | liveness probe (verbose only) + fallback; if no daemon: `NoSidecar sidecar_port_stale` + restart hint — correct, the thing is actually dead. |
+| daemon-backed descriptor | 503 | authoritative: NO rediscovery (`initial_endpoint_is_daemon && initial_index_not_ready`), `SidecarError`@that session, exactly 1 enrichment request — pinned by a mock that COUNTS requests (`run_hook_daemon_descriptor_index_not_ready_is_not_retried`). |
+| daemon-backed descriptor | 409 / 404/500 / transport | one rediscovery EXCLUDING the failed session (`try_daemon_fallback(root, excluded)`); alternate active session may answer; bounded at 2 enrichment requests total, every alternate-result arm terminal — no loop. |
+| missing descriptor | — | step-1 daemon fallback (`DaemonFallback` on success; `NoSidecar sidecar_port_missing` otherwise). |
+| stale descriptor (dead port) | — | transport lane above. |
+| empty legacy session id | — | normalized to `None` at descriptor read (S2 `normalize_session_id`); routes local, fallback-eligible — the S1 defect (P2-3) is closed. |
+
+The enrichment mocks now match the daemon route only when the query carries
+`caller_root=`, pinning that the fallback request stays root-pinned (the S1
+change that made the daemon request pinned too).
+
+### Q6 — Public API compatibility
+
+No breaks found (checked across `store.rs`, `single_file.rs`,
+`sidecar/mod.rs`, `watcher/mod.rs`, `daemon.rs`, not just the embed facade):
+
+- `ReindexResult` (public, embed) keeps exactly six variants; contention is
+  carried on crate-private `ReindexOutcome`, folded at the boundary by
+  `into_public_compat` (`PublicationRejected` → `Skipped`, preserving main's
+  observable behavior for embedders). External exhaustive matches compile
+  unchanged.
+- `SidecarState::symbol_cache` — the field type is now the alias
+  `SymbolSnapshotCache = HashMap<String, Vec<SymbolSnapshot>>`: type-identical,
+  source-compatible; S2's redesign moved generation tracking OUT of the key
+  format into a private registry, so embedder-visible cache shape is unchanged.
+- `update_file_from_disk`, `remove_file_at_generation`,
+  `remove_file_at_publication_fence`, `take_pre_update_snapshot` — signatures
+  unchanged (`take_pre_update_snapshot` now also takes the writer lock; no
+  public caller can hold that lock, so no deadlock surface).
+- Additive only: `pub take_pre_update_snapshot_at_generation`, the alias, and
+  assorted `pub(crate)` machinery. `from_indexed_files`/`from_source_files`
+  pre-exist on main. `read_and_index_with_stable_read` became `#[cfg(test)]`
+  but was `pub(crate)`.
+
+### Q7 — Tests that can fail
+
+High-value tests and the smallest reversion each catches:
+
+- `loading_sidecar_refuses_all_content_routes_without_mutation` — real Axum
+  server, all 10 content routes, asserts 503 + EMPTY body + no
+  publication/content/project-generation movement + no admission of
+  `src/new.rs` + all four stat counters flat. Fails if any single handler
+  drops `require_queryable_sidecar_index`, if a refusal body leaks, or if a
+  refused request mutates anything.
+- `sidecar_queryability_requires_status_source_and_root_independently` (+ S2
+  freshness variants) — each conjunct reverted individually flips an assert.
+- `ready_but_source_unbound_index_is_not_queryable_by_sidecar` — kills
+  status-only readiness (the original cold-start defect shape).
+- `test_write_hook_confirms_index` (extended) — source-bound Empty admits its
+  first file over real HTTP AND the follow-up edit diffs against the receipt-
+  seeded baseline (fails if new-file impact reverts to seeding an empty
+  baseline, or if Empty is refused: invariant 3 both halves).
+- `reindex_receipt_remains_exact_after_later_publication` — fails if the
+  response/publication is sampled from current state instead of the receipt,
+  or if an old receipt can drain a later snapshot.
+- `bridge_only_publication_does_not_invalidate_live_index_reindex_cas` —
+  fails if any seam CAS-es on the full publication generation again
+  (known-finding #3).
+- `stale_not_found_fence_preserves_recreated_file_and_reports_rejection` and
+  `scout_reconciliation_removal_refuses_a_recreated_disk_path` (S2) — fail if
+  the `symlink_metadata` absence re-confirmation is removed; the publication
+  fence alone would admit both removals.
+- `stale_project_generation_cannot_remove_from_rebound_project`,
+  `stale_impact_generation_cannot_consume_or_overwrite_rebound_project_state`,
+  `publication_bound_snapshot_take_preserves_same_hash_aba_update`,
+  `generic_write_guard_invalidates_pre_update_snapshot_tokens` (S2) — the
+  cross-project and ABA fences, each with a one-line reversion target.
+- `impact_entry_points_share_the_index_single_flight_lock` — holds the lock
+  and asserts BOTH entry points block then complete; fails if either drops it.
+- `test_impact_handler_edit_preserves_index_when_file_unreadable` (rewritten)
+  — fails if impact resumes deleting index entries on a single missing-file
+  observation.
+- Hook subprocess suite — the daemon-503 no-retry test asserts the REQUEST
+  COUNT (not just output), the fallback test's mock only matches the daemon
+  route when `caller_root=` is present, and the session-filter mock lists a
+  NEWER wrong-project session that would be selected (and 404) without the
+  filter — all genuinely revert-sensitive.
+
+Mock quality: mock servers are deadline-bounded (no unbounded joins),
+tolerate probe connections, and 404 unexpected routes rather than accepting
+the wrong path. Gaps: (a) no test for the 404/500 `HttpFailure` lane (P2-4);
+(b) nothing pins P2-1 or P2-2 (they are open defects); (c) the enrichment
+matrix test depends on process-CWD juggling under `CWD_LOCK` — brittle under
+future parallelization but sound at `--test-threads=1`.
+
+### Q8 — Anything else materially wrong
+
+- The measured H.7 perf regression (P1-1) — the only candidate for
+  "materially wrong" outside the fencing logic itself.
+- The moving-target process issue (P3-5): three of the S1 findings in this
+  report were fixed by the implementer WHILE the review ran. Nothing wrong
+  with the fixes — but it means no reviewer statement, including "the suite
+  passes", has yet been true of the diff that will actually land.
+- No path returning wrong-project data, global absence from partial state,
+  stale exact-path content, or an infinite wait was found in S2+ beyond the
+  items above. No patch-release API break found.
+
+## 3. Validation record (this review's runs)
+
+| Check | Snapshot | Result |
+|---|---|---|
+| `cargo fmt --check` | S1 | **FAIL** (3 locations, `tools.rs`) |
+| `cargo clippy --all-targets -- -D warnings` | S1 | **FAIL** (dead code: the unwired ABA guard, P1-2) |
+| `cargo test --all-targets -- --test-threads=1` | ~S1 | **FAIL** — 1 failure: `batch_rename_health_dry_run_stays_under_h7_budget` (20,663 ms best-of-3 vs 5,000 ms budget); everything else green (3,125 lib + all integration suites) |
+| Baseline `batch_rename_perf` | `71fb8842` worktree | **PASS** (<5,000 ms) — same machine, isolated |
+| `cargo fmt --check` | S3 | **FAIL** (9+ locations) |
+| `cargo clippy --all-targets -- -D warnings` | S3 | **PASS** |
+| `cargo test --all-targets -- --test-threads=1` | S3 | **FAIL** — `hook_enrichment_integration::test_write_hook_confirms_index`: the new-file `/impact` against a rooted, source-bound EMPTY index returned an empty refusal body ("new_file response must contain 'Indexed'; body: <empty>"). **At S3, invariant 3 (rooted empty repo must admit its first file) is itself broken** — most plausibly by the S2/S3 freshness conjunct or the reworked new-file impact flow. The suite fail-fasted here, so `batch_rename_perf` was not re-measured on S3; P1-1 stands on the S1 measurement. |
+| `node scripts/verify-tools.cjs` (both surfaces) | — | NOT RUN (blocked on a green build of a frozen snapshot) |
+
+## 4. Verdict
+
+**Block** — until (1) the diff is frozen, (2) the H.7 `batch_rename`
+regression (P1-1) is root-caused and resolved or measurably refuted on the
+final snapshot, (3) `cargo fmt` is green, (4) the S3 regression that refuses
+first-file admission into a rooted Empty index (invariant 3; caught by the
+author's own `test_write_hook_confirms_index`) is fixed, and (5) P2-1 and
+P2-2 are fixed or explicitly accepted with rationale. The readiness/fencing architecture itself
+is sound and well-tested — the S2/S3 in-flight fixes closed every structural
+hole S1 had — so once the perf regression is explained and the gate runs
+green on one frozen diff, the remaining items are small, and this lands.

--- a/docs/reviews/REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-round2-2026-08-10.md
+++ b/docs/reviews/REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-round2-2026-08-10.md
@@ -1,0 +1,331 @@
+# Review findings — claude-fable — round 2 (frozen target)
+
+Reviewer: Claude Fable. Adversarial correctness re-review per the updated
+`REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md`. Round 1
+(`REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-2026-08-10.md`) is
+historical; every claim below was re-verified against the frozen target only.
+
+## 0. Review target identity — verified
+
+- Base: `71fb88429134462cc8bdf1022ee3037bcec5f65d` (`origin/main`, 10.0.3).
+- Frozen implementation commit: `71c14e309a9a45ad01d145b136ef556a6b86190e`
+  ("fix: gate sidecar enrichment on trusted index state").
+- Computed `git diff --binary 71fb8842 71c14e30 | git hash-object --stdin` =
+  `920e3002030392732514f2d560839da05e214099` — **matches the expected hash**
+  (71fb8842 is the merge-base, so two-dot and three-dot agree).
+- Reviewed tree: branch `fix/http-sidecar-readiness` at HEAD
+  `61f84672e2cf4a3d568f0cf80bda9e352c36425f` = 71c14e30 + one docs-only pin
+  commit; `git status` clean for the entire review. No drift this round.
+- Diff size: 13 files, 4,362 insertions, 618 deletions.
+
+Method: full re-read of the frozen diff (delta-read against the round-1
+snapshots I had already read line-by-line, then targeted in-situ reads of
+every changed decision point), plus the full release-grade gate executed on
+this exact tree (§3).
+
+## 1. Round-1 blockers, re-tested against 71c14e30
+
+| Round-1 finding | Status at 71c14e30 | Evidence |
+|---|---|---|
+| H.7 `batch_rename` perf regression (~20.6 s vs 5 s budget) | **CLOSED — passes** | `batch_rename_health_dry_run_stays_under_h7_budget` green in this review's own full-suite run on this machine (the same machine that measured the round-1 failure; baseline main also passes here). See §3 for the measured attempt time. |
+| Rooted Empty first-file admission broken (S3 regression) | **CLOSED — passes** | `published_sidecar_index_is_queryable` (`handlers.rs:416-443`) now admits `Empty` + `Verifying` only when `snapshot_verify_state == NotNeeded` — the deliberate empty-repo initialization shape; `test_write_hook_confirms_index` (real HTTP: Empty serves, admits `src/new_module.rs`, and the follow-up edit diffs against the receipt-seeded baseline) green in this run. |
+| Impact 503-after-commit → retry reports "no changes" | **CLOSED** | `finish_impact_response_at_fence` (`handlers.rs:1025-1038`) validates a successful impact response with `capture_sidecar_generation_at_fence`, which checks **identity only** (`published_matches_sidecar_fence`: project generation + source identity + indexed root — `handlers.rs:463-470`), not freshness/queryability. A freshness-only transition can no longer erase a committed response; a project rebind still refuses. Pinned both ways by `post_impact_fence_preserves_response_across_freshness_only_transition`. |
+| Deletion convergence (confirmed-absent removal dropped forever on unrelated publication) | **CLOSED** | `remove_file_if_absent_at_publication_fence_with_receipt` (`store.rs:2870-2900`) now passes `expected_publication = None`: the deletion authority is project generation + under-write-lock `symlink_metadata` absence, exactly as known-finding #11 prescribes. Applied on all four lanes: `finalize_missing_file` (`single_file.rs:171-197`), both watcher event-lane calls (`watcher/mod.rs` `process_events`), scout reconciliation (`remove_file_if_scout_entry_at_generation` passes the entry's absolute path), and the snapshot verifier (`persist.rs remove_snapshot_deleted_file_if_still_absent`). Pinned by `missing_file_finalization_ignores_unrelated_same_project_publication` (removal proceeds past an unrelated publication), the two recreation-refusal tests, and `background_verify_deleted_file_removal_refuses_disk_recreation`. |
+| `cargo fmt --check` red | **CLOSED — passes** (§3) | |
+| `cargo clippy --all-targets -- -D warnings` red (dead-code ABA guard) | **CLOSED — passes** (§3); the formerly dead seam is now the production removal authority on all four lanes. | |
+| Empty/whitespace legacy session id suppressed daemon fallback (round-1 P2-3) | **CLOSED** | `normalize_session_id` at descriptor read (`hook.rs:1068-1078`); pinned end-to-end by `run_hook_empty_descriptor_session_503_routes_locally_then_falls_back` and the whitespace/409 variant, which assert the recorded request routes on BOTH endpoints and root-pinning of both requests. |
+| 404/500 from a live sidecar → `sidecar_port_stale` + restart hint (round-1 P2-4) | **CLOSED** | `EnrichmentHttpResult::HttpFailure(u16)` lane (`hook.rs:1332-1339` and the four handler arms); the stale-port lane is reserved for transport failure. The round-1 test gap is also closed: `run_hook_local_http_500_fails_open_as_http_failure_without_restart_hint`. |
+
+## 2. Findings (P0/P1/P2/P3) against the frozen target
+
+### P0 — none found.
+
+### P1 — none found.
+
+### P2 — none found.
+
+The round-1 P2s are all closed (§1). I attempted to break the replacement
+mechanisms and could not:
+
+- **Deletion authority without the exact fence.** Attack: delete → absence
+  fence F → recreate → watcher admits recreated content → delete again →
+  stale-fence `finalize_missing_file`. The removal is *correct* (disk is
+  absent at removal time, under the writer lock, same project), and the second
+  delete's own event converges identically. Attack: recreate between the
+  under-lock `symlink_metadata` check and the publish — impossible; both
+  happen under `write_mutex`, and a disk write cannot be fenced by an index
+  lock in ANY design; the create event re-admits (the same window main had).
+- **Identity-only post-impact fence.** Attack: rebind to project B between
+  commit and `finish_impact_response_at_fence` — refused (project generation
+  differs). Attack: rebind to a *same-root, same-source* project — project
+  generation is monotonic and never reused, so the fence still differs.
+  Attack: freshness flip — response preserved by design; the NEXT request is
+  gated by `require_queryable_sidecar_index`, which is the correct boundary.
+- **Freshness recompute (`recompute_freshness_locked`, `store.rs:1829-1921`).**
+  Attack: does healing ObservationFailed skip a pending snapshot verification?
+  No — with no reasons left it publishes `Verifying` while
+  `SnapshotVerifyState::{Pending,Running}`, `Current` only otherwise; pinned
+  by `healed_observation_does_not_bypass_pending_snapshot_verification`.
+  Attack: does a snapshot-verify transition clobber unrelated reasons? No —
+  Observation/Reconciliation/SnapshotVerification reasons are recomputed from
+  live state; watcher/capacity/derived reasons are preserved verbatim; pinned
+  by `snapshot_verify_transitions_preserve_other_degraded_reasons`. Attack:
+  degraded-at-construction race (known-finding #8) — the constructor now
+  computes degraded coverage inline (`store.rs:1420-1435`), so the published
+  bundle is never falsely `Current`; pinned by
+  `degraded_initial_scout_is_published_in_the_trust_bundle`. The
+  `set_freshness_status` bypass seam has exactly one production caller — the
+  daemon catalog-capacity cold refusal (`daemon.rs:3526`) — whose capacity
+  reason is in recompute's preserved set, so later publications keep the
+  refusal sticky, which is the §5 requirement for that out-of-scope state.
+- **Reconcile publication minting.** `publish_reconciled_scout_plan_at_generation`
+  (`store.rs:1970`) takes the writer lock, CAS-es the project generation, and
+  republishes only when the trust bundle actually changed — an unchanged
+  periodic reconcile can no longer mint publication generations (pinned by
+  `reconciled_coverage_publishes_freshness_once_per_transition` and the
+  reconcile no-mint assertion in the watcher tests). This also removes the
+  standing supply of unrelated publications that made exact-fence CAS lanes
+  livelock-prone.
+
+### P3-1 — one unreadable in-scope file degrades freshness and blacks out the whole sidecar surface (likely; design consequence to confirm, not a contract violation)
+
+1. **Confidence:** likely (mechanism proven from code; frequency depends on
+   repo contents and OS file-locking behavior).
+2. **Location:** `recompute_freshness_locked` — `observation_failed` is true if
+   ANY manifest entry has `FileDisposition::Unreadable`/`UnstableDuringRead`
+   (`store.rs:1856-1862`); `published_sidecar_index_is_queryable` refuses all
+   Degraded freshness.
+3. **Sequence:** one in-scope source file is persistently locked/unreadable
+   (on Windows, a file held open with a deny-share handle). Any publication
+   recomputes freshness → `Degraded { ObservationFailed }` → every `/outline`,
+   `/impact`, `/symbol-context`, `/repo-map`, `/prompt-context` request 503s
+   project-wide until that one path is successfully re-observed — which for a
+   persistently locked file is never. Healing exists and works
+   (`healed_observation_restores_current_freshness`) but requires the path to
+   become readable.
+4. **Consequence:** availability, not correctness — hooks fail open, honestly.
+   The contract says Degraded must refuse, so this is the specified behavior;
+   I am flagging the radius (one file → whole-surface blackout, indefinitely).
+5. **Smallest remediation, if unintended:** none required for this patch. If
+   the radius is unwanted later, scope `ObservationFailed` refusal to the
+   affected paths or to a count/proportion threshold — as a follow-up, since
+   any change here alters the trust contract.
+6. **Regression test:** n/a while the behavior is intended; the two healing
+   tests already pin the recovery direction.
+
+### P3-2 — MCP `analyze_file_impact` remains outside the sidecar queryability fence (likely; pre-existing surface split, unchanged risk)
+
+`impact_tool_text` (`handlers.rs:1048-1072`) is reached from MCP
+`analyze_file_impact` (`tools.rs:5306`) behind `loading_guard!` (health only)
+plus generation checks and the shared impact single-flight lock — but not
+behind source-binding/root/freshness queryability. Under `Degraded` freshness
+the MCP tool still serves/mutates while every sidecar HTTP route refuses.
+Invariant 1 only binds the HTTP routes, their aliases, and the daemon proxy —
+all of which are symmetric (verified §Q1) — so this is consistent with the
+request as written and with the MCP surface's trust-banner philosophy. Flagged
+so the asymmetry is a decision, not an accident. No change requested for this
+patch.
+
+### P3-3 — global symbol-cache generation registry (note only)
+
+`SYMBOL_CACHE_GENERATIONS` (`handlers.rs:519-527`): process-global mutex +
+map keyed by `Arc::as_ptr as usize`. The `Weak::upgrade` + `Arc::ptr_eq`
+check defeats address reuse and dead entries are purged each call — I could
+not construct a mis-association. It does serialize all sidecars' cache ops on
+one lock; acceptable at hook rates. Note only.
+
+## 3. Validation — full release-grade gate on the frozen tree
+
+Executed by this review on the clean checkout at `61f84672` (implementation
+identical to 71c14e30):
+
+| Check | Result |
+|---|---|
+| `cargo fmt --check` | **PASS** |
+| `cargo clippy --all-targets -- -D warnings` | **PASS** |
+| `cargo test --all-targets -- --test-threads=1` | **PASS** — 115 test binaries/suites, zero failures, including `batch_rename_health_dry_run_stays_under_h7_budget` and every suite named in the request §6 |
+| `cargo build --release` | **PASS** |
+| `node scripts/verify-tools.cjs --bin target/release/symforge.exe` | **PASS** — 8 PASS, 0 REVIEW, 0 FAIL |
+| `node scripts/verify-tools.cjs --fixture verify-tools-real --bin target/release/symforge.exe` | **PASS** — 11 PASS, 0 REVIEW, 0 FAIL |
+
+Harness-invocation caveat (request erratum, not a code defect): the request
+§6 command `node scripts/verify-tools.cjs --fixture --surface compact` does
+not match the script's CLI — `--fixture` takes a value and no `--surface`
+flag exists (`scripts/verify-tools.cjs:32-46`); run literally, it fails with
+ENOENT on `tests/fixtures/--surface/cases.jsonl`. The compact surface is
+exercised *inside* the default fixture: the harness relay sets
+`SYMFORGE_SURFACE=compact` per compact-marked case
+(`verify-tools.cjs:131-140`). I therefore ran the two CI-canonical
+invocations (`.github/workflows/ci.yml:127-128`, `.exe` suffix for Windows),
+which are the commands the release gate actually enforces. Fix the command
+lines in the request/runbook so a future operator's literal run does not
+false-alarm.
+
+H.7 note: this is the same machine on which round 1 measured the 20.6 s
+best-of-3 failure against the 5 s budget (and on which `origin/main` passed
+in an isolated baseline worktree), so this pass is a like-for-like
+refutation of the round-1 regression, not a different-hardware artifact.
+
+## 4. Required questions
+
+### Q1 — Complete route sweep
+
+Local Axum router (`src/sidecar/router.rs:23-56`), `caller_root_guard`
+middleware on everything except the diagnostics:
+
+| Route(s) | Class | Verdict |
+|---|---|---|
+| `/health`, `/stats` | deliberately diagnostic | root-agnostic; no global claims; stats counters proven flat across refusals. |
+| `/outline` + `/workflows/source-read` | read + fence-pinned freshen | guarded. |
+| `/impact` + `/workflows/post-edit-impact` | read + freshen + admit + cache + stats | guarded + single-flighted; post-commit validation identity-only (§1). |
+| `/symbol-context` + `/workflows/search-hit-expansion` | read + fence-pinned freshen | guarded. |
+| `/repo-map` + `/workflows/repo-start` | global read | guarded. |
+| `/prompt-context` + `/workflows/prompt-context` | global read + freshen | guarded; hints, nested symbol-context and repo-map body all render from the captured generation. |
+
+All five aliases are one-line delegations to the canonical handlers. Daemon
+proxy (`daemon.rs:3584-3628`): twelve `/v1/sessions/{id}/sidecar/*` routes —
+authorize → resolve runtime → `guard_session_caller_root` (409 parity) →
+`block_on` the same canonical handlers with `repo_root =
+runtime.canonical_root`. Behaviorally identical; no divergent copy of any
+handler exists. The only asymmetric entry point is MCP `analyze_file_impact`
+(P3-2, deliberate surface split). No unsafe route found.
+
+### Q2 — Readiness and root fence
+
+No source-unbound Ready, rootless Empty, Loading, or Degraded publication
+passes: status ∈ {Ready, Empty} ∧ source ∧ root ∧ freshness-queryable, where
+`Verifying` is accepted only for Empty with `SnapshotVerifyState::NotNeeded` —
+a pending/running empty snapshot verification refuses (pinned by the
+`snapshot_verifying_empty` variant). Each conjunct is independently pinned.
+Rooted Empty serves and admits its first file over real HTTP, and the
+admission receipt seeds the next edit's baseline. Validate-A-serve-B: refused
+by the repo-root/indexed-root 409 in `require_queryable_sidecar_index`, the
+per-render fence re-capture (project generation + source identity + root),
+generation-CAS'd mutations, and the caller_root guards on both surfaces.
+Remaining failure direction is fail-closed. No additional finding.
+
+### Q3 — Mutation and receipt linearizability
+
+Linearization point: the winning store publication under `write_mutex`
+(generation-domain CAS), returned as an immutable
+`Arc<PublishedGeneration>` receipt while the lock is held. The response —
+including skipped-text and callers — renders from the receipt, never from
+re-sampled current state (`reindex_receipt_remains_exact_after_later_publication`).
+Rejected mutations are typed and surface as 503, never success. Concurrent
+impacts are serialized across all four entry lanes by `lock_impact_analysis`
+(pinned). Snapshot consumption is publication-bound: an older receipt cannot
+drain a newer same-hash replacement's baseline
+(`publication_bound_snapshot_take_preserves_same_hash_aba_update`), retarget
+clears the table, generic write-guard drops invalidate stale tokens, and the
+baseline priority is snapshot → indexed content → symbols-only cache last
+(known-finding #12; pinned by the `[Changed]`-precision asserts in
+`test_write_hook_confirms_index`). The round-1 side-effects-before-503 defect
+is closed by identity-only post-commit validation (§1). No additional
+finding.
+
+### Q4 — Single-file publication semantics
+
+Re-audited every branch on the frozen code. Store CAS uses the health/live
+generation domain everywhere (`bridge_only_publication_does_not_invalidate_live_index_reindex_cas`);
+project generation is checked first and independently; winning publications
+are returned under the writer lock; `Removed` is reported only when the
+project-generation + under-lock-disk-absence removal actually published;
+`Skipped`/`HashSkip`/`Reindexed` always carry their publication; every
+no-publication path is `PublicationRejected`. Disk delete→recreate cannot
+authorize removal on any of the four removal lanes (all pinned). Confirmed
+convergence: unrelated same-project publications no longer starve confirmed
+deletions (§1). Residual (pre-existing on main, unchanged): an
+excluded-path eviction with no prior record still clones-and-publishes.
+No additional finding.
+
+### Q5 — Hook behavior matrix
+
+Re-traced on frozen code; every row lands in valid fail-open JSON, bounded
+request counts, honest attribution:
+
+| Endpoint | Response | Behavior |
+|---|---|---|
+| local descriptor | 200 | `Routed`, 1 request. |
+| local descriptor | 503 / 409 / 404-500 | one daemon fallback (root-pinned query, active-project-filtered session); success → `DaemonFallback`@daemon session; live failure → `SidecarError` with typed reason (`index_not_ready` / `root_conflict` / `http_failure`); no daemon → `SidecarError`@initial session. Never a restart hint, never `sidecar_port_stale`. |
+| local descriptor | transport | fallback; if none, `NoSidecar sidecar_port_stale` + restart hint — correct, actually dead. |
+| daemon descriptor | 503 | authoritative: zero rediscovery, exactly 1 request (request-count pinned). |
+| daemon descriptor | 409 / 404-500 / transport | one rediscovery EXCLUDING the failed session; recovery through a different active session or typed fail-open; ≤2 enrichment requests, no loop (route-recording mocks pin the exact request sequences on both endpoints, including root-pinning of each request). |
+| missing descriptor | — | step-1 daemon fallback; `NoSidecar sidecar_port_missing` otherwise. |
+| stale descriptor | — | transport lane. |
+| empty/whitespace legacy session id | — | normalized to `None` at read; routes locally, fallback-eligible — pinned end-to-end for both the 503 and 409 initial responses. |
+
+`SessionSummary` serializes `project_id` from `active_project_id`
+(`daemon.rs:705-712`, `1484-1491`), so the active-project filter holds against
+the real daemon, not only the mocks. No additional finding.
+
+### Q6 — Public API compatibility
+
+Re-diffed the public surface across all changed files: `ReindexResult` keeps
+exactly six variants (internal `ReindexOutcome` folds `PublicationRejected` →
+`Skipped` at the embed boundary — main-compatible for exhaustive matchers);
+`SidecarState::symbol_cache` is the type-identical alias
+`SymbolSnapshotCache`; `take_pre_update_snapshot` keeps its signature (now
+writer-locked; no public caller can hold that lock); additions are purely
+additive (`take_pre_update_snapshot_at_generation`, the alias, fence-suffixed
+snapshot-verify markers); everything else is `pub(crate)`.
+`from_indexed_files`/`from_source_files` pre-exist on main. No break found.
+
+### Q7 — Tests that can fail
+
+The round-1 catalog stands (10-route loading matrix with no-mutation
+asserts; independent queryability conjuncts; source-unbound-Ready refusal;
+Empty first-file admission; exact receipts after later publication; same-hash
+snapshot ABA; cross-project removal/publish/consume fences; shared impact
+lock; unreadable-file baseline preservation; hook 503/409 no-loop/attribution
+/no-hint suite). New at the frozen commit, each with a real smallest
+reversion:
+
+- `missing_file_finalization_ignores_unrelated_same_project_publication` —
+  fails if the exact publication fence is reinstated on the absence path.
+- `background_verify_deleted_file_removal_refuses_disk_recreation` and
+  `scout_reconciliation_removal_refuses_a_recreated_disk_path` — fail if the
+  under-lock disk-absence check is dropped from those lanes.
+- `post_impact_fence_preserves_response_across_freshness_only_transition` —
+  fails in one direction if the post-commit check re-includes freshness, and
+  in the other if it stops rejecting a rebind.
+- `snapshot_verify_transitions_preserve_other_degraded_reasons`,
+  `healed_observation_restores_current_freshness`,
+  `healed_observation_does_not_bypass_pending_snapshot_verification`,
+  `degraded_initial_scout_is_published_in_the_trust_bundle`,
+  `reconciled_coverage_publishes_freshness_once_per_transition` — pin the
+  freshness engine's four properties (atomic construction, reason
+  preservation, healing, no-mint); each fails against the naive direct-store
+  implementations they replaced.
+- `run_hook_local_http_500_fails_open_as_http_failure_without_restart_hint`,
+  the empty/whitespace-session pair, and the descriptor-404/409
+  rediscovery pair — the hook mocks now RECORD request routes and assert the
+  exact sequences (`assert_request_routes`), 404 unexpected routes, and are
+  deadline-bounded: the mock-accepts-wrong-path and unbounded-join failure
+  modes are structurally addressed.
+
+False-green audit: the queryability variant tests build synthetic
+`PublishedGeneration` values — acceptable because the same conjuncts are also
+exercised through the real Axum server in the loading matrix and
+Empty-admission tests; the direct-helper tests are the decomposition, not the
+only coverage. The CWD-lock env juggling in the enrichment suite remains
+brittle-but-sound at `--test-threads=1`. No false-green fixture found.
+
+### Q8 — Anything else materially wrong
+
+No additional finding. Specifically re-checked after the freshness engine
+landed: no path serves wrong-project data, claims global absence from partial
+state, serves stale exact-path content after a rejected freshen (rejection
+propagates as refusal on every read lane), invents success from a rejected
+publication, waits unboundedly (all retry loops are bounded; all mocks and
+locks deadline- or scope-bounded), or breaks the 10.0.x public surface.
+
+## 5. Verdict
+
+**Clear to land.** Every round-1 blocker is closed on the frozen commit and
+re-verified here by both code reading and the full release-grade gate run on
+the exact tree (fmt, clippy `-D warnings`, full `--all-targets` suite
+including the H.7 perf gate on the machine that originally caught the
+regression, release build, and both CI-canonical `verify-tools.cjs` harness
+passes on the release binary — all green). The three P3 notes are design
+consequences to confirm, not landing blockers; the only action item outside
+the code is the §3 erratum in the request's own verify-tools command lines.

--- a/docs/reviews/REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md
+++ b/docs/reviews/REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md
@@ -292,17 +292,23 @@ existing 5-second best-of-N gate. Likewise, the early pass's first-file Empty
 admission, formatting, post-impact 503, deletion convergence, and live HTTP 500
 findings are fixed and covered on the frozen target.
 
-The full release-grade gate remains intentionally pending until the three frozen
-reviews return:
+Claude Fable's frozen-target round-2 review independently ran the full
+release-grade gate below and reported every command green. The landing agent
+accepted that frozen review as the external gate; no implementation changed
+afterward, and PR CI will rerun the repository gates before merge:
 
 ```text
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets -- --test-threads=1
 cargo build --release
-node scripts/verify-tools.cjs --fixture
-node scripts/verify-tools.cjs --fixture --surface compact
+node scripts/verify-tools.cjs --bin target/release/symforge.exe
+node scripts/verify-tools.cjs --fixture verify-tools-real --bin target/release/symforge.exe
 ```
+
+On Unix, omit the `.exe` suffix. There is no `--surface` CLI flag: compact
+cases are exercised inside the canonical fixture harness, which sets
+`SYMFORGE_SURFACE=compact` for the cases that require it.
 
 Green commands are evidence of build/test health, not proof of the concurrency
 contracts above.

--- a/docs/reviews/REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md
+++ b/docs/reviews/REVIEW-REQUEST-http-sidecar-readiness-2026-08-10.md
@@ -1,0 +1,322 @@
+# Review request — HTTP sidecar readiness and publication fencing
+
+## 0. Review target
+
+Repository: `special-place-ai-heaven/symforge`
+
+Branch/worktree: `fix/http-sidecar-readiness`
+
+Base: `origin/main` at SymForge 10.0.3,
+`71fb88429134462cc8bdf1022ee3037bcec5f65d`.
+
+**Frozen implementation target:**
+`71c14e309a9a45ad01d145b136ef556a6b86190e`.
+
+**Expected binary diff hash:**
+`920e3002030392732514f2d560839da05e214099`.
+
+Review that commit, not the branch tip and not an uncommitted working tree:
+
+```text
+git fetch origin
+git show --stat 71c14e309a9a45ad01d145b136ef556a6b86190e
+git diff --binary 71fb88429134462cc8bdf1022ee3037bcec5f65d...71c14e309a9a45ad01d145b136ef556a6b86190e | git hash-object --stdin
+git diff 71fb88429134462cc8bdf1022ee3037bcec5f65d...71c14e309a9a45ad01d145b136ef556a6b86190e
+```
+
+Abort the review if the computed diff hash is not the expected hash above.
+Record both identities in the answer. Do not assume this packet's line numbers
+remain current.
+
+This is an adversarial correctness review. I want concrete defects, not a
+summary or a style pass. A clean verdict is useful if it follows an actual
+sweep.
+
+### Three-reviewer protocol
+
+This request is being sent independently to Grok 4.5, Composer 2.5, and Claude
+Fable. Do not read or incorporate another reviewer's findings before submitting
+your own. All three reviewers should answer Q1–Q8; the emphasis below is an
+additional lens, not permission to skip the rest:
+
+- **Grok 4.5:** emphasize state-space enumeration, publication-generation
+  domains, and concrete concurrency/ABA interleavings.
+- **Composer 2.5:** emphasize the complete production call-path/route sweep,
+  public API compatibility, and tests that can genuinely fail.
+- **Claude Fable:** emphasize end-to-end semantic truth across HTTP, hook
+  fallback/telemetry, impact claims, and any defect the stated invariants failed
+  to anticipate.
+
+An earlier Claude Fable pass reviewed four moving, uncommitted snapshots and is
+preserved as
+`REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-2026-08-10.md`. It is
+historical evidence, **not** a verdict on the frozen target. Do not read it (or
+either other review) before completing your independent pass.
+
+Write findings to the reviewer-specific final file below without editing the
+implementation or this request:
+
+```text
+Grok 4.5:      docs/reviews/REVIEW-FINDINGS-grok-4.5-http-sidecar-readiness-final-2026-08-10.md
+Composer 2.5: docs/reviews/REVIEW-FINDINGS-composer-2.5-http-sidecar-readiness-final-2026-08-10.md
+Claude Fable: docs/reviews/REVIEW-FINDINGS-claude-fable-http-sidecar-readiness-round2-2026-08-10.md
+```
+
+## 1. Original defect and intended contract
+
+The merged cold-start repair stopped MCP reads from treating a rootless
+`EmptyBootstrap` placeholder as Ready. The HTTP sidecar remained another route
+to the same unsafe state: handlers could freshen/admit one file into the
+placeholder and then answer global questions from a partial, source-unbound
+index.
+
+The implementation under review intends to establish all of these invariants:
+
+1. Five sidecar content families refuse an unqueryable publication:
+   `/outline`, `/symbol-context`, `/prompt-context`, `/repo-map`, and `/impact`.
+   Their workflow aliases and daemon proxy paths must behave identically.
+2. `/health` and `/stats` remain available diagnostics while the index is not
+   queryable.
+3. A queryable sidecar publication is `Ready` or source-bound `Empty`, has both
+   a source identity and an indexed root, and has queryable freshness. `Current`
+   is queryable. `Degraded` always refuses. `Verifying` is queryable only for a
+   source-bound `Empty` publication whose snapshot verification state is
+   `NotNeeded` (the deliberate empty-repository initialization shape), never a
+   pending/running snapshot. A legitimate rooted empty repository must still
+   serve repo-map and admit its first file.
+4. Readiness refusal is HTTP 503 with no enrichment body. Hook clients fail
+   open, may use one valid daemon fallback, and must not call a live-but-loading
+   sidecar dead or stale.
+5. Root mismatch is HTTP 409, remains a live-refusal/sidecar-error signal, and
+   must not produce a restart hint. A root-resolved alternate daemon session
+   may still be tried when doing so cannot loop back to the same session.
+6. A request that is already unqueryable at entry performs no freshen, index,
+   cache, pre-update-snapshot, or hook-stat mutation.
+7. A project rebind cannot cause bytes or side-table state from project A to be
+   committed into project B. Project generation, source identity, and indexed
+   root form the cross-project fence.
+8. A successful same-project freshen is allowed to publish. The fence must not
+   pin full publication/content generation and reject its own update.
+9. Impact rendering consumes the exact immutable publication receipt produced
+   by its mutation. A later watcher publication must not change what the request
+   claims it indexed, nor let it drain a later pre-update snapshot.
+10. This is a 10.0.x patch. Existing public Rust types and public struct fields
+    must remain source-compatible, especially `embed::ReindexResult` and
+    `SidecarState::symbol_cache`.
+
+## 2. Ground rules
+
+- A comment is a claim under review, not evidence.
+- Existence is not invocation. Trace production call paths.
+- For every race finding, give a concrete A/B interleaving and identify the
+  mutation or wrong response.
+- Distinguish the full `PublishedGeneration.publication_generation` from the
+  health/live `PublishedIndexState.generation`; bridge- or authority-only
+  publications can advance only the former.
+- Exact publication fencing supplements, and never replaces, the caller's
+  project-generation fence.
+- Do not call a test protective merely because it is green. Explain why it
+  fails when the relevant guard/fence is removed.
+- Cite `file:symbol` and current `file:line`. Label each finding **proven**,
+  **likely**, or **speculative**.
+- Do not spend the review on formatting, naming, or comment prose.
+
+## 3. Known findings being remediated
+
+These were found internally during the final pass. Verify that the reviewed
+snapshot actually closes them, but do not stop after rediscovering them:
+
+1. A new `PublicationRejected` variant was temporarily added to the semver-public,
+   exhaustively matchable `ReindexResult`. The final design must keep rejection
+   typed inside the crate and preserve the six-variant public enum.
+2. `freshen_exact_path_for_targeted_retrieval` temporarily collapsed a rejected
+   publication to boolean `false`, allowing exact-path reads to continue from
+   stale state. Rejection must propagate as an explicit retry/refusal.
+3. Single-file CAS temporarily passed the full publication generation into
+   store seams that compare the health/live generation. A bridge-only publish
+   then caused four deterministic CAS losses. The two generation domains must
+   stay distinct.
+4. Hook topology temporarily inferred “initial endpoint is daemon” from
+   `session_id.is_some()` while the routing function treats empty/whitespace IDs
+   as local. Normalize once and use one predicate.
+5. Suppressing daemon rediscovery for every failure from a daemon-shaped
+   descriptor can strand a hook on a closed session. The no-loop rule is needed
+   for an index-not-ready response; unavailable/root-conflict cases require a
+   failure-specific analysis.
+6. New edit retry messages initially classified as `InvalidRequest` instead of
+   retryable/internal failure.
+7. An exact index-publication fence alone does not prove continued filesystem
+   absence. Audit delete/recreate ABA windows and the direct watcher removal
+   paths rather than assuming the receipt work closes disk-only races.
+8. Degraded freshness was initially written after construction, leaving the
+   immutable published bundle falsely `Current`; startup construction must
+   publish the degraded reason atomically.
+9. Observation/reconciliation degradation was initially sticky after healing,
+   then snapshot-verification transitions briefly overwrote unrelated degraded
+   reasons. Freshness must be recomputed from manifest, scout coverage, and
+   snapshot state while preserving unrelated typed reasons.
+10. Impact initially performed a readiness check after committing its receipt,
+    cache, snapshot, and stats effects; a freshness-only transition could turn
+    the useful first response into 503. Post-commit validation must preserve the
+    response while still rejecting project/source/root rebinding.
+11. Confirmed-absent removal initially rejected on unrelated same-project
+    publications and the snapshot verifier had a separate disk-recreation ABA
+    path. Project generation plus under-lock filesystem absence is the deletion
+    authority; every production removal lane must use it.
+12. A symbols-only impact cache initially made a later one-symbol edit report
+    every matching symbol as changed. Exact snapshot/index content must outrank
+    the compatibility cache when computing body changes.
+
+## 4. Required questions
+
+### Q1 — Complete route sweep
+
+Enumerate every production HTTP route and workflow alias that can read, freshen,
+admit, remove, or derive global absence/caller claims from the live index. For
+each, state whether it is guarded, deliberately diagnostic, or still unsafe.
+Include daemon proxy dispatch, not only the local Axum router.
+
+### Q2 — Readiness and root fence
+
+Can any source-unbound `Ready`, rootless `Empty`, `Loading`, or `Degraded`
+publication pass? Can a rooted `Empty` repository still serve and admit its
+first file? Can caller-root validation pass for A and the handler subsequently
+serve or mutate B after a rebind?
+
+### Q3 — Mutation and receipt linearizability
+
+For edit impact and new-file impact, trace disk observation, pre-update snapshot,
+parse/admission, publication, cache write, stats write, caller lookup, and final
+response. Identify the linearization point. Look specifically for:
+
+- a response derived from a later publication rather than the receipt;
+- a rejected mutation rendered as success;
+- same-generation concurrent impacts regressing cache state;
+- one request consuming another request's snapshot;
+- side effects committed before a later 503 that callers may retry.
+
+### Q4 — Single-file publication semantics
+
+Audit every success, terminal admission, hash-skip, missing-file, exclusion,
+retry-exhaustion, and publication-failure branch. Confirm:
+
+- the store CAS uses the correct generation domain;
+- the exact winning publication is returned while the writer lock still owns it;
+- project generation is checked independently;
+- `Removed`, `Skipped`, and `Reindexed` are never reported when no corresponding
+  publication occurred;
+- disk-only delete/recreate cannot authorize removal of a recreated path.
+
+### Q5 — Hook behavior matrix
+
+Trace local descriptor, daemon-backed descriptor, missing descriptor, stale
+descriptor, empty legacy session ID, and fallback-selected daemon for HTTP 200,
+409, 503, 404/500, and transport failure. For each, check request count, fallback
+eligibility, fail-open output, session attribution, outcome telemetry, and
+presence/absence of stale-port restart hints.
+
+### Q6 — Public API compatibility
+
+Diff the public/embed facade and public struct fields against `origin/main`.
+Look for enum-variant additions, public field type changes, visibility changes,
+or signature changes that break an external exhaustive match or custom router.
+Do not limit this check to files named `embed.rs` or `lib.rs`.
+
+### Q7 — Tests that can fail
+
+For each new high-value test, name the production condition it pins and the
+smallest code reversion that makes it fail. In particular check:
+
+- the 10-route real Axum loading matrix and no-mutation assertions;
+- independent readiness conjuncts (status, source, root);
+- source-bound Empty first-file admission;
+- exact Reindexed and HashSkip receipts after later publication;
+- same-hash snapshot ABA preservation;
+- stale project A unable to remove or publish into rebound project B;
+- impact entry points sharing one single-flight lock;
+- failed impact preserving its pre-update baseline;
+- hook 503/409 fallback, no-loop, attribution, and no-restart-hint cases.
+
+Call out false-green fixtures, mocks that accept the wrong path, unbounded joins,
+or tests that only exercise a direct helper while the real Axum/daemon path can
+still differ.
+
+### Q8 — Anything else materially wrong
+
+Report any additional path that can return wrong-project data, global absence
+from partial state, stale exact-path content, invented success, an infinite wait,
+or a patch-release API break.
+
+## 5. Deliberately out of scope
+
+Do not treat these as new findings for this patch unless this diff makes them
+worse:
+
+- the separate typed bootstrap lifecycle work for daemon catalog-capacity
+  refusal and failed local cold-start reload;
+- snapshot verification liveness/retry redesign;
+- Spec 027 answer identity disclosure;
+- `feat/knowledge-llm-sift`;
+- Terminal Commander watcher-stop semantics.
+
+The sidecar must nevertheless refuse the currently published nonqueryable states
+those follow-ups produce.
+
+## 6. Verification state for the frozen implementation commit
+
+The following passed on
+`71c14e309a9a45ad01d145b136ef556a6b86190e` (or the identical staged tree
+immediately before that commit):
+
+```text
+cargo check --all-targets
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --lib freshness -- --test-threads=1
+cargo test --lib snapshot_verify_transitions_preserve_other_degraded_reasons -- --test-threads=1
+cargo test --lib degraded_initial_scout_is_published_in_the_trust_bundle -- --test-threads=1
+cargo test --lib sidecar_queryability_requires_status_source_and_root_independently -- --test-threads=1
+cargo test --lib removal -- --test-threads=1
+cargo test --lib missing_file_finalization_ignores_unrelated_same_project_publication -- --test-threads=1
+cargo test --lib targeted_retrieval_refuses -- --test-threads=1
+cargo test --test hook_subprocess_integration -- --test-threads=1
+cargo test --test hook_enrichment_integration -- --test-threads=1
+cargo test --test sidecar_contract -- --test-threads=1
+cargo test --test sidecar_integration -- --test-threads=1
+cargo test --test batch_rename_perf -- --test-threads=1
+```
+
+The last command is important: an early moving-target review measured a real H.7
+failure on its first uncommitted snapshot. The frozen candidate passes the
+existing 5-second best-of-N gate. Likewise, the early pass's first-file Empty
+admission, formatting, post-impact 503, deletion convergence, and live HTTP 500
+findings are fixed and covered on the frozen target.
+
+The full release-grade gate remains intentionally pending until the three frozen
+reviews return:
+
+```text
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets -- --test-threads=1
+cargo build --release
+node scripts/verify-tools.cjs --fixture
+node scripts/verify-tools.cjs --fixture --surface compact
+```
+
+Green commands are evidence of build/test health, not proof of the concurrency
+contracts above.
+
+## 7. Expected answer format
+
+Start with findings ordered P0/P1/P2/P3. For each finding provide:
+
+1. confidence;
+2. current `file:line` and symbol;
+3. concrete reachable sequence/interleaving;
+4. user-visible or state-corruption consequence;
+5. smallest safe remediation;
+6. a regression test that fails before the remediation.
+
+Then answer Q1–Q8 explicitly, including “no additional finding” where appropriate.
+End with one verdict: **block**, **land after listed fixes**, or **clear to land**.

--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -297,7 +297,8 @@ pub fn run_hook_with_input_at(
                 "process control state unavailable",
             )
         })
-        .and_then(|state_dir| read_sidecar_endpoint(state_dir, &repo_root));
+        .and_then(|state_dir| read_sidecar_endpoint(state_dir, &repo_root))
+        .map(|(port, session_id)| (port, normalize_session_id(session_id)));
     let session_id = sidecar_endpoint
         .as_ref()
         .ok()
@@ -340,7 +341,7 @@ pub fn run_hook_with_input_at(
             if verbose {
                 eprintln!("[symforge-hook] attempting daemon fallback...");
             }
-            match try_daemon_fallback(&repo_root) {
+            match try_daemon_fallback(&repo_root, None) {
                 Some(fallback) => {
                     if verbose {
                         eprintln!(
@@ -378,6 +379,12 @@ pub fn run_hook_with_input_at(
             }
         }
     };
+    // A descriptor carrying a session id already targets the daemon proxy.
+    // Keep this separate from `used_daemon_fallback`: descriptor routing is a
+    // normal route (and records `Routed`), but it must not rediscover and call
+    // the same daemon a second time after a 503. Session ids are normalized at
+    // descriptor read so this predicate is identical to `proxy_path` routing.
+    let initial_endpoint_is_daemon = effective_session_id.is_some();
 
     // Step 2 — determine endpoint + query string.
     let resolved_ref = resolved.as_ref();
@@ -388,107 +395,208 @@ pub fn run_hook_with_input_at(
         eprintln!("[symforge-hook] HTTP GET 127.0.0.1:{port}{request_path}?{query}");
     }
 
-    // Keep a copy of the query so the stale-sidecar daemon fallback below can
-    // re-issue the same enrichment request — `sync_http_get` consumes `query`.
-    let fallback_query = query.clone();
-
     // Dogfood #6 / spec 012 FR-006b (hook half): pin the sidecar request to
     // the caller's repo root. A sidecar whose shared session was retargeted by
     // another agent's `index_folder` answers 409, and the daemon fallback
-    // below re-resolves the caller's project BY ROOT — no false alarms. The
-    // daemon fallback request itself stays unpinned (it is already
-    // root-resolved by `try_daemon_fallback`).
-    let query = if used_daemon_fallback {
-        query
-    } else {
-        append_caller_root(query)
-    };
+    // below re-resolves the caller's project BY ROOT. Keep the daemon request
+    // pinned too: a session can remain open while its active project changes.
+    let query = append_caller_root(query);
+    // Keep a copy so the stale-sidecar daemon fallback can re-issue the same
+    // root-pinned enrichment request — the first HTTP call consumes `query`.
+    let fallback_query = query.clone();
 
     // Step 3/4 — make sync HTTP GET with 50 ms timeout.
-    let (body, outcome) = match sync_http_get(port, &request_path, query) {
-        Ok(b) => {
+    let (body, outcome, outcome_session_id) = match sync_enrichment_http_get(
+        port,
+        &request_path,
+        query,
+    ) {
+        EnrichmentHttpResult::Success(b) => {
             let initial_outcome = if used_daemon_fallback {
                 HookOutcome::DaemonFallback
             } else {
                 HookOutcome::Routed
             };
-            (b, initial_outcome)
+            (b, initial_outcome, effective_session_id.clone())
         }
-        Err(_) => {
-            // Port file existed but the HTTP call failed — the sidecar is dead
-            // or stale. Before failing open to a NON-enriched pass-through, try
-            // routing the SAME enrichment request through the daemon, which
-            // holds the same index. This mirrors the missing-port branch above
-            // so a dead sidecar still yields enriched results.
+        initial_failure @ (EnrichmentHttpResult::IndexNotReady
+        | EnrichmentHttpResult::RootConflict
+        | EnrichmentHttpResult::HttpFailure(_)
+        | EnrichmentHttpResult::Unavailable) => {
+            let initial_index_not_ready =
+                matches!(initial_failure, EnrichmentHttpResult::IndexNotReady);
+            let initial_root_conflict =
+                matches!(initial_failure, EnrichmentHttpResult::RootConflict);
+            let initial_http_failure =
+                matches!(initial_failure, EnrichmentHttpResult::HttpFailure(_));
+
+            // Before failing open, try routing the SAME enrichment request
+            // through the daemon. A local sidecar may still be loading while a
+            // separate root-matched daemon session is already queryable.
             //
-            // Skip the fallback when we were already talking to the daemon
-            // (`used_daemon_fallback`): the daemon is the thing that just
-            // failed, so a second round-trip would be pointless — and this
-            // guard guarantees at most one daemon attempt, never a loop.
+            // A 503 from a daemon-backed endpoint is authoritative for that
+            // root-matched project and must not be retried through the same
+            // daemon. A closed session (404/unavailable) or a root conflict can
+            // still recover through a different active session, so rediscover
+            // while excluding the session that just failed.
             let port_file_path = control_state_dir
                 .as_ref()
                 .map(sidecar_descriptor_path)
                 .unwrap_or_default();
 
-            // Honest liveness diagnostics (item b): probe the actual sidecar
-            // state so a dead sidecar is never a silent bypass. The probe does
-            // a real TCP connect, so it is gated behind verbose to avoid adding
-            // latency to the degraded path on every call. The always-on honest
-            // signal is the adoption-log outcome recorded below: a successful
-            // daemon fallback records `DaemonFallback` (sidecar dead/degraded,
-            // served via daemon), and a total miss records `sidecar_port_stale`.
             if verbose {
-                let liveness = control_state_dir
-                    .as_ref()
-                    .map(|state_dir| {
-                        crate::sidecar::port_file::read_sidecar_status(
-                            state_dir,
-                            "127.0.0.1",
-                            Some(&repo_root),
-                        )
-                        .liveness
-                        .as_str()
-                    })
-                    .unwrap_or("unavailable");
-                eprintln!(
-                    "[symforge-hook] HTTP request failed — sidecar liveness={liveness}, \
-                     attempting daemon fallback before fail-open"
-                );
-            }
-
-            let daemon_enriched = if used_daemon_fallback {
-                None
-            } else {
-                try_daemon_fallback(&repo_root).and_then(|fallback| {
-                    let daemon_request_path = proxy_path(path, Some(&fallback.session_id));
-                    if verbose {
+                if initial_index_not_ready {
+                    if initial_endpoint_is_daemon {
+                        eprintln!("[symforge-hook] daemon index not ready — failing open");
+                    } else {
                         eprintln!(
-                            "[symforge-hook] daemon fallback (stale sidecar): \
-                             port={}, session={}",
-                            fallback.daemon_port, fallback.session_id
+                            "[symforge-hook] index not ready — attempting daemon fallback before fail-open"
                         );
                     }
-                    sync_http_get_with_timeout(
-                        fallback.daemon_port,
-                        &daemon_request_path,
-                        fallback_query,
-                        DAEMON_FALLBACK_DEADLINE,
-                    )
-                    .ok()
-                })
+                } else if initial_root_conflict {
+                    if initial_endpoint_is_daemon {
+                        eprintln!(
+                            "[symforge-hook] daemon root conflict — attempting alternate daemon session"
+                        );
+                    } else {
+                        eprintln!(
+                            "[symforge-hook] sidecar root conflict — attempting daemon fallback before fail-open"
+                        );
+                    }
+                } else if initial_http_failure {
+                    eprintln!(
+                        "[symforge-hook] sidecar returned a live HTTP failure — attempting daemon fallback before fail-open"
+                    );
+                } else {
+                    // Probe only transport failures. A 503 already proves the
+                    // sidecar is live and must never produce a restart hint.
+                    let liveness = control_state_dir
+                        .as_ref()
+                        .map(|state_dir| {
+                            crate::sidecar::port_file::read_sidecar_status(
+                                state_dir,
+                                "127.0.0.1",
+                                Some(&repo_root),
+                            )
+                            .liveness
+                            .as_str()
+                        })
+                        .unwrap_or("unavailable");
+                    if initial_endpoint_is_daemon {
+                        eprintln!(
+                            "[symforge-hook] daemon HTTP request failed — liveness={liveness}, attempting alternate daemon session"
+                        );
+                    } else {
+                        eprintln!(
+                            "[symforge-hook] HTTP request failed — sidecar liveness={liveness}, \
+                             attempting daemon fallback before fail-open"
+                        );
+                    }
+                }
+            }
+
+            let daemon_enriched = if initial_endpoint_is_daemon && initial_index_not_ready {
+                None
+            } else {
+                let excluded_session_id = initial_endpoint_is_daemon
+                    .then_some(effective_session_id.as_deref())
+                    .flatten();
+                match try_daemon_fallback(&repo_root, excluded_session_id) {
+                    Some(fallback) => {
+                        let fallback_session_id = fallback.session_id.clone();
+                        let daemon_request_path = proxy_path(path, Some(&fallback.session_id));
+                        if verbose {
+                            eprintln!(
+                                "[symforge-hook] daemon fallback (stale sidecar): \
+                                 port={}, session={}",
+                                fallback.daemon_port, fallback.session_id
+                            );
+                        }
+                        Some((
+                            sync_enrichment_http_get_with_timeout(
+                                fallback.daemon_port,
+                                &daemon_request_path,
+                                fallback_query,
+                                DAEMON_FALLBACK_DEADLINE,
+                            ),
+                            fallback_session_id,
+                        ))
+                    }
+                    None => None,
+                }
             };
 
             match daemon_enriched {
-                Some(b) => {
+                Some((EnrichmentHttpResult::Success(b), daemon_session_id)) => {
                     if verbose {
                         eprintln!(
                             "[symforge-hook] daemon fallback succeeded — \
                              sidecar dead/degraded, served enriched result via daemon"
                         );
                     }
-                    (b, HookOutcome::DaemonFallback)
+                    (b, HookOutcome::DaemonFallback, Some(daemon_session_id))
                 }
-                None => {
+                Some((EnrichmentHttpResult::IndexNotReady, daemon_session_id)) => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        Some(&daemon_session_id),
+                        "index_not_ready",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::RootConflict, daemon_session_id)) => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        Some(&daemon_session_id),
+                        "root_conflict",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::HttpFailure(_), daemon_session_id)) => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        Some(&daemon_session_id),
+                        "http_failure",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::Unavailable, _)) | None if initial_index_not_ready => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        effective_session_id.as_deref(),
+                        "index_not_ready",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::Unavailable, _)) | None if initial_root_conflict => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        effective_session_id.as_deref(),
+                        "root_conflict",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::Unavailable, _)) | None if initial_http_failure => {
+                    emit_live_refusal_fail_open(
+                        workflow,
+                        event_name,
+                        effective_session_id.as_deref(),
+                        "http_failure",
+                        verbose,
+                    );
+                    return Ok(());
+                }
+                Some((EnrichmentHttpResult::Unavailable, _)) | None => {
                     // Both sidecar and daemon are unreachable: degrade to a
                     // pass-through, never hang, never error the editor.
                     if verbose {
@@ -521,9 +629,23 @@ pub fn run_hook_with_input_at(
     }
 
     // Step 5/6 — output result JSON.
-    record_hook_outcome(workflow, outcome, effective_session_id.as_deref());
+    record_hook_outcome(workflow, outcome, outcome_session_id.as_deref());
     println!("{}", success_json(event_name, &body));
     Ok(())
+}
+
+fn emit_live_refusal_fail_open(
+    workflow: HookWorkflow,
+    event_name: &str,
+    session_id: Option<&str>,
+    reason: &str,
+    verbose: bool,
+) {
+    if verbose {
+        eprintln!("[symforge-hook] outcome=SidecarError reason={reason}");
+    }
+    record_hook_outcome(workflow, HookOutcome::SidecarError, session_id);
+    println!("{}", fail_open_json(event_name));
 }
 
 // ---------------------------------------------------------------------------
@@ -946,6 +1068,12 @@ fn read_sidecar_endpoint(
     )
 }
 
+fn normalize_session_id(session_id: Option<String>) -> Option<String> {
+    session_id
+        .map(|session_id| session_id.trim().to_string())
+        .filter(|session_id| !session_id.is_empty())
+}
+
 fn proxy_path(base_path: &str, session_id: Option<&str>) -> String {
     match session_id {
         Some(session_id) if !session_id.trim().is_empty() => {
@@ -1018,7 +1146,10 @@ struct DaemonFallbackResult {
 /// daemon is unreachable, has no matching project, or any step times out.
 ///
 /// Total budget: DAEMON_FALLBACK_DEADLINE (500ms shared across all steps).
-fn try_daemon_fallback(repo_root: &Path) -> Option<DaemonFallbackResult> {
+fn try_daemon_fallback(
+    repo_root: &Path,
+    excluded_session_id: Option<&str>,
+) -> Option<DaemonFallbackResult> {
     let deadline = std::time::Instant::now() + DAEMON_FALLBACK_DEADLINE;
 
     // Step 1: Read the daemon port file (~/.symforge/daemon.port).
@@ -1054,12 +1185,21 @@ fn try_daemon_fallback(repo_root: &Path) -> Option<DaemonFallbackResult> {
 
     let sessions: Vec<DaemonSessionEntry> = serde_json::from_str(&sessions_json).ok()?;
 
-    // Pick the most recently seen session.
-    let session = sessions.iter().max_by_key(|s| s.last_seen_at_unix_secs)?;
+    // A session listed under this project may since have activated another
+    // project. Only route through a session whose current active project still
+    // matches the root-resolved project, then prefer the most recently seen.
+    let session = sessions
+        .iter()
+        .filter(|session| {
+            session.project_id == matching.project_id
+                && !session.session_id.trim().is_empty()
+                && excluded_session_id.is_none_or(|excluded| session.session_id.trim() != excluded)
+        })
+        .max_by_key(|session| session.last_seen_at_unix_secs)?;
 
     Some(DaemonFallbackResult {
         daemon_port,
-        session_id: session.session_id.clone(),
+        session_id: session.session_id.trim().to_string(),
     })
 }
 
@@ -1075,7 +1215,23 @@ struct DaemonProjectEntry {
 #[derive(serde::Deserialize)]
 struct DaemonSessionEntry {
     session_id: String,
+    project_id: String,
     last_seen_at_unix_secs: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct HttpResponse {
+    status_code: u16,
+    body: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum EnrichmentHttpResult {
+    Success(String),
+    IndexNotReady,
+    RootConflict,
+    HttpFailure(u16),
+    Unavailable,
 }
 
 /// Normalize a path for cross-platform comparison: lowercase on Windows,
@@ -1090,13 +1246,12 @@ fn normalize_path_for_match(path: &Path) -> String {
     }
 }
 
-/// Like `sync_http_get` but with a configurable timeout.
-fn sync_http_get_with_timeout(
+fn sync_http_response_with_timeout(
     port: u16,
     path: &str,
     query: String,
     timeout: Duration,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<HttpResponse> {
     let addr = format!("127.0.0.1:{port}");
     let sock_addr: std::net::SocketAddr = addr.parse()?;
 
@@ -1142,10 +1297,6 @@ fn sync_http_get_with_timeout(
         .parse()
         .map_err(|_| anyhow::anyhow!("non-numeric HTTP status code in: {status_line}"))?;
 
-    if !(200..=299).contains(&status_code) {
-        anyhow::bail!("HTTP {status_code} from {path}");
-    }
-
     // Check for chunked transfer-encoding. The sidecar uses hyper which may
     // send chunked responses. Since we use Connection: close and read_to_string,
     // the raw body includes chunk framing that must be decoded.
@@ -1154,10 +1305,47 @@ fn sync_http_get_with_timeout(
         lower.starts_with("transfer-encoding:") && lower.contains("chunked")
     });
 
-    if is_chunked {
-        Ok(decode_chunked_body(body))
+    let body = if is_chunked {
+        decode_chunked_body(body)
     } else {
-        Ok(body.to_string())
+        body.to_string()
+    };
+
+    Ok(HttpResponse { status_code, body })
+}
+
+/// Like `sync_http_get` but with a configurable timeout.
+fn sync_http_get_with_timeout(
+    port: u16,
+    path: &str,
+    query: String,
+    timeout: Duration,
+) -> anyhow::Result<String> {
+    let response = sync_http_response_with_timeout(port, path, query, timeout)?;
+    if !(200..=299).contains(&response.status_code) {
+        anyhow::bail!("HTTP {} from {path}", response.status_code);
+    }
+    Ok(response.body)
+}
+
+fn classify_enrichment_response(response: HttpResponse) -> EnrichmentHttpResult {
+    match response.status_code {
+        200..=299 => EnrichmentHttpResult::Success(response.body),
+        409 => EnrichmentHttpResult::RootConflict,
+        503 => EnrichmentHttpResult::IndexNotReady,
+        status_code => EnrichmentHttpResult::HttpFailure(status_code),
+    }
+}
+
+fn sync_enrichment_http_get_with_timeout(
+    port: u16,
+    path: &str,
+    query: String,
+    timeout: Duration,
+) -> EnrichmentHttpResult {
+    match sync_http_response_with_timeout(port, path, query, timeout) {
+        Ok(response) => classify_enrichment_response(response),
+        Err(_) => EnrichmentHttpResult::Unavailable,
     }
 }
 
@@ -1441,12 +1629,13 @@ fn load_hook_adoption_snapshot_at(
         .unwrap_or_default()
 }
 
-/// Make a synchronous HTTP/1.1 GET request to `127.0.0.1:{port}{path}?{query}`.
+/// Make a synchronous enrichment GET to `127.0.0.1:{port}{path}?{query}`.
 ///
 /// Uses a raw `TcpStream` (no HTTP client crate) so there is no async runtime
-/// and the startup cost is near zero.  The timeout covers both connect and read.
-fn sync_http_get(port: u16, path: &str, query: String) -> anyhow::Result<String> {
-    sync_http_get_with_timeout(port, path, query, HTTP_TIMEOUT)
+/// and the startup cost is near zero. A 503 is kept distinct from transport
+/// failure so an index-loading refusal is not reported as a dead sidecar.
+fn sync_enrichment_http_get(port: u16, path: &str, query: String) -> EnrichmentHttpResult {
+    sync_enrichment_http_get_with_timeout(port, path, query, HTTP_TIMEOUT)
 }
 
 /// Minimal percent-encoding for query parameter values.
@@ -1540,6 +1729,45 @@ mod tests {
             .as_str()
             .expect("additionalContext must be a string");
         assert_eq!(ctx, context);
+    }
+
+    #[test]
+    fn enrichment_response_keeps_live_refusals_distinct_from_transport_failure() {
+        assert_eq!(
+            classify_enrichment_response(HttpResponse {
+                status_code: 503,
+                body: "partial index data must not be injected".to_string(),
+            }),
+            EnrichmentHttpResult::IndexNotReady
+        );
+        assert_eq!(
+            classify_enrichment_response(HttpResponse {
+                status_code: 409,
+                body: String::new(),
+            }),
+            EnrichmentHttpResult::RootConflict
+        );
+        assert_eq!(
+            classify_enrichment_response(HttpResponse {
+                status_code: 500,
+                body: String::new(),
+            }),
+            EnrichmentHttpResult::HttpFailure(500)
+        );
+        assert_eq!(
+            classify_enrichment_response(HttpResponse {
+                status_code: 404,
+                body: String::new(),
+            }),
+            EnrichmentHttpResult::HttpFailure(404)
+        );
+        assert_eq!(
+            classify_enrichment_response(HttpResponse {
+                status_code: 200,
+                body: "trusted context".to_string(),
+            }),
+            EnrichmentHttpResult::Success("trusted context".to_string())
+        );
     }
 
     // --- parse_stdin_input ---

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -43,7 +43,7 @@ use crate::protocol::tools::{
     SearchTextInput, SmartQueryInput, TraceSymbolInput, ValidateFileSyntaxInput, WhatChangedInput,
     search_symbols_options_from_input, search_text_options_from_input,
 };
-use crate::sidecar::{SidecarState, SymbolSnapshot, TokenStats};
+use crate::sidecar::{SidecarState, SymbolSnapshotCache, TokenStats};
 use crate::watcher::{self, WatcherInfo};
 
 // Daemon runtime files are OS-tagged (daemon.<os>.port) so a Windows daemon and a
@@ -296,7 +296,7 @@ struct ProjectInstance {
     watcher_task: Option<tokio::task::JoinHandle<()>>,
     stop_token: Arc<AtomicBool>,
     token_stats: Arc<TokenStats>,
-    symbol_cache: Arc<RwLock<HashMap<String, Vec<SymbolSnapshot>>>>,
+    symbol_cache: Arc<RwLock<SymbolSnapshotCache>>,
     session_ids: HashSet<String>,
     opened_at: SystemTime,
     activation_state: ActivationState,
@@ -756,7 +756,7 @@ struct SessionRuntime {
     session_id: String,
     index: SharedIndex,
     token_stats: Arc<TokenStats>,
-    symbol_cache: Arc<RwLock<HashMap<String, Vec<SymbolSnapshot>>>>,
+    symbol_cache: Arc<RwLock<SymbolSnapshotCache>>,
     /// Session-private, project-keyed `SymForgeServer` clone.
     server: SymForgeServer,
     /// Feature 012 (Phase 3): the session's working set, shared by `Arc` so the

--- a/src/live_index/persist.rs
+++ b/src/live_index/persist.rs
@@ -2362,6 +2362,18 @@ pub async fn background_verify(
     background_verify_with_hook(index, root, snapshot_mtimes, || {}).await;
 }
 
+fn remove_snapshot_deleted_file_if_still_absent(
+    index: &crate::live_index::store::SharedIndex,
+    root: &Path,
+    path: &str,
+    expected: crate::live_index::store::PublicationFence,
+) -> bool {
+    let absolute_path = root.join(path);
+    index
+        .remove_file_if_absent_at_publication_fence_with_receipt(path, &absolute_path, expected)
+        .is_some()
+}
+
 async fn background_verify_with_hook<F>(
     index: crate::live_index::store::SharedIndex,
     root: std::path::PathBuf,
@@ -2392,7 +2404,7 @@ async fn background_verify_with_hook<F>(
     // 2. Remove deleted files
     if !stat_result.deleted.is_empty() {
         for path in &stat_result.deleted {
-            if !index.remove_file_at_publication_fence(path, commit_fence) {
+            if !remove_snapshot_deleted_file_if_still_absent(&index, &root, path, commit_fence) {
                 return;
             }
             commit_fence = index.publication_fence();
@@ -3425,6 +3437,39 @@ mod tests {
         assert_eq!(published.parsed_count, 0);
         assert_eq!(published.partial_parse_count, 0);
         assert_eq!(published.failed_count, 0);
+    }
+
+    #[test]
+    fn background_verify_deleted_file_removal_refuses_disk_recreation() {
+        let tmp = TempDir::new().unwrap();
+        let relative_path = "src/main.rs";
+        let file_path = tmp.path().join(relative_path);
+        let shared = crate::live_index::SharedIndexHandle::shared(make_live_index_with_files(
+            vec![(relative_path, b"fn before() {}\n")],
+        ));
+
+        assert!(
+            !file_path.exists(),
+            "the verifier's stat observation starts from disk absence"
+        );
+        let absence_fence = shared.publication_fence();
+
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, b"fn recreated() {}\n").unwrap();
+
+        assert!(
+            !remove_snapshot_deleted_file_if_still_absent(
+                &shared,
+                tmp.path(),
+                relative_path,
+                absence_fence,
+            ),
+            "a disk recreation after stat must reject snapshot cleanup"
+        );
+        assert!(
+            shared.read().get_file(relative_path).is_some(),
+            "the last-valid indexed entry must survive the rejected removal"
+        );
     }
 
     #[tokio::test]

--- a/src/live_index/single_file.rs
+++ b/src/live_index/single_file.rs
@@ -12,6 +12,7 @@
 //! hand-rolled parse-and-poke (which would bypass admission entirely).
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use tracing::{debug, trace, warn};
 
@@ -19,7 +20,7 @@ use crate::domain::{
     FileClassification, FileDisposition, LanguageId, MetadataOnlyReason, ScoutDecision,
 };
 use crate::hash;
-use crate::live_index::store::{IndexedFile, SharedIndex};
+use crate::live_index::store::{IndexedFile, PublicationFence, PublishedGeneration, SharedIndex};
 use crate::parsing;
 
 /// Result of a single re-index attempt for one file.
@@ -41,6 +42,77 @@ pub enum ReindexResult {
     ReadError(String),
 }
 
+/// Crate-internal result of a single-file publication attempt.
+///
+/// `ReindexResult` is part of the semver-public embed facade and downstream
+/// callers can exhaustively match its six variants. Publication contention is
+/// therefore carried on this private result instead of widening that public
+/// enum in a patch release.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReindexOutcome {
+    HashSkip,
+    Reindexed,
+    Skipped,
+    NotFound,
+    Removed,
+    ReadError(String),
+    /// The observed change did not reach a publication boundary. Callers must
+    /// retry or refuse rather than claim the stale state was reconciled.
+    PublicationRejected,
+}
+
+impl ReindexOutcome {
+    fn into_public_compat(self) -> ReindexResult {
+        match self {
+            Self::HashSkip => ReindexResult::HashSkip,
+            Self::Reindexed => ReindexResult::Reindexed,
+            Self::Skipped => ReindexResult::Skipped,
+            Self::NotFound => ReindexResult::NotFound,
+            Self::Removed => ReindexResult::Removed,
+            Self::ReadError(error) => ReindexResult::ReadError(error),
+            // Before this patch the public update seam reported a lost
+            // publication race as Skipped. Preserve that compatibility only at
+            // the frozen embed boundary; in-crate callers retain the typed
+            // rejection and must retry or refuse.
+            Self::PublicationRejected => ReindexResult::Skipped,
+        }
+    }
+}
+
+pub(crate) struct ReindexReceipt {
+    pub outcome: ReindexOutcome,
+    /// Publication fence captured immediately before this attempt's
+    /// filesystem observation.
+    pub observed_at: PublicationFence,
+    /// Exact immutable generation returned by the winning publication seam.
+    pub published: Option<Arc<PublishedGeneration>>,
+    pub snapshot_created: bool,
+}
+
+impl ReindexReceipt {
+    fn observed(outcome: ReindexOutcome, observed_at: PublicationFence) -> Self {
+        Self {
+            outcome,
+            observed_at,
+            published: None,
+            snapshot_created: false,
+        }
+    }
+
+    fn published(
+        outcome: ReindexOutcome,
+        observed_at: PublicationFence,
+        published: Arc<PublishedGeneration>,
+    ) -> Self {
+        Self {
+            outcome,
+            observed_at,
+            published: Some(published),
+            snapshot_created: false,
+        }
+    }
+}
+
 /// Content-hash-gated single-file re-index.
 ///
 /// Reads the file, compares its hash against the existing index entry, and
@@ -58,33 +130,70 @@ pub(crate) fn maybe_reindex<L>(
     shared: &SharedIndex,
     language: L,
     expected_gen: u64,
-) -> ReindexResult
+) -> ReindexOutcome
 where
     L: Into<Option<LanguageId>>,
 {
     let language = language.into();
-    match read_and_index(relative_path, abs_path, shared, language, expected_gen) {
-        ReindexResult::NotFound => {}
-        other => return other,
+    let first =
+        read_and_index_with_receipt(relative_path, abs_path, shared, language, expected_gen);
+    if first.observed_at.project_generation != expected_gen {
+        return ReindexOutcome::PublicationRejected;
     }
+    let mut last_absence_fence = match first.outcome {
+        ReindexOutcome::NotFound => first.observed_at,
+        other => return other,
+    };
 
     let delays_ms = [50u64, 200, 500];
     for delay_ms in delays_ms {
         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-        match read_and_index(relative_path, abs_path, shared, language, expected_gen) {
-            ReindexResult::NotFound => continue,
+        let retry =
+            read_and_index_with_receipt(relative_path, abs_path, shared, language, expected_gen);
+        if retry.observed_at.project_generation != expected_gen {
+            return ReindexOutcome::PublicationRejected;
+        }
+        match retry.outcome {
+            ReindexOutcome::NotFound => last_absence_fence = retry.observed_at,
             other => return other,
         }
     }
 
-    if shared.remove_file_at_generation(relative_path, expected_gen) {
+    finalize_missing_file(
+        shared,
+        relative_path,
+        abs_path,
+        expected_gen,
+        last_absence_fence,
+    )
+}
+
+fn finalize_missing_file(
+    shared: &SharedIndex,
+    relative_path: &str,
+    abs_path: &Path,
+    expected_gen: u64,
+    absence_fence: PublicationFence,
+) -> ReindexOutcome {
+    if absence_fence.project_generation != expected_gen {
+        return ReindexOutcome::PublicationRejected;
+    }
+    if shared
+        .remove_file_if_absent_at_publication_fence_with_receipt(
+            relative_path,
+            abs_path,
+            absence_fence,
+        )
+        .is_some()
+    {
         warn!("watcher: file not found after retries, removed from index: {relative_path}");
+        ReindexOutcome::Removed
     } else {
         trace!(
-            "watcher: file not found after retries, stale generation rejected remove: {relative_path}"
+            "watcher: file not found after retries, stale publication rejected remove: {relative_path}"
         );
+        ReindexOutcome::PublicationRejected
     }
-    ReindexResult::Removed
 }
 
 /// Recover the project root by walking up from the absolute event path once per
@@ -112,11 +221,24 @@ pub(crate) fn read_and_index<L>(
     shared: &SharedIndex,
     language: L,
     expected_gen: u64,
-) -> ReindexResult
+) -> ReindexOutcome
 where
     L: Into<Option<LanguageId>>,
 {
-    read_and_index_with_stable_read(
+    read_and_index_with_receipt(relative_path, abs_path, shared, language, expected_gen).outcome
+}
+
+fn read_and_index_with_receipt<L>(
+    relative_path: &str,
+    abs_path: &Path,
+    shared: &SharedIndex,
+    language: L,
+    expected_gen: u64,
+) -> ReindexReceipt
+where
+    L: Into<Option<LanguageId>>,
+{
+    read_and_index_with_stable_read_receipt(
         relative_path,
         abs_path,
         shared,
@@ -133,23 +255,65 @@ pub(crate) fn admit_and_index_single_path(
     abs_path: &Path,
     shared: &SharedIndex,
     expected_gen: u64,
-) -> ReindexResult {
-    read_and_index(relative_path, abs_path, shared, None, expected_gen)
+) -> ReindexOutcome {
+    admit_and_index_single_path_with_receipt(relative_path, abs_path, shared, expected_gen).outcome
 }
 
+pub(crate) fn admit_and_index_single_path_with_receipt(
+    relative_path: &str,
+    abs_path: &Path,
+    shared: &SharedIndex,
+    expected_gen: u64,
+) -> ReindexReceipt {
+    read_and_index_with_stable_read_receipt(
+        relative_path,
+        abs_path,
+        shared,
+        None,
+        expected_gen,
+        crate::live_index::store::stable_read_file,
+    )
+}
+
+#[cfg(test)]
 pub(crate) fn read_and_index_with_stable_read<L, R>(
     relative_path: &str,
     abs_path: &Path,
     shared: &SharedIndex,
     language: L,
     expected_gen: u64,
+    stable_read: R,
+) -> ReindexOutcome
+where
+    L: Into<Option<LanguageId>>,
+    R: FnMut(&Path, &crate::domain::FileStamp) -> crate::live_index::store::StableReadOutcome,
+{
+    read_and_index_with_stable_read_receipt(
+        relative_path,
+        abs_path,
+        shared,
+        language,
+        expected_gen,
+        stable_read,
+    )
+    .outcome
+}
+
+fn read_and_index_with_stable_read_receipt<L, R>(
+    relative_path: &str,
+    abs_path: &Path,
+    shared: &SharedIndex,
+    language: L,
+    expected_gen: u64,
     mut stable_read: R,
-) -> ReindexResult
+) -> ReindexReceipt
 where
     L: Into<Option<LanguageId>>,
     R: FnMut(&Path, &crate::domain::FileStamp) -> crate::live_index::store::StableReadOutcome,
 {
     let language = language.into();
+    let mut base = shared.published_generation();
+    let mut observed_at = PublicationFence::from_published(&base);
     // Keep single-file watcher/freshen paths symmetric with the bulk walk.
     // Both universal name exclusions and placement-derived subtree exclusions
     // run before any metadata/content read from VCS or runtime-state internals.
@@ -158,18 +322,32 @@ where
         || shared.is_source_excluded(relative)
         || shared.read().is_path_gitignored(relative_path)
     {
-        let removed = shared.remove_file_at_generation(relative_path, expected_gen);
-        if removed {
-            debug!("watcher: source-scope eviction {relative_path}");
-        } else {
-            trace!("watcher: source-scope skip (no prior record) {relative_path}");
+        if observed_at.project_generation != expected_gen {
+            return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
         }
-        return ReindexResult::Skipped;
+        return match shared
+            .remove_file_at_publication_fence_with_receipt(relative_path, observed_at)
+        {
+            Some(published) => {
+                debug!("watcher: source-scope eviction {relative_path}");
+                ReindexReceipt::published(ReindexOutcome::Skipped, observed_at, published)
+            }
+            None => {
+                trace!("watcher: source-scope eviction publication rejected {relative_path}");
+                ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at)
+            }
+        };
     }
 
     const MAX_PUBLICATION_ATTEMPTS: usize = 4;
     for attempt in 1..=MAX_PUBLICATION_ATTEMPTS {
-        let base_publication_gen = shared.published_state().generation;
+        base = shared.published_generation();
+        observed_at = PublicationFence::from_published(&base);
+        // The store mutation CAS protects the health/live index base, whose
+        // generation is intentionally distinct from the full publication
+        // bundle generation. Bridge- or authority-only publishes can advance
+        // the latter while retaining this same live-index base.
+        let expected_index_state_generation = base.health.generation;
 
         // Run the same metadata-first scout as cold load before any whole-file read.
         let mut scouted = match crate::discovery::scout_single_path(relative_path, abs_path) {
@@ -179,10 +357,13 @@ where
                     std::fs::metadata(abs_path),
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound
                 ) {
-                    return ReindexResult::NotFound;
+                    return ReindexReceipt::observed(ReindexOutcome::NotFound, observed_at);
                 }
                 warn!("watcher: failed to scout {relative_path}: {error}");
-                return ReindexResult::ReadError(error.to_string());
+                return ReindexReceipt::observed(
+                    ReindexOutcome::ReadError(error.to_string()),
+                    observed_at,
+                );
             }
         };
         let mtime_secs = scouted
@@ -193,51 +374,55 @@ where
             .unwrap_or(0);
 
         if let Some(disposition) = catalog_terminal_disposition(&scouted.decision) {
-            if shared.publish_terminal_disposition_at_generation(
+            if let Some(published) = shared.publish_terminal_disposition_at_generation(
                 relative_path,
                 scouted,
                 disposition,
                 expected_gen,
-                base_publication_gen,
+                expected_index_state_generation,
             ) {
                 debug!("watcher: metadata-terminal admission {relative_path}");
-                return ReindexResult::Skipped;
+                return ReindexReceipt::published(ReindexOutcome::Skipped, observed_at, published);
             }
             if shared.current_project_generation() == expected_gen
-                && shared.published_state().generation != base_publication_gen
+                && shared.published_state().generation != expected_index_state_generation
             {
                 trace!(attempt, "watcher: retrying metadata-terminal publication");
                 continue;
             }
             trace!("watcher: stale metadata-terminal admission rejected: {relative_path}");
-            return ReindexResult::Skipped;
+            return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
         }
         if let ScoutDecision::Unavailable { stage, kind } = &scouted.decision {
             if *stage == crate::domain::AccessStage::Metadata
                 && *kind == crate::domain::AccessErrorKind::NotFound
             {
-                return ReindexResult::NotFound;
+                return ReindexReceipt::observed(ReindexOutcome::NotFound, observed_at);
             }
             let disposition = FileDisposition::Unreadable {
                 stage: *stage,
                 kind: *kind,
             };
-            if shared.publish_terminal_disposition_at_generation(
+            if let Some(published) = shared.publish_terminal_disposition_at_generation(
                 relative_path,
                 scouted,
                 disposition,
                 expected_gen,
-                base_publication_gen,
+                expected_index_state_generation,
             ) {
-                return ReindexResult::ReadError("single-path scout unavailable".to_string());
+                return ReindexReceipt::published(
+                    ReindexOutcome::ReadError("single-path scout unavailable".to_string()),
+                    observed_at,
+                    published,
+                );
             }
             if shared.current_project_generation() == expected_gen
-                && shared.published_state().generation != base_publication_gen
+                && shared.published_state().generation != expected_index_state_generation
             {
                 trace!(attempt, "watcher: retrying unavailable publication");
                 continue;
             }
-            return ReindexResult::ReadError("single-path scout unavailable".to_string());
+            return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
         }
 
         // Generated-output placement is metadata policy too; evaluate it before
@@ -251,22 +436,22 @@ where
             let disposition = catalog_terminal_disposition(&decision)
                 .expect("metadata-only decision must project to a terminal disposition");
             scouted.decision = decision;
-            if shared.publish_terminal_disposition_at_generation(
+            if let Some(published) = shared.publish_terminal_disposition_at_generation(
                 relative_path,
                 scouted,
                 disposition,
                 expected_gen,
-                base_publication_gen,
+                expected_index_state_generation,
             ) {
-                return ReindexResult::Skipped;
+                return ReindexReceipt::published(ReindexOutcome::Skipped, observed_at, published);
             }
             if shared.current_project_generation() == expected_gen
-                && shared.published_state().generation != base_publication_gen
+                && shared.published_state().generation != expected_index_state_generation
             {
                 trace!(attempt, "watcher: retrying generated-output publication");
                 continue;
             }
-            return ReindexResult::Skipped;
+            return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
         }
 
         let targets = match &scouted.decision {
@@ -283,17 +468,21 @@ where
                 let disposition = catalog_terminal_disposition(&decision)
                     .expect("hard-skip decision must project to a terminal disposition");
                 scouted.decision = decision;
-                if shared.publish_terminal_disposition_at_generation(
+                if let Some(published) = shared.publish_terminal_disposition_at_generation(
                     relative_path,
                     scouted,
                     disposition,
                     expected_gen,
-                    base_publication_gen,
+                    expected_index_state_generation,
                 ) {
-                    return ReindexResult::Skipped;
+                    return ReindexReceipt::published(
+                        ReindexOutcome::Skipped,
+                        observed_at,
+                        published,
+                    );
                 }
                 if shared.current_project_generation() == expected_gen
-                    && shared.published_state().generation != base_publication_gen
+                    && shared.published_state().generation != expected_index_state_generation
                 {
                     trace!(
                         attempt,
@@ -301,17 +490,25 @@ where
                     );
                     continue;
                 }
-                return ReindexResult::Skipped;
+                return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
             }
             crate::live_index::store::StableReadOutcome::Unreadable { stage, kind } => {
-                if !shared.publish_terminal_disposition_at_generation(
+                let publication = shared.publish_terminal_disposition_at_generation(
                     relative_path,
                     scouted,
                     FileDisposition::Unreadable { stage, kind },
                     expected_gen,
-                    base_publication_gen,
-                ) && shared.current_project_generation() == expected_gen
-                    && shared.published_state().generation != base_publication_gen
+                    expected_index_state_generation,
+                );
+                if let Some(published) = publication {
+                    return ReindexReceipt::published(
+                        ReindexOutcome::ReadError("stable read unavailable".to_string()),
+                        observed_at,
+                        published,
+                    );
+                }
+                if shared.current_project_generation() == expected_gen
+                    && shared.published_state().generation != expected_index_state_generation
                 {
                     trace!(
                         attempt,
@@ -319,22 +516,30 @@ where
                     );
                     continue;
                 }
-                return ReindexResult::ReadError("stable read unavailable".to_string());
+                return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
             }
             crate::live_index::store::StableReadOutcome::UnstableDuringRead => {
-                if !shared.publish_terminal_disposition_at_generation(
+                let publication = shared.publish_terminal_disposition_at_generation(
                     relative_path,
                     scouted,
                     FileDisposition::UnstableDuringRead,
                     expected_gen,
-                    base_publication_gen,
-                ) && shared.current_project_generation() == expected_gen
-                    && shared.published_state().generation != base_publication_gen
+                    expected_index_state_generation,
+                );
+                if let Some(published) = publication {
+                    return ReindexReceipt::published(
+                        ReindexOutcome::ReadError("file changed during stable read".to_string()),
+                        observed_at,
+                        published,
+                    );
+                }
+                if shared.current_project_generation() == expected_gen
+                    && shared.published_state().generation != expected_index_state_generation
                 {
                     trace!(attempt, "watcher: retrying unstable-read publication");
                     continue;
                 }
-                return ReindexResult::ReadError("file changed during stable read".to_string());
+                return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
             }
         };
 
@@ -344,22 +549,22 @@ where
         if let crate::knowledge::StableContentAdmission::MetadataOnly(reason) =
             crate::knowledge::classify_stable_content(relative_path, targets, &bytes)
         {
-            if shared.publish_terminal_disposition_at_generation(
+            if let Some(published) = shared.publish_terminal_disposition_at_generation(
                 relative_path,
                 scouted,
                 FileDisposition::MetadataOnly { reason },
                 expected_gen,
-                base_publication_gen,
+                expected_index_state_generation,
             ) {
-                return ReindexResult::Skipped;
+                return ReindexReceipt::published(ReindexOutcome::Skipped, observed_at, published);
             }
             if shared.current_project_generation() == expected_gen
-                && shared.published_state().generation != base_publication_gen
+                && shared.published_state().generation != expected_index_state_generation
             {
                 trace!(attempt, "watcher: retrying content-policy publication");
                 continue;
             }
-            return ReindexResult::Skipped;
+            return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
         }
 
         // Compute the hash and compare without holding the publication writer lock.
@@ -370,24 +575,29 @@ where
                 && existing.content_hash == new_hash
             {
                 drop(index);
-                if shared.publish_hash_skip_at_generation(
+                if let Some(published) = shared.publish_hash_skip_at_generation(
                     relative_path,
                     mtime_secs,
                     scouted,
                     targets,
                     expected_gen,
-                    base_publication_gen,
+                    expected_index_state_generation,
                 ) {
                     debug!("watcher: hash-skip {relative_path}");
-                    return ReindexResult::HashSkip;
+                    return ReindexReceipt {
+                        outcome: ReindexOutcome::HashSkip,
+                        observed_at,
+                        published: Some(published),
+                        snapshot_created: false,
+                    };
                 }
                 if shared.current_project_generation() == expected_gen
-                    && shared.published_state().generation != base_publication_gen
+                    && shared.published_state().generation != expected_index_state_generation
                 {
                     trace!(attempt, "watcher: retrying hash-skip publication");
                     continue;
                 }
-                return ReindexResult::Skipped;
+                return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
             }
         }
 
@@ -403,31 +613,36 @@ where
         // Commit every observable lane under one source-base fence and one
         // publication boundary. If another update won while this build was
         // off-lock, retry from disk instead of overwriting that newer bundle.
-        if shared.publish_indexed_file_at_generation(
+        if let Some(publication) = shared.publish_indexed_file_at_generation(
             relative_path,
             indexed,
             scouted,
             targets,
             expected_gen,
-            base_publication_gen,
+            expected_index_state_generation,
         ) {
             debug!("watcher: re-indexed {relative_path}");
-            return ReindexResult::Reindexed;
+            return ReindexReceipt {
+                outcome: ReindexOutcome::Reindexed,
+                observed_at,
+                published: Some(publication.published),
+                snapshot_created: publication.snapshot_created,
+            };
         }
         if shared.current_project_generation() == expected_gen
-            && shared.published_state().generation != base_publication_gen
+            && shared.published_state().generation != expected_index_state_generation
         {
             trace!(attempt, "watcher: retrying indexed-file publication");
             continue;
         }
         trace!("watcher: stale indexed-file publication rejected: {relative_path}");
-        return ReindexResult::Skipped;
+        return ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at);
     }
 
     warn!(
         "watcher: aborting {relative_path} after {MAX_PUBLICATION_ATTEMPTS} concurrent publications"
     );
-    ReindexResult::Skipped
+    ReindexReceipt::observed(ReindexOutcome::PublicationRejected, observed_at)
 }
 
 /// Re-index one repository file FROM DISK through the canonical single-file
@@ -451,7 +666,7 @@ pub fn update_file_from_disk(
     let relative = relative_path.replace('\\', "/");
     let abs_path = repo_root.join(&relative);
     let expected_gen = shared.current_project_generation();
-    admit_and_index_single_path(&relative, &abs_path, shared, expected_gen)
+    admit_and_index_single_path(&relative, &abs_path, shared, expected_gen).into_public_compat()
 }
 
 /// Remove one file from the live index (embed facade; task #24 / AAP ask 3).
@@ -535,5 +750,270 @@ mod tests {
             matches!(outcome, ReindexResult::NotFound),
             "missing file must be NotFound, got {outcome:?}"
         );
+    }
+
+    #[test]
+    fn reindex_receipt_remains_exact_after_later_publication() {
+        let dir = tempfile::TempDir::new().expect("root");
+        let path = dir.path().join("lib.rs");
+        std::fs::write(&path, "pub fn first() {}\n").expect("seed");
+        let shared = LiveIndex::load(dir.path()).expect("cold load");
+        let expected_gen = shared.current_project_generation();
+
+        std::fs::write(&path, "pub fn second() {}\n").expect("first edit");
+        let second =
+            admit_and_index_single_path_with_receipt("lib.rs", &path, &shared, expected_gen);
+        assert_eq!(second.outcome, ReindexOutcome::Reindexed);
+        assert!(second.snapshot_created);
+        let second_published = second.published.expect("second publication receipt");
+        let second_fence = PublicationFence::from_published(&second_published);
+
+        let unchanged =
+            admit_and_index_single_path_with_receipt("lib.rs", &path, &shared, expected_gen);
+        assert_eq!(unchanged.outcome, ReindexOutcome::HashSkip);
+        assert!(!unchanged.snapshot_created);
+        let unchanged_published = unchanged.published.expect("hash-skip publication receipt");
+        assert!(
+            unchanged_published
+                .live
+                .get_file("lib.rs")
+                .expect("hash-skip file")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "second")
+        );
+
+        std::fs::write(&path, "pub fn third() {}\n").expect("second edit");
+        let third =
+            admit_and_index_single_path_with_receipt("lib.rs", &path, &shared, expected_gen);
+        assert_eq!(third.outcome, ReindexOutcome::Reindexed);
+        let third_published = third.published.expect("third publication receipt");
+        let third_fence = PublicationFence::from_published(&third_published);
+        assert_ne!(second_fence, third_fence);
+
+        let second_file = second_published
+            .live
+            .get_file("lib.rs")
+            .expect("second file");
+        assert!(
+            second_file
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "second")
+        );
+        assert!(
+            !second_file
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "third")
+        );
+        assert!(
+            !unchanged_published
+                .live
+                .get_file("lib.rs")
+                .expect("immutable hash-skip file")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "third")
+        );
+        assert!(
+            third_published
+                .live
+                .get_file("lib.rs")
+                .expect("third file")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "third")
+        );
+
+        assert!(
+            shared
+                .take_pre_update_snapshot_for_publication_at_generation(
+                    "lib.rs",
+                    expected_gen,
+                    second_fence,
+                )
+                .is_none(),
+            "the old receipt must not drain the later publication's snapshot"
+        );
+        let third_baseline = shared
+            .take_pre_update_snapshot_for_publication_at_generation(
+                "lib.rs",
+                expected_gen,
+                third_fence,
+            )
+            .expect("third publication owns the current snapshot");
+        assert!(
+            third_baseline
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "second")
+        );
+    }
+
+    #[test]
+    fn bridge_only_publication_does_not_invalidate_live_index_reindex_cas() {
+        let dir = tempfile::TempDir::new().expect("root");
+        let path = dir.path().join("lib.rs");
+        std::fs::write(&path, "pub fn before() {}\n").expect("seed");
+        let shared = LiveIndex::load(dir.path()).expect("cold load");
+        let before = shared.published_generation();
+        let health_generation = before.health.generation;
+
+        let prepared = shared.prepare_bridge_rebuild();
+        assert!(shared.publish_prepared_bridge(prepared));
+        let bridge_only = shared.published_generation();
+        assert!(
+            bridge_only.publication_generation > before.publication_generation,
+            "bridge publication must advance the full publication bundle"
+        );
+        assert_eq!(
+            bridge_only.health.generation, health_generation,
+            "bridge publication must retain the live-index health base"
+        );
+
+        std::fs::write(&path, "pub fn after() {}\n").expect("edit");
+        let receipt = admit_and_index_single_path_with_receipt(
+            "lib.rs",
+            &path,
+            &shared,
+            shared.current_project_generation(),
+        );
+        assert_eq!(receipt.outcome, ReindexOutcome::Reindexed);
+        assert!(
+            receipt
+                .published
+                .expect("winning reindex publication")
+                .live
+                .get_file("lib.rs")
+                .expect("reindexed file")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "after")
+        );
+    }
+
+    #[test]
+    fn stale_not_found_fence_preserves_recreated_file_and_reports_rejection() {
+        let dir = tempfile::TempDir::new().expect("root");
+        let path = dir.path().join("lib.rs");
+        std::fs::write(&path, "pub fn first() {}\n").expect("seed");
+        let shared = LiveIndex::load(dir.path()).expect("cold load");
+
+        std::fs::remove_file(&path).expect("simulate missing observation");
+        let absence_fence = shared.publication_fence();
+
+        std::fs::write(&path, "pub fn recreated() {}\n").expect("recreate");
+        assert_eq!(
+            finalize_missing_file(
+                &shared,
+                "lib.rs",
+                &path,
+                shared.current_project_generation(),
+                absence_fence,
+            ),
+            ReindexOutcome::PublicationRejected,
+            "a rejected stale removal must not claim the file was removed"
+        );
+        assert!(
+            shared
+                .read()
+                .get_file("lib.rs")
+                .expect("last-valid indexed file remains")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "first")
+        );
+        assert!(
+            std::fs::read_to_string(&path)
+                .expect("recreated disk file")
+                .contains("recreated")
+        );
+    }
+
+    #[test]
+    fn missing_file_finalization_ignores_unrelated_same_project_publication() {
+        let dir = tempfile::TempDir::new().expect("root");
+        let a_path = dir.path().join("a.rs");
+        let b_path = dir.path().join("b.rs");
+        std::fs::write(&a_path, "pub fn a_before() {}\n").expect("seed a");
+        std::fs::write(&b_path, "pub fn b_before() {}\n").expect("seed b");
+        let shared = LiveIndex::load(dir.path()).expect("cold load");
+        let expected_gen = shared.current_project_generation();
+
+        std::fs::remove_file(&a_path).expect("observe a missing");
+        let absence_fence = shared.publication_fence();
+
+        std::fs::write(&b_path, "pub fn b_after() {}\n").expect("edit b");
+        let b_receipt =
+            admit_and_index_single_path_with_receipt("b.rs", &b_path, &shared, expected_gen);
+        assert_eq!(b_receipt.outcome, ReindexOutcome::Reindexed);
+        let after_b = shared.publication_fence();
+        assert_eq!(after_b.project_generation, absence_fence.project_generation);
+        assert_ne!(
+            after_b.publication_generation, absence_fence.publication_generation,
+            "the regression requires an intervening unrelated publication"
+        );
+
+        assert_eq!(
+            finalize_missing_file(&shared, "a.rs", &a_path, expected_gen, absence_fence,),
+            ReindexOutcome::Removed,
+            "an unrelated publication must not prevent convergence to disk absence"
+        );
+        let published = shared.published_generation();
+        assert!(published.live.get_file("a.rs").is_none());
+        assert!(
+            published
+                .live
+                .get_file("b.rs")
+                .expect("unrelated publication survives")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "b_after")
+        );
+    }
+
+    #[test]
+    fn stale_project_generation_cannot_remove_from_rebound_project() {
+        let project_a = tempfile::TempDir::new().expect("project A");
+        let project_b = tempfile::TempDir::new().expect("project B");
+        std::fs::write(project_a.path().join("lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(project_b.path().join("lib.rs"), "pub fn b() {}\n").unwrap();
+        let shared = LiveIndex::load(project_a.path()).expect("load A");
+        let stale_gen = shared.current_project_generation();
+        shared.reload(project_b.path()).expect("rebind to B");
+        let rebound_fence = shared.publication_fence();
+
+        assert_eq!(
+            finalize_missing_file(
+                &shared,
+                "lib.rs",
+                &project_a.path().join("lib.rs"),
+                stale_gen,
+                rebound_fence,
+            ),
+            ReindexOutcome::PublicationRejected
+        );
+        assert!(
+            shared
+                .read()
+                .get_file("lib.rs")
+                .expect("B file survives stale absence finalization")
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "b")
+        );
+
+        let publication_before = shared.publication_fence();
+        let excluded = read_and_index_with_receipt(
+            ".git/config",
+            &project_b.path().join(".git/config"),
+            &shared,
+            None::<LanguageId>,
+            stale_gen,
+        );
+        assert_eq!(excluded.outcome, ReindexOutcome::PublicationRejected);
+        assert_eq!(shared.publication_fence(), publication_before);
+        assert!(shared.read().get_file("lib.rs").is_some());
     }
 }

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -991,6 +991,21 @@ pub struct PublicationFence {
     pub project_generation: u64,
 }
 
+impl PublicationFence {
+    pub(crate) fn from_published(published: &PublishedGeneration) -> Self {
+        Self {
+            publication_generation: published.publication_generation,
+            content_generation: published.content_generation,
+            project_generation: published.project_generation,
+        }
+    }
+}
+
+pub(crate) struct IndexedFilePublicationReceipt {
+    pub published: Arc<PublishedGeneration>,
+    pub snapshot_created: bool,
+}
+
 pub struct PreparedKnowledgeBridge {
     fence: PublicationFence,
     bridge: Arc<KnowledgeBridge>,
@@ -1250,6 +1265,29 @@ pub struct PreUpdateSnapshot {
 }
 
 #[derive(Clone, Debug)]
+struct StoredPreUpdateSnapshot {
+    snapshot: PreUpdateSnapshot,
+    /// Exact publication that installed the replacement content.
+    replacement: PublicationFence,
+}
+
+fn pre_update_snapshot(existing: &IndexedFile) -> PreUpdateSnapshot {
+    PreUpdateSnapshot {
+        content: existing.content.clone(),
+        symbols: existing
+            .symbols
+            .iter()
+            .map(|symbol| PreUpdateSymbol {
+                name: symbol.name.clone(),
+                kind: symbol.kind.to_string(),
+                line_range: symbol.line_range,
+                byte_range: symbol.byte_range,
+            })
+            .collect(),
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct PreUpdateSymbol {
     pub name: String,
     pub kind: String,
@@ -1283,6 +1321,10 @@ pub struct SharedIndexHandle {
     freshness_status: ArcSwap<FreshnessStatus>,
     /// Serializes writers — only one mutation in flight at a time.
     write_mutex: Mutex<()>,
+    /// Serializes impact analyses that share this index. Watcher publications
+    /// remain concurrent, but two hook/tool requests cannot regress the
+    /// sidecar's per-file baseline cache out of order.
+    impact_mutex: tokio::sync::Mutex<()>,
     published_state: ArcSwap<PublishedIndexState>,
     published_repo_outline: ArcSwap<RepoOutlineView>,
     /// Publish-versioning counter for `PublishedIndexState`; bumped on every publish.
@@ -1303,7 +1345,7 @@ pub struct SharedIndexHandle {
     /// Pre-update file snapshots: saved automatically by `update_file` before
     /// the index entry is replaced. Consumed (take) by `analyze_file_impact` to
     /// compute accurate diffs even when the watcher re-indexes before the hook fires.
-    pre_update_snapshots: Mutex<HashMap<String, PreUpdateSnapshot>>,
+    pre_update_snapshots: Mutex<HashMap<String, StoredPreUpdateSnapshot>>,
     /// Single-flights P1 local-ref/worktree reconcile. A reconcile pass reads the
     /// latest git topology, so two overlapping passes are redundant AND unsafe: the
     /// older pass's deletion step, working from a stale `local_branch_refs`
@@ -1378,7 +1420,15 @@ impl SharedIndexHandle {
             }
         }));
         let temporal = Arc::clone(&code_signals.temporal);
-        let freshness_status = if index.is_empty
+        let freshness_status = if scout_plan
+            .as_deref()
+            .is_some_and(|plan| plan.coverage == crate::domain::CoverageStatus::Degraded)
+        {
+            FreshnessStatus::Degraded {
+                last_valid_content_generation: 0,
+                reason_codes: vec![FreshnessReason::ReconciliationPending],
+            }
+        } else if index.is_empty
             || !matches!(index.snapshot_verify_state, SnapshotVerifyState::NotNeeded)
         {
             FreshnessStatus::Verifying
@@ -1469,6 +1519,7 @@ impl SharedIndexHandle {
             scout_plan: ArcSwapOption::new(scout_plan),
             freshness_status: ArcSwap::new(Arc::new(freshness_status)),
             write_mutex: Mutex::new(()),
+            impact_mutex: tokio::sync::Mutex::new(()),
             published_state: ArcSwap::new(published_state),
             published_repo_outline: ArcSwap::new(published_repo_outline),
             next_generation: AtomicU64::new(1),
@@ -1721,17 +1772,8 @@ impl SharedIndexHandle {
         scout_plan: discovery::ScoutPlan,
         source_exclusions: discovery::SourceExclusions,
     ) -> Arc<Self> {
-        let is_degraded = matches!(scout_plan.coverage, crate::domain::CoverageStatus::Degraded);
         let handle = Self::new_with_scout_plan(index, Some(Arc::new(scout_plan)));
         handle.source_exclusions.store(Arc::new(source_exclusions));
-        if is_degraded {
-            handle
-                .freshness_status
-                .store(Arc::new(FreshnessStatus::Degraded {
-                    last_valid_content_generation: 0,
-                    reason_codes: vec![FreshnessReason::ReconciliationPending],
-                }));
-        }
         Arc::new(handle)
     }
 
@@ -1785,6 +1827,92 @@ impl SharedIndexHandle {
     #[must_use]
     pub(crate) fn source_exclusions(&self) -> Arc<discovery::SourceExclusions> {
         self.source_exclusions.load_full()
+    }
+
+    /// Recompute freshness reasons owned by live observation, scout
+    /// reconciliation, and snapshot verification. Unrelated reasons (watcher
+    /// availability, capacity, derived publication) are retained verbatim. A
+    /// pending snapshot verification remains `Verifying` after transient
+    /// failures heal; recovery must never silently authorize an unverified
+    /// snapshot.
+    ///
+    /// Must be called while holding `write_mutex` and before publishing `live`.
+    fn recompute_freshness_locked(
+        &self,
+        live: &LiveIndex,
+        scout_plan: Option<&discovery::ScoutPlan>,
+    ) -> bool {
+        let current = self.freshness_status.load_full();
+        let (last_valid_content_generation, reason_codes) = match current.as_ref() {
+            FreshnessStatus::Degraded {
+                last_valid_content_generation,
+                reason_codes,
+            } => (*last_valid_content_generation, reason_codes.as_slice()),
+            FreshnessStatus::Current | FreshnessStatus::Verifying => (
+                self.published_generation().content_generation,
+                &[] as &[FreshnessReason],
+            ),
+        };
+
+        let observation_failed = live.manifest_entries.iter().any(|entry| {
+            matches!(
+                entry.disposition,
+                FileDisposition::Unreadable { .. } | FileDisposition::UnstableDuringRead
+            )
+        });
+        let reconciliation_pending =
+            scout_plan.is_some_and(|plan| plan.coverage == crate::domain::CoverageStatus::Degraded);
+        let snapshot_verification_failed = matches!(
+            &live.snapshot_verify_state,
+            SnapshotVerifyState::Completed(report) if report.mismatch_count > 0
+        );
+        let mut next_reasons = Vec::new();
+        for reason in reason_codes.iter().copied().filter(|reason| {
+            !matches!(
+                reason,
+                FreshnessReason::ObservationFailed
+                    | FreshnessReason::ReconciliationPending
+                    | FreshnessReason::SnapshotVerificationFailed
+            )
+        }) {
+            if !next_reasons.contains(&reason) {
+                next_reasons.push(reason);
+            }
+        }
+        if observation_failed && !next_reasons.contains(&FreshnessReason::ObservationFailed) {
+            next_reasons.push(FreshnessReason::ObservationFailed);
+        }
+        if reconciliation_pending && !next_reasons.contains(&FreshnessReason::ReconciliationPending)
+        {
+            next_reasons.push(FreshnessReason::ReconciliationPending);
+        }
+        if snapshot_verification_failed
+            && !next_reasons.contains(&FreshnessReason::SnapshotVerificationFailed)
+        {
+            next_reasons.push(FreshnessReason::SnapshotVerificationFailed);
+        }
+
+        let next = if next_reasons.is_empty() {
+            if matches!(
+                live.snapshot_verify_state,
+                SnapshotVerifyState::Pending | SnapshotVerifyState::Running
+            ) {
+                FreshnessStatus::Verifying
+            } else {
+                FreshnessStatus::Current
+            }
+        } else {
+            FreshnessStatus::Degraded {
+                last_valid_content_generation,
+                reason_codes: next_reasons,
+            }
+        };
+        if &next != current.as_ref() {
+            self.freshness_status.store(Arc::new(next));
+            true
+        } else {
+            false
+        }
     }
 
     fn scout_plan_with_entry_locked(
@@ -1912,7 +2040,26 @@ impl SharedIndexHandle {
         if manifest_requires_degraded_coverage(&self.live.load_full()) {
             scout_plan.coverage = crate::domain::CoverageStatus::Degraded;
         }
-        self.scout_plan.store(Some(Arc::new(scout_plan)));
+        let live = self.live.load_full();
+        let scout_plan = Arc::new(scout_plan);
+        let current_scout_plan = self.scout_plan.load_full();
+        let scout_plan_changed = match current_scout_plan.as_deref() {
+            Some(current) => {
+                current.coverage != scout_plan.coverage
+                    || current.entries != scout_plan.entries
+                    || current.issues != scout_plan.issues
+                    || current.usage != scout_plan.usage
+            }
+            None => true,
+        };
+        self.scout_plan.store(Some(Arc::clone(&scout_plan)));
+        let freshness_changed = self.recompute_freshness_locked(&live, Some(&scout_plan));
+        if scout_plan_changed || freshness_changed {
+            // The scout plan and freshness are part of the published trust
+            // bundle. Republish only when that bundle changed; an unchanged
+            // periodic reconcile must not mint a generation forever.
+            self.swap_and_publish_retaining_content((*live).clone());
+        }
         true
     }
 
@@ -1953,6 +2100,12 @@ impl SharedIndexHandle {
     /// that subsequent `read()` calls will see.
     pub fn read(&self) -> Arc<LiveIndex> {
         Arc::clone(&self.published_generation().live)
+    }
+
+    /// Single-flight impact analyses that share this index and its sidecar
+    /// baseline cache. Watcher updates remain generation/publication fenced.
+    pub(crate) async fn lock_impact_analysis(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.impact_mutex.lock().await
     }
 
     pub fn published_generation(&self) -> Arc<PublishedGeneration> {
@@ -2245,7 +2398,7 @@ impl SharedIndexHandle {
         self.scout_plan.store(Some(scout_plan));
         self.freshness_status.store(Arc::new(if is_degraded {
             FreshnessStatus::Degraded {
-                last_valid_content_generation: self.published_state.load().generation,
+                last_valid_content_generation: self.published_generation().content_generation,
                 reason_codes: vec![FreshnessReason::ReconciliationPending],
             }
         } else {
@@ -2254,6 +2407,10 @@ impl SharedIndexHandle {
         self.project_state_dir
             .store(project_state_dir.map(Arc::new));
         self.project_generation.fetch_add(1, Ordering::AcqRel);
+        // Path-keyed pre-update snapshots belong to the previous project
+        // generation. Clear them under the same writer lock as the retarget so
+        // a late impact request cannot consume a replacement project's state.
+        self.pre_update_snapshots.lock().clear();
         self.swap_and_publish(live);
         self.last_reset_project_generation
             .store(0, Ordering::Release);
@@ -2264,6 +2421,31 @@ impl SharedIndexHandle {
         self.source_exclusions
             .load()
             .excludes_relative(relative_path)
+    }
+
+    fn record_pre_update_snapshot_for_publication(
+        &self,
+        path: &str,
+        snapshot: Option<PreUpdateSnapshot>,
+        replacement: PublicationFence,
+    ) -> bool {
+        let snapshot_created = snapshot.is_some();
+        let mut snapshots = self.pre_update_snapshots.lock();
+        if let Some(snapshot) = snapshot {
+            snapshots.insert(
+                path.to_string(),
+                StoredPreUpdateSnapshot {
+                    snapshot,
+                    replacement,
+                },
+            );
+        } else {
+            // A path can be removed/demoted and later re-admitted without a
+            // pre-state in the current lifetime. Do not let an older lifetime's
+            // baseline survive that successful publication.
+            snapshots.remove(path);
+        }
+        snapshot_created
     }
 
     /// Drop all indexed state and publish a fresh empty index.
@@ -2295,33 +2477,24 @@ impl SharedIndexHandle {
     pub fn update_file(&self, path: String, file: IndexedFile) {
         let _wg = self.write_mutex.lock();
         let current = self.live.load_full();
+        let path_clone = path.clone();
         // Capture pre-update symbols so analyze_file_impact can diff correctly
         // even when the watcher re-indexes before the hook fires.
-        if let Some(existing) = current.get_file(&path) {
-            self.pre_update_snapshots.lock().insert(
-                path.clone(),
-                PreUpdateSnapshot {
-                    content: existing.content.clone(),
-                    symbols: existing
-                        .symbols
-                        .iter()
-                        .map(|s| PreUpdateSymbol {
-                            name: s.name.clone(),
-                            kind: s.kind.to_string(),
-                            line_range: s.line_range,
-                            byte_range: s.byte_range,
-                        })
-                        .collect(),
-                },
-            );
-        }
+        let pre_update = current.get_file(&path).map(pre_update_snapshot);
         let mut live = (*current).clone();
-        let path_clone = path.clone();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             live.update_file(path, file);
         }));
         match result {
-            Ok(()) => self.swap_and_publish(live),
+            Ok(()) => {
+                self.swap_and_publish(live);
+                let replacement = self.publication_fence();
+                self.record_pre_update_snapshot_for_publication(
+                    &path_clone,
+                    pre_update,
+                    replacement,
+                );
+            }
             Err(panic_info) => {
                 // Clone-mutate-swap means the original index is untouched on panic —
                 // no repair needed, just log and discard the failed clone.
@@ -2362,24 +2535,7 @@ impl SharedIndexHandle {
         let current = self.live.load_full();
         // Capture pre-update symbols so analyze_file_impact can diff correctly
         // even when the watcher re-indexes before the hook fires.
-        if let Some(existing) = current.get_file(path) {
-            self.pre_update_snapshots.lock().insert(
-                path.to_string(),
-                PreUpdateSnapshot {
-                    content: existing.content.clone(),
-                    symbols: existing
-                        .symbols
-                        .iter()
-                        .map(|s| PreUpdateSymbol {
-                            name: s.name.clone(),
-                            kind: s.kind.to_string(),
-                            line_range: s.line_range,
-                            byte_range: s.byte_range,
-                        })
-                        .collect(),
-                },
-            );
-        }
+        let pre_update = current.get_file(path).map(pre_update_snapshot);
         let mut live = (*current).clone();
         let path_owned = path.to_string();
         let path_clone = path_owned.clone();
@@ -2387,7 +2543,15 @@ impl SharedIndexHandle {
             live.update_file(path_owned, file);
         }));
         match result {
-            Ok(()) => self.swap_and_publish(live),
+            Ok(()) => {
+                self.swap_and_publish(live);
+                let replacement = self.publication_fence();
+                self.record_pre_update_snapshot_for_publication(
+                    &path_clone,
+                    pre_update,
+                    replacement,
+                );
+            }
             Err(panic_info) => {
                 // Clone-mutate-swap means the original index is untouched on panic —
                 // no repair needed, just log and discard the failed clone.
@@ -2415,8 +2579,8 @@ impl SharedIndexHandle {
         scouted: crate::domain::ScoutedEntry,
         targets: crate::domain::IndexTargets,
         expected_gen: u64,
-        expected_publication_gen: u64,
-    ) -> bool {
+        expected_index_state_generation: u64,
+    ) -> Option<IndexedFilePublicationReceipt> {
         let _wg = self.write_mutex.lock();
         let current_gen = self.project_generation.load(Ordering::Acquire);
         if current_gen != expected_gen {
@@ -2428,38 +2592,21 @@ impl SharedIndexHandle {
                 current_gen,
                 "rejecting stale indexed-file publication"
             );
-            return false;
+            return None;
         }
-        let current_publication_gen = self.published_state.load().generation;
-        if current_publication_gen != expected_publication_gen {
+        let current_index_state_generation = self.published_state.load().generation;
+        if current_index_state_generation != expected_index_state_generation {
             tracing::trace!(
                 path,
-                expected_publication_gen,
-                current_publication_gen,
+                expected_index_state_generation,
+                current_index_state_generation,
                 "rejecting indexed-file publication prepared from a stale source bundle"
             );
-            return false;
+            return None;
         }
 
         let current = self.live.load_full();
-        if let Some(existing) = current.get_file(path) {
-            self.pre_update_snapshots.lock().insert(
-                path.to_string(),
-                PreUpdateSnapshot {
-                    content: existing.content.clone(),
-                    symbols: existing
-                        .symbols
-                        .iter()
-                        .map(|symbol| PreUpdateSymbol {
-                            name: symbol.name.clone(),
-                            kind: symbol.kind.to_string(),
-                            line_range: symbol.line_range,
-                            byte_range: symbol.byte_range,
-                        })
-                        .collect(),
-                },
-            );
-        }
+        let pre_update = current.get_file(path).map(pre_update_snapshot);
 
         let parse_status = match &file.parse_status {
             ParseStatus::Parsed => crate::domain::index::ParseStatus::Parsed,
@@ -2490,22 +2637,31 @@ impl SharedIndexHandle {
                 path_for_log,
                 msg
             );
-            return false;
+            return None;
         }
 
         let updated_scout_plan = match self.scout_plan_with_entry_locked(scouted, &live) {
             Ok(plan) => plan,
             Err(error) => {
                 tracing::error!(path, %error, "failed to refresh indexed-file scout plan");
-                return false;
+                return None;
             }
         };
 
         if let Some(plan) = updated_scout_plan {
             self.scout_plan.store(Some(plan));
         }
+        let scout_plan = self.scout_plan.load_full();
+        self.recompute_freshness_locked(&live, scout_plan.as_deref());
         self.swap_and_publish(live);
-        true
+        let published = self.published_generation();
+        let replacement = PublicationFence::from_published(&published);
+        let snapshot_created =
+            self.record_pre_update_snapshot_for_publication(path, pre_update, replacement);
+        Some(IndexedFilePublicationReceipt {
+            published,
+            snapshot_created,
+        })
     }
 
     /// Update only the stored mtime for a file without re-parsing.
@@ -2563,8 +2719,8 @@ impl SharedIndexHandle {
         scouted: crate::domain::ScoutedEntry,
         targets: crate::domain::IndexTargets,
         expected_gen: u64,
-        expected_publication_gen: u64,
-    ) -> bool {
+        expected_index_state_generation: u64,
+    ) -> Option<Arc<PublishedGeneration>> {
         let _wg = self.write_mutex.lock();
         let current_gen = self.project_generation.load(Ordering::Acquire);
         if current_gen != expected_gen {
@@ -2576,25 +2732,23 @@ impl SharedIndexHandle {
                 current_gen,
                 "rejecting stale hash-skip publication"
             );
-            return false;
+            return None;
         }
-        let current_publication_gen = self.published_state.load().generation;
-        if current_publication_gen != expected_publication_gen {
+        let current_index_state_generation = self.published_state.load().generation;
+        if current_index_state_generation != expected_index_state_generation {
             tracing::trace!(
                 path,
-                expected_publication_gen,
-                current_publication_gen,
+                expected_index_state_generation,
+                current_index_state_generation,
                 "rejecting hash-skip prepared from a stale source bundle"
             );
-            return false;
+            return None;
         }
 
         let current = self.live.load_full();
         let mut live = (*current).clone();
         let mut live_changed = false;
-        let Some(file) = current.files.get(path) else {
-            return false;
-        };
+        let file = current.files.get(path)?;
         if file.mtime_secs != new_mtime && new_mtime != 0 {
             let mut updated = (**file).clone();
             updated.mtime_secs = new_mtime;
@@ -2626,28 +2780,40 @@ impl SharedIndexHandle {
             Ok(plan) => plan,
             Err(error) => {
                 tracing::error!(path, %error, "failed to refresh hash-skip scout plan");
-                return false;
+                return None;
             }
         };
         if !live_changed && updated_scout_plan.is_none() && !manifest_changed {
-            return true;
+            return Some(self.published_generation());
         }
         if let Some(plan) = updated_scout_plan {
             self.scout_plan.store(Some(plan));
         }
+        let scout_plan = self.scout_plan.load_full();
+        self.recompute_freshness_locked(&live, scout_plan.as_deref());
         self.swap_and_publish(live);
-        true
+        Some(self.published_generation())
     }
 
     pub fn add_file(&self, path: String, file: IndexedFile) {
         let _wg = self.write_mutex.lock();
-        let mut live = (*self.live.load_full()).clone();
+        let current = self.live.load_full();
+        let pre_update = current.get_file(&path).map(pre_update_snapshot);
+        let mut live = (*current).clone();
         let path_clone = path.clone();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             live.add_file(path, file);
         }));
         match result {
-            Ok(()) => self.swap_and_publish(live),
+            Ok(()) => {
+                self.swap_and_publish(live);
+                let replacement = self.publication_fence();
+                self.record_pre_update_snapshot_for_publication(
+                    &path_clone,
+                    pre_update,
+                    replacement,
+                );
+            }
             Err(panic_info) => {
                 let msg = panic_info
                     .downcast_ref::<String>()
@@ -2671,7 +2837,10 @@ impl SharedIndexHandle {
             live.remove_file(path);
         }));
         match result {
-            Ok(()) => self.swap_and_publish(live),
+            Ok(()) => {
+                self.swap_and_publish(live);
+                self.pre_update_snapshots.lock().remove(path);
+            }
             Err(panic_info) => {
                 let msg = panic_info
                     .downcast_ref::<String>()
@@ -2688,11 +2857,47 @@ impl SharedIndexHandle {
     }
 
     pub fn remove_file_at_generation(&self, path: &str, expected_gen: u64) -> bool {
-        self.remove_file_with_fences(path, expected_gen, None, None)
+        self.remove_file_with_fences(path, expected_gen, None, None, None)
+            .is_some()
     }
 
     pub fn remove_file_at_publication_fence(&self, path: &str, expected: PublicationFence) -> bool {
-        self.remove_file_with_fences(path, expected.project_generation, None, Some(expected))
+        self.remove_file_at_publication_fence_with_receipt(path, expected)
+            .is_some()
+    }
+
+    pub(crate) fn remove_file_at_publication_fence_with_receipt(
+        &self,
+        path: &str,
+        expected: PublicationFence,
+    ) -> Option<Arc<PublishedGeneration>> {
+        self.remove_file_with_fences(
+            path,
+            expected.project_generation,
+            None,
+            Some(expected),
+            None,
+        )
+    }
+
+    pub(crate) fn remove_file_if_absent_at_publication_fence_with_receipt(
+        &self,
+        path: &str,
+        absolute_path: &Path,
+        expected: PublicationFence,
+    ) -> Option<Arc<PublishedGeneration>> {
+        // The observation fence contributes project identity, but an unrelated
+        // same-project publication must not pin a confirmed deletion forever.
+        // Re-checking filesystem absence under `write_mutex` is the path-local
+        // fence: it rejects a delete/recreate race without coupling this path to
+        // publications for other files.
+        self.remove_file_with_fences(
+            path,
+            expected.project_generation,
+            None,
+            None,
+            Some(absolute_path),
+        )
     }
 
     pub(crate) fn remove_file_if_scout_entry_at_generation(
@@ -2701,7 +2906,14 @@ impl SharedIndexHandle {
         expected_entry: &crate::domain::ScoutedEntry,
         expected_gen: u64,
     ) -> bool {
-        self.remove_file_with_fences(path, expected_gen, Some(expected_entry), None)
+        self.remove_file_with_fences(
+            path,
+            expected_gen,
+            Some(expected_entry),
+            None,
+            expected_entry.absolute_path.as_deref(),
+        )
+        .is_some()
     }
 
     fn remove_file_with_fences(
@@ -2710,7 +2922,8 @@ impl SharedIndexHandle {
         expected_gen: u64,
         expected_scout_entry: Option<&crate::domain::ScoutedEntry>,
         expected_publication: Option<PublicationFence>,
-    ) -> bool {
+        expected_absent_path: Option<&Path>,
+    ) -> Option<Arc<PublishedGeneration>> {
         let _wg = self.write_mutex.lock();
         let current_gen = self.project_generation.load(Ordering::Acquire);
         if current_gen != expected_gen {
@@ -2722,7 +2935,7 @@ impl SharedIndexHandle {
                 current_gen,
                 "rejecting stale file removal"
             );
-            return false;
+            return None;
         }
         if let Some(expected_publication) = expected_publication {
             let current_publication = self.publication_fence();
@@ -2733,7 +2946,7 @@ impl SharedIndexHandle {
                     ?current_publication,
                     "rejecting stale file removal publication"
                 );
-                return false;
+                return None;
             }
         }
         if let Some(expected_scout_entry) = expected_scout_entry {
@@ -2748,7 +2961,27 @@ impl SharedIndexHandle {
                     path,
                     "rejecting file removal because its scouted base changed"
                 );
-                return false;
+                return None;
+            }
+        }
+        if let Some(absolute_path) = expected_absent_path {
+            match std::fs::symlink_metadata(absolute_path) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Ok(_) => {
+                    tracing::trace!(
+                        path,
+                        "rejecting file removal because the path was recreated"
+                    );
+                    return None;
+                }
+                Err(error) => {
+                    tracing::trace!(
+                        path,
+                        %error,
+                        "rejecting file removal because absence could not be confirmed"
+                    );
+                    return None;
+                }
             }
         }
 
@@ -2769,22 +3002,25 @@ impl SharedIndexHandle {
                 path_owned,
                 msg
             );
-            return false;
+            return None;
         }
 
         let updated_scout_plan = match self.scout_plan_without_path_locked(path) {
             Ok(plan) => plan,
             Err(error) => {
                 tracing::error!(path, %error, "failed to refresh scout plan after removal");
-                return false;
+                return None;
             }
         };
 
         if let Some(plan) = updated_scout_plan {
             self.scout_plan.store(Some(plan));
         }
+        let scout_plan = self.scout_plan.load_full();
+        self.recompute_freshness_locked(&live, scout_plan.as_deref());
         self.swap_and_publish(live);
-        true
+        self.pre_update_snapshots.lock().remove(path);
+        Some(self.published_generation())
     }
 
     /// Publish one metadata-terminal observation under the same generation
@@ -2795,8 +3031,8 @@ impl SharedIndexHandle {
         scouted: crate::domain::ScoutedEntry,
         disposition: crate::domain::FileDisposition,
         expected_gen: u64,
-        expected_publication_gen: u64,
-    ) -> bool {
+        expected_index_state_generation: u64,
+    ) -> Option<Arc<PublishedGeneration>> {
         let _wg = self.write_mutex.lock();
         let current_gen = self.project_generation.load(Ordering::Acquire);
         if current_gen != expected_gen {
@@ -2808,17 +3044,17 @@ impl SharedIndexHandle {
                 current_gen,
                 "rejecting stale terminal disposition"
             );
-            return false;
+            return None;
         }
-        let current_publication_gen = self.published_state.load().generation;
-        if current_publication_gen != expected_publication_gen {
+        let current_index_state_generation = self.published_state.load().generation;
+        if current_index_state_generation != expected_index_state_generation {
             tracing::trace!(
                 path,
-                expected_publication_gen,
-                current_publication_gen,
+                expected_index_state_generation,
+                current_index_state_generation,
                 "rejecting terminal disposition prepared from a stale source bundle"
             );
-            return false;
+            return None;
         }
         let manifest_entry = catalog_entry_from_scout(&scouted, disposition.clone(), None);
         let mut live = (*self.live.load_full()).clone();
@@ -2844,14 +3080,14 @@ impl SharedIndexHandle {
                 path,
                 msg
             );
-            return false;
+            return None;
         }
 
         let updated_scout_plan = match self.scout_plan_with_entry_locked(scouted, &live) {
             Ok(plan) => plan,
             Err(error) => {
                 tracing::error!(path, %error, "failed to refresh terminal scout plan");
-                return false;
+                return None;
             }
         };
 
@@ -2859,17 +3095,16 @@ impl SharedIndexHandle {
             self.scout_plan.store(Some(plan));
         }
         if retains_last_valid_content {
-            let last_valid_content_generation = self.published_generation().content_generation;
-            self.freshness_status
-                .store(Arc::new(FreshnessStatus::Degraded {
-                    last_valid_content_generation,
-                    reason_codes: vec![FreshnessReason::ObservationFailed],
-                }));
+            let scout_plan = self.scout_plan.load_full();
+            self.recompute_freshness_locked(&live, scout_plan.as_deref());
             self.swap_and_publish_retaining_content(live);
         } else {
+            let scout_plan = self.scout_plan.load_full();
+            self.recompute_freshness_locked(&live, scout_plan.as_deref());
             self.swap_and_publish(live);
+            self.pre_update_snapshots.lock().remove(path);
         }
-        true
+        Some(self.published_generation())
     }
 
     pub fn mark_snapshot_verify_running(&self) {
@@ -2898,8 +3133,8 @@ impl SharedIndexHandle {
         }
         let mut live = (*self.live.load_full()).clone();
         live.mark_snapshot_verify_running();
-        self.freshness_status
-            .store(Arc::new(FreshnessStatus::Verifying));
+        let scout_plan = self.scout_plan.load_full();
+        self.recompute_freshness_locked(&live, scout_plan.as_deref());
         self.swap_and_publish_retaining_content(live);
         Some(self.publication_fence())
     }
@@ -2933,16 +3168,9 @@ impl SharedIndexHandle {
             return false;
         }
         let mut live = (*self.live.load_full()).clone();
-        let freshness = if mismatched_paths.is_empty() {
-            FreshnessStatus::Current
-        } else {
-            FreshnessStatus::Degraded {
-                last_valid_content_generation: expected.content_generation,
-                reason_codes: vec![FreshnessReason::SnapshotVerificationFailed],
-            }
-        };
         live.mark_snapshot_verify_completed(mismatched_paths);
-        self.freshness_status.store(Arc::new(freshness));
+        let scout_plan = self.scout_plan.load_full();
+        self.recompute_freshness_locked(&live, scout_plan.as_deref());
         self.swap_and_publish_retaining_content(live);
         true
     }
@@ -3091,7 +3319,101 @@ impl SharedIndexHandle {
     /// *before* the last `update_file` call — prevents the watcher race where
     /// the index is already updated to the post-edit state before the hook fires.
     pub fn take_pre_update_snapshot(&self, path: &str) -> Option<PreUpdateSnapshot> {
-        self.pre_update_snapshots.lock().remove(path)
+        let _wg = self.write_mutex.lock();
+        self.pre_update_snapshots
+            .lock()
+            .remove(path)
+            .map(|stored| stored.snapshot)
+    }
+
+    /// Take a pre-update snapshot only while `expected_gen` is still the
+    /// active project generation.
+    ///
+    /// The generation check and removal share the index writer lock with
+    /// reload publication, so a stale sidecar request cannot consume a
+    /// snapshot produced by the replacement project.
+    pub fn take_pre_update_snapshot_at_generation(
+        &self,
+        path: &str,
+        expected_gen: u64,
+    ) -> Option<PreUpdateSnapshot> {
+        let _wg = self.write_mutex.lock();
+        let current_gen = self.project_generation.load(Ordering::Acquire);
+        if current_gen != expected_gen {
+            self.rejected_stale_mutations
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::trace!(
+                path,
+                expected_gen,
+                current_gen,
+                "rejecting stale pre-update snapshot take"
+            );
+            return None;
+        }
+        self.pre_update_snapshots
+            .lock()
+            .remove(path)
+            .map(|stored| stored.snapshot)
+    }
+
+    /// Clone a pre-update snapshot without consuming it, together with the
+    /// exact publication that owns the slot. The caller can later consume only
+    /// that same slot after its operation succeeds; a newer watcher publication
+    /// remains untouched.
+    pub(crate) fn peek_pre_update_snapshot_at_generation(
+        &self,
+        path: &str,
+        expected_gen: u64,
+    ) -> Option<(PreUpdateSnapshot, PublicationFence)> {
+        let _wg = self.write_mutex.lock();
+        let current_gen = self.project_generation.load(Ordering::Acquire);
+        if current_gen != expected_gen {
+            self.rejected_stale_mutations
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::trace!(
+                path,
+                expected_gen,
+                current_gen,
+                "rejecting stale pre-update snapshot peek"
+            );
+            return None;
+        }
+        self.pre_update_snapshots
+            .lock()
+            .get(path)
+            .map(|stored| (stored.snapshot.clone(), stored.replacement))
+    }
+
+    /// Consume the pre-state only when it belongs to the exact replacement
+    /// publication owned by this request. A later same-project watcher update
+    /// replaces the slot with a different fence and remains untouched.
+    pub(crate) fn take_pre_update_snapshot_for_publication_at_generation(
+        &self,
+        path: &str,
+        expected_gen: u64,
+        replacement: PublicationFence,
+    ) -> Option<PreUpdateSnapshot> {
+        let _wg = self.write_mutex.lock();
+        let current_gen = self.project_generation.load(Ordering::Acquire);
+        if current_gen != expected_gen {
+            self.rejected_stale_mutations
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::trace!(
+                path,
+                expected_gen,
+                current_gen,
+                "rejecting stale publication-bound pre-update snapshot take"
+            );
+            return None;
+        }
+        let mut snapshots = self.pre_update_snapshots.lock();
+        if snapshots
+            .get(path)
+            .is_none_or(|stored| stored.replacement != replacement)
+        {
+            return None;
+        }
+        snapshots.remove(path).map(|stored| stored.snapshot)
     }
 
     /// Backward-compatible accessor for callers that only need the symbol half.
@@ -3184,6 +3506,12 @@ impl Drop for SharedIndexWriteGuard<'_> {
             && let Some(live) = self.index.take()
         {
             self.handle.swap_and_publish(live);
+            // A generic mutable guard can alter any number of paths, so an
+            // existing path-scoped snapshot can no longer be tied to the
+            // publication that owns its replacement. Exact reconstruction is
+            // impossible here; discard the side table rather than let a later
+            // impact request consume an old-lifetime baseline.
+            self.handle.pre_update_snapshots.lock().clear();
         }
     }
 }
@@ -6158,6 +6486,71 @@ mod tests {
     }
 
     #[test]
+    fn generic_write_guard_invalidates_pre_update_snapshot_tokens() {
+        let shared = LiveIndex::empty();
+        shared.add_file(
+            "src/tracked.rs".to_string(),
+            make_indexed_file_for_mutation("src/tracked.rs"),
+        );
+        shared.update_file(
+            "src/tracked.rs".to_string(),
+            make_indexed_file_for_mutation("src/tracked.rs"),
+        );
+        let generation = shared.current_project_generation();
+        assert!(
+            shared
+                .peek_pre_update_snapshot_at_generation("src/tracked.rs", generation)
+                .is_some(),
+            "the exact update must create a baseline token"
+        );
+
+        {
+            let mut live = shared.write();
+            live.add_file(
+                "src/other.rs".to_string(),
+                make_indexed_file_for_mutation("src/other.rs"),
+            );
+        }
+
+        assert!(
+            shared
+                .peek_pre_update_snapshot_at_generation("src/tracked.rs", generation)
+                .is_none(),
+            "an arbitrary write publication must invalidate old path tokens"
+        );
+    }
+
+    #[test]
+    fn scout_reconciliation_removal_refuses_a_recreated_disk_path() {
+        let dir = TempDir::new().expect("root");
+        let path = dir.path().join("lib.rs");
+        fs::write(&path, "pub fn before() {}\n").expect("seed");
+        let shared = LiveIndex::load(dir.path()).expect("load");
+        let expected_entry = shared
+            .scout_plan
+            .load_full()
+            .expect("scout plan")
+            .entries
+            .iter()
+            .find(|entry| entry.path.normalized_utf8.as_deref() == Some("lib.rs"))
+            .cloned()
+            .expect("lib.rs scout entry");
+
+        fs::remove_file(&path).expect("scan observes absence");
+        fs::write(&path, "pub fn recreated() {}\n").expect("recreate before removal");
+
+        assert!(
+            !shared.remove_file_if_scout_entry_at_generation(
+                "lib.rs",
+                &expected_entry,
+                shared.current_project_generation(),
+            ),
+            "a complete-scout deletion must re-confirm absence at publication"
+        );
+        assert!(shared.read().get_file("lib.rs").is_some());
+    }
+
+    #[test]
     fn mtime_only_update_is_visible_in_published_root_without_advancing_content_generation() {
         let shared = LiveIndex::empty();
         shared.add_file(
@@ -6271,6 +6664,58 @@ mod tests {
         assert_eq!(completed.file_count, initial.file_count);
         assert_eq!(completed.partial_parse_count, initial.partial_parse_count);
         assert_eq!(completed.failed_count, initial.failed_count);
+    }
+
+    #[test]
+    fn snapshot_verify_transitions_preserve_other_degraded_reasons() {
+        let project = TempDir::new().unwrap();
+        write_file(project.path(), "main.rs", "fn main() {}\n");
+        let loaded = LiveIndex::load(project.path()).unwrap();
+        let mut live = (*loaded.published_generation().live).clone();
+        live.load_source = IndexLoadSource::SnapshotRestore;
+        live.snapshot_verify_state = SnapshotVerifyState::Pending;
+        let mut degraded_plan = (*loaded.scout_plan().expect("cold scout plan")).clone();
+        degraded_plan.issues.push(crate::domain::ScoutIssue {
+            path_id: Some("transient-walk-entry".to_string()),
+            safe_path: Some("temporarily-locked".to_string()),
+            kind: crate::domain::ScoutIssueKind::DirectoryEntryUnreadable {
+                kind: crate::domain::AccessErrorKind::PermissionDenied,
+            },
+            safe_message: "directory entry unavailable".to_string(),
+        });
+        crate::discovery::refresh_scout_plan(&mut degraded_plan).unwrap();
+        let shared = SharedIndexHandle::shared_with_scout_plan(
+            live,
+            degraded_plan,
+            crate::discovery::SourceExclusions::default(),
+        );
+        assert!(matches!(
+            shared.published_generation().freshness.as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
+        ));
+
+        let running_fence = shared
+            .mark_snapshot_verify_running_at_fence(shared.publication_fence())
+            .expect("verification starts at the captured fence");
+        assert!(matches!(
+            shared.published_generation().freshness.as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
+        ));
+
+        assert!(shared.mark_snapshot_verify_completed_at_fence(running_fence, Vec::new()));
+        let completed = shared.published_generation();
+        assert!(matches!(
+            completed.live.snapshot_verify_state,
+            SnapshotVerifyState::Completed(_)
+        ));
+        assert!(matches!(
+            completed.freshness.as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
+                    && !reason_codes.contains(&FreshnessReason::SnapshotVerificationFailed)
+        ));
     }
 
     #[test]
@@ -6553,16 +6998,20 @@ mod tests {
             },
         };
 
-        assert!(shared.publish_terminal_disposition_at_generation(
-            path,
-            scouted,
-            FileDisposition::Unreadable {
-                stage: crate::domain::AccessStage::FullRead,
-                kind: crate::domain::AccessErrorKind::PermissionDenied,
-            },
-            shared.current_project_generation(),
-            before.publication_generation,
-        ));
+        assert!(
+            shared
+                .publish_terminal_disposition_at_generation(
+                    path,
+                    scouted,
+                    FileDisposition::Unreadable {
+                        stage: crate::domain::AccessStage::FullRead,
+                        kind: crate::domain::AccessErrorKind::PermissionDenied,
+                    },
+                    shared.current_project_generation(),
+                    before.health.generation,
+                )
+                .is_some()
+        );
 
         let after = shared.published_generation();
         assert!(after.publication_generation > before.publication_generation);
@@ -6577,10 +7026,215 @@ mod tests {
         assert!(matches!(
             &*shared.freshness_status(),
             FreshnessStatus::Degraded {
-                last_valid_content_generation,
+                last_valid_content_generation: _,
                 reason_codes,
-            } if *last_valid_content_generation == before.content_generation
-                && reason_codes == &[FreshnessReason::ObservationFailed]
+            } if reason_codes.contains(&FreshnessReason::ObservationFailed)
+        ));
+    }
+
+    #[test]
+    fn healed_observation_restores_current_freshness() {
+        let project = TempDir::new().unwrap();
+        let path = "src/retained.rs";
+        write_file(project.path(), path, "fn retained() {}\n");
+        let shared = LiveIndex::load(project.path()).unwrap();
+        let before = shared.published_generation();
+        let mut scouted = shared
+            .scout_plan()
+            .expect("cold scout plan")
+            .entries
+            .iter()
+            .find(|entry| entry.path.normalized_utf8.as_deref() == Some(path))
+            .expect("retained file scout entry")
+            .clone();
+        scouted.decision = crate::domain::ScoutDecision::Unavailable {
+            stage: crate::domain::AccessStage::FullRead,
+            kind: crate::domain::AccessErrorKind::PermissionDenied,
+        };
+
+        assert!(
+            shared
+                .publish_terminal_disposition_at_generation(
+                    path,
+                    scouted,
+                    FileDisposition::Unreadable {
+                        stage: crate::domain::AccessStage::FullRead,
+                        kind: crate::domain::AccessErrorKind::PermissionDenied,
+                    },
+                    shared.current_project_generation(),
+                    before.health.generation,
+                )
+                .is_some()
+        );
+        assert!(matches!(
+            shared.freshness_status().as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ObservationFailed)
+        ));
+
+        write_file(project.path(), path, "fn retained_and_healed() {}\n");
+        assert_eq!(
+            crate::live_index::single_file::update_file_from_disk(&shared, project.path(), path),
+            crate::live_index::single_file::ReindexResult::Reindexed
+        );
+        let healed = shared.published_generation();
+        assert_eq!(healed.freshness.as_ref(), &FreshnessStatus::Current);
+        assert_eq!(healed.live.index_state(), IndexState::Ready);
+    }
+
+    #[test]
+    fn healed_observation_does_not_bypass_pending_snapshot_verification() {
+        let project = TempDir::new().unwrap();
+        let path = "src/retained.rs";
+        write_file(project.path(), path, "fn retained() {}\n");
+        let mut live = LiveIndex::from_source_files(HashMap::from([(
+            path.to_string(),
+            Arc::new(make_indexed_file_for_mutation(path)),
+        )]));
+        live.indexed_root = Some(dunce::canonicalize(project.path()).unwrap());
+        live.snapshot_verify_state = SnapshotVerifyState::Pending;
+        let shared = SharedIndexHandle::shared(live);
+        let before = shared.published_generation();
+        assert_eq!(before.freshness.as_ref(), &FreshnessStatus::Verifying);
+        let scouted = crate::domain::ScoutedEntry {
+            path: crate::domain::CatalogPath {
+                public_id: path.to_string(),
+                normalized_utf8: Some(path.to_string()),
+            },
+            absolute_path: Some(project.path().join(path)),
+            stamp: crate::domain::FileStamp {
+                size: 0,
+                created_hint: None,
+                modified_hint: None,
+                platform_id: None,
+            },
+            language: Some(LanguageId::Rust),
+            classification: crate::domain::FileClassification::for_code_path(path),
+            decision: crate::domain::ScoutDecision::Unavailable {
+                stage: crate::domain::AccessStage::FullRead,
+                kind: crate::domain::AccessErrorKind::PermissionDenied,
+            },
+        };
+
+        assert!(
+            shared
+                .publish_terminal_disposition_at_generation(
+                    path,
+                    scouted,
+                    FileDisposition::Unreadable {
+                        stage: crate::domain::AccessStage::FullRead,
+                        kind: crate::domain::AccessErrorKind::PermissionDenied,
+                    },
+                    shared.current_project_generation(),
+                    before.health.generation,
+                )
+                .is_some()
+        );
+        assert!(matches!(
+            shared.freshness_status().as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ObservationFailed)
+        ));
+
+        write_file(project.path(), path, "fn retained_and_healed() {}\n");
+        assert_eq!(
+            crate::live_index::single_file::update_file_from_disk(&shared, project.path(), path),
+            crate::live_index::single_file::ReindexResult::Reindexed
+        );
+        let healed = shared.published_generation();
+        assert_eq!(healed.freshness.as_ref(), &FreshnessStatus::Verifying);
+        assert_eq!(
+            healed.live.snapshot_verify_state,
+            SnapshotVerifyState::Pending
+        );
+    }
+
+    #[test]
+    fn reconciled_coverage_publishes_freshness_once_per_transition() {
+        let project = TempDir::new().unwrap();
+        write_file(project.path(), "main.rs", "fn main() {}\n");
+        let shared = LiveIndex::load(project.path()).unwrap();
+        let complete_plan = (*shared.scout_plan().expect("cold scout plan")).clone();
+        let mut degraded_plan = complete_plan.clone();
+        degraded_plan.issues.push(crate::domain::ScoutIssue {
+            path_id: Some("transient-walk-entry".to_string()),
+            safe_path: Some("temporarily-locked".to_string()),
+            kind: crate::domain::ScoutIssueKind::DirectoryEntryUnreadable {
+                kind: crate::domain::AccessErrorKind::PermissionDenied,
+            },
+            safe_message: "directory entry unavailable".to_string(),
+        });
+        crate::discovery::refresh_scout_plan(&mut degraded_plan).unwrap();
+        let project_generation = shared.current_project_generation();
+        let initial = shared.published_generation();
+
+        assert!(shared.publish_reconciled_scout_plan_at_generation(
+            Some(&complete_plan),
+            degraded_plan.clone(),
+            project_generation,
+        ));
+        let degraded = shared.published_generation();
+        assert!(degraded.publication_generation > initial.publication_generation);
+        assert_eq!(degraded.content_generation, initial.content_generation);
+        assert!(matches!(
+            degraded.freshness.as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
+        ));
+
+        assert!(shared.publish_reconciled_scout_plan_at_generation(
+            Some(&degraded_plan),
+            complete_plan.clone(),
+            project_generation,
+        ));
+        let healed = shared.published_generation();
+        assert!(healed.publication_generation > degraded.publication_generation);
+        assert_eq!(healed.content_generation, initial.content_generation);
+        assert_eq!(healed.freshness.as_ref(), &FreshnessStatus::Current);
+
+        assert!(shared.publish_reconciled_scout_plan_at_generation(
+            Some(&complete_plan),
+            complete_plan.clone(),
+            project_generation,
+        ));
+        let unchanged = shared.published_generation();
+        assert_eq!(
+            unchanged.publication_generation, healed.publication_generation,
+            "an unchanged Complete reconciliation must not mint a publication"
+        );
+        assert_eq!(unchanged.content_generation, healed.content_generation);
+    }
+
+    #[test]
+    fn degraded_initial_scout_is_published_in_the_trust_bundle() {
+        let project = TempDir::new().unwrap();
+        write_file(project.path(), "main.rs", "fn main() {}\n");
+        let loaded = LiveIndex::load(project.path()).unwrap();
+        let mut degraded_plan = (*loaded.scout_plan().expect("cold scout plan")).clone();
+        degraded_plan.issues.push(crate::domain::ScoutIssue {
+            path_id: Some("transient-walk-entry".to_string()),
+            safe_path: Some("temporarily-locked".to_string()),
+            kind: crate::domain::ScoutIssueKind::DirectoryEntryUnreadable {
+                kind: crate::domain::AccessErrorKind::PermissionDenied,
+            },
+            safe_message: "directory entry unavailable".to_string(),
+        });
+        crate::discovery::refresh_scout_plan(&mut degraded_plan).unwrap();
+        let shared = SharedIndexHandle::shared_with_scout_plan(
+            (*loaded.published_generation().live).clone(),
+            degraded_plan,
+            crate::discovery::SourceExclusions::default(),
+        );
+
+        assert!(matches!(
+            shared.freshness_status().as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
+        ));
+        assert!(matches!(
+            shared.published_generation().freshness.as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::ReconciliationPending)
         ));
     }
 

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -64,6 +64,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rejected_index_publications_classify_as_retryable_internal_failures() {
+        for output in [
+            "Error: index refresh for 'src/lib.rs' did not publish; retry the edit.",
+            "Error: index refresh for 'src/lib.rs' did not publish; retry the batch edit.",
+        ] {
+            assert_eq!(
+                classify_edit_output(output, false),
+                EditResultStatus::InternalFailure,
+                "output was: {output}"
+            );
+        }
+    }
+
     /// Test-only RAII guard serializing `SYMFORGE_SURFACE` mutation so the D23
     /// stale-session regressions can prove the CONNECTION surface overrides the
     /// daemon's own env. Single-threaded test context (`--test-threads=1`).
@@ -298,6 +312,8 @@ fn classify_edit_output(text: &str, dry_run: bool) -> EditResultStatus {
         || text.contains("File disappeared:")
         || text.contains("byte range")
         || text.contains("Session stale")
+        || (text.starts_with("Error: index refresh for '")
+            && text.contains(" did not publish; retry the "))
     {
         EditResultStatus::InternalFailure
     } else if is_error_output(text)
@@ -418,6 +434,12 @@ pub(crate) fn prepare_exact_path_for_edit(
                     }
                 ));
             }
+            watcher::FreshenResult::PublicationRejected => {
+                return Err(format!(
+                    "Error: index refresh for '{}' did not publish; retry the edit.",
+                    relative_path
+                ));
+            }
         };
     Ok((abs_path, source_authority))
 }
@@ -457,6 +479,12 @@ pub(super) fn prepare_batch_paths_for_edit(
                         path: abs_path,
                         recovery: session_stale_recovery(),
                     }
+                ));
+            }
+            watcher::FreshenResult::PublicationRejected => {
+                return Err(format!(
+                    "Error: index refresh for '{}' did not publish; retry the batch edit.",
+                    relative_path
                 ));
             }
         }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -169,6 +169,7 @@ pub(super) fn is_index_unavailable_output(text: &str) -> bool {
     text.starts_with("Index not loaded.")
         || text.starts_with("Index is loading")
         || text.starts_with("Index degraded:")
+        || text.starts_with("Index refresh interrupted:")
 }
 
 /// The ONE error-shape predicate for the whole protocol surface, read/write
@@ -1060,26 +1061,64 @@ fn enrich_with_callers(
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TargetedFreshenRefusal {
+    ProjectGenerationChanged,
+    PublicationRejected,
+}
+
+impl TargetedFreshenRefusal {
+    fn message(self, relative_path: &str) -> String {
+        match self {
+            Self::ProjectGenerationChanged => format!(
+                "Index refresh interrupted: project changed while refreshing '{relative_path}'; retry the read."
+            ),
+            Self::PublicationRejected => format!(
+                "Index refresh interrupted: refresh for '{relative_path}' did not publish; retry the read."
+            ),
+        }
+    }
+
+    fn permits_authoritative_disk_fallback(self) -> bool {
+        matches!(self, Self::PublicationRejected)
+    }
+}
+
+fn classify_targeted_freshen_result(
+    result: watcher::FreshenResult,
+) -> Result<bool, TargetedFreshenRefusal> {
+    match result {
+        watcher::FreshenResult::Fresh => Ok(false),
+        watcher::FreshenResult::StaleReindexed | watcher::FreshenResult::StaleRemoved => Ok(true),
+        watcher::FreshenResult::GenerationMismatch => {
+            Err(TargetedFreshenRefusal::ProjectGenerationChanged)
+        }
+        watcher::FreshenResult::PublicationRejected => {
+            Err(TargetedFreshenRefusal::PublicationRejected)
+        }
+    }
+}
+
 fn freshen_exact_path_for_targeted_retrieval(
     server: &SymForgeServer,
     path_scope: &search::PathScope,
-) -> bool {
+) -> Result<bool, TargetedFreshenRefusal> {
     let search::PathScope::Exact(relative_path) = path_scope else {
-        return false;
+        return Ok(false);
     };
     let expected_gen = server.index.current_project_generation();
     let Some(repo_root) = server.capture_repo_root() else {
-        return false;
+        return Ok(false);
     };
     let Ok(abs_path) = safe_repo_path_for_freshen(&repo_root, relative_path) else {
-        return false;
+        return Ok(false);
     };
-    match watcher::freshen_file_if_stale(relative_path, &abs_path, &server.index, expected_gen) {
-        watcher::FreshenResult::Fresh => false,
-        watcher::FreshenResult::StaleReindexed => true,
-        watcher::FreshenResult::StaleRemoved => true,
-        watcher::FreshenResult::GenerationMismatch => false,
-    }
+    classify_targeted_freshen_result(watcher::freshen_file_if_stale(
+        relative_path,
+        &abs_path,
+        &server.index,
+        expected_gen,
+    ))
 }
 
 pub(super) fn safe_repo_path_for_freshen(
@@ -4580,7 +4619,12 @@ impl SymForgeServer {
             return refusal;
         }
         let force_refresh = params.0.force_refresh == Some(true);
-        freshen_exact_path_for_targeted_retrieval(self, &search::PathScope::exact(&params.0.path));
+        if let Err(refusal) = freshen_exact_path_for_targeted_retrieval(
+            self,
+            &search::PathScope::exact(&params.0.path),
+        ) {
+            return refusal.message(&params.0.path);
+        }
         let published = self.index.published_generation();
         if let Some(message) = loading_guard_message_from_published(&published.health) {
             return message;
@@ -4833,14 +4877,14 @@ impl SymForgeServer {
         if let Some(refusal) = self.foreign_project_refusal(params.0.project.as_deref()) {
             return refusal;
         }
-        let refreshed = params
-            .0
-            .path
-            .as_deref()
-            .or(params.0.file.as_deref())
-            .is_some_and(|path| {
-                freshen_exact_path_for_targeted_retrieval(self, &search::PathScope::exact(path))
-            });
+        let refreshed = if let Some(path) = params.0.path.as_deref().or(params.0.file.as_deref()) {
+            match freshen_exact_path_for_targeted_retrieval(self, &search::PathScope::exact(path)) {
+                Ok(refreshed) => refreshed,
+                Err(refusal) => return refusal.message(path),
+            }
+        } else {
+            false
+        };
         let published = self.index.published_generation();
         if let Some(message) = loading_guard_message_from_published(&published.health) {
             return message;
@@ -8678,7 +8722,9 @@ impl SymForgeServer {
             Ok(options) => options,
             Err(message) => return message,
         };
-        freshen_exact_path_for_targeted_retrieval(self, &options.path_scope);
+        if let Err(refusal) = freshen_exact_path_for_targeted_retrieval(self, &options.path_scope) {
+            return refusal.message(&input.path);
+        }
 
         // Capture freshness and the immutable publication before consulting the
         // repeat-read cache. The same request against a later watcher publication
@@ -8846,7 +8892,16 @@ impl SymForgeServer {
         }
 
         let path_scope = search::PathScope::exact(&input.path);
-        freshen_exact_path_for_targeted_retrieval(self, &path_scope);
+        let force_disk_fallback = match freshen_exact_path_for_targeted_retrieval(self, &path_scope)
+        {
+            Ok(_) => false,
+            // This tool has an authoritative disk-read lane below. A rejected
+            // same-project publication therefore means "do not trust the indexed
+            // hit", not "validation is impossible". A project-generation change
+            // remains ambiguous and must be retried against the newly bound root.
+            Err(refusal) if refusal.permits_authoritative_disk_fallback() => true,
+            Err(refusal) => return refusal.message(&input.path),
+        };
 
         // One publication for the whole handler: the gate below reads the recorded
         // disposition off the SAME publication that produced the index miss, and
@@ -8862,7 +8917,7 @@ impl SymForgeServer {
         // repository. While not Ready, ignore the indexed entry and answer from
         // the authoritative disk parse below.
         let not_ready = loading_guard_message_from_published(&published.health);
-        let indexed_file = if not_ready.is_some() {
+        let indexed_file = if force_disk_fallback || not_ready.is_some() {
             None
         } else {
             published.live.capture_shared_file(&input.path)
@@ -13495,8 +13550,8 @@ mod tests {
     /// deliberately leaving `project_generation` AND `content_generation`
     /// untouched. So a publication landing mid-test breaks `Arc::ptr_eq` on the
     /// published state, and makes the CAS in `read_and_index_with_stable_read`
-    /// lose its race (4 losses → `ReindexResult::Skipped`), with no generation
-    /// counter moving to hint at why. Both failure modes are invisible to the
+    /// lose its race (4 losses → the internal `PublicationRejected` outcome),
+    /// with no generation counter moving to hint at why. Both failure modes are invisible to the
     /// generation asserts sitting right next to them.
     ///
     /// Only reproducible under full-suite load: `#[tokio::test]` is a
@@ -27603,10 +27658,54 @@ mod tests {
         let refreshed = super::freshen_exact_path_for_targeted_retrieval(
             &server,
             &super::search::PathScope::exact("src/lib.rs"),
-        );
+        )
+        .expect("confirmed removal should publish against the captured project");
 
         assert!(refreshed);
         assert!(server.index().read().get_file("src/lib.rs").is_none());
+    }
+
+    #[test]
+    fn targeted_retrieval_refuses_project_generation_mismatch() {
+        let refusal = super::classify_targeted_freshen_result(
+            crate::watcher::FreshenResult::GenerationMismatch,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            refusal,
+            super::TargetedFreshenRefusal::ProjectGenerationChanged
+        );
+        let message = refusal.message("src/lib.rs");
+        assert!(message.contains("retry the read"));
+        assert_eq!(
+            super::classify_get_file_content_output(&message),
+            OutcomeClass::InternalFailure
+        );
+        assert!(
+            !refusal.permits_authoritative_disk_fallback(),
+            "a project rebind makes even a relative-path disk fallback ambiguous"
+        );
+    }
+
+    #[test]
+    fn targeted_retrieval_refuses_unpublished_refresh_but_validation_may_use_disk() {
+        let refusal = super::classify_targeted_freshen_result(
+            crate::watcher::FreshenResult::PublicationRejected,
+        )
+        .unwrap_err();
+
+        assert_eq!(refusal, super::TargetedFreshenRefusal::PublicationRejected);
+        let message = refusal.message("src/lib.rs");
+        assert!(message.contains("did not publish"));
+        assert_eq!(
+            super::classify_get_file_context_output(&message),
+            OutcomeClass::InternalFailure
+        );
+        assert!(
+            refusal.permits_authoritative_disk_fallback(),
+            "syntax validation owns an authoritative disk-read lane and need not trust the stale index"
+        );
     }
 
     #[test]

--- a/src/sidecar/handlers.rs
+++ b/src/sidecar/handlers.rs
@@ -14,7 +14,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::domain::{LanguageId, ReferenceKind};
-use crate::sidecar::{SidecarState, SymbolSnapshot, build_with_budget};
+use crate::sidecar::{SidecarState, SymbolSnapshot, SymbolSnapshotCache, build_with_budget};
 use crate::{protocol::edit, watcher};
 
 // ---------------------------------------------------------------------------
@@ -219,14 +219,6 @@ fn format_context_envelope(
     }
 }
 
-fn freshen_sidecar_path_if_stale(
-    state: &SidecarState,
-    relative_path: &str,
-) -> ContextSourceAuthority {
-    let expected_gen = state.index.current_project_generation();
-    freshen_sidecar_path_if_stale_at_generation(state, relative_path, expected_gen)
-}
-
 fn safe_sidecar_path_for_freshen(
     repo_root: &std::path::Path,
     relative_path: &str,
@@ -253,20 +245,22 @@ fn safe_sidecar_path_for_freshen(
 
 fn freshen_sidecar_path_if_stale_at_generation(
     state: &SidecarState,
+    repo_root: Option<&std::path::Path>,
     relative_path: &str,
     expected_gen: u64,
-) -> ContextSourceAuthority {
-    let Some(repo_root) = &state.repo_root else {
-        return ContextSourceAuthority::CurrentIndex;
+) -> Result<ContextSourceAuthority, StatusCode> {
+    let Some(repo_root) = repo_root else {
+        return Ok(ContextSourceAuthority::CurrentIndex);
     };
     let Ok(abs_path) = safe_sidecar_path_for_freshen(repo_root, relative_path) else {
-        return ContextSourceAuthority::CurrentIndex;
+        return Ok(ContextSourceAuthority::CurrentIndex);
     };
     match watcher::freshen_file_if_stale(relative_path, &abs_path, &state.index, expected_gen) {
-        watcher::FreshenResult::Fresh => ContextSourceAuthority::CurrentIndex,
-        watcher::FreshenResult::StaleReindexed => ContextSourceAuthority::DiskRefreshed,
-        watcher::FreshenResult::StaleRemoved => ContextSourceAuthority::DiskRefreshed,
-        watcher::FreshenResult::GenerationMismatch => ContextSourceAuthority::CurrentIndex,
+        watcher::FreshenResult::Fresh => Ok(ContextSourceAuthority::CurrentIndex),
+        watcher::FreshenResult::StaleReindexed => Ok(ContextSourceAuthority::DiskRefreshed),
+        watcher::FreshenResult::StaleRemoved => Ok(ContextSourceAuthority::DiskRefreshed),
+        watcher::FreshenResult::GenerationMismatch => Ok(ContextSourceAuthority::CurrentIndex),
+        watcher::FreshenResult::PublicationRejected => Err(StatusCode::SERVICE_UNAVAILABLE),
     }
 }
 
@@ -412,6 +406,205 @@ pub async fn health_handler(
     }))
 }
 
+#[derive(Clone, Debug)]
+struct SidecarQueryFence {
+    project_generation: u64,
+    source: crate::domain::SourceIdentity,
+    indexed_root: std::path::PathBuf,
+}
+
+fn published_sidecar_index_is_queryable(
+    published: &crate::live_index::PublishedGeneration,
+) -> bool {
+    let health_is_ready = matches!(
+        published.health.status,
+        crate::live_index::PublishedIndexStatus::Ready
+    );
+    let health_is_empty = matches!(
+        published.health.status,
+        crate::live_index::PublishedIndexStatus::Empty
+    );
+    let freshness_is_queryable = matches!(
+        published.freshness.as_ref(),
+        crate::domain::FreshnessStatus::Current
+    ) || (health_is_empty
+        && matches!(
+            published.freshness.as_ref(),
+            crate::domain::FreshnessStatus::Verifying
+        )
+        && matches!(
+            published.health.snapshot_verify_state,
+            crate::live_index::SnapshotVerifyState::NotNeeded
+        ));
+    (health_is_ready || health_is_empty)
+        && published.source.is_some()
+        && published.live.indexed_root.is_some()
+        && freshness_is_queryable
+}
+
+fn sidecar_query_fence_for(
+    published: &crate::live_index::PublishedGeneration,
+) -> Option<SidecarQueryFence> {
+    Some(SidecarQueryFence {
+        project_generation: published.project_generation,
+        source: published.source.as_deref()?.clone(),
+        indexed_root: published.live.indexed_root.clone()?,
+    })
+}
+
+fn published_matches_sidecar_query(
+    published: &crate::live_index::PublishedGeneration,
+    fence: &SidecarQueryFence,
+) -> bool {
+    published_sidecar_index_is_queryable(published)
+        && published_matches_sidecar_fence(published, fence)
+}
+
+fn published_matches_sidecar_fence(
+    published: &crate::live_index::PublishedGeneration,
+    fence: &SidecarQueryFence,
+) -> bool {
+    published.project_generation == fence.project_generation
+        && published.source.as_deref() == Some(&fence.source)
+        && published.live.indexed_root.as_ref() == Some(&fence.indexed_root)
+}
+
+fn require_queryable_sidecar_index(state: &SidecarState) -> Result<SidecarQueryFence, StatusCode> {
+    let published = state.index.published_generation();
+    if published_sidecar_index_is_queryable(&published)
+        && state.index.current_project_generation() == published.project_generation
+    {
+        let fence = sidecar_query_fence_for(&published).ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+        if state
+            .repo_root
+            .as_deref()
+            .is_some_and(|root| !roots_match(root, &fence.indexed_root))
+        {
+            return Err(StatusCode::CONFLICT);
+        }
+        Ok(fence)
+    } else {
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+fn capture_queryable_sidecar_generation(
+    state: &SidecarState,
+    fence: &SidecarQueryFence,
+) -> Result<std::sync::Arc<crate::live_index::PublishedGeneration>, StatusCode> {
+    let published = state.index.published_generation();
+    if published_matches_sidecar_query(&published, fence)
+        && state.index.current_project_generation() == published.project_generation
+    {
+        Ok(published)
+    } else {
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+fn capture_sidecar_generation_at_fence(
+    state: &SidecarState,
+    fence: &SidecarQueryFence,
+) -> Result<std::sync::Arc<crate::live_index::PublishedGeneration>, StatusCode> {
+    let published = state.index.published_generation();
+    if published_matches_sidecar_fence(&published, fence)
+        && state.index.current_project_generation() == published.project_generation
+    {
+        Ok(published)
+    } else {
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+struct SymbolCacheGenerationEntry {
+    cache: std::sync::Weak<parking_lot::RwLock<SymbolSnapshotCache>>,
+    project_generation: u64,
+}
+
+static SYMBOL_CACHE_GENERATIONS: std::sync::LazyLock<
+    parking_lot::Mutex<std::collections::HashMap<usize, SymbolCacheGenerationEntry>>,
+> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
+
+fn ensure_symbol_cache_generation(
+    state: &SidecarState,
+    expected_generation: u64,
+) -> Result<(), StatusCode> {
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let identity = std::sync::Arc::as_ptr(&state.symbol_cache) as usize;
+    let mut generations = SYMBOL_CACHE_GENERATIONS.lock();
+    generations.retain(|_, entry| entry.cache.strong_count() > 0);
+    match generations.get_mut(&identity) {
+        Some(entry)
+            if entry
+                .cache
+                .upgrade()
+                .is_some_and(|cache| std::sync::Arc::ptr_eq(&cache, &state.symbol_cache)) =>
+        {
+            if entry.project_generation != expected_generation {
+                state.symbol_cache.write().clear();
+                entry.project_generation = expected_generation;
+            }
+        }
+        _ => {
+            // A caller may pre-seed the public path-keyed cache before the first
+            // handler call. Associate that initial state with the current
+            // project; subsequent generation changes are cleared deterministically.
+            generations.insert(
+                identity,
+                SymbolCacheGenerationEntry {
+                    cache: std::sync::Arc::downgrade(&state.symbol_cache),
+                    project_generation: expected_generation,
+                },
+            );
+        }
+    }
+    if state.index.current_project_generation() == expected_generation {
+        Ok(())
+    } else {
+        state.symbol_cache.write().clear();
+        generations.remove(&identity);
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+fn cached_symbols_at_generation(
+    state: &SidecarState,
+    path: &str,
+    expected_generation: u64,
+) -> Result<Option<Vec<SymbolSnapshot>>, StatusCode> {
+    ensure_symbol_cache_generation(state, expected_generation)?;
+    let cache = state.symbol_cache.read();
+    if state.index.current_project_generation() != expected_generation {
+        drop(cache);
+        state.symbol_cache.write().clear();
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    Ok(cache.get(path).cloned())
+}
+
+fn store_cached_symbols_at_generation(
+    state: &SidecarState,
+    path: &str,
+    symbols: Vec<SymbolSnapshot>,
+    expected_generation: u64,
+) -> Result<(), StatusCode> {
+    ensure_symbol_cache_generation(state, expected_generation)?;
+    let mut cache = state.symbol_cache.write();
+    if state.index.current_project_generation() != expected_generation {
+        cache.clear();
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    cache.insert(path.to_string(), symbols);
+    if state.index.current_project_generation() == expected_generation {
+        Ok(())
+    } else {
+        cache.clear();
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
 /// `GET /outline?path=<relative>[&max_tokens=N]` — symbol outline for a single file.
 ///
 /// Returns formatted plain text with:
@@ -424,7 +617,10 @@ pub async fn outline_handler(
     State(state): State<SidecarState>,
     Query(params): Query<OutlineParams>,
 ) -> Result<String, StatusCode> {
-    outline_hook_text(&state, &params)
+    let fence = require_queryable_sidecar_index(&state)?;
+    let result = outline_hook_text(&state, &params, &fence);
+    capture_queryable_sidecar_generation(&state, &fence)?;
+    result
 }
 
 /// Workflow adapter for source-code reads/orientation.
@@ -452,8 +648,12 @@ pub(crate) fn outline_tool_text_for_generation(
     )
 }
 
-fn outline_hook_text(state: &SidecarState, params: &OutlineParams) -> Result<String, StatusCode> {
-    outline_text(state, params, HOOK_RENDER_OPTIONS)
+fn outline_hook_text(
+    state: &SidecarState,
+    params: &OutlineParams,
+    fence: &SidecarQueryFence,
+) -> Result<String, StatusCode> {
+    outline_text(state, params, HOOK_RENDER_OPTIONS, fence)
 }
 
 fn append_parse_status_lines(
@@ -520,9 +720,15 @@ fn outline_text(
     state: &SidecarState,
     params: &OutlineParams,
     options: RenderOptions,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
-    let source_authority = freshen_sidecar_path_if_stale(state, &params.path);
-    let published = state.index.published_generation();
+    let source_authority = freshen_sidecar_path_if_stale_at_generation(
+        state,
+        Some(fence.indexed_root.as_path()),
+        &params.path,
+        fence.project_generation,
+    )?;
+    let published = capture_queryable_sidecar_generation(state, fence)?;
     outline_text_for_generation(state, &published, params, options, source_authority)
 }
 
@@ -808,7 +1014,27 @@ pub async fn impact_handler(
     State(state): State<SidecarState>,
     Query(params): Query<ImpactParams>,
 ) -> Result<String, StatusCode> {
-    impact_hook_text(state, &params).await
+    let fence = require_queryable_sidecar_index(&state)?;
+    let impact_index = state.index.clone();
+    let _impact_guard = impact_index.lock_impact_analysis().await;
+    capture_queryable_sidecar_generation(&state, &fence)?;
+    let result = impact_hook_text(state.clone(), &params, &fence).await;
+    finish_impact_response_at_fence(&state, &fence, result)
+}
+
+fn finish_impact_response_at_fence(
+    state: &SidecarState,
+    fence: &SidecarQueryFence,
+    result: Result<String, StatusCode>,
+) -> Result<String, StatusCode> {
+    let response = result?;
+    // The impact operation has already committed its receipt-owned index,
+    // snapshot, cache, and stats effects. A later freshness-only transition
+    // gates the next request; it must not erase this useful response. Keep the
+    // final project/source/root fence so a concurrent project rebind still
+    // refuses cross-project output.
+    capture_sidecar_generation_at_fence(state, fence)?;
+    Ok(response)
 }
 
 /// Workflow adapter for post-edit impact summaries.
@@ -823,22 +1049,54 @@ pub(crate) async fn impact_tool_text(
     state: SidecarState,
     params: &ImpactParams,
 ) -> Result<String, StatusCode> {
-    impact_text(state, params, TOOL_RENDER_OPTIONS).await
+    let impact_index = state.index.clone();
+    let _impact_guard = impact_index.lock_impact_analysis().await;
+    let published = state.index.published_generation();
+    let expected_generation = published.project_generation;
+    let root = match published.live.indexed_root.clone() {
+        Some(root) => root,
+        None => resolve_repo_root(&state)?,
+    };
+    let result = impact_text(
+        state.clone(),
+        params,
+        TOOL_RENDER_OPTIONS,
+        root,
+        expected_generation,
+    )
+    .await;
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    result
 }
 
 async fn impact_hook_text(
     state: SidecarState,
     params: &ImpactParams,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
-    impact_text(state, params, HOOK_RENDER_OPTIONS).await
+    let root = fence.indexed_root.clone();
+    impact_text(
+        state,
+        params,
+        HOOK_RENDER_OPTIONS,
+        root,
+        fence.project_generation,
+    )
+    .await
 }
 
 async fn impact_text(
     state: SidecarState,
     params: &ImpactParams,
     options: RenderOptions,
+    root: std::path::PathBuf,
+    expected_generation: u64,
 ) -> Result<String, StatusCode> {
-    let root = resolve_repo_root(&state)?;
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
     let requested = std::path::Path::new(&params.path);
     let absolute = if requested.is_absolute() {
         requested.to_path_buf()
@@ -856,7 +1114,14 @@ async fn impact_text(
 
     if is_new_file {
         // HOOK-06: Index a new file from disk.
-        return handle_new_file_impact(state, &normalized_path, options).await;
+        return handle_new_file_impact(
+            state,
+            &root,
+            &normalized_path,
+            options,
+            expected_generation,
+        )
+        .await;
     }
 
     let should_auto_index_new_file = {
@@ -868,25 +1133,28 @@ async fn impact_text(
             let guard = state.index.read();
             guard.get_file(&normalized_path).is_some()
         };
-        is_supported
-            && !indexed
-            && resolve_repo_root(&state)
-                .map(|root| root.join(&normalized_path).is_file())
-                .unwrap_or(false)
+        is_supported && !indexed && root.join(&normalized_path).is_file()
     };
 
     if should_auto_index_new_file {
-        return handle_new_file_impact(state, &normalized_path, options).await;
+        return handle_new_file_impact(
+            state,
+            &root,
+            &normalized_path,
+            options,
+            expected_generation,
+        )
+        .await;
     }
 
     // HOOK-05: Re-index existing file and compute symbol diff.
-    handle_edit_impact(state, &normalized_path, options).await
+    handle_edit_impact(state, &root, &normalized_path, options, expected_generation).await
 }
 
-fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
+fn impact_skipped_text(published: &crate::live_index::PublishedGeneration, path: &str) -> String {
     use crate::domain::index::AdmissionTier;
 
-    let view = state.index.read().capture_admission_tier_lookup_view(path);
+    let view = published.live.capture_admission_tier_lookup_view(path);
     let Some(view) = view else {
         return format!(
             "Not indexed: {path} is excluded by repository scope. The admission gate applies to \
@@ -918,8 +1186,7 @@ fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
     // Key the recovery sentence on the read gate's predicted verdict (spec-023):
     // "Use get_file_content" must never point at a read the gate will refuse.
     let raw_read_advice =
-        if crate::protocol::read_gate::disk_read_would_refuse(&state.index.read(), path, view.size)
-        {
+        if crate::protocol::read_gate::disk_read_would_refuse(&published.live, path, view.size) {
             "Its contents are withheld by the admission policy — get_file_content will refuse \
          this file."
         } else {
@@ -934,7 +1201,7 @@ fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
         );
     }
 
-    let generation = state.index.current_project_generation();
+    let generation = published.project_generation;
     // Reconciled non-parser file: EXISTS in the catalog, analysis simply
     // unsupported. Report truthful existence + generation/Tier evidence and a
     // typed unsupported-analysis outcome — never false absence for a tracked file.
@@ -951,23 +1218,48 @@ fn impact_skipped_text(state: &SidecarState, path: &str) -> String {
 
 async fn handle_new_file_impact(
     state: SidecarState,
+    root: &std::path::Path,
     path: &str,
     options: RenderOptions,
+    expected_generation: u64,
 ) -> Result<String, StatusCode> {
-    let abs_path = resolve_repo_root(&state)?.join(path);
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let abs_path = root.join(path);
     let path_owned = path.to_string();
     let index = state.index.clone();
-    let expected_gen = index.current_project_generation();
-    let outcome = tokio::task::spawn_blocking(move || {
-        crate::watcher::admit_and_index_single_path(&path_owned, &abs_path, &index, expected_gen)
+    let receipt = tokio::task::spawn_blocking(move || {
+        crate::watcher::admit_and_index_single_path_with_receipt(
+            &path_owned,
+            &abs_path,
+            &index,
+            expected_generation,
+        )
     })
     .await
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    match outcome {
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    match &receipt.outcome {
         crate::watcher::ReindexResult::Reindexed | crate::watcher::ReindexResult::HashSkip => {}
-        crate::watcher::ReindexResult::Skipped => return Ok(impact_skipped_text(&state, path)),
+        crate::watcher::ReindexResult::Skipped => {
+            let published = receipt
+                .published
+                .as_deref()
+                .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+            return Ok(impact_skipped_text(published, path));
+        }
+        crate::watcher::ReindexResult::PublicationRejected => {
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
         crate::watcher::ReindexResult::NotFound | crate::watcher::ReindexResult::Removed => {
+            if state.index.publication_fence() != receipt.observed_at {
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
+            }
             return Err(StatusCode::NOT_FOUND);
         }
         crate::watcher::ReindexResult::ReadError(_) => {
@@ -980,13 +1272,29 @@ async fn handle_new_file_impact(
     // Build symbol kind breakdown.
     let mut kind_counts: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
-    let language = {
-        let index = state.index.read();
-        let file = index.get_file(path).ok_or(StatusCode::NOT_FOUND)?;
+    let published = receipt
+        .published
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    if published.project_generation != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let (language, post_symbols) = {
+        let file = published.live.get_file(path).ok_or(StatusCode::NOT_FOUND)?;
         for symbol in &file.symbols {
             *kind_counts.entry(symbol.kind.to_string()).or_insert(0) += 1;
         }
-        file.language
+        let symbols = file
+            .symbols
+            .iter()
+            .map(|symbol| SymbolSnapshot {
+                name: symbol.name.clone(),
+                kind: symbol.kind.to_string(),
+                line_range: symbol.line_range,
+                byte_range: symbol.byte_range,
+            })
+            .collect();
+        (file.language, symbols)
     };
 
     let mut kind_parts: Vec<String> = kind_counts
@@ -1000,11 +1308,19 @@ async fn handle_new_file_impact(
         kind_parts.join(", ")
     };
 
-    // Update symbol cache with empty pre-edit snapshot (it's new, no pre-state).
-    {
-        let mut cache = state.symbol_cache.write();
-        cache.insert(path.to_string(), Vec::new());
+    if receipt.snapshot_created {
+        let replacement = crate::live_index::store::PublicationFence::from_published(published);
+        let _ = state
+            .index
+            .take_pre_update_snapshot_for_publication_at_generation(
+                path,
+                expected_generation,
+                replacement,
+            );
     }
+    // The next edit must diff against the newly indexed file, not an empty
+    // baseline that would report every existing symbol as added.
+    store_cached_symbols_at_generation(&state, path, post_symbols, expected_generation)?;
 
     if options.record_stats {
         state.token_stats.record_write();
@@ -1058,121 +1374,146 @@ fn symbol_body_bytes_changed(
 }
 async fn handle_edit_impact(
     state: SidecarState,
+    root: &std::path::Path,
     path: &str,
     options: RenderOptions,
+    expected_generation: u64,
 ) -> Result<String, StatusCode> {
-    // Get pre-edit symbols and bytes: sidecar cache → index pre-update snapshot → current index.
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    // Get pre-edit symbols and bytes from the exact index-owned baseline first.
+    // The public symbols-only cache is a last-resort compatibility fallback: it
+    // cannot prove symbol-body identity, so it must never shadow available
+    // content from a pre-update snapshot or the current indexed file.
     //
     // The index pre-update snapshot (`take_pre_update_snapshot`) fixes a race
     // where the watcher re-indexes the file before this hook fires, causing the
     // current index to already contain post-edit symbols/content while the hook
     // still needs the pre-edit baseline for an accurate diff.
+    let pre_update = state
+        .index
+        .peek_pre_update_snapshot_at_generation(path, expected_generation);
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let pre_snapshot_replacement = pre_update.as_ref().map(|(_, replacement)| *replacement);
     let (pre_symbols, pre_content): (Vec<SymbolSnapshot>, Option<Vec<u8>>) = {
-        let cache = state.symbol_cache.read();
-        if let Some(cached) = cache.get(path) {
-            (cached.clone(), None)
+        if let Some((pre, _)) = pre_update {
+            let symbols = pre
+                .symbols
+                .into_iter()
+                .map(|s| SymbolSnapshot {
+                    name: s.name,
+                    kind: s.kind,
+                    line_range: s.line_range,
+                    byte_range: s.byte_range,
+                })
+                .collect();
+            (symbols, Some(pre.content))
+        } else if let Some(file) = state.index.read().get_file(path).cloned() {
+            let symbols = file
+                .symbols
+                .iter()
+                .map(|s| SymbolSnapshot {
+                    name: s.name.clone(),
+                    kind: s.kind.to_string(),
+                    line_range: s.line_range,
+                    byte_range: s.byte_range,
+                })
+                .collect();
+            (symbols, Some(file.content))
+        } else if let Some(cached) =
+            cached_symbols_at_generation(&state, path, expected_generation)?
+        {
+            (cached, None)
         } else {
-            drop(cache);
-            if let Some(pre) = state.index.take_pre_update_snapshot(path) {
-                let symbols = pre
-                    .symbols
-                    .into_iter()
-                    .map(|s| SymbolSnapshot {
-                        name: s.name,
-                        kind: s.kind,
-                        line_range: s.line_range,
-                        byte_range: s.byte_range,
-                    })
-                    .collect();
-                (symbols, Some(pre.content))
-            } else {
-                let guard = state.index.read();
-                if let Some(file) = guard.get_file(path) {
-                    let symbols = file
-                        .symbols
-                        .iter()
-                        .map(|s| SymbolSnapshot {
-                            name: s.name.clone(),
-                            kind: s.kind.to_string(),
-                            line_range: s.line_range,
-                            byte_range: s.byte_range,
-                        })
-                        .collect();
-                    (symbols, Some(file.content.clone()))
-                } else {
-                    (Vec::new(), None)
-                }
-            }
+            (Vec::new(), None)
         }
     };
 
     // File byte_len before re-indexing (content baseline comes from `pre_content` above).
     let file_bytes_pre: u64 = pre_content.as_ref().map_or(0, |b| b.len() as u64);
 
-    let abs_path = resolve_repo_root(&state)?.join(path);
+    let abs_path = root.join(path);
     let path_owned = path.to_string();
     let index = state.index.clone();
-    let expected_gen = index.current_project_generation();
-    let outcome = tokio::task::spawn_blocking(move || {
-        crate::watcher::admit_and_index_single_path(&path_owned, &abs_path, &index, expected_gen)
+    let receipt = tokio::task::spawn_blocking(move || {
+        crate::watcher::admit_and_index_single_path_with_receipt(
+            &path_owned,
+            &abs_path,
+            &index,
+            expected_generation,
+        )
     })
     .await
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    match outcome {
+    if state.index.current_project_generation() != expected_generation {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    match &receipt.outcome {
         crate::watcher::ReindexResult::Reindexed | crate::watcher::ReindexResult::HashSkip => {}
-        crate::watcher::ReindexResult::Skipped => return Ok(impact_skipped_text(&state, path)),
+        crate::watcher::ReindexResult::Skipped => {
+            let published = receipt
+                .published
+                .as_deref()
+                .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+            return Ok(impact_skipped_text(published, path));
+        }
+        crate::watcher::ReindexResult::PublicationRejected => {
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
         crate::watcher::ReindexResult::ReadError(_) => {
             return Ok(format!(
                 "── Impact: {path} ──\nStatus: temporarily unreadable — last-valid state retained"
             ));
         }
         crate::watcher::ReindexResult::NotFound | crate::watcher::ReindexResult::Removed => {
-            // File not on disk — remove it from the index so stale data is purged.
-            let prev_symbol_count = pre_symbols.len();
-            state.index.remove_file_at_generation(path, expected_gen);
-            // Also clear the symbol cache entry.
-            {
-                let mut cache = state.symbol_cache.write();
-                cache.remove(path);
+            if state.index.publication_fence() != receipt.observed_at {
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
             }
-            // Dogfood #6 (2026-07-06): ALWAYS name the root the lookup ran
-            // against. When another session retargets the shared daemon
-            // (index_folder on a different project), every path from THIS
-            // session resolves against the wrong root and this branch fires
-            // for files that exist — a bare "not found" reads as a false
-            // alarm; naming the root exposes the mismatch immediately.
-            let root_display = resolve_repo_root(&state)
-                .map(|r| r.display().to_string())
-                .unwrap_or_else(|_| "<unresolved root>".to_string());
-            let text = if prev_symbol_count > 0 {
-                format!(
-                    "── Impact: {} ──\nStatus: not found under {} — removed from index\nPreviously had {} symbols.",
-                    path, root_display, prev_symbol_count
+            // One latency-bounded observation cannot distinguish a durable
+            // deletion from delete→recreate disk ABA. Retain last-valid state;
+            // the watcher retry/reconciliation path owns confirmed removal.
+            let prev_symbol_count = pre_symbols.len();
+            let root_display = root.display().to_string();
+            let has_index_record = state.index.read().get_file(path).is_some();
+            let (status, detail) = if has_index_record {
+                (
+                    "last-valid index state retained pending watcher confirmation",
+                    format!("Previously indexed symbols: {prev_symbol_count}."),
                 )
             } else {
-                // The file-watcher may have already purged the index entry
-                // between the on-disk delete and this call; in that case we
-                // have no pre-count to report, so say so plainly instead of
-                // printing a misleading `Previously had 0 symbols.`.
-                format!(
-                    "── Impact: {} ──\nStatus: not found under {} — no index record remains (removed by watcher, \
-                     or this daemon is rooted at a different project than your session; \
-                     re-run index_folder on your repo if the root looks wrong).",
-                    path, root_display
+                (
+                    "no index record remains; watcher confirmation pending",
+                    "No prior symbol count was observed.".to_string(),
                 )
             };
-            return Ok(text);
+            return Ok(format!(
+                "── Impact: {path} ──\nStatus: not found under {root_display} — {status}\n{detail}"
+            ));
         }
     }
 
-    // The shared publication seam captures its own pre-update snapshot. This
-    // handler already captured the authoritative baseline above, so drain the
-    // duplicate before it can leak into a later impact call.
-    let _ = state.index.take_pre_update_snapshot(path);
+    // Use the immutable generation returned by this request's winning
+    // publication seam. Sampling current state here could accidentally adopt a
+    // later watcher update and consume that update's snapshot.
+    let post_generation = receipt
+        .published
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    if post_generation.project_generation != expected_generation
+        || state.index.current_project_generation() != expected_generation
+    {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
     let (post_symbols, post_content) = {
-        let index = state.index.read();
-        let file = index.get_file(path).ok_or(StatusCode::NOT_FOUND)?;
+        let file = post_generation
+            .live
+            .get_file(path)
+            .ok_or(StatusCode::NOT_FOUND)?;
         let symbols: Vec<SymbolSnapshot> = file
             .symbols
             .iter()
@@ -1185,6 +1526,27 @@ async fn handle_edit_impact(
             .collect();
         (symbols, file.content.clone())
     };
+    if receipt.snapshot_created {
+        let replacement =
+            crate::live_index::store::PublicationFence::from_published(post_generation);
+        let _ = state
+            .index
+            .take_pre_update_snapshot_for_publication_at_generation(
+                path,
+                expected_generation,
+                replacement,
+            );
+    } else if matches!(receipt.outcome, crate::watcher::ReindexResult::HashSkip)
+        && let Some(replacement) = pre_snapshot_replacement
+    {
+        let _ = state
+            .index
+            .take_pre_update_snapshot_for_publication_at_generation(
+                path,
+                expected_generation,
+                replacement,
+            );
+    }
     let file_bytes: u64 = (post_content.len() as u64).max(file_bytes_pre);
 
     // Compute symbol diff using positional proximity for duplicate name+kind pairs.
@@ -1229,10 +1591,7 @@ async fn handle_edit_impact(
     let changed: Vec<&SymbolSnapshot> = changed_post.iter().map(|&i| &post_symbols[i]).collect();
 
     // Update cache with post-edit snapshot.
-    {
-        let mut cache = state.symbol_cache.write();
-        cache.insert(path.to_string(), post_symbols.clone());
-    }
+    store_cached_symbols_at_generation(&state, path, post_symbols.clone(), expected_generation)?;
 
     // Build response lines.
     let mut lines: Vec<String> = Vec::new();
@@ -1272,7 +1631,7 @@ async fn handle_edit_impact(
         let impacted: Vec<&SymbolSnapshot> =
             changed.iter().chain(removed.iter()).copied().collect();
         if !impacted.is_empty() {
-            let guard = state.index.read();
+            let guard = post_generation.live.as_ref();
             let post_file = guard.get_file(path);
             let mut callers_lines: Vec<String> = Vec::new();
             for sym in &impacted {
@@ -1318,7 +1677,6 @@ async fn handle_edit_impact(
                     }
                 }
             }
-            drop(guard);
             if !callers_lines.is_empty() {
                 lines.push(String::new());
                 lines.push("Callers to review:".to_string());
@@ -1355,7 +1713,10 @@ pub async fn symbol_context_handler(
     State(state): State<SidecarState>,
     Query(params): Query<SymbolContextParams>,
 ) -> Result<String, StatusCode> {
-    symbol_context_hook_text(&state, &params)
+    let fence = require_queryable_sidecar_index(&state)?;
+    let result = symbol_context_hook_text(&state, &params, &fence);
+    capture_queryable_sidecar_generation(&state, &fence)?;
+    result
 }
 
 /// Workflow adapter for search-hit expansion and quick caller/context reads.
@@ -1383,23 +1744,35 @@ pub(crate) fn symbol_context_tool_text_for_generation(
 fn symbol_context_hook_text(
     state: &SidecarState,
     params: &SymbolContextParams,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
-    symbol_context_text(state, params, HOOK_RENDER_OPTIONS)
+    symbol_context_text(state, params, HOOK_RENDER_OPTIONS, fence)
 }
 
 fn symbol_context_text(
     state: &SidecarState,
     params: &SymbolContextParams,
     options: RenderOptions,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
     let source_authority = if let Some(path) = params.path.as_deref() {
-        freshen_sidecar_path_if_stale(state, path)
+        freshen_sidecar_path_if_stale_at_generation(
+            state,
+            Some(fence.indexed_root.as_path()),
+            path,
+            fence.project_generation,
+        )?
     } else if let Some(file) = params.file.as_deref() {
-        freshen_sidecar_path_if_stale(state, file)
+        freshen_sidecar_path_if_stale_at_generation(
+            state,
+            Some(fence.indexed_root.as_path()),
+            file,
+            fence.project_generation,
+        )?
     } else {
         ContextSourceAuthority::CurrentIndex
     };
-    let published = state.index.published_generation();
+    let published = capture_queryable_sidecar_generation(state, fence)?;
     symbol_context_text_for_generation(state, &published, params, options, source_authority)
 }
 
@@ -1660,7 +2033,10 @@ fn symbol_context_text_for_generation(
 ///
 /// Budget: 500 tokens (2000 bytes). No token savings recorded (additive, not replacement).
 pub async fn repo_map_handler(State(state): State<SidecarState>) -> Result<String, StatusCode> {
-    repo_map_text(&state)
+    let fence = require_queryable_sidecar_index(&state)?;
+    let result = repo_map_text(&state, &fence);
+    capture_queryable_sidecar_generation(&state, &fence)?;
+    result
 }
 
 /// Workflow adapter for repo-start quick maps.
@@ -1691,8 +2067,8 @@ fn is_intra_workspace_path(path: &str) -> bool {
         .split('/')
         .any(|segment| segment == "..")
 }
-pub(crate) fn repo_map_text(state: &SidecarState) -> Result<String, StatusCode> {
-    let generation = state.index.published_source_set().current_generation();
+fn repo_map_text(state: &SidecarState, fence: &SidecarQueryFence) -> Result<String, StatusCode> {
+    let generation = capture_queryable_sidecar_generation(state, fence)?;
     repo_map_text_for_generation(&generation)
 }
 
@@ -1906,7 +2282,10 @@ pub async fn prompt_context_handler(
     State(state): State<SidecarState>,
     Query(params): Query<PromptContextParams>,
 ) -> Result<String, StatusCode> {
-    prompt_context_hook_text(&state, &params).await
+    let fence = require_queryable_sidecar_index(&state)?;
+    let result = prompt_context_hook_text(&state, &params, &fence).await;
+    capture_queryable_sidecar_generation(&state, &fence)?;
+    result
 }
 
 /// Workflow adapter for prompt-context narrowing.
@@ -1920,21 +2299,24 @@ pub async fn workflow_prompt_narrowing_handler(
 async fn prompt_context_hook_text(
     state: &SidecarState,
     params: &PromptContextParams,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
-    prompt_context_text(state, params, HOOK_RENDER_OPTIONS).await
+    prompt_context_text(state, params, HOOK_RENDER_OPTIONS, fence).await
 }
 
 async fn prompt_context_text(
     state: &SidecarState,
     params: &PromptContextParams,
     options: RenderOptions,
+    fence: &SidecarQueryFence,
 ) -> Result<String, StatusCode> {
     let prompt = params.text.trim();
     if prompt.is_empty() {
         return Ok(String::new());
     }
+    let hint_generation = capture_queryable_sidecar_generation(state, fence)?;
 
-    if let Some(symbol_hint) = find_prompt_qualified_symbol_hint(state, prompt)? {
+    if let Some(symbol_hint) = find_prompt_qualified_symbol_hint(&hint_generation, prompt)? {
         let line_hint = find_prompt_line_hint(prompt, Some(&symbol_hint.file_hint));
         let body = symbol_context_text(
             state,
@@ -1946,13 +2328,14 @@ async fn prompt_context_text(
                 symbol_line: line_hint,
             },
             options,
+            fence,
         )?;
         let (level, evidence) = describe_file_hint(&symbol_hint.file_hint);
         return Ok(format_prompt_context_signal(level, evidence, body));
     }
 
-    let file_hint = find_prompt_file_hint(state, prompt)?;
-    let symbol_hint = find_prompt_symbol_hint(state, prompt)?;
+    let file_hint = find_prompt_file_hint(&hint_generation, prompt)?;
+    let symbol_hint = find_prompt_symbol_hint(&hint_generation, prompt)?;
     let line_hint = find_prompt_line_hint(prompt, file_hint.as_ref());
 
     match (file_hint, symbol_hint) {
@@ -1974,8 +2357,13 @@ async fn prompt_context_text(
             // the file under several candidates, and the existing rendering
             // already reports that usefully -- so this guard must use the same
             // resolver the renderer does, not a looser name comparison.
-            let source_authority = freshen_sidecar_path_if_stale(state, &file_hint.path);
-            let published = state.index.published_generation();
+            let source_authority = freshen_sidecar_path_if_stale_at_generation(
+                state,
+                Some(fence.indexed_root.as_path()),
+                &file_hint.path,
+                fence.project_generation,
+            )?;
+            let published = capture_queryable_sidecar_generation(state, fence)?;
             let symbol_is_in_file = published
                 .live
                 .as_ref()
@@ -2017,6 +2405,7 @@ async fn prompt_context_text(
                     sections: None,
                 },
                 options,
+                fence,
             )?;
             let (level, evidence) = describe_file_hint(&file_hint);
             return Ok(format_prompt_context_signal(level, evidence, body));
@@ -2030,6 +2419,7 @@ async fn prompt_context_text(
                     sections: None,
                 },
                 options,
+                fence,
             )?;
             let (level, evidence) = describe_file_hint(&file_hint);
             return Ok(format_prompt_context_signal(level, evidence, body));
@@ -2047,7 +2437,7 @@ async fn prompt_context_text(
     }
 
     if prompt_requests_repo_map(prompt) {
-        let body = repo_map_text(state)?;
+        let body = repo_map_text_for_generation(&hint_generation)?;
         return Ok(format_prompt_context_signal(
             "high-confidence",
             "repo-map request phrase matched in the prompt",
@@ -2088,10 +2478,10 @@ fn get_dir_2level(path: &str) -> String {
 }
 
 fn find_prompt_file_hint(
-    state: &SidecarState,
+    generation: &crate::live_index::PublishedGeneration,
     prompt: &str,
 ) -> Result<Option<PromptFileHint>, StatusCode> {
-    let guard = state.index.read();
+    let guard = generation.live.as_ref();
     let prompt_lower = prompt.to_ascii_lowercase();
     let mut module_match: Option<PromptFileHint> = None;
     let mut module_ambiguous = false;
@@ -2207,10 +2597,10 @@ fn find_prompt_file_hint(
 }
 
 fn find_prompt_qualified_symbol_hint(
-    state: &SidecarState,
+    generation: &crate::live_index::PublishedGeneration,
     prompt: &str,
 ) -> Result<Option<PromptQualifiedSymbolHint>, StatusCode> {
-    let guard = state.index.read();
+    let guard = generation.live.as_ref();
     let mut qualified_symbol_match: Option<PromptQualifiedSymbolHint> = None;
     let mut qualified_symbol_ambiguous = false;
 
@@ -2290,10 +2680,10 @@ fn is_distinctive_symbol_token(token: &str) -> bool {
     token.len() >= 4 && !PROMPT_NOISE_WORDS.contains(&token)
 }
 fn find_prompt_symbol_hint(
-    state: &SidecarState,
+    generation: &crate::live_index::PublishedGeneration,
     prompt: &str,
 ) -> Result<Option<String>, StatusCode> {
-    let guard = state.index.read();
+    let guard = generation.live.as_ref();
     for token in prompt_tokens(prompt) {
         // Path- and module-qualified mentions are served by the dedicated file
         // and qualified-symbol hints; this bare-token branch only handles plain
@@ -2582,13 +2972,17 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use std::time::{Duration, Instant, SystemTime};
 
+    use once_cell::sync::Lazy;
     use parking_lot::RwLock;
+    use tempfile::TempDir;
 
     use crate::domain::{LanguageId, ReferenceKind, ReferenceRecord, SymbolKind, SymbolRecord};
-    use crate::live_index::store::{CircuitBreakerState, IndexedFile, LiveIndex, ParseStatus};
+    use crate::live_index::store::{IndexedFile, LiveIndex, ParseStatus};
     use crate::sidecar::{SidecarState, SymbolSnapshot, TokenStats};
+
+    static GENERIC_TEST_ROOT: Lazy<TempDir> =
+        Lazy::new(|| TempDir::new().expect("create generic sidecar handler test root"));
 
     // -----------------------------------------------------------------------
     // Test helper: minimal LiveIndex with known contents
@@ -2758,42 +3152,40 @@ mod tests {
     }
 
     fn build_shared_index(
+        root: &std::path::Path,
         files: Vec<(&str, IndexedFile)>,
     ) -> crate::live_index::store::SharedIndex {
-        use crate::live_index::trigram::TrigramIndex;
-        let files_map: HashMap<String, std::sync::Arc<IndexedFile>> = files
-            .into_iter()
-            .map(|(p, f)| (p.to_string(), std::sync::Arc::new(f)))
-            .collect();
-        let trigram_index = TrigramIndex::build_from_files(&files_map);
-        let mut index = LiveIndex {
-            files: files_map,
-            loaded_at: Instant::now(),
-            loaded_at_system: SystemTime::now(),
-            load_duration: Duration::from_millis(10),
-            cb_state: CircuitBreakerState::new(0.20),
-            is_empty: false,
-            load_source: crate::live_index::store::IndexLoadSource::FreshLoad,
-            snapshot_verify_state: crate::live_index::store::SnapshotVerifyState::NotNeeded,
-            reverse_index: HashMap::new(),
-            files_by_basename: HashMap::new(),
-            files_by_dir_component: HashMap::new(),
-            trigram_index,
-            gitignore: None,
-            manifest_entries: Vec::new(),
-            coupling_store: None,
-            local_empty_reason: std::sync::Arc::new(parking_lot::RwLock::new(None)),
-            indexed_root: None,
-        };
-        index.rebuild_reverse_index();
-        index.rebuild_path_indices();
-        crate::live_index::SharedIndexHandle::shared(index)
+        LiveIndex::from_indexed_files(
+            root,
+            files
+                .into_iter()
+                .map(|(path, file)| (path.to_string(), file))
+                .collect(),
+        )
+        .expect("sidecar handler test root resolves")
     }
 
     /// Build a SidecarState wrapping a SharedIndex for use in tests.
     fn make_state(files: Vec<(&str, IndexedFile)>) -> SidecarState {
+        let root = GENERIC_TEST_ROOT.path().to_path_buf();
         SidecarState {
-            index: build_shared_index(files),
+            index: build_shared_index(&root, files),
+            token_stats: TokenStats::new(),
+            repo_root: None,
+            symbol_cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn make_bootstrap_placeholder_state(files: Vec<(&str, IndexedFile)>) -> SidecarState {
+        let index = LiveIndex::empty();
+        {
+            let mut guard = index.write();
+            for (path, file) in files {
+                guard.add_file(path.to_string(), file);
+            }
+        }
+        SidecarState {
+            index,
             token_stats: TokenStats::new(),
             repo_root: None,
             symbol_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -2805,7 +3197,7 @@ mod tests {
         repo_root: std::path::PathBuf,
     ) -> SidecarState {
         SidecarState {
-            index: build_shared_index(files),
+            index: build_shared_index(&repo_root, files),
             token_stats: TokenStats::new(),
             repo_root: Some(repo_root),
             symbol_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -2831,14 +3223,199 @@ mod tests {
             symbol_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
-        let source_authority =
-            freshen_sidecar_path_if_stale_at_generation(&state, "src/b.rs", stale_gen);
+        let source_authority = freshen_sidecar_path_if_stale_at_generation(
+            &state,
+            state.repo_root.as_deref(),
+            "src/b.rs",
+            stale_gen,
+        )
+        .unwrap();
 
         assert!(matches!(
             source_authority,
             ContextSourceAuthority::CurrentIndex
         ));
         assert!(state.index.read().get_file("src/b.rs").is_some());
+    }
+
+    #[test]
+    fn stale_impact_generation_cannot_consume_or_overwrite_rebound_project_state() {
+        let project_a = tempfile::tempdir().unwrap();
+        let project_b = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(project_a.path().join("src")).unwrap();
+        std::fs::create_dir_all(project_b.path().join("src")).unwrap();
+        std::fs::write(
+            project_b.path().join("src/shared.rs"),
+            "pub fn project_b() {}\n",
+        )
+        .unwrap();
+
+        let initial = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("project_a", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let state = make_state_with_root(
+            vec![("src/shared.rs", initial)],
+            project_a.path().to_path_buf(),
+        );
+        let stale_generation = state.index.current_project_generation();
+
+        // Seed an A-generation pre-update snapshot, then prove the project
+        // retarget clears it before B can publish any path-identical state.
+        let replacement_a = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("project_a_next", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        assert!(state.index.update_file_at_generation(
+            "src/shared.rs",
+            replacement_a,
+            stale_generation,
+        ));
+        state.index.reload(project_b.path()).unwrap();
+        let current_generation = state.index.current_project_generation();
+        assert_ne!(current_generation, stale_generation);
+        assert!(
+            state
+                .index
+                .take_pre_update_snapshot_at_generation("src/shared.rs", current_generation)
+                .is_none(),
+            "retarget must discard the previous project's path-keyed snapshot"
+        );
+
+        // Publish a B-generation update so both the shared pre-update snapshot
+        // and the sidecar-local cache contain replacement-project evidence.
+        let replacement_b = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("project_b_next", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        assert!(state.index.update_file_at_generation(
+            "src/shared.rs",
+            replacement_b,
+            current_generation,
+        ));
+        let project_b_cache = vec![SymbolSnapshot {
+            name: "project_b".to_string(),
+            kind: SymbolKind::Function.to_string(),
+            line_range: (1, 2),
+            byte_range: (0, 10),
+        }];
+        store_cached_symbols_at_generation(
+            &state,
+            "src/shared.rs",
+            project_b_cache.clone(),
+            current_generation,
+        )
+        .unwrap();
+
+        assert_eq!(
+            cached_symbols_at_generation(&state, "src/shared.rs", stale_generation),
+            Err(StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(
+            store_cached_symbols_at_generation(
+                &state,
+                "src/shared.rs",
+                vec![SymbolSnapshot {
+                    name: "stale_project_a".to_string(),
+                    kind: SymbolKind::Function.to_string(),
+                    line_range: (1, 2),
+                    byte_range: (0, 10),
+                }],
+                stale_generation,
+            ),
+            Err(StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert!(
+            state
+                .index
+                .take_pre_update_snapshot_at_generation("src/shared.rs", stale_generation)
+                .is_none(),
+            "a stale impact request must not consume B's pre-update snapshot"
+        );
+
+        assert_eq!(
+            cached_symbols_at_generation(&state, "src/shared.rs", current_generation).unwrap(),
+            Some(project_b_cache)
+        );
+        let project_b_snapshot = state
+            .index
+            .take_pre_update_snapshot_at_generation("src/shared.rs", current_generation)
+            .expect("B's snapshot must remain available to the current generation");
+        assert!(
+            project_b_snapshot
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "project_b"),
+            "the preserved snapshot must belong to project B"
+        );
+    }
+
+    #[test]
+    fn publication_bound_snapshot_take_preserves_same_hash_aba_update() {
+        let mut first = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("alpha", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        first.content_hash = "hash-alpha".to_string();
+        let state = make_state(vec![("src/shared.rs", first)]);
+        let generation = state.index.current_project_generation();
+
+        let mut second = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("beta", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        second.content_hash = "hash-aba".to_string();
+        assert!(
+            state
+                .index
+                .update_file_at_generation("src/shared.rs", second, generation)
+        );
+        let second_fence = state.index.publication_fence();
+
+        let mut third = make_indexed_file(
+            "src/shared.rs",
+            vec![make_symbol("gamma", SymbolKind::Function, 1, 2)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        third.content_hash = "hash-aba".to_string();
+        assert!(
+            state
+                .index
+                .update_file_at_generation("src/shared.rs", third, generation)
+        );
+        let third_fence = state.index.publication_fence();
+
+        assert!(
+            state
+                .index
+                .take_pre_update_snapshot_for_publication_at_generation(
+                    "src/shared.rs",
+                    generation,
+                    second_fence,
+                )
+                .is_none(),
+            "an older receipt must not drain a newer same-hash replacement's baseline"
+        );
+        let latest = state
+            .index
+            .take_pre_update_snapshot_for_publication_at_generation(
+                "src/shared.rs",
+                generation,
+                third_fence,
+            )
+            .expect("the latest replacement must retain its own baseline");
+        assert!(latest.symbols.iter().any(|symbol| symbol.name == "beta"));
     }
 
     // -----------------------------------------------------------------------
@@ -2881,6 +3458,327 @@ mod tests {
         let body = result.0;
         assert_eq!(body.file_count, 0);
         assert_eq!(body.symbol_count, 0);
+    }
+
+    #[test]
+    fn sidecar_queryability_requires_status_source_and_root_independently() {
+        let file = make_indexed_file(
+            "src/foo.rs",
+            vec![make_symbol("alpha", SymbolKind::Function, 1, 5)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let state = make_state(vec![("src/foo.rs", file)]);
+        let base = state.index.published_generation();
+        assert!(base.source.is_some());
+        assert!(base.live.indexed_root.is_some());
+
+        let variant = |status, source_bound: bool, root_bound: bool| {
+            let mut health = (*base.health).clone();
+            health.status = status;
+            let mut live = (*base.live).clone();
+            if !root_bound {
+                live.indexed_root = None;
+            }
+            crate::live_index::PublishedGeneration {
+                publication_generation: base.publication_generation,
+                content_generation: base.content_generation,
+                project_generation: base.project_generation,
+                source: source_bound.then(|| Arc::clone(base.source.as_ref().unwrap())),
+                source_version: base.source_version.clone(),
+                freshness: Arc::clone(&base.freshness),
+                manifest: base.manifest.clone(),
+                code_signals: Arc::clone(&base.code_signals),
+                bridge: Arc::clone(&base.bridge),
+                authority: Arc::clone(&base.authority),
+                live: Arc::new(live),
+                health: Arc::new(health),
+                outline: Arc::clone(&base.outline),
+            }
+        };
+
+        use crate::live_index::PublishedIndexStatus::{Empty, Loading, Ready};
+        assert!(published_sidecar_index_is_queryable(&variant(
+            Ready, true, true
+        )));
+        assert!(published_sidecar_index_is_queryable(&variant(
+            Empty, true, true
+        )));
+        assert!(!published_sidecar_index_is_queryable(&variant(
+            Loading, true, true
+        )));
+        assert!(!published_sidecar_index_is_queryable(&variant(
+            Ready, false, true
+        )));
+        assert!(!published_sidecar_index_is_queryable(&variant(
+            Ready, true, false
+        )));
+        let mut freshness_degraded = variant(Ready, true, true);
+        freshness_degraded.freshness = Arc::new(crate::domain::FreshnessStatus::Degraded {
+            last_valid_content_generation: base.content_generation,
+            reason_codes: vec![crate::domain::FreshnessReason::ObservationFailed],
+        });
+        assert!(
+            !published_sidecar_index_is_queryable(&freshness_degraded),
+            "a retained Ready health view with degraded freshness must refuse"
+        );
+        let mut freshness_verifying_ready = variant(Ready, true, true);
+        freshness_verifying_ready.freshness = Arc::new(crate::domain::FreshnessStatus::Verifying);
+        assert!(
+            !published_sidecar_index_is_queryable(&freshness_verifying_ready),
+            "a non-empty index still being verified must refuse"
+        );
+        let mut freshness_verifying_empty = variant(Empty, true, true);
+        freshness_verifying_empty.freshness = Arc::new(crate::domain::FreshnessStatus::Verifying);
+        assert!(
+            published_sidecar_index_is_queryable(&freshness_verifying_empty),
+            "a source-bound rooted empty repository is a terminal queryable state"
+        );
+        let mut snapshot_verifying_empty = freshness_verifying_empty;
+        let mut snapshot_health = (*snapshot_verifying_empty.health).clone();
+        snapshot_health.snapshot_verify_state = crate::live_index::SnapshotVerifyState::Pending;
+        snapshot_verifying_empty.health = Arc::new(snapshot_health);
+        assert!(
+            !published_sidecar_index_is_queryable(&snapshot_verifying_empty),
+            "an empty snapshot still being verified cannot authorize absence claims"
+        );
+    }
+
+    #[test]
+    fn post_impact_fence_preserves_response_across_freshness_only_transition() {
+        let file = make_indexed_file(
+            "src/foo.rs",
+            vec![make_symbol("alpha", SymbolKind::Function, 1, 5)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let state = make_state(vec![("src/foo.rs", file)]);
+        let fence = require_queryable_sidecar_index(&state).expect("ready sidecar fence");
+        let last_valid_content_generation = state.index.published_generation().content_generation;
+
+        state
+            .index
+            .set_freshness_status(crate::domain::FreshnessStatus::Degraded {
+                last_valid_content_generation,
+                reason_codes: vec![crate::domain::FreshnessReason::ObservationFailed],
+            });
+
+        let gated_error = capture_queryable_sidecar_generation(&state, &fence)
+            .err()
+            .expect("degraded freshness must gate a new read");
+        assert_eq!(gated_error, StatusCode::SERVICE_UNAVAILABLE);
+        let response = finish_impact_response_at_fence(
+            &state,
+            &fence,
+            Ok("committed impact response".to_string()),
+        )
+        .expect("freshness alone must not erase a committed impact response");
+        assert_eq!(response, "committed impact response");
+
+        let rebound = tempfile::tempdir().unwrap();
+        std::fs::write(rebound.path().join("lib.rs"), "pub fn rebound() {}\n").unwrap();
+        state.index.reload(rebound.path()).unwrap();
+        assert_eq!(
+            finish_impact_response_at_fence(
+                &state,
+                &fence,
+                Ok("cross-project response".to_string()),
+            )
+            .expect_err("a project rebind must still reject the old response"),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[tokio::test]
+    async fn read_handlers_refuse_bootstrap_placeholder() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/new.rs"), "pub fn newly_added() {}\n").unwrap();
+        let file = make_indexed_file(
+            "src/foo.rs",
+            vec![make_symbol("alpha", SymbolKind::Function, 1, 5)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let mut state = make_bootstrap_placeholder_state(vec![("src/foo.rs", file)]);
+        state.repo_root = Some(repo.path().to_path_buf());
+        let generation_before = state.index.current_project_generation();
+        let replacement = make_indexed_file(
+            "src/foo.rs",
+            vec![make_symbol("beta", SymbolKind::Function, 1, 5)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        assert!(state.index.update_file_at_generation(
+            "src/foo.rs",
+            replacement,
+            generation_before,
+        ));
+        let seeded_cache = vec![SymbolSnapshot {
+            name: "cached_alpha".to_string(),
+            kind: SymbolKind::Function.to_string(),
+            line_range: (1, 5),
+            byte_range: (0, 10),
+        }];
+        store_cached_symbols_at_generation(&state, "src/foo.rs", seeded_cache, generation_before)
+            .unwrap();
+        let cache_before = state.symbol_cache.read().clone();
+        let published_before = state.index.published_generation();
+        let published = state.index.published_state();
+        assert!(matches!(
+            published.status,
+            crate::live_index::PublishedIndexStatus::Loading
+        ));
+        assert_eq!(published.file_count, 1);
+        assert!(state.index.read().get_file("src/foo.rs").is_some());
+        let write_fires_before = state
+            .token_stats
+            .write_fires
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let edit_fires_before = state
+            .token_stats
+            .edit_fires
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        let outline_error = outline_handler(
+            State(state.clone()),
+            Query(OutlineParams {
+                path: "src/foo.rs".to_string(),
+                max_tokens: None,
+                sections: None,
+            }),
+        )
+        .await
+        .expect_err("/outline must refuse an unready bootstrap placeholder");
+        assert_eq!(outline_error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let impact_error = impact_handler(
+            State(state.clone()),
+            Query(ImpactParams {
+                path: "src/foo.rs".to_string(),
+                new_file: Some(false),
+            }),
+        )
+        .await
+        .expect_err("/impact must refuse an unready bootstrap placeholder");
+        assert_eq!(impact_error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let new_file_impact_error = impact_handler(
+            State(state.clone()),
+            Query(ImpactParams {
+                path: "src/new.rs".to_string(),
+                new_file: Some(true),
+            }),
+        )
+        .await
+        .expect_err("/impact?new_file=true must refuse before admitting into a placeholder");
+        assert_eq!(new_file_impact_error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let symbol_error = symbol_context_handler(
+            State(state.clone()),
+            Query(SymbolContextParams {
+                name: "alpha".to_string(),
+                file: None,
+                path: None,
+                symbol_kind: None,
+                symbol_line: None,
+            }),
+        )
+        .await
+        .expect_err("/symbol-context must refuse an unready bootstrap placeholder");
+        assert_eq!(symbol_error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let repo_map_error = repo_map_handler(State(state.clone()))
+            .await
+            .expect_err("/repo-map must refuse an unready bootstrap placeholder");
+        assert_eq!(repo_map_error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let prompt_error = prompt_context_handler(
+            State(state.clone()),
+            Query(PromptContextParams {
+                text: "alpha".to_string(),
+            }),
+        )
+        .await
+        .expect_err("the prompt hint must refuse an unready bootstrap placeholder");
+        assert_eq!(prompt_error, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(state.index.current_project_generation(), generation_before);
+        let published_after = state.index.published_generation();
+        assert_eq!(
+            published_after.publication_generation,
+            published_before.publication_generation
+        );
+        assert_eq!(
+            published_after.content_generation,
+            published_before.content_generation
+        );
+        assert_eq!(published_after.health.file_count, 1);
+        assert!(state.index.read().get_file("src/new.rs").is_none());
+        assert_eq!(&*state.symbol_cache.read(), &cache_before);
+        let preserved_snapshot = state
+            .index
+            .take_pre_update_snapshot_at_generation("src/foo.rs", generation_before)
+            .expect("loading refusal must preserve the pre-update snapshot");
+        assert!(
+            preserved_snapshot
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "alpha")
+        );
+        assert_eq!(
+            state
+                .token_stats
+                .write_fires
+                .load(std::sync::atomic::Ordering::Relaxed),
+            write_fires_before
+        );
+        assert_eq!(
+            state
+                .token_stats
+                .edit_fires
+                .load(std::sync::atomic::Ordering::Relaxed),
+            edit_fires_before
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_but_source_unbound_index_is_not_queryable_by_sidecar() {
+        let file = make_indexed_file(
+            "src/foo.rs",
+            vec![make_symbol("alpha", SymbolKind::Function, 1, 5)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let mut files = HashMap::new();
+        files.insert("src/foo.rs".to_string(), Arc::new(file));
+        let index = crate::live_index::store::SharedIndexHandle::shared(
+            LiveIndex::from_source_files(files),
+        );
+        let published = index.published_generation();
+        assert!(matches!(
+            published.health.status,
+            crate::live_index::PublishedIndexStatus::Ready
+        ));
+        assert!(published.source.is_none());
+        assert!(published.live.indexed_root.is_none());
+
+        let state = SidecarState {
+            index,
+            token_stats: TokenStats::new(),
+            repo_root: None,
+            symbol_cache: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let error = outline_handler(
+            State(state),
+            Query(OutlineParams {
+                path: "src/foo.rs".to_string(),
+                max_tokens: None,
+                sections: None,
+            }),
+        )
+        .await
+        .expect_err("a Ready label cannot authorize a source-unbound index");
+        assert_eq!(error, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     // -----------------------------------------------------------------------
@@ -3063,11 +3961,79 @@ mod tests {
         };
 
         // The handler uses cwd.join(path), so with abs path it resolves correctly.
-        let result = impact_handler(State(state), Query(params)).await;
+        let result = impact_handler(State(state.clone()), Query(params)).await;
         // It may fail if the extension detection doesn't work for absolute paths, but
         // the basic test is that it doesn't panic.
         // The result depends on file system state.
         let _ = result; // just verify no panic
+    }
+
+    #[tokio::test]
+    async fn impact_entry_points_share_the_index_single_flight_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/db.rs"), "pub fn connect() {}\n").unwrap();
+        let file = make_indexed_file(
+            "src/db.rs",
+            vec![make_symbol("connect", SymbolKind::Function, 1, 1)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        let state = make_state_with_root(vec![("src/db.rs", file)], tmp.path().to_path_buf());
+
+        let held = state.index.lock_impact_analysis().await;
+        let http_state = state.clone();
+        let mut http = tokio::spawn(async move {
+            impact_handler(
+                State(http_state),
+                Query(ImpactParams {
+                    path: "src/db.rs".to_string(),
+                    new_file: None,
+                }),
+            )
+            .await
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut http)
+                .await
+                .is_err(),
+            "HTTP impact must wait for the shared index lock"
+        );
+        drop(held);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(2), http)
+                .await
+                .expect("HTTP impact completes after lock release")
+                .expect("HTTP impact task joins")
+                .is_ok()
+        );
+
+        let held = state.index.lock_impact_analysis().await;
+        let tool_state = state.clone();
+        let mut tool = tokio::spawn(async move {
+            impact_tool_text(
+                tool_state,
+                &ImpactParams {
+                    path: "src/db.rs".to_string(),
+                    new_file: None,
+                },
+            )
+            .await
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut tool)
+                .await
+                .is_err(),
+            "direct-tool impact must wait for the shared index lock"
+        );
+        drop(held);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(2), tool)
+                .await
+                .expect("direct-tool impact completes after lock release")
+                .expect("direct-tool impact task joins")
+                .is_ok()
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3106,16 +4072,17 @@ mod tests {
         // The handler will try to read src/db.rs from disk (cwd). Since the file
         // doesn't exist on disk in this test, the handler should return Ok with a
         // "not readable" message and preserve the index instead of destroying it.
-        let result = impact_handler(State(state), Query(params)).await;
+        let result = impact_handler(State(state.clone()), Query(params)).await;
         assert!(
             result.is_ok(),
             "impact_handler should return Ok even if file missing from disk"
         );
         let text = result.unwrap();
         assert!(
-            text.contains("removed from index") || text.contains("not found on disk"),
-            "should indicate file was removed from index; got: {text}"
+            text.contains("last-valid index state retained"),
+            "should report that the last-valid index record was retained; got: {text}"
         );
+        assert!(state.index.read().get_file("src/db.rs").is_some());
     }
 
     /// When the watcher purges the index entry before analyze_file_impact
@@ -3309,8 +4276,8 @@ mod tests {
         }
     }
 
-    /// Proves that analyze_file_impact removes the file from the index when
-    /// it cannot be read from disk (deleted externally).
+    /// A single missing-file observation retains the last-valid index record;
+    /// the watcher retry/reconciliation path owns confirmed deletion.
     #[tokio::test]
     async fn test_impact_handler_edit_preserves_index_when_file_unreadable() {
         let file = make_indexed_file(
@@ -3320,21 +4287,50 @@ mod tests {
             ParseStatus::Parsed,
         );
         let state = make_state(vec![("src/db.rs", file)]);
+        let generation = state.index.current_project_generation();
+        let replacement = make_indexed_file(
+            "src/db.rs",
+            vec![make_symbol("connect_v2", SymbolKind::Function, 1, 10)],
+            vec![],
+            ParseStatus::Parsed,
+        );
+        assert!(
+            state
+                .index
+                .update_file_at_generation("src/db.rs", replacement, generation)
+        );
 
         let params = ImpactParams {
             path: "src/db.rs".to_string(),
             new_file: None,
         };
 
-        // File doesn't exist on disk — impact should remove it from the index.
+        // File doesn't exist on disk — impact must fail open without deleting
+        // a path that may be in a delete→recreate window.
         let result = impact_handler(State(state.clone()), Query(params)).await;
         assert!(result.is_ok(), "should return Ok, got: {result:?}");
+        assert!(
+            result
+                .as_ref()
+                .is_ok_and(|text| text.contains("last-valid index state retained"))
+        );
 
-        // Verify the file was removed from the index.
+        // Verify the last-valid file remains indexed pending confirmation.
         let guard = state.index.read();
         assert!(
-            guard.get_file("src/db.rs").is_none(),
-            "deleted file should be removed from index"
+            guard.get_file("src/db.rs").is_some(),
+            "one missing observation must not remove the last-valid index entry"
+        );
+        drop(guard);
+        let preserved = state
+            .index
+            .take_pre_update_snapshot_at_generation("src/db.rs", generation)
+            .expect("failed impact must preserve the watcher baseline");
+        assert!(
+            preserved
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "connect")
         );
     }
 
@@ -6414,7 +7410,8 @@ mod tests {
             symbol_line: None,
         };
 
-        let hook = symbol_context_hook_text(&state, &params).expect("hook render");
+        let fence = require_queryable_sidecar_index(&state).expect("queryable fixture");
+        let hook = symbol_context_hook_text(&state, &params, &fence).expect("hook render");
 
         assert!(
             hook.contains("[truncated]"),

--- a/src/sidecar/mod.rs
+++ b/src/sidecar/mod.rs
@@ -208,6 +208,9 @@ pub struct SymbolSnapshot {
     pub byte_range: (u32, u32),
 }
 
+/// Public cache shape retained for sidecar embedders.
+pub type SymbolSnapshotCache = HashMap<String, Vec<SymbolSnapshot>>;
+
 // ---------------------------------------------------------------------------
 // SidecarState — bundles index + stats + symbol cache for all handlers
 // ---------------------------------------------------------------------------
@@ -224,8 +227,8 @@ pub struct SidecarState {
     /// `None` falls back to process cwd for local test setups.
     pub repo_root: Option<PathBuf>,
     /// Per-file symbol snapshot cache for impact diff.
-    /// Key: relative file path. Value: symbol list captured before last edit.
-    pub symbol_cache: Arc<RwLock<HashMap<String, Vec<SymbolSnapshot>>>>,
+    /// Key: relative file path. Value: symbol list captured after the last impact.
+    pub symbol_cache: Arc<RwLock<SymbolSnapshotCache>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -24,7 +24,8 @@ pub use crate::watcher_state::{WatcherInfo, WatcherState};
 #[cfg(test)]
 pub(crate) use crate::live_index::single_file::read_and_index_with_stable_read;
 pub(crate) use crate::live_index::single_file::{
-    ReindexResult, admit_and_index_single_path, maybe_reindex, read_and_index,
+    ReindexOutcome as ReindexResult, admit_and_index_single_path,
+    admit_and_index_single_path_with_receipt, maybe_reindex, read_and_index,
 };
 
 /// Tracks event bursts to adaptively extend the debounce window.
@@ -113,6 +114,7 @@ pub(crate) enum FreshenResult {
     StaleReindexed,
     StaleRemoved,
     GenerationMismatch,
+    PublicationRejected,
 }
 
 /// Strip `\\?\` Windows extended-length path prefix and normalize backslashes.
@@ -224,6 +226,7 @@ pub(crate) fn freshen_file_if_stale(
         // state has been resolved — without claiming the file is still indexed.
         ReindexResult::Skipped => FreshenResult::StaleReindexed,
         ReindexResult::NotFound | ReindexResult::Removed => FreshenResult::StaleRemoved,
+        ReindexResult::PublicationRejected => FreshenResult::PublicationRejected,
     }
 }
 
@@ -397,7 +400,10 @@ where
                 ReindexResult::Reindexed | ReindexResult::HashSkip | ReindexResult::Skipped => {
                     repairs_applied += 1
                 }
-                ReindexResult::NotFound | ReindexResult::Removed | ReindexResult::ReadError(_) => {}
+                ReindexResult::NotFound
+                | ReindexResult::Removed
+                | ReindexResult::ReadError(_)
+                | ReindexResult::PublicationRejected => {}
             }
         }
         for (relative_path, expected_entry) in removed_paths {
@@ -433,7 +439,9 @@ where
             let abs_path = repo_root.join(relative_path);
             match freshen_file_if_stale(relative_path, &abs_path, shared, fence_gen) {
                 FreshenResult::StaleReindexed | FreshenResult::StaleRemoved => stale_count += 1,
-                FreshenResult::Fresh | FreshenResult::GenerationMismatch => {}
+                FreshenResult::Fresh
+                | FreshenResult::GenerationMismatch
+                | FreshenResult::PublicationRejected => {}
             }
         }
     }
@@ -772,7 +780,14 @@ pub(crate) fn process_events(
 
         let mut debounce_ms = None;
         if definitely_missing {
-            shared.remove_file_at_generation(&pending.relative_path, expected_gen);
+            let fence = shared.publication_fence();
+            if fence.project_generation == expected_gen {
+                let _ = shared.remove_file_if_absent_at_publication_fence_with_receipt(
+                    &pending.relative_path,
+                    &pending.absolute_path,
+                    fence,
+                );
+            }
         } else {
             if pending.saw_write_hint {
                 let tracker = burst_trackers
@@ -798,7 +813,14 @@ pub(crate) fn process_events(
                 // The path disappeared after the batch observation. Converge to
                 // current disk truth without serially sleeping in the event lane;
                 // any later create hint or periodic reconciliation can re-admit it.
-                shared.remove_file_at_generation(&pending.relative_path, expected_gen);
+                let fence = shared.publication_fence();
+                if fence.project_generation == expected_gen {
+                    let _ = shared.remove_file_if_absent_at_publication_fence_with_receipt(
+                        &pending.relative_path,
+                        &pending.absolute_path,
+                        fence,
+                    );
+                }
             }
         }
 
@@ -2296,13 +2318,18 @@ mod tests {
         let project = TempDir::new().unwrap();
         std::fs::write(project.path().join("main.rs"), b"fn main() {}\n").unwrap();
         let shared = crate::live_index::LiveIndex::load(project.path()).unwrap();
-        let generation_before = shared.published_state().generation;
+        let published_before = shared.published_generation();
 
         assert_eq!(reconcile_stale_files(project.path(), &shared), 0);
         assert_eq!(
             shared.published_state().generation,
-            generation_before,
+            published_before.health.generation,
             "an unchanged Complete observation cannot publish a content generation"
+        );
+        assert_eq!(
+            shared.published_generation().publication_generation,
+            published_before.publication_generation,
+            "an unchanged Complete observation cannot mint a publication generation"
         );
         assert_eq!(
             shared.scout_plan().expect("complete plan").coverage,
@@ -2643,13 +2670,17 @@ mod tests {
             .clone();
         let publication_gen = shared.published_state().generation;
 
-        assert!(shared.publish_terminal_disposition_at_generation(
-            relative_path,
-            scouted,
-            FileDisposition::AbortedCircuitBreaker,
-            expected_gen,
-            publication_gen,
-        ));
+        assert!(
+            shared
+                .publish_terminal_disposition_at_generation(
+                    relative_path,
+                    scouted,
+                    FileDisposition::AbortedCircuitBreaker,
+                    expected_gen,
+                    publication_gen,
+                )
+                .is_some()
+        );
         assert_eq!(
             shared.scout_plan().expect("degraded plan").coverage,
             crate::domain::CoverageStatus::Degraded

--- a/tests/hook_enrichment_integration.rs
+++ b/tests/hook_enrichment_integration.rs
@@ -127,17 +127,17 @@ fn make_rust_file_with_refs(
     file
 }
 
-/// Build a `SharedIndex` from a list of `IndexedFile`s using the public API.
+/// Build the healthy, source-bound index expected by hook happy-path tests.
 fn build_shared_index(files: Vec<IndexedFile>) -> SharedIndex {
-    let shared = LiveIndex::empty();
-    {
-        let mut guard = shared.write();
-        for file in files {
-            let path = file.relative_path.clone();
-            guard.add_file(path, file);
-        }
-    }
-    shared
+    let root = std::env::current_dir().expect("hook test cwd must be available");
+    LiveIndex::from_indexed_files(
+        &root,
+        files
+            .into_iter()
+            .map(|file| (file.relative_path.clone(), file))
+            .collect(),
+    )
+    .expect("hook test cwd resolves")
 }
 
 fn control_state(root: &std::path::Path) -> ControlStateDir {
@@ -186,6 +186,138 @@ fn raw_http_get_with_status(
 /// Returns the response body or an error.
 fn raw_http_get(port: u16, path: &str, query: &str) -> anyhow::Result<String> {
     raw_http_get_with_status(port, path, query).map(|(_, body)| body)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn loading_sidecar_refuses_all_content_routes_without_mutation() {
+    let tmp = TempDir::new().expect("tempdir creation");
+    let _guard = CWD_LOCK.lock().await;
+    let original = std::env::current_dir().expect("current directory");
+    std::env::set_current_dir(tmp.path()).expect("switch to sidecar test root");
+
+    std::fs::create_dir_all(tmp.path().join("src")).expect("create source directory");
+    std::fs::write(
+        tmp.path().join("src/foo.rs"),
+        "pub fn alpha() { println!(\"disk version\"); }\n",
+    )
+    .expect("write stale-on-disk source fixture");
+    std::fs::write(
+        tmp.path().join("src/new.rs"),
+        "pub fn newly_admitted() {}\n",
+    )
+    .expect("write mutation-capable new-file fixture");
+
+    let index = LiveIndex::empty();
+    let empty_handle = spawn_sidecar(
+        Arc::clone(&index),
+        "127.0.0.1",
+        Some(tmp.path().to_path_buf()),
+        Some(control_state(tmp.path())),
+    )
+    .await
+    .expect("spawn source-unbound empty sidecar");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let (empty_status, empty_body) = raw_http_get_with_status(empty_handle.port, "/repo-map", "")
+        .expect("GET /repo-map against source-unbound Empty");
+    assert!(empty_status.contains(" 503 "));
+    assert!(empty_body.is_empty());
+    empty_handle.shutdown_and_join().await;
+
+    {
+        let mut guard = index.write();
+        let file = make_rust_file_with_symbols("src/foo.rs", vec![("alpha", SymbolKind::Function)]);
+        guard.add_file(file.relative_path.clone(), file);
+    }
+    let before = index.published_generation();
+    assert!(
+        before.source.is_none(),
+        "fixture must remain source-unbound"
+    );
+    assert!(
+        index.published_state().indexed_root.is_none(),
+        "fixture must remain rootless"
+    );
+    assert!(matches!(
+        before.health.status,
+        symforge::live_index::PublishedIndexStatus::Loading
+    ));
+    let before_foo = before
+        .live
+        .get_file("src/foo.rs")
+        .expect("placeholder contains foo")
+        .content
+        .clone();
+
+    let handle = spawn_sidecar(
+        Arc::clone(&index),
+        "127.0.0.1",
+        Some(tmp.path().to_path_buf()),
+        Some(control_state(tmp.path())),
+    )
+    .await
+    .expect("spawn loading sidecar");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let routes = [
+        ("/outline", "path=src/foo.rs"),
+        ("/workflows/source-read", "path=src/foo.rs"),
+        ("/impact", "path=src/foo.rs"),
+        (
+            "/workflows/post-edit-impact",
+            "path=src/new.rs&new_file=true",
+        ),
+        ("/symbol-context", "name=alpha"),
+        ("/workflows/search-hit-expansion", "name=alpha"),
+        ("/repo-map", ""),
+        ("/workflows/repo-start", ""),
+        ("/prompt-context", "text=alpha"),
+        ("/workflows/prompt-context", "text=alpha"),
+    ];
+    for (path, query) in routes {
+        let (status, body) = raw_http_get_with_status(handle.port, path, query)
+            .unwrap_or_else(|error| panic!("GET {path}?{query} failed: {error}"));
+        assert!(
+            status.contains(" 503 "),
+            "{path} must refuse a loading index; status={status}, body={body:?}"
+        );
+        assert!(
+            body.is_empty(),
+            "{path} refusal body must be empty: {body:?}"
+        );
+    }
+
+    let (health_status, health_body) =
+        raw_http_get_with_status(handle.port, "/health", "").expect("GET /health");
+    assert!(health_status.contains(" 200 "));
+    let health: serde_json::Value =
+        serde_json::from_str(&health_body).expect("health body is JSON");
+    assert_eq!(health["index_state"], "Loading");
+
+    let (stats_status, stats_body) =
+        raw_http_get_with_status(handle.port, "/stats", "").expect("GET /stats");
+    assert!(stats_status.contains(" 200 "));
+    let stats: serde_json::Value = serde_json::from_str(&stats_body).expect("stats body is JSON");
+    for field in ["read_fires", "edit_fires", "write_fires", "grep_fires"] {
+        assert_eq!(stats[field], 0, "{field} must not advance on refusals");
+    }
+
+    let after = index.published_generation();
+    assert_eq!(after.publication_generation, before.publication_generation);
+    assert_eq!(after.content_generation, before.content_generation);
+    assert_eq!(after.project_generation, before.project_generation);
+    assert_eq!(after.health.file_count, 1);
+    assert_eq!(
+        after
+            .live
+            .get_file("src/foo.rs")
+            .expect("placeholder retains foo")
+            .content,
+        before_foo
+    );
+    assert!(after.live.get_file("src/new.rs").is_none());
+
+    handle.shutdown_and_join().await;
+    std::env::set_current_dir(original).expect("restore current directory");
 }
 
 // ---------------------------------------------------------------------------
@@ -476,7 +608,20 @@ async fn test_write_hook_confirms_index() {
     )
     .unwrap();
 
-    let index = build_shared_index(vec![]); // empty — file not yet indexed
+    let index = build_shared_index(vec![]); // source-bound empty; file not yet indexed
+    let empty = index.published_generation();
+    assert!(matches!(
+        empty.health.status,
+        symforge::live_index::PublishedIndexStatus::Empty
+    ));
+    assert!(
+        empty.source.is_some(),
+        "an empty project must retain its source identity"
+    );
+    assert!(
+        index.published_state().indexed_root.is_some(),
+        "an empty project must retain its indexed root"
+    );
     let handle = spawn_sidecar(
         Arc::clone(&index),
         "127.0.0.1",
@@ -505,6 +650,45 @@ async fn test_write_hook_confirms_index() {
     assert!(
         body.contains("fn") || body.contains("struct") || body.contains("Symbols"),
         "new_file response must mention symbols or language info; body: {body}"
+    );
+
+    std::fs::write(
+        &new_file_path,
+        b"pub fn create_thing() { println!(\"changed\"); }\npub struct Config {}\npub fn destroy_thing() {}",
+    )
+    .unwrap();
+    let (edited_status, edited) =
+        raw_http_get_with_status(handle.port, "/impact", "path=src/new_module.rs")
+            .expect("the first edit after new-file admission must succeed");
+    assert!(
+        edited_status.contains(" 200 "),
+        "the first edit must be accepted; status={edited_status}, body={edited}"
+    );
+    assert!(
+        !edited.is_empty(),
+        "the accepted edit must render impact text"
+    );
+    assert!(
+        !edited.contains("[Added]"),
+        "the new-file receipt must seed the next edit baseline; body: {edited}"
+    );
+    let changed: Vec<&str> = edited
+        .lines()
+        .filter(|line| line.contains("[Changed]"))
+        .collect();
+    assert_eq!(
+        changed.len(),
+        1,
+        "only the edited function may be reported changed; body: {edited}"
+    );
+    assert!(
+        changed[0].contains("create_thing"),
+        "the changed function must be named; body: {edited}"
+    );
+    assert!(
+        !edited.contains("[Changed] struct Config")
+            && !edited.contains("[Changed] function destroy_thing"),
+        "unchanged symbols must not be invented as changes; body: {edited}"
     );
 
     handle.shutdown_and_join().await;

--- a/tests/hook_subprocess_integration.rs
+++ b/tests/hook_subprocess_integration.rs
@@ -59,11 +59,28 @@ fn write_sidecar_descriptor(control_root: &Path, project_root: &Path, port: u16)
     symforge::sidecar::port_file::write_session_descriptor(
         &control_state,
         port,
-        Some("hook-subprocess-test"),
+        None,
         Some(project_root),
         None,
     )
     .expect("write sidecar session descriptor");
+}
+
+fn write_daemon_session_descriptor(
+    control_root: &Path,
+    project_root: &Path,
+    port: u16,
+    session_id: &str,
+) {
+    let control_state = symforge::domain::ControlStateDir::new(control_root.to_path_buf());
+    symforge::sidecar::port_file::write_session_descriptor(
+        &control_state,
+        port,
+        Some(session_id),
+        Some(project_root),
+        None,
+    )
+    .expect("write daemon-backed session descriptor");
 }
 
 fn write_daemon_port(control_root: &Path, port: u16) {
@@ -201,6 +218,602 @@ fn run_hook_routed_success_writes_source_read_routed_event() {
     );
 }
 
+#[test]
+fn run_hook_index_not_ready_fails_open_as_sidecar_error() {
+    const PARTIAL_MARKER: &str = "partial-index-context-must-not-escape";
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let port = listener
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let mock = thread::spawn(move || {
+        serve_mock_http_response(listener, "503 Service Unavailable", PARTIAL_MARKER)
+    });
+
+    let tmp = TempDir::new().expect("tempdir creation");
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), port);
+
+    let (stdout, log, stderr) = run_hook_in_tempdir_with_env_and_stderr(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[
+            ("SYMFORGE_HOME", home.path().to_string_lossy().as_ref()),
+            ("SYMFORGE_HOOK_VERBOSE", "1"),
+        ],
+    );
+    mock.join().expect("mock sidecar thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PostToolUse");
+    assert_eq!(
+        parsed["hookSpecificOutput"]["additionalContext"], "",
+        "an index-loading refusal must fail open with empty context"
+    );
+    assert!(
+        !stdout.contains(PARTIAL_MARKER),
+        "503 response body must not be injected into hook context; got:\n{stdout}"
+    );
+    assert!(
+        log.contains("\tsource-read\tsidecar-error"),
+        "an index-loading refusal must use the honest sidecar-error lane; \
+         stderr:\n{stderr}\nlog:\n{log}"
+    );
+    assert!(
+        !log.contains("sidecar_port_stale"),
+        "an index-loading refusal must not suggest restarting a live sidecar; got:\n{log}"
+    );
+    assert!(
+        stderr.contains("index not ready"),
+        "verbose diagnostics must name the live-but-loading condition; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("sidecar not running"),
+        "a live sidecar's 503 must not emit the restart diagnostic; got:\n{stderr}"
+    );
+    let hint_marker = symforge::paths::control_state_path(
+        &symforge::domain::ControlStateDir::new(home.path().to_path_buf()),
+        "hook-hint-shown",
+    );
+    assert!(
+        !hint_marker.exists(),
+        "an index-loading refusal must not create the sidecar restart-hint marker"
+    );
+}
+
+#[test]
+fn run_hook_local_http_500_fails_open_as_http_failure_without_restart_hint() {
+    const ERROR_MARKER: &str = "live-sidecar-500-body-must-not-escape";
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let port = listener
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let mock = thread::spawn(move || {
+        serve_mock_http_response(listener, "500 Internal Server Error", ERROR_MARKER)
+    });
+
+    let tmp = TempDir::new().expect("tempdir creation");
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), port);
+
+    let (stdout, log, stderr) = run_hook_in_tempdir_with_env_and_stderr(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[
+            ("SYMFORGE_HOME", home.path().to_string_lossy().as_ref()),
+            ("SYMFORGE_HOOK_VERBOSE", "1"),
+        ],
+    );
+    mock.join().expect("mock sidecar thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(ERROR_MARKER));
+    assert!(log.contains("\tsource-read\tsidecar-error"));
+    assert!(!log.contains("sidecar_port_stale"));
+    assert!(stderr.contains("outcome=SidecarError reason=http_failure"));
+    assert!(!stderr.contains("sidecar not running"));
+    assert!(!stderr.contains("restart_sidecar"));
+    let hint_marker = symforge::paths::control_state_path(
+        &symforge::domain::ControlStateDir::new(home.path().to_path_buf()),
+        "hook-hint-shown",
+    );
+    assert!(!hint_marker.exists());
+}
+
+#[test]
+fn run_hook_root_conflict_fails_open_without_stale_sidecar_hint() {
+    const CONFLICT_MARKER: &str = "wrong-project-context-must-not-escape";
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let port = listener
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let mock =
+        thread::spawn(move || serve_mock_http_response(listener, "409 Conflict", CONFLICT_MARKER));
+
+    let tmp = TempDir::new().expect("tempdir creation");
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), port);
+    let (stdout, log, stderr) = run_hook_in_tempdir_with_env_and_stderr(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[
+            ("SYMFORGE_HOME", home.path().to_string_lossy().as_ref()),
+            ("SYMFORGE_HOOK_VERBOSE", "1"),
+        ],
+    );
+    mock.join().expect("mock sidecar thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(CONFLICT_MARKER));
+    assert!(log.contains("\tsource-read\tsidecar-error"));
+    assert!(!log.contains("sidecar_port_stale"));
+    assert!(stderr.contains("root conflict"));
+    assert!(!stderr.contains("sidecar not running"));
+    let hint_marker = symforge::paths::control_state_path(
+        &symforge::domain::ControlStateDir::new(home.path().to_path_buf()),
+        "hook-hint-shown",
+    );
+    assert!(!hint_marker.exists());
+}
+
+#[test]
+fn run_hook_index_not_ready_uses_ready_daemon_fallback() {
+    const PARTIAL_MARKER: &str = "partial-local-sidecar-context-must-not-escape";
+
+    let sidecar = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let sidecar_port = sidecar
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let sidecar_thread = thread::spawn(move || {
+        serve_mock_http_response(sidecar, "503 Service Unavailable", PARTIAL_MARKER)
+    });
+
+    let daemon = TcpListener::bind("127.0.0.1:0").expect("bind mock daemon listener");
+    let daemon_port = daemon.local_addr().expect("daemon local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = std::fs::canonicalize(tmp.path())
+        .unwrap_or_else(|_| tmp.path().to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let daemon_thread = thread::spawn(move || serve_mock_daemon(daemon, &canonical_root));
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), sidecar_port);
+    write_daemon_port(home.path(), daemon_port);
+
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    sidecar_thread
+        .join()
+        .expect("mock loading sidecar thread joins");
+    daemon_thread.join().expect("mock daemon thread joins");
+
+    assert!(
+        stdout.contains(ENRICHED_MARKER),
+        "a ready daemon must enrich when the selected local sidecar is still loading; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(PARTIAL_MARKER),
+        "the local 503 body must never be injected; got:\n{stdout}"
+    );
+    assert!(
+        log.contains("mock-session\tsource-read\tdaemon-fallback"),
+        "daemon-routed enrichment must be attributed to the daemon session; got:\n{log}"
+    );
+}
+
+#[test]
+fn run_hook_daemon_index_not_ready_uses_daemon_session_error() {
+    const LOCAL_PARTIAL: &str = "partial-local-context-must-not-escape";
+    const DAEMON_PARTIAL: &str = "partial-daemon-context-must-not-escape";
+
+    let sidecar = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let sidecar_port = sidecar
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let sidecar_thread = thread::spawn(move || {
+        serve_mock_http_response(sidecar, "503 Service Unavailable", LOCAL_PARTIAL)
+    });
+
+    let daemon = TcpListener::bind("127.0.0.1:0").expect("bind mock daemon listener");
+    let daemon_port = daemon.local_addr().expect("daemon local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = std::fs::canonicalize(tmp.path())
+        .unwrap_or_else(|_| tmp.path().to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let daemon_thread = thread::spawn(move || {
+        serve_mock_daemon_with_enrichment(
+            daemon,
+            &canonical_root,
+            "503 Service Unavailable",
+            DAEMON_PARTIAL,
+        )
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), sidecar_port);
+    write_daemon_port(home.path(), daemon_port);
+
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    sidecar_thread
+        .join()
+        .expect("mock loading sidecar thread joins");
+    daemon_thread.join().expect("mock daemon thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(LOCAL_PARTIAL));
+    assert!(!stdout.contains(DAEMON_PARTIAL));
+    assert!(
+        log.contains("mock-session\tsource-read\tsidecar-error"),
+        "the daemon's 503 must be attributed to the daemon session; got:\n{log}"
+    );
+    assert!(!log.contains("sidecar_port_stale"));
+    assert!(!log.contains("restart_sidecar"));
+}
+
+#[test]
+fn run_hook_daemon_root_conflict_uses_daemon_session_error() {
+    const LOCAL_PARTIAL: &str = "partial-local-context-before-daemon-conflict";
+    const DAEMON_CONFLICT: &str = "wrong-project-daemon-context-must-not-escape";
+
+    let sidecar = TcpListener::bind("127.0.0.1:0").expect("bind mock sidecar listener");
+    let sidecar_port = sidecar
+        .local_addr()
+        .expect("mock sidecar local_addr")
+        .port();
+    let sidecar_thread = thread::spawn(move || {
+        serve_mock_http_response(sidecar, "503 Service Unavailable", LOCAL_PARTIAL)
+    });
+
+    let daemon = TcpListener::bind("127.0.0.1:0").expect("bind mock daemon listener");
+    let daemon_port = daemon.local_addr().expect("daemon local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = std::fs::canonicalize(tmp.path())
+        .unwrap_or_else(|_| tmp.path().to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let daemon_thread = thread::spawn(move || {
+        serve_mock_daemon_with_enrichment(daemon, &canonical_root, "409 Conflict", DAEMON_CONFLICT)
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_sidecar_descriptor(home.path(), tmp.path(), sidecar_port);
+    write_daemon_port(home.path(), daemon_port);
+    let (stdout, log, stderr) = run_hook_in_tempdir_with_env_and_stderr(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[
+            ("SYMFORGE_HOME", home.path().to_string_lossy().as_ref()),
+            ("SYMFORGE_HOOK_VERBOSE", "1"),
+        ],
+    );
+    sidecar_thread
+        .join()
+        .expect("mock loading sidecar thread joins");
+    daemon_thread.join().expect("mock daemon thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(LOCAL_PARTIAL));
+    assert!(!stdout.contains(DAEMON_CONFLICT));
+    assert!(log.contains("mock-session\tsource-read\tsidecar-error"));
+    assert!(!log.contains("sidecar_port_stale"));
+    assert!(stderr.contains("reason=root_conflict"));
+    assert!(!stderr.contains("restart_sidecar"));
+}
+
+#[test]
+fn run_hook_initial_daemon_index_not_ready_fails_open_without_retry() {
+    const DAEMON_PARTIAL: &str = "initial-daemon-partial-context-must-not-escape";
+
+    let daemon = TcpListener::bind("127.0.0.1:0").expect("bind mock daemon listener");
+    let daemon_port = daemon.local_addr().expect("daemon local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = std::fs::canonicalize(tmp.path())
+        .unwrap_or_else(|_| tmp.path().to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let daemon_thread = thread::spawn(move || {
+        serve_initially_discovered_loading_daemon(daemon, &canonical_root, DAEMON_PARTIAL)
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_daemon_port(home.path(), daemon_port);
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    let daemon_requests = daemon_thread.join().expect("mock daemon thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(DAEMON_PARTIAL));
+    assert!(
+        log.contains("mock-session\tsource-read\tsidecar-error"),
+        "the initially selected daemon's 503 must use its own session; got:\n{log}"
+    );
+    assert!(!log.contains("sidecar_port_stale"));
+    assert_request_routes(
+        &daemon_requests,
+        &[
+            "/v1/projects",
+            "/v1/projects/mock-project/sessions",
+            "/v1/sessions/mock-session/sidecar/outline",
+        ],
+        "initial daemon discovery",
+    );
+    assert!(
+        daemon_requests
+            .last()
+            .is_some_and(|path| path.contains("caller_root=")),
+        "the initially discovered daemon request must retain the root fence; got {daemon_requests:?}"
+    );
+}
+
+#[test]
+fn run_hook_daemon_descriptor_index_not_ready_is_not_retried() {
+    const DAEMON_PARTIAL: &str = "descriptor-daemon-partial-context-must-not-escape";
+
+    let daemon = TcpListener::bind("127.0.0.1:0").expect("bind mock daemon listener");
+    let daemon_port = daemon.local_addr().expect("daemon local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = std::fs::canonicalize(tmp.path())
+        .unwrap_or_else(|_| tmp.path().to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let daemon_thread = thread::spawn(move || {
+        serve_descriptor_selected_loading_daemon(daemon, &canonical_root, DAEMON_PARTIAL)
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_daemon_session_descriptor(home.path(), tmp.path(), daemon_port, "mock-session");
+    // Keep daemon discovery available so the regression would make a second
+    // enrichment request instead of merely failing to find a fallback port.
+    write_daemon_port(home.path(), daemon_port);
+
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    let enrichment_requests = daemon_thread.join().expect("mock daemon thread joins");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("hook output must be valid fail-open JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["additionalContext"], "");
+    assert!(!stdout.contains(DAEMON_PARTIAL));
+    assert_eq!(
+        enrichment_requests, 1,
+        "a descriptor-selected daemon must not be rediscovered and called twice after 503"
+    );
+    assert!(log.contains("mock-session\tsource-read\tsidecar-error"));
+    assert!(!log.contains("sidecar_port_stale"));
+}
+
+#[test]
+fn run_hook_empty_descriptor_session_503_routes_locally_then_falls_back() {
+    assert_blank_descriptor_session_routes_locally_then_falls_back(
+        "",
+        "503 Service Unavailable",
+        "empty-session-local-503-must-not-escape",
+    );
+}
+
+#[test]
+fn run_hook_whitespace_descriptor_session_409_routes_locally_then_falls_back() {
+    assert_blank_descriptor_session_routes_locally_then_falls_back(
+        " \t ",
+        "409 Conflict",
+        "whitespace-session-local-409-must-not-escape",
+    );
+}
+
+fn assert_blank_descriptor_session_routes_locally_then_falls_back(
+    descriptor_session_id: &str,
+    initial_status: &'static str,
+    initial_body: &'static str,
+) {
+    let initial = TcpListener::bind("127.0.0.1:0").expect("bind descriptor endpoint");
+    let initial_port = initial.local_addr().expect("descriptor local_addr").port();
+    let initial_thread = thread::spawn(move || {
+        serve_recording_descriptor_endpoint(initial, initial_status, initial_body)
+    });
+
+    let fallback = TcpListener::bind("127.0.0.1:0").expect("bind fallback daemon");
+    let fallback_port = fallback.local_addr().expect("fallback local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = canonical_root_for_mock(tmp.path());
+    let fallback_thread = thread::spawn(move || {
+        serve_recording_daemon(
+            fallback,
+            &canonical_root,
+            r#"[{"session_id":"fresh-session","project_id":"mock-project","last_seen_at_unix_secs":1}]"#,
+            "fresh-session",
+        )
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_daemon_session_descriptor(home.path(), tmp.path(), initial_port, descriptor_session_id);
+    write_daemon_port(home.path(), fallback_port);
+
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    let initial_requests = initial_thread
+        .join()
+        .expect("descriptor endpoint thread joins");
+    let fallback_requests = fallback_thread
+        .join()
+        .expect("fallback daemon thread joins");
+
+    assert!(
+        stdout.contains(ENRICHED_MARKER),
+        "a blank descriptor session id must remain local and permit one daemon fallback; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(initial_body),
+        "the initial refusal body must never escape into hook context; got:\n{stdout}"
+    );
+    assert!(
+        log.contains("fresh-session\tsource-read\tdaemon-fallback"),
+        "the successful fallback must be attributed to the discovered daemon session; got:\n{log}"
+    );
+
+    assert_request_routes(
+        &initial_requests,
+        &["/health", "/outline"],
+        "blank-session descriptor endpoint",
+    );
+    let local_request = initial_requests
+        .last()
+        .expect("local enrichment request must exist");
+    assert!(
+        local_request.contains("path=") && local_request.contains("caller_root="),
+        "the local request must preserve both source path and root fence; got {local_request:?}"
+    );
+    assert_request_routes(
+        &fallback_requests,
+        &[
+            "/v1/projects",
+            "/v1/projects/mock-project/sessions",
+            "/v1/sessions/fresh-session/sidecar/outline",
+        ],
+        "blank-session daemon fallback",
+    );
+    assert!(
+        fallback_requests
+            .last()
+            .is_some_and(|path| path.contains("caller_root=")),
+        "the fallback enrichment request must retain the root fence; got {fallback_requests:?}"
+    );
+}
+
+#[test]
+fn run_hook_daemon_descriptor_404_rediscovers_different_session() {
+    assert_descriptor_daemon_failure_rediscovers_different_session(
+        "404 Not Found",
+        "closed-descriptor-session-must-not-escape",
+    );
+}
+
+#[test]
+fn run_hook_daemon_descriptor_409_rediscovers_different_session() {
+    assert_descriptor_daemon_failure_rediscovers_different_session(
+        "409 Conflict",
+        "conflicted-descriptor-session-must-not-escape",
+    );
+}
+
+fn assert_descriptor_daemon_failure_rediscovers_different_session(
+    initial_status: &'static str,
+    initial_body: &'static str,
+) {
+    let initial = TcpListener::bind("127.0.0.1:0").expect("bind descriptor daemon");
+    let initial_port = initial
+        .local_addr()
+        .expect("descriptor daemon local_addr")
+        .port();
+    let initial_thread = thread::spawn(move || {
+        serve_recording_descriptor_endpoint(initial, initial_status, initial_body)
+    });
+
+    let fallback = TcpListener::bind("127.0.0.1:0").expect("bind alternate daemon");
+    let fallback_port = fallback.local_addr().expect("alternate local_addr").port();
+    let tmp = TempDir::new().expect("tempdir creation");
+    let canonical_root = canonical_root_for_mock(tmp.path());
+    let fallback_thread = thread::spawn(move || {
+        serve_recording_daemon(
+            fallback,
+            &canonical_root,
+            r#"[{"session_id":"stale-session","project_id":"mock-project","last_seen_at_unix_secs":2},{"session_id":"fresh-session","project_id":"mock-project","last_seen_at_unix_secs":1}]"#,
+            "fresh-session",
+        )
+    });
+
+    let home = TempDir::new().expect("control-state tempdir creation");
+    write_daemon_session_descriptor(home.path(), tmp.path(), initial_port, "stale-session");
+    write_daemon_port(home.path(), fallback_port);
+
+    let (stdout, log) = run_hook_in_tempdir_with_env(
+        tmp.path(),
+        READ_PAYLOAD,
+        &[("SYMFORGE_HOME", home.path().to_string_lossy().as_ref())],
+    );
+    let initial_requests = initial_thread
+        .join()
+        .expect("descriptor daemon thread joins");
+    let fallback_requests = fallback_thread
+        .join()
+        .expect("alternate daemon thread joins");
+
+    assert!(
+        stdout.contains(ENRICHED_MARKER),
+        "a closed or conflicted descriptor session must recover through a different active session; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(initial_body),
+        "the failed descriptor session body must never escape into hook context; got:\n{stdout}"
+    );
+    assert!(
+        log.contains("fresh-session\tsource-read\tdaemon-fallback"),
+        "the recovered request must be attributed to the alternate session; got:\n{log}"
+    );
+
+    assert_request_routes(
+        &initial_requests,
+        &["/health", "/v1/sessions/stale-session/sidecar/outline"],
+        "descriptor-selected daemon",
+    );
+    assert!(
+        initial_requests
+            .last()
+            .is_some_and(|path| path.contains("caller_root=")),
+        "the failed descriptor request must be root-fenced; got {initial_requests:?}"
+    );
+    assert_request_routes(
+        &fallback_requests,
+        &[
+            "/v1/projects",
+            "/v1/projects/mock-project/sessions",
+            "/v1/sessions/fresh-session/sidecar/outline",
+        ],
+        "alternate daemon discovery",
+    );
+    assert!(
+        fallback_requests
+            .last()
+            .is_some_and(|path| path.contains("caller_root=")),
+        "the alternate daemon request must retain the root fence; got {fallback_requests:?}"
+    );
+}
+
 /// Pin the stale-sidecar daemon-fallback path: the sidecar port file points
 /// at a dead listener (HTTP times out), but a live mock daemon is reachable
 /// via `SYMFORGE_HOME`. The hook must route the SAME enrichment request
@@ -260,7 +873,7 @@ fn run_hook_stale_sidecar_with_live_daemon_routes_via_daemon_fallback() {
     );
     // The adoption log must record the degraded-but-routed state honestly.
     assert!(
-        log.contains("\tsource-read\tdaemon-fallback"),
+        log.contains("mock-session\tsource-read\tdaemon-fallback"),
         "log must contain a tab-separated `source-read\\tdaemon-fallback` \
          entry (regression: stale sidecar served via daemon must record \
          DaemonFallback, not no-sidecar); got:\n{log}"
@@ -361,12 +974,156 @@ fn run_hook_stdin_held_open_exits_fail_open_within_deadline() {
 /// from any fail-open output so the test can prove enrichment was served.
 const ENRICHED_MARKER: &str = "MOCK_DAEMON_ENRICHED_OUTLINE";
 
+fn canonical_root_for_mock(root: &Path) -> String {
+    std::fs::canonicalize(root)
+        .unwrap_or_else(|_| root.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn assert_request_routes(requests: &[String], expected: &[&str], label: &str) {
+    let actual: Vec<_> = requests
+        .iter()
+        .map(|path| path.split('?').next().unwrap_or(path))
+        .collect();
+    assert_eq!(
+        actual.as_slice(),
+        expected,
+        "{label} must make exactly the expected requests; full paths: {requests:?}"
+    );
+}
+
+/// Records the semantic HTTP requests made to a descriptor endpoint. The
+/// descriptor scan may also open a bare TCP liveness connection; empty reads
+/// are intentionally ignored because they are not hook HTTP requests.
+fn serve_recording_descriptor_endpoint(
+    listener: TcpListener,
+    enrichment_status: &str,
+    enrichment_body: &str,
+) -> Vec<String> {
+    listener
+        .set_nonblocking(true)
+        .expect("set descriptor endpoint non-blocking");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut requests = Vec::new();
+
+    while Instant::now() < deadline {
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => panic!("descriptor endpoint accept failed: {error}"),
+        };
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+        let request = read_http_request(&mut stream);
+        if request.is_empty() {
+            continue;
+        }
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("")
+            .to_string();
+        let route = path.split('?').next().unwrap_or(&path);
+        requests.push(path.clone());
+
+        if route == "/health" {
+            let health = r#"{"project_count":0,"session_count":1,"daemon_version":"10.0.3","executable_path":"mock","auth_required":true,"pid":0}"#;
+            write_http_ok(&mut stream, health);
+            continue;
+        }
+
+        write_http_response(&mut stream, enrichment_status, enrichment_body);
+        return requests;
+    }
+
+    panic!("hook never sent enrichment to descriptor endpoint; requests={requests:?}")
+}
+
+/// Records one complete daemon rediscovery: root lookup, active-session lookup,
+/// then the root-fenced enrichment request through `expected_session_id`.
+fn serve_recording_daemon(
+    listener: TcpListener,
+    canonical_root: &str,
+    sessions_json: &str,
+    expected_session_id: &str,
+) -> Vec<String> {
+    listener
+        .set_nonblocking(true)
+        .expect("set recording daemon non-blocking");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut requests = Vec::new();
+    let expected_enrichment_route = format!("/v1/sessions/{expected_session_id}/sidecar/outline");
+
+    while Instant::now() < deadline {
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => panic!("recording daemon accept failed: {error}"),
+        };
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+        let request = read_http_request(&mut stream);
+        if request.is_empty() {
+            continue;
+        }
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("")
+            .to_string();
+        let route = path.split('?').next().unwrap_or(&path);
+        requests.push(path.clone());
+
+        if route == "/v1/projects" {
+            let body = format!(
+                r#"[{{"project_id":"mock-project","canonical_root":"{}","session_count":2}}]"#,
+                canonical_root.replace('"', "\\\"")
+            );
+            write_http_ok(&mut stream, &body);
+        } else if route == "/v1/projects/mock-project/sessions" {
+            write_http_ok(&mut stream, sessions_json);
+        } else if route == expected_enrichment_route {
+            let body = format!(r#"{{"enriched":"{ENRICHED_MARKER}"}}"#);
+            write_http_ok(&mut stream, &body);
+            return requests;
+        } else {
+            write_http_response(
+                &mut stream,
+                "404 Not Found",
+                "unexpected recording-daemon route",
+            );
+            return requests;
+        }
+    }
+
+    panic!("hook did not complete daemon rediscovery; requests={requests:?}")
+}
+
 /// Single-purpose mock daemon HTTP server for the fallback test. Serves each
 /// `Connection: close` request the hook makes — `/v1/projects`, the project's
 /// `/sessions` list, then the `/v1/sessions/{id}/sidecar/outline` enrichment —
 /// routing by request-line path. Loops until the enrichment request is served
 /// or the listener is dropped.
 fn serve_mock_daemon(listener: TcpListener, canonical_root: &str) {
+    let body = format!("{{\"enriched\":\"{ENRICHED_MARKER}\"}}");
+    serve_mock_daemon_with_enrichment(listener, canonical_root, "200 OK", &body);
+}
+
+fn serve_mock_daemon_with_enrichment(
+    listener: TcpListener,
+    canonical_root: &str,
+    enrichment_status: &str,
+    enrichment_body: &str,
+) {
     // Non-blocking accept so a missing enrichment request can never hang the
     // join() on the test thread — the deadline always wins.
     listener
@@ -386,32 +1143,31 @@ fn serve_mock_daemon(listener: TcpListener, canonical_root: &str) {
         // timeout so the request read below behaves like a normal server.
         let _ = stream.set_nonblocking(false);
         let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
-        let mut buf = [0u8; 4096];
-        let n = stream.read(&mut buf).unwrap_or(0);
-        let request = String::from_utf8_lossy(&buf[..n]);
+        let request = read_http_request(&mut stream);
         let path = request
             .lines()
             .next()
             .and_then(|line| line.split_whitespace().nth(1))
             .unwrap_or("");
+        let route = path.split('?').next().unwrap_or(path);
 
-        let body: String = if path.starts_with("/v1/projects/") && path.contains("/sessions") {
-            // Sessions list for the matched project.
-            r#"[{"session_id":"mock-session","last_seen_at_unix_secs":1}]"#.to_string()
-        } else if path.starts_with("/v1/projects") {
+        let body: String = if route.starts_with("/v1/projects/") && route.contains("/sessions") {
+            // Include a newer session whose active project no longer matches.
+            // The hook must filter it out and route through `mock-session`.
+            r#"[{"session_id":"wrong-session","project_id":"other-project","last_seen_at_unix_secs":2},{"session_id":"mock-session","project_id":"mock-project","last_seen_at_unix_secs":1}]"#.to_string()
+        } else if route == "/v1/projects" {
             // Projects list — advertise our canonical root.
             format!(
                 r#"[{{"project_id":"mock-project","canonical_root":"{}","session_count":1}}]"#,
                 canonical_root.replace('"', "\\\"")
             )
+        } else if route == "/v1/sessions/mock-session/sidecar/outline"
+            && path.contains("caller_root=")
+        {
+            write_http_response(&mut stream, enrichment_status, enrichment_body);
+            return;
         } else {
-            // Enrichment endpoint (/v1/sessions/.../sidecar/outline).
-            let last = path.contains("sidecar");
-            let out = format!("{{\"enriched\":\"{ENRICHED_MARKER}\"}}");
-            write_http_ok(&mut stream, &out);
-            if last {
-                return;
-            }
+            write_http_response(&mut stream, "404 Not Found", "unexpected mock-daemon route");
             continue;
         };
 
@@ -419,10 +1175,222 @@ fn serve_mock_daemon(listener: TcpListener, canonical_root: &str) {
     }
 }
 
+/// Record an initially discovered daemon's complete request sequence and keep
+/// listening briefly after its first 503. An erroneous fallback retry then
+/// reaches the same live mock and becomes an observable duplicate discovery.
+fn serve_initially_discovered_loading_daemon(
+    listener: TcpListener,
+    canonical_root: &str,
+    enrichment_body: &str,
+) -> Vec<String> {
+    listener
+        .set_nonblocking(true)
+        .expect("set initially discovered daemon listener non-blocking");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut first_enrichment_at: Option<Instant> = None;
+    let mut requests = Vec::new();
+
+    while Instant::now() < deadline {
+        if first_enrichment_at.is_some_and(|at| at.elapsed() >= Duration::from_millis(750)) {
+            return requests;
+        }
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => panic!("initially discovered daemon accept failed: {error}"),
+        };
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+        let request = read_http_request(&mut stream);
+        if request.is_empty() {
+            continue;
+        }
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("")
+            .to_string();
+        let route = path.split('?').next().unwrap_or(&path);
+        requests.push(path.clone());
+
+        if route == "/v1/projects" {
+            let body = format!(
+                r#"[{{"project_id":"mock-project","canonical_root":"{}","session_count":1}}]"#,
+                canonical_root.replace('"', "\\\"")
+            );
+            write_http_ok(&mut stream, &body);
+        } else if route == "/v1/projects/mock-project/sessions" {
+            let body = r#"[{"session_id":"mock-session","project_id":"mock-project","last_seen_at_unix_secs":1}]"#;
+            write_http_ok(&mut stream, body);
+        } else if route == "/v1/sessions/mock-session/sidecar/outline"
+            && path.contains("caller_root=")
+        {
+            first_enrichment_at.get_or_insert_with(Instant::now);
+            write_http_response(&mut stream, "503 Service Unavailable", enrichment_body);
+        } else {
+            write_http_response(&mut stream, "404 Not Found", "unexpected mock-daemon route");
+        }
+    }
+
+    panic!("hook never sent enrichment to the initially discovered daemon; requests={requests:?}")
+}
+
+/// Serve a daemon selected directly from a session descriptor and keep it
+/// alive briefly after the first 503. If the hook incorrectly rediscovers
+/// the same daemon, this mock serves the discovery endpoints and counts the
+/// second enrichment request deterministically.
+fn serve_descriptor_selected_loading_daemon(
+    listener: TcpListener,
+    canonical_root: &str,
+    enrichment_body: &str,
+) -> usize {
+    listener
+        .set_nonblocking(true)
+        .expect("set descriptor daemon listener non-blocking");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut first_enrichment_at: Option<Instant> = None;
+    let mut enrichment_requests = 0usize;
+
+    while Instant::now() < deadline {
+        if first_enrichment_at.is_some_and(|at| at.elapsed() >= Duration::from_millis(750)) {
+            return enrichment_requests;
+        }
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => panic!("descriptor daemon accept failed: {error}"),
+        };
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+        let request = read_http_request(&mut stream);
+        if request.is_empty() {
+            continue;
+        }
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("");
+        let route = path.split('?').next().unwrap_or(path);
+
+        if route == "/health" {
+            let health = r#"{"project_count":0,"session_count":1,"daemon_version":"10.0.3","executable_path":"mock","auth_required":true,"pid":0}"#;
+            write_http_ok(&mut stream, health);
+        } else if route == "/v1/projects" {
+            let body = format!(
+                r#"[{{"project_id":"mock-project","canonical_root":"{}","session_count":1}}]"#,
+                canonical_root.replace('"', "\\\"")
+            );
+            write_http_ok(&mut stream, &body);
+        } else if route.starts_with("/v1/projects/") && route.contains("/sessions") {
+            let body = r#"[{"session_id":"mock-session","project_id":"mock-project","last_seen_at_unix_secs":1}]"#;
+            write_http_ok(&mut stream, body);
+        } else if route == "/v1/sessions/mock-session/sidecar/outline"
+            && path.contains("caller_root=")
+        {
+            enrichment_requests += 1;
+            first_enrichment_at.get_or_insert_with(Instant::now);
+            write_http_response(&mut stream, "503 Service Unavailable", enrichment_body);
+            if enrichment_requests > 1 {
+                return enrichment_requests;
+            }
+        } else {
+            write_http_response(&mut stream, "404 Not Found", "unexpected mock-daemon route");
+        }
+    }
+
+    panic!("hook never sent an enrichment request to the descriptor-selected daemon")
+}
+
+/// Serve one real HTTP response while tolerating descriptor-liveness probes
+/// that connect without sending a request. The non-blocking deadline keeps a
+/// failed hook connection from stranding the test on `join()`.
+fn serve_mock_http_response(listener: TcpListener, status: &str, body: &str) {
+    listener
+        .set_nonblocking(true)
+        .expect("set mock sidecar listener non-blocking");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => panic!("mock sidecar accept failed: {error}"),
+        };
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+        let request = read_http_request(&mut stream);
+        if request.is_empty() {
+            continue;
+        }
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("");
+        if path.split('?').next().unwrap_or(path) == "/health" {
+            let health = r#"{"project_count":0,"session_count":0,"daemon_version":"10.0.3","executable_path":"mock","auth_required":true,"pid":0}"#;
+            write_http_ok(&mut stream, health);
+            continue;
+        }
+
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write mock HTTP response");
+        stream.flush().expect("flush mock HTTP response");
+        return;
+    }
+    panic!("hook never sent an HTTP request to the mock sidecar before the deadline");
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+    const MAX_REQUEST_BYTES: usize = 16 * 1024;
+    let mut request = Vec::new();
+    while request.len() < MAX_REQUEST_BYTES {
+        let mut chunk = [0u8; 1024];
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                request.extend_from_slice(&chunk[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                break;
+            }
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&request).into_owned()
+}
+
 /// Write a minimal `200 OK` HTTP response with the given body and close.
 fn write_http_ok(stream: &mut std::net::TcpStream, body: &str) {
+    write_http_response(stream, "200 OK", body);
+}
+
+fn write_http_response(stream: &mut std::net::TcpStream, status: &str, body: &str) {
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         body.len(),
         body
     );
@@ -452,6 +1420,15 @@ fn run_hook_in_tempdir_with_env(
     payload: &str,
     extra_env: &[(&str, &str)],
 ) -> (String, String) {
+    let (stdout, log, _) = run_hook_in_tempdir_with_env_and_stderr(cwd, payload, extra_env);
+    (stdout, log)
+}
+
+fn run_hook_in_tempdir_with_env_and_stderr(
+    cwd: &Path,
+    payload: &str,
+    extra_env: &[(&str, &str)],
+) -> (String, String, String) {
     let control_root = extra_env
         .iter()
         .rev()
@@ -492,6 +1469,10 @@ fn run_hook_in_tempdir_with_env(
     if let Some(mut out) = child.stdout.take() {
         let _ = out.read_to_string(&mut stdout);
     }
+    let mut stderr = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut stderr);
+    }
 
     let log_path = control_root.join(ADOPTION_LOG_FILE);
     assert!(
@@ -503,7 +1484,7 @@ fn run_hook_in_tempdir_with_env(
     );
 
     let log = std::fs::read_to_string(&log_path).expect("log readable");
-    (stdout, log)
+    (stdout, log, stderr)
 }
 
 /// Poll the child for exit with a timeout. `Ok(Some)` on clean exit,

--- a/tests/sidecar_integration.rs
+++ b/tests/sidecar_integration.rs
@@ -76,24 +76,17 @@ fn make_rust_file(path: &str, fn_name: &str) -> IndexedFile {
     }
 }
 
-/// Build a `SharedIndex` as an unrooted bootstrap placeholder
-/// (`LiveIndex::empty()` + `add_file`).
-///
-/// NOT the embedder construction route — that is `LiveIndex::from_indexed_files`
-/// (rooted, Ready). This shape is retained here only because these tests assert
-/// sidecar ENDPOINT behaviour, which does not consult index readiness. Anything
-/// asserting on index state must build a rooted index instead; see
-/// `tests/sidecar_contract.rs::build_shared_index`.
+/// Build the healthy, source-bound index expected by endpoint happy-path tests.
 fn build_shared_index(files: Vec<IndexedFile>) -> SharedIndex {
-    let shared = LiveIndex::empty();
-    {
-        let mut guard = shared.write();
-        for file in files {
-            let path = file.relative_path.clone();
-            guard.add_file(path, file);
-        }
-    }
-    shared
+    let root = std::env::current_dir().expect("sidecar test cwd must be available");
+    LiveIndex::from_indexed_files(
+        &root,
+        files
+            .into_iter()
+            .map(|file| (file.relative_path.clone(), file))
+            .collect(),
+    )
+    .expect("sidecar test cwd resolves")
 }
 
 fn control_state(root: &Path) -> ControlStateDir {
@@ -102,7 +95,11 @@ fn control_state(root: &Path) -> ControlStateDir {
 
 /// Make a synchronous raw HTTP GET request to `127.0.0.1:{port}{path}?{query}`.
 /// Returns the response body or an error.
-fn raw_http_get(port: u16, path: &str, query: &str) -> anyhow::Result<String> {
+fn raw_http_get_with_status(
+    port: u16,
+    path: &str,
+    query: &str,
+) -> anyhow::Result<(String, String)> {
     let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse()?;
     let timeout = Duration::from_millis(500);
     let mut stream = TcpStream::connect_timeout(&addr, timeout)?;
@@ -123,12 +120,17 @@ fn raw_http_get(port: u16, path: &str, query: &str) -> anyhow::Result<String> {
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
 
+    let status = response.lines().next().unwrap_or_default().to_string();
     let body = response
         .split_once("\r\n\r\n")
         .map(|(_, b)| b)
         .unwrap_or("")
         .to_string();
-    Ok(body)
+    Ok((status, body))
+}
+
+fn raw_http_get(port: u16, path: &str, query: &str) -> anyhow::Result<String> {
+    raw_http_get_with_status(port, path, query).map(|(_, body)| body)
 }
 
 fn stable_cwd() -> PathBuf {
@@ -332,10 +334,14 @@ async fn test_workflow_source_read_endpoint_matches_outline() {
 
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    let canonical = raw_http_get(handle.port, "/outline", "path=src/foo.rs")
-        .expect("GET /outline must succeed");
-    let workflow = raw_http_get(handle.port, "/workflows/source-read", "path=src/foo.rs")
-        .expect("GET /workflows/source-read must succeed");
+    let (canonical_status, canonical) =
+        raw_http_get_with_status(handle.port, "/outline", "path=src/foo.rs")
+            .expect("GET /outline must succeed");
+    let (workflow_status, workflow) =
+        raw_http_get_with_status(handle.port, "/workflows/source-read", "path=src/foo.rs")
+            .expect("GET /workflows/source-read must succeed");
+    assert!(canonical_status.contains(" 200 "));
+    assert!(workflow_status.contains(" 200 "));
 
     assert_eq!(
         workflow, canonical,
@@ -626,9 +632,13 @@ async fn test_workflow_repo_start_endpoint_matches_repo_map() {
 
     tokio::time::sleep(Duration::from_millis(20)).await;
 
-    let canonical = raw_http_get(handle.port, "/repo-map", "").expect("GET /repo-map must succeed");
-    let workflow = raw_http_get(handle.port, "/workflows/repo-start", "")
-        .expect("GET /workflows/repo-start must succeed");
+    let (canonical_status, canonical) =
+        raw_http_get_with_status(handle.port, "/repo-map", "").expect("GET /repo-map must succeed");
+    let (workflow_status, workflow) =
+        raw_http_get_with_status(handle.port, "/workflows/repo-start", "")
+            .expect("GET /workflows/repo-start must succeed");
+    assert!(canonical_status.contains(" 200 "));
+    assert!(workflow_status.contains(" 200 "));
 
     assert_eq!(
         workflow, canonical,
@@ -698,10 +708,14 @@ async fn test_workflow_prompt_context_endpoint_matches_prompt_context() {
     tokio::time::sleep(Duration::from_millis(20)).await;
 
     let query = "text=please%20inspect%20src%2Ffoo.rs";
-    let canonical = raw_http_get(handle.port, "/prompt-context", query)
-        .expect("GET /prompt-context must succeed");
-    let workflow = raw_http_get(handle.port, "/workflows/prompt-context", query)
-        .expect("GET /workflows/prompt-context must succeed");
+    let (canonical_status, canonical) =
+        raw_http_get_with_status(handle.port, "/prompt-context", query)
+            .expect("GET /prompt-context must succeed");
+    let (workflow_status, workflow) =
+        raw_http_get_with_status(handle.port, "/workflows/prompt-context", query)
+            .expect("GET /workflows/prompt-context must succeed");
+    assert!(canonical_status.contains(" 200 "));
+    assert!(workflow_status.contains(" 200 "));
 
     assert_eq!(
         workflow, canonical,


### PR DESCRIPTION
## Summary

- refuse all five HTTP sidecar content families, workflow aliases, and daemon proxy routes unless the published index is source-bound, rooted, and queryable
- preserve `/health` and `/stats` diagnostics while loading/degraded, and make hooks fail open with typed 409/503/live-HTTP behavior and bounded daemon fallback
- fence freshening and impact mutations by project/source/root identity, render impact from exact publication receipts, and close deletion/snapshot ABA and convergence races
- preserve the patch-release Rust API surface (`ReindexResult` and `SidecarState::symbol_cache`)

## Review

Frozen implementation: `71c14e309a9a45ad01d145b136ef556a6b86190e`
Binary diff hash: `920e3002030392732514f2d560839da05e214099`

Claude Fable round 2 verified the exact target and returned **clear to land** with no P0/P1/P2 findings. The earlier moving-target review is retained as historical evidence.

Accepted P3 decisions:
- one unresolved in-scope observation failure degrades and refuses the whole HTTP enrichment surface; correctness wins over partial availability
- MCP `analyze_file_impact` remains a separate health-guarded, trust-labeled recovery lane rather than inheriting the HTTP sidecar refusal contract
- the private process-global symbol-cache generation registry is accepted at current hook traffic rates

## Verification

The frozen target passed:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets -- --test-threads=1` (115 binaries/suites, zero failures)
- `cargo build --release`
- both CI-canonical `verify-tools.cjs` release-binary harnesses (8/8 and 11/11)
- H.7 `batch_rename_perf`

The review request and both review rounds are committed under `docs/reviews/`.