### PR TITLE
docs: correct the build-artifact location claim

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
-# Build artifacts stay with the repo on E: (see CLAUDE.md § Windows build cache).
+# Build artifacts stay beside the checkout, on whatever drive the repo is on
+# (see CLAUDE.md, Windows build cache). Not a fixed drive: this said "on E:" while
+# the checkout lived there, which went stale when it moved.
 [build]
 target-dir = "target"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ### Windows build cache (disk)
 
-- Artifacts: repo `.cargo/config.toml` → `target/` on **E:** (gitignored). Do **not** pass `CARGO_TARGET_DIR=...` on the command line (older handoffs suggested `C:/symforge-target` — that filled **C:**).
+- Artifacts: repo `.cargo/config.toml` sets `target-dir = "target"`, i.e. artifacts land **beside the checkout, on whatever drive the repo is on** (gitignored). The comment in that file and this line both used to say "on **E:**", which was only ever true while the checkout lived there; as_of 2026-08-12 the repo is on **C:** with no E: drive present, and `target/` had reached **180 GB** on C:. Do **not** pass `CARGO_TARGET_DIR=...` on the command line (older handoffs suggested `C:/symforge-target` — that filled **C:**).
 - **Agent discipline**: OK to run full `cargo` gates locally; **clean up after yourself** — when you finish a heavy local session (`test --all-targets`, `build --release`), run `cargo clean` before ending so debug artifacts do not accumulate. If `target/debug` is already large before your gate, `cargo clean` first.
 
 ## CI Gates


### PR DESCRIPTION
`CLAUDE.md` and `.cargo/config.toml` both stated that build artifacts live "on
**E:**". That was true only while the checkout lived on E:. The config sets
`target-dir = "target"`, which puts artifacts beside the checkout on whatever
drive it is on.

Found while doing end-of-session disk hygiene: this machine has **no E: drive**,
the repo is on **C:**, and `target/` had reached **180 GB** there — the same drive
the warning immediately after that line says a previous `CARGO_TARGET_DIR`
override filled. Anyone acting on the stale claim would look for those artifacts
on a drive that does not exist.

Not urgent on its own (C: has ~1.5 TB free, and I left `target/` alone since I ran
no cargo builds this session and clearing it costs a full rebuild), but
`CLAUDE.md` is the repo's designated live-truth document and its own hygiene rule
says to update it when a change falsifies a claim.

Also removed 2722 leaked `refreeze-*` fixture directories from the gitignored
`.tmp/execution-tests` — the accumulation the fixture-cleanup fix stopped growing
but did not reclaim.

Docs and a comment only; no code, no test, no frozen path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY