### PR TITLE
fix(release): restore releases after the pre-activation gate skip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
+# Every blob in this repo is already LF (1054 text files, 0 crlf/mixed), and a
+# growing number of consumers pin a sha256 over those blob bytes: the refreeze
+# manifest inventory, public-api-v11.json's input_corpus, the retirement closure
+# census, and release.yml's pinned_blob. Some read git objects, but the refreeze
+# test fixtures copy the WORKTREE -- so on a CRLF checkout the two disagree and
+# 19 tests fail on Windows while CI stays green. Pinning LF repo-wide makes
+# worktree == blob everywhere and closes that class; git skips binary files on
+# its own. This changes no committed byte.
+* text=auto eol=lf
+
 # Tool-correctness harness fixtures: byte-exact snapshots (get_symbol byte
 # counts, get_file_context token estimates) must be platform-stable. Without
 # this, core.autocrlf checks these out as CRLF on Windows and LF on Linux, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,22 @@ jobs:
           SYMFORGE_REQUIRE_SSHSIG: '1'
         run: python -m unittest discover -s execution -p 'test_*.py'
 
+      - name: Verify every text blob in the index is LF
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Six release-gating assertions compare a worktree read against a hash
+          # taken over blob bytes. They are latent on these runners because Linux
+          # checks out LF regardless, so a CRLF blob entering the index would go
+          # unnoticed here and break every Windows checkout. The index census is
+          # platform-independent, so it is checkable from ubuntu.
+          offenders="$(git ls-files --eol | grep -vE '^i/(lf|-text|none)' || true)"
+          if [[ -n "$offenders" ]]; then
+            echo "::error::These blobs are not LF in the index:"
+            printf '%s\n' "$offenders"
+            exit 1
+          fi
+
       - name: Verify Feature 020 V11 refreeze integrity
         run: python execution/refreeze_v11.py verify-internal --target-ref HEAD
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -868,6 +868,7 @@ jobs:
             scripts/validate-lifecycle-oracle-traceability.cjs
             scripts/validate-lifecycle-oracle-traceability.test.cjs
             specs/020-repository-knowledge-index
+            tests/fixtures/public-api-v11-consumer
           )
           if ! "$TRUSTED_GIT" diff --quiet --no-ext-diff --no-textconv \
             "$APPROVED_TARGET^{tree}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1949,6 +1949,12 @@ jobs:
     needs:
       - resolve-release-ref
       - gate-release-ref
+    # feature-020-v11-gate is skipped in pre-activation, and a skip propagates
+    # transitively through needs. gate-release-ref survives it via always() and
+    # already hard-fails unless the phase-appropriate result held, so every job
+    # below it must name a status function to stop inheriting that skip, and must
+    # then restate the success it would otherwise have got implicitly.
+    if: ${{ !cancelled() && needs.resolve-release-ref.result == 'success' && needs.gate-release-ref.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -2216,7 +2222,7 @@ jobs:
     needs:
       - prepare-release
       - gate-release-ref
-    if: needs.prepare-release.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.gate-release-ref.result == 'success' && needs.prepare-release.result == 'success' && needs.prepare-release.outputs.release_created == 'true' }}
     strategy:
       matrix:
         include:
@@ -2276,7 +2282,7 @@ jobs:
       - prepare-release
       - gate-release-ref
       - build
-    if: needs.prepare-release.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.gate-release-ref.result == 'success' && needs.prepare-release.result == 'success' && needs.build.result == 'success' && needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2385,7 +2391,7 @@ jobs:
       - gate-release-ref
       - build
       - build-npm-package
-    if: needs.prepare-release.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.gate-release-ref.result == 'success' && needs.prepare-release.result == 'success' && needs.build.result == 'success' && needs.build-npm-package.result == 'success' && needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -2417,7 +2423,7 @@ jobs:
       - build
       - build-npm-package
       - upload-release-assets
-    if: needs.prepare-release.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.gate-release-ref.result == 'success' && needs.prepare-release.result == 'success' && needs.build.result == 'success' && needs.build-npm-package.result == 'success' && needs.upload-release-assets.result == 'success' && needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     environment: cargo-publish
     steps:
@@ -2449,7 +2455,7 @@ jobs:
       - gate-release-ref
       - build-npm-package
       - upload-release-assets
-    if: needs.prepare-release.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.gate-release-ref.result == 'success' && needs.prepare-release.result == 'success' && needs.build-npm-package.result == 'success' && needs.upload-release-assets.result == 'success' && needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:

--- a/execution/test_refreeze_v11.py
+++ b/execution/test_refreeze_v11.py
@@ -48,6 +48,38 @@ def system_executable(name: str) -> Path:
 
 
 SYSTEM_GIT_EXECUTABLE = system_executable("git")
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+
+
+def repository_blob(path: str) -> bytes:
+    """Read a tracked file from this repository's git objects, not the worktree.
+
+    Everything these fixtures are checked against is pinned over blob bytes. Seeding
+    from the worktree instead made the suite correct only while a checkout stayed
+    normalized, and when it did not the symptom was 19 Windows-only failures that CI
+    could never see, because on Linux the worktree happens to equal the blob. The
+    verifier under test reads blobs on every path; so does this.
+    """
+    result = subprocess.run(
+        [
+            str(SYSTEM_GIT_EXECUTABLE),
+            "--no-replace-objects",
+            "cat-file",
+            "blob",
+            f"HEAD:{path}",
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"cannot read {path!r} from HEAD: {result.stderr.decode(errors='replace')}"
+        )
+    return result.stdout
+
+
 _discovered_ssh_keygen = shutil.which("ssh-keygen")
 REAL_SSH_KEYGEN_EXECUTABLE = (
     Path(_discovered_ssh_keygen).resolve()
@@ -136,10 +168,9 @@ class RefreezeFixture:
         self.git("config", "user.name", "Refreeze Test")
         self.git("config", "core.autocrlf", "false")
 
-        repository_root = Path(__file__).resolve().parent.parent
         self.write(
             RELEASE_EVIDENCE_REQUIREMENTS_PATH,
-            (repository_root / RELEASE_EVIDENCE_REQUIREMENTS_PATH).read_bytes(),
+            repository_blob(RELEASE_EVIDENCE_REQUIREMENTS_PATH),
         )
         baseline_lines = [f"baseline clause {index}\n" for index in range(1, 20)]
         self.write(f"{FEATURE_ROOT}/spec.md", "".join(baseline_lines).encode())
@@ -224,16 +255,16 @@ class RefreezeFixture:
             ).encode(),
         )
 
-        api_bytes = (repository_root / API_PATH).read_bytes()
+        api_bytes = repository_blob(API_PATH)
         self.api = json.loads(api_bytes)
         for corpus_entry in self.api["configuration_domain"]["cover"][
             "input_corpus"
         ]:
             corpus_path = corpus_entry["path"]
-            self.write(corpus_path, (repository_root / corpus_path).read_bytes())
+            self.write(corpus_path, repository_blob(corpus_path))
         self.write(
             FIXTURE_MANIFEST_PATH,
-            (repository_root / FIXTURE_MANIFEST_PATH).read_bytes(),
+            repository_blob(FIXTURE_MANIFEST_PATH),
         )
         self.write(API_PATH, api_bytes)
 

--- a/execution/test_release_workflow_conditions.py
+++ b/execution/test_release_workflow_conditions.py
@@ -1,0 +1,181 @@
+"""Guard the release workflow's job conditions against a fail-open edit.
+
+A job-level `if` containing no status check function is implicitly wrapped in
+`success()`, which is false when any job in `needs` was skipped. The release
+workflow's pre-activation gate is skipped by design, and that skip propagates
+past `gate-release-ref` even though it survives via `always()`, so every job
+below names a status function to stop inheriting it.
+
+Naming a status function also discards the implicit `success()`. From then on,
+adding an entry to that job's `needs` without also asserting its result lets the
+job run when its new dependency FAILED. The `needs:` list and the `if:` line sit
+two lines apart and are semantically decoupled, so review does not reliably catch
+it. This test does.
+
+Deliberately hand-parsed: PyYAML is not in the stdlib and the CI runners do not
+install it, and a test that skips when its import fails is the same silent-pass
+defect it exists to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "release.yml"
+
+STATUS_FUNCTIONS = ("success(", "failure(", "cancelled(", "always(")
+
+# Jobs that legitimately keep the implicit success() wrap. Each is listed with
+# why, so removing one is a deliberate act rather than an oversight.
+IMPLICIT_SUCCESS_ALLOWED = {
+    "resolve-release-ref": "root job, no needs",
+    "verify-release-ref": "implicit success() over resolve-release-ref is what we want",
+    "feature-020-v11-gate": "implicit success() plus the phase check; must not run if verification failed",
+    "gate-release-ref": "always() by design; its result checks live in the step body",
+}
+
+# Strictly narrower, and deliberately NOT the set above: the only job allowed to
+# name a status function without asserting its dependencies in the expression,
+# because it asserts them in the step body instead. Reusing the wider set here
+# would exempt any job that later grows a status function -- the exact fail-open
+# this file exists to catch.
+STEP_BODY_RESULT_CHECKS = {
+    "gate-release-ref": "checks VERIFY_RESULT/FEATURE_GATE_RESULT in the step body",
+}
+
+JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+NEEDS_ITEM_RE = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*$")
+IF_RE = re.compile(r"^    if:\s*(.+?)\s*$")
+
+
+def parse_jobs(text: str) -> dict[str, dict[str, object]]:
+    """Return {job_id: {"needs": [...], "if": str|None}} for release.yml."""
+    jobs: dict[str, dict[str, object]] = {}
+    current: str | None = None
+    in_needs = False
+    in_jobs = False
+    for line in text.splitlines():
+        if line.startswith("jobs:"):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        # A non-indented key ends the jobs block.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        job = JOB_RE.match(line)
+        if job:
+            current = job.group(1)
+            jobs[current] = {"needs": [], "if": None}
+            in_needs = False
+            continue
+        if current is None:
+            continue
+        if line.strip() == "needs:":
+            in_needs = True
+            continue
+        if in_needs:
+            item = NEEDS_ITEM_RE.match(line)
+            if item:
+                jobs[current]["needs"].append(item.group(1))  # type: ignore[union-attr]
+                continue
+            in_needs = False
+        single = re.match(r"^    needs:\s*([A-Za-z0-9_-]+)\s*$", line)
+        if single:
+            jobs[current]["needs"] = [single.group(1)]
+            continue
+        condition = IF_RE.match(line)
+        if condition:
+            jobs[current]["if"] = condition.group(1)
+    return jobs
+
+
+class ReleaseWorkflowConditions(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(WORKFLOW.is_file(), f"missing {WORKFLOW}")
+        self.jobs = parse_jobs(WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_parse_found_the_workflow_shape(self) -> None:
+        """Fail loudly rather than vacuously if the hand parse stops matching."""
+        self.assertGreaterEqual(len(self.jobs), 10, f"parsed only {sorted(self.jobs)}")
+        for required in ("resolve-release-ref", "gate-release-ref", "prepare-release", "cargo-publish"):
+            self.assertIn(required, self.jobs)
+        self.assertEqual(self.jobs["verify-release-ref"]["needs"], ["resolve-release-ref"])
+        self.assertGreaterEqual(len(self.jobs["cargo-publish"]["needs"]), 5)
+
+    @staticmethod
+    def _requires_success(condition: str, dependency: str) -> bool:
+        """True only if the condition demands that dependency SUCCEEDED.
+
+        Both reference forms are accepted. Matching the whole comparison matters:
+        `needs.build.result != 'cancelled'` mentions the dependency but still
+        permits `skipped` and `failure`.
+        """
+        return any(
+            term in condition
+            for term in (
+                f"needs.{dependency}.result == 'success'",
+                f"needs['{dependency}'].result == 'success'",
+            )
+        )
+
+    def test_status_function_jobs_assert_every_dependency_succeeded(self) -> None:
+        checked = 0
+        for name, job in sorted(self.jobs.items()):
+            condition = job["if"]
+            if not isinstance(condition, str) or not any(f in condition for f in STATUS_FUNCTIONS):
+                continue
+            checked += 1
+            if name in STEP_BODY_RESULT_CHECKS:
+                continue
+            for dependency in job["needs"]:  # type: ignore[union-attr]
+                self.assertTrue(
+                    self._requires_success(condition, dependency),
+                    f"job {name!r} names a status function, which discards the implicit "
+                    f"success(), but never requires needs.{dependency}.result == 'success' "
+                    f"-- it will run when {dependency!r} fails",
+                )
+        self.assertGreaterEqual(
+            checked, 6, "expected the six post-gate jobs to name a status function"
+        )
+
+    def test_conditions_never_reference_a_job_they_do_not_need(self) -> None:
+        """A reference to a job absent from `needs` evaluates to null forever.
+
+        `null == 'success'` is false, so the job never runs and nothing reports an
+        error -- a permanent silent no-release, the same family as the skip bug in
+        the opposite direction.
+        """
+        for name, job in sorted(self.jobs.items()):
+            condition = job["if"]
+            if not isinstance(condition, str):
+                continue
+            referenced = set(re.findall(r"needs\.([A-Za-z0-9_-]+)\.", condition))
+            referenced |= set(re.findall(r"needs\['([A-Za-z0-9_-]+)'\]", condition))
+            declared = set(job["needs"])  # type: ignore[arg-type]
+            stray = sorted(referenced - declared)
+            self.assertEqual(
+                stray,
+                [],
+                f"job {name!r} references {stray} which are not in its needs; those "
+                f"expressions evaluate to null and silently block the job forever",
+            )
+
+    def test_jobs_without_a_status_function_are_deliberate(self) -> None:
+        for name, job in sorted(self.jobs.items()):
+            condition = job["if"]
+            if isinstance(condition, str) and any(f in condition for f in STATUS_FUNCTIONS):
+                continue
+            self.assertIn(
+                name,
+                IMPLICIT_SUCCESS_ALLOWED,
+                f"job {name!r} relies on the implicit success() wrap; if anything it needs "
+                f"is skipped it silently skips too. Add a status function plus explicit "
+                f"result checks, or record why here.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

Merging #549 stopped all releases. The Release workflow on `main` reported
**success while releasing nothing**: `prepare-release`, `build`, and all four
publish jobs skipped. The previous release run on `1521abb0` ran ten jobs
including both publishes.

GitHub propagates a skip transitively through `needs`. `feature-020-v11-gate`
skips by design in pre-activation; `gate-release-ref` survives via `always()`;
but `prepare-release` had no `if` at all, so its implicit `success()` inherited
the skip even though both of its direct needs succeeded — and the five jobs below
it inherited it too. It failed green, which is worse than failing red.

## What this changes

**1. Restores releases.** Each of the six downstream jobs names a status check
function to stop inheriting the skip, and restates explicitly the upstream success
it would otherwise have received implicitly. Every job's `needs` list is fully
covered; `needs.prepare-release.result == 'success'` is load-bearing, since that
job sets `release_created` and can still fail afterwards.

**2. Guards the next edit.** Naming a status function discards the implicit
`success()`, so adding a job to one of those `needs` lists without asserting its
result silently produces a job that runs after a failed dependency. A new test
asserts every such job requires `== 'success'` for every one of its needs, and
that no condition references a job absent from its needs (which evaluates to null
and blocks the job forever). Hand-parsed: PyYAML is absent on the runners, and a
test that skips on ImportError is the same silent pass it exists to prevent.

**3. Fixes 19 test failures nobody could see.** Every blob here is LF, but a
Windows checkout is CRLF, and fourteen files are seeded into the refreeze test
fixtures from the *worktree* while their pins are over blob bytes. All 36
manifest-inventory files and all 11 API `input_corpus` files mismatched locally.
CI never saw it because on Linux worktree == blob. Pinned LF repo-wide (no
committed byte changes — 1054 text blobs are already `i/lf`, none `i/crlf`), and
then made the test read blobs directly so its correctness no longer depends on
checkout normalization at all.

**4. Closes a freeze gap.** `tests/fixtures/public-api-v11-consumer` was absent
from `FROZEN_PATHS`. Eleven of its files were protected indirectly by the
`input_corpus` digests and one by `refreeze_v11.py`'s checks, but `README.md` by
nothing — one file in the corpus that could be rewritten between approval and
release undetected, whose operative sentence is the disclaimer that the V11 API is
not yet exported or compilable. Freezing the directory covers all thirteen and
costs no re-cut.

**5. Guards the LF invariant.** Six release-gating assertions compare a worktree
read against a blob-derived hash. They fail closed but are latent on these runners,
so a CRLF blob entering the index would be invisible in CI. CI now asserts the
index census, which is platform-independent.

## Verification

- `execution/test_refreeze_v11.py`: **164 tests OK** (was 19 failures, 3 errors)
- `verify-internal` and traceability checker: pass; self-test 99 fail-closed cases
- workflow guard mutation-tested: weakening a clause to `!= 'cancelled'`, adding a
  status function without assertions, and referencing a job not in `needs` are each
  caught by name
- blob-seeding proven checkout-independent: the previously failing test now passes
  against deliberately CRLF-corrupted worktree copies
- index guard proven to fire: staging a CRLF blob is reported by path
- independently reviewed; the workflow fix audited bidirectionally for
  under-coverage and over-reach, and the byte-reading sweep enumerated all thirteen
  hash/read sites across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY