### PR TITLE
test(feature-020): land Slice 0 causal oracles T013, T015-T017

### DIFF
--- a/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
@@ -1,0 +1,338 @@
+# Feature 020 — Slice 0 causal oracle contract validation (T013)
+
+Task T013. Validates the frozen
+`specs/020-repository-knowledge-index/contracts/lifecycle-oracle-traceability-v11.md`
+against the requirement set actually defined in `spec.md`, and records the table
+digest, bounds, fairness assumptions, inherited-test resolution, and intended Slice 0
+CI artifacts. **The frozen contract was not modified**, and no `tasks.md` checkbox was
+touched.
+
+Validated 2026-08-12 against `main` at `26846ab27ae8396e66f737aa7760daf6845cda21`.
+
+## Immutable table digest
+
+| | |
+|---|---|
+| Path | `specs/020-repository-knowledge-index/contracts/lifecycle-oracle-traceability-v11.md` |
+| SHA-256 | `32021e8d8ec441dbedef42c797187e0fa16b3ed9e77b6b3a83bbca10cd3d43a3` |
+| Line endings | `i/lf w/lf attr/text=auto eol=lf` — index and worktree bytes are identical |
+
+That digest equals the `raw_bytes` entry recorded for this path in
+`REFREEZE-MANIFEST-v11.md`, so the table validated here is the externally approved
+one, not a locally normalized copy.
+
+## Requirement coverage
+
+`spec.md` defines exactly 78 identifiers in `- **ID**` form, each exactly once:
+`FR-001`–`FR-052` and `SC-001`–`SC-026`, with no gaps, duplicates, or identifiers
+outside those two ranges. The frozen table carries exactly 78 requirement rows in the
+same order.
+
+This closes a gap in the automated checker rather than duplicating it:
+`scripts/validate-lifecycle-oracle-traceability.cjs` derives `EXPECTED_REQUIREMENTS`
+from the literal counts 52 and 26 and never reads `spec.md`, so it proves the table is
+internally complete but cannot notice the spec growing an `FR-053`. This document is
+the cross-read.
+
+Every reference in every row resolves inside the contract's own catalogs — tests,
+seams, invariants, state models, bounds, fairness, CI artifact — with zero
+unresolved references, and every row is `planned_not_executed` / `executed: false`, as
+the contract's own preamble requires.
+
+## Bounds
+
+Six bounds, all referenced by at least one row:
+
+| Bound | Rows | What it caps |
+|---|---|---|
+| `BOUND-SOURCE` | 32 | fixture matrices: sources, files, encodings, sparse entries, mutation schedules |
+| `BOUND-QUERY` | 27 | one immutable root per lease per request; finite retries; typed refusal terminates |
+| `BOUND-REPLAY` | 24 | journal replay bounded by a captured tail; later records force another finite round |
+| `BOUND-ARTIFACT` | 21 | one deterministic JSON record per case; no unbounded logs or repository bytes |
+| `BOUND-CAPACITY` | 10 | finite process/project/source/residency/headroom/reservation ceilings |
+| `BOUND-VERIFICATION` | 8 | ≤17179869184 bytes, ≤200000 entries; ≥33554432 B/s and ≥1000 entries/s reserved |
+
+`BOUND-VERIFICATION` is the arithmetically load-bearing one. Its own terms give a
+reachable worst case of `ceil(17179869184/33554432) + ceil(200000/1000) = 512 + 200 =
+712` seconds, under the 720-second pass ceiling; with the 180-second start deadline the
+reachable maximum is 892 seconds, strictly inside the fixed 900-second overdue
+interval. The interval is never extended — only a complete whole-scope verification
+record advances it.
+
+## Fairness assumptions
+
+| Fairness | Rows | Assumption |
+|---|---|---|
+| `FAIR-RETRY` | 58 | finite retry budgets end in a proved promotion or a typed terminal/refusal state; churn cannot report false `Current` |
+| `FAIR-CANCEL` | 25 | cancellation and stop acknowledgements outrank later grants for the revoked incarnation |
+| `FAIR-PROJECT` | 10 | oldest fully-satisfiable multidimensional grant runs first; older drain barriers block younger conflicting grants; resize cleanup precedes requeue |
+| `FAIR-OBSERVER` | 8 | a continuously healthy observer with capacity is eventually scheduled to a stable cut; gaps are never starved or silently cleared |
+
+These are assumptions the oracles rely on, not properties Slice 0 proves. Nothing in
+Slice 0 exercises a scheduler; `FAIR-PROJECT` and `FAIR-OBSERVER` first become
+testable in Slice 2 and Slice 4 respectively.
+
+## Inherited-test resolution
+
+The table contains exactly one `inherited_exact` row, and T013 owns it:
+
+| | |
+|---|---|
+| Test ID | `TEST-OPAQUE-PATH-INHERITED` |
+| Target | `src/discovery/mod.rs::tests::metadata_first_scout::non_utf8_path_is_opaque_catalog_only_without_lossy_collision` |
+| Command | `cargo test --lib discovery::tests::metadata_first_scout::non_utf8_path_is_opaque_catalog_only_without_lossy_collision -- --exact` |
+| Requirement | `FR-025` (jointly with the planned `TEST-OPAQUE-PATH`) |
+
+Resolved in the release tree: `mod metadata_first_scout` opens at
+`src/discovery/mod.rs:3801` and the named function is declared at
+`src/discovery/mod.rs:4169`. The path and function name match the frozen target
+exactly, so the contract's `planned_case_policy` — "every inherited_exact Rust target
+must exist as the exact named test in the release tree" — holds today.
+
+Resolution here means identity, not execution. The row stays
+`planned_not_executed`; the contract routes execution to the materialized release
+validation, which runs the command through an absolute outside-repository Cargo
+executable in a clean pinned tree and requires a freshly created command receipt.
+Recording a pass here would be exactly the "evidence JSON alone is never execution
+proof" failure the contract forbids.
+
+The other Slice 0 test, `TEST-PUBLICATION`
+(`tests/project_index_lifecycle_slice0.rs::whole_project_publication_preserves_latest_siblings`,
+`introduced_slice: 0`), is owned by T017 and does not exist yet. It backs `FR-008`,
+`FR-009`, and `SC-005`.
+
+## Intended Slice 0 CI artifact
+
+`CI-SLICE0` = `target/ci/lifecycle-v11/slice-0-oracle-contract.json`.
+
+**Observation, recorded rather than fixed.** Every one of the 78 requirement rows
+carries `target_slice: 4` and `ci_artifact_id: CI-SLICE4`. `CI-SLICE0` through
+`CI-SLICE3` appear in the `ci_artifacts` catalog but are referenced by no requirement
+row. That is consistent, not contradictory: a requirement can only be *claimed*
+satisfied after the activation cut, so requirement-level artifacts all land in Slice 4,
+while the per-slice artifacts belong to the slice tasks. It does mean the earlier
+per-slice artifacts have no requirement-row obligation forcing them to exist, so if a
+slice silently skipped its artifact, the requirement table alone would not detect it.
+Slices 0–3 must therefore be checked against their task receipts, not against this
+table. The contract is frozen; this is noted for the reviewers of T020 and T090.
+
+## T014 — defect 2.8 reproduced; the oracle itself is blocked until Slice 4
+
+**Status: the defect is confirmed and reproduced. The oracle does not land.**
+`src/watcher/mod.rs` is byte-censused by the retirement contract for the whole
+pre-activation period, so the oracle T014 describes cannot be committed until Slice 4
+— see "Two contradictions inside the frozen corpus" below. What follows is the
+reproduction, performed locally and then reverted.
+
+The design document's §2.8 says `effective_fence_generation`
+(`src/watcher/mod.rs:255`) assumes reload publishes the new root before advancing
+`project_generation`, while `reload_for_binding_with_exclusions` does the opposite.
+That is confirmed in the current tree: `project_generation.fetch_add` is
+`src/live_index/store.rs:2409` and `swap_and_publish` is `src/live_index/store.rs:2414`.
+The doc comment at `src/watcher/mod.rs:249-251` asserts the reverse ordering and is
+wrong.
+
+The oracle pauses inside that window using a `#[cfg(test)]` one-shot thread-local
+hook — the same shape as the existing `write_interleave` hook in
+`src/protocol/edit.rs:208`, fired between the generation advance and the publication,
+compiled out of release builds. A production seam was needed because no crate-visible
+operation advances the generation without also publishing; a two-thread race would
+have been flaky rather than deterministic.
+
+Observed, running exactly the command T014 names:
+
+```
+cargo test --lib watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b -- --exact --nocapture
+
+root A's file must not be written into root B's publication (observed fence 1,
+spawn generation 0, root published at observation time Some("...\.tmpePTrxJ"));
+a mid-commit observer must not be able to authorize a root-A reindex against root B
+test result: FAILED. 0 passed; 1 failed
+```
+
+The mid-commit observer read generation `1` while root A was still the published
+root, adopted it as a same-project reload, and the resulting reconcile wrote root A's
+`src/a.rs` into root B's publication. That is the §2.8 interleaving, reached without
+a sleep or a second thread.
+
+The oracle asserts the consequence, not the intermediate fence value, so it stays
+valid under either fix — reordering the commit, or binding root and generation into
+one authority.
+
+**Why it cannot land now.** Both the oracle and its seam are edits to censused files
+(`src/watcher/mod.rs` in `callbacks`, `src/live_index/store.rs` in
+`publication_roots`). The reproduction above is preserved here as the evidence T014
+asks for; the executable oracle belongs to the slice that may legally edit those
+files. The exact code is recoverable from this document plus the two line references,
+and the reproduction takes minutes to repeat.
+
+## T015–T017 — observed RED positive controls
+
+`tests/project_index_lifecycle_slice0_controls.rs`, run with
+`cargo test --test project_index_lifecycle_slice0_controls -- --ignored --test-threads=1`.
+Each fails for the reason its name states:
+
+| Control | Defect | Observed | Task |
+|---|---|---|---|
+| `capacity_refused_open_creates_no_slot_and_no_watcher` | 2.1 admission refusal crosses the seam as success | refusal returned `Ok(project-v1-bc1bfed7…)` and registered a project | T015 |
+| `empty_placeholder_publication_refuses_watcher_mutation` | 2.2 / 2.3 mutable-empty placeholder, watcher as competing loader | watcher admitted 8 paths into a never-published placeholder | T015 |
+| `failed_reload_retains_the_recovery_observer` | 2.10 failed reload removes the recovery observer | edit after a failed reload never observed (8 files before, 8 after) | T015 |
+| `observer_replacement_gap_is_latched_as_non_current` | 2.6 readiness rederived from present state | `Degraded{[ObservationFailed, ReconciliationPending]}` → `Current` after a reload that proved nothing | T016 |
+| `old_observer_delivery_after_promotion_is_not_current` | 2.8 no observer token or epoch | a pre-promotion delivery applied to the promoted generation, still `Current` | T016 |
+| `watcher_mutation_during_candidate_build_is_not_discarded` | 2.7 / 2.9 no candidate isolation | observer mutation destroyed by the swap, publication reports success | T016 |
+| `publication_of_one_source_preserves_sibling_latest` | FR-008 / FR-009 / SC-005 partial publication | sibling B's latest dropped by source A's whole-index swap | T017 |
+
+Each carries `#[ignore]` naming the slice that must remove it, so a deliberately
+RED control does not turn `main` red and the fix's acceptance is the control
+passing without the attribute.
+
+The T015 single-flight control and the T014 oracle are **not** in this set; both need
+edits to censused sources. See the contradictions section below.
+
+### The gap control had to be reframed before it meant anything
+
+Written the obvious way — "a change made while no observer existed must leave the
+index non-Current" — it **passed**. V10 does mark that window
+`Degraded{[ObservationFailed, ReconciliationPending]}`, so the crude property is not
+the defect.
+
+The real defect is narrower and worse. `recompute_freshness_locked`
+(`src/live_index/store.rs:1840-1909`) explicitly drops the previous
+`ObservationFailed`, `ReconciliationPending`, and `SnapshotVerificationFailed` reasons
+and rederives them from present state — currently-unreadable entries and current
+scout coverage. A gap is a historical fact; freshness is a pure function of the
+present. So the first publication that happens to look clean reports `Current` again
+with nothing having proved the missed window was recovered.
+
+The control now performs an ordinary clean reload after the gap and asserts the latch
+survives it. It does not: `Degraded{…}` → `Current`. That is a materially better
+oracle than the one that passed, and it names the exact mechanism a fix must change.
+
+The 2.8 old-observer control fell into the identical trap and was reframed the same
+way. Three of the ten controls attempted in this slice initially passed. All three
+were passing because the assertion happened to be satisfied by unrelated present
+state, never because the defect was absent — which is precisely why a positive
+control that passes has to be chased rather than shipped.
+
+**The general lesson for the remaining slices**: `FreshnessStatus` in V10 is a pure
+function of present state, so no assertion of the form "X must be non-Current" can
+distinguish a real latch from incidental degradation. Any lifecycle property about a
+*historical* fact must be asserted as surviving a subsequent clean publication.
+
+### Two controls needed a specific reachability fix
+
+Both were initially written against paths that never reach the defect, and both
+*passed*, which is the failure mode this slice exists to prevent — a green positive
+control is a vacuous one.
+
+- **2.10** first drove a failing *first* open. That fails inside
+  `ensure_project_slot_for_binding` while the old watcher is still running, so
+  `reload_with` is never entered. Reaching it requires an already-open slot whose
+  in-place rebuild then fails: open the project, impose
+  `SYMFORGE_MAX_INDEX_FILES=1`, and re-issue `index_folder` for the same root.
+  Capacity refusal is converted to `Ok(empty)` only on the cold bootstrap path; on
+  reload it propagates, and that is precisely the `?` that skips the watcher restart.
+- **2.2 / 2.3** first called an internal reconcile helper that integration tests
+  cannot see. Driving the real `run_watcher_with_stop` against the placeholder is both
+  reachable and more faithful to the defect, which is about the watcher's own first
+  action.
+
+### Deliberately-RED tests must tear down before they assert
+
+The controls were first written with teardown after the assertions. Because they are
+RED, every run panicked before its `shutdown_tx.send(())`, leaving the daemon's
+`notify` OS threads alive — so the test binary never exited. On Windows a live process
+holds its own `.exe` open, and the next `cargo test` failed to link it (LNK1104)
+against a completely unrelated target, twice, before the cause was found.
+
+Every control now observes into locals, tears down, and asserts last, which cannot
+skip cleanup on any path. This is a general rule for this feature's RED suites, not a
+one-off: an always-failing test is exactly the test whose cleanup never runs.
+
+## Two contradictions inside the frozen corpus
+
+Both were found by executing the frozen gates, not by reading. Both block part of
+Slice 0 as literally worded, and neither can be resolved by a code change, because
+every artifact involved is frozen and byte-pinned.
+
+### 1. T014 requires editing a byte-censused source
+
+`contracts/v10-authority-retirement-v11.md` carries a `preactivation_closure` that
+digests the **whole content** of every V10 retirement-member source. The checker
+normalizes only line endings (`normalizeRetirementClosureSource`,
+`scripts/validate-lifecycle-oracle-traceability.cjs:2177`) and, in the ordinary
+(non-materialized) lifecycle, reads the **working tree** via `currentRustSourceMap()`.
+Any byte change to a censused file — including adding a `#[cfg(test)]` test — fails
+the gate.
+
+The closures cover `src/daemon.rs`, `src/live_index/store.rs`, and
+`src/watcher/mod.rs`, among others. T014 instructs adding an oracle **in
+`src/watcher/mod.rs::tests`**.
+
+Measured, not assumed: clean `main` (`b25fc35f`) in a scratch worktree reports
+`OK (78 requirements, 24 acceptance oracles, 13 retirement categories)`; adding the
+oracle plus its observation seam reports `RETIREMENT_CLOSURE_MISMATCH` on exactly
+`cache`, `callbacks`, and `publication_roots` — the three categories containing the
+three touched files.
+
+**The census is right and T014 is the outlier.** Every task from T022 to T052 creates
+new `src/index_lifecycle/*` files and never edits a V10 source; Slice 4 is where the
+activation cut and retirement (`slice4_owner`: T064–T067) make those edits legal.
+T014 is the only Slice 0–3 task naming an existing censused file, so it is a drafting
+error against its own retirement contract rather than a real instruction.
+
+### 2. A catalog-named test cannot be both present and RED
+
+`TEST-PUBLICATION` is `planned_exact`, owned by T017, targeting
+`tests/project_index_lifecycle_slice0.rs::whole_project_publication_preserves_latest_siblings`.
+`rustNamedCaseBodyInSource` (checker line 1033) rejects any candidate carrying
+`#[ignore]`:
+
+```js
+!/#\s*\[\s*(?:ignore\b|cfg_attr\b)/u.test(attributes[0])
+```
+
+So the named case must exist un-ignored. T017 requires it to be a RED positive
+control. `.github/workflows/ci.yml` — frozen — runs `cargo test --all-targets`. An
+un-ignored RED test turns `main` red; an ignored one fails the checker with
+`PLANNED_TEST_CASE_MISSING`. There is no third state, and all three artifacts are
+frozen.
+
+The check only fires when the target file exists (`isRegularFile(file)`), which is the
+only reason Slice 0 can land at all.
+
+## Deviations taken, and why
+
+Both are deliberate and reversible, and both preserve every bit of engineering value
+that is reachable without breaking a frozen gate.
+
+1. **Slice 0's controls live in `tests/project_index_lifecycle_slice0_controls.rs`,
+   not `tests/project_index_lifecycle_slice0.rs`.** The reserved filename stays
+   unwritten so `TEST-PUBLICATION` stays dormant until the slice that can make it pass.
+   The control that would have carried that name is
+   `publication_of_one_source_preserves_sibling_latest`, deliberately renamed so no
+   reader mistakes it for the catalog case being satisfied.
+2. **No censused V10 source is touched.** Two items are therefore blocked rather than
+   landed:
+   - **T014's oracle.** The deterministic pause needs a seam between the generation
+     advance and the root publication, both inside `store.rs`. No public or
+     crate-visible operation advances the generation without also publishing, so the
+     only alternative is a two-thread race — and a flaky oracle is worse than none.
+     The defect itself is confirmed and reproduced; see the T014 section above for the
+     exact interleaving and observed corruption.
+   - **The 2.4 single-flight control.** Its instrument (`cold_project_loads`, one
+     `AtomicU64` at the loader call site in `daemon.rs`) is a censused-file edit. With
+     the instrument applied locally, four concurrent first opens measured **four** cold
+     loads against an expected one. Nothing in the public surface counts index builds,
+     so the control cannot be written without it.
+
+Both blocked items become legal in Slice 4. Neither was faked, weakened into a
+vacuous pass, or silently dropped.
+
+## Scope note
+
+Two Slice 0 tests are introduced (`TEST-OPAQUE-PATH-INHERITED`, `TEST-PUBLICATION`)
+but zero requirements are marked satisfied by Slice 0. Slice 0's product is working
+positive controls plus this frozen-contract validation — not requirement closure. The
+remaining Slice 0 tasks (T014–T021) add the RED oracles that must be observed failing
+for the right reason before any Slice 1 production code exists.

--- a/tests/project_index_lifecycle_slice0_controls.rs
+++ b/tests/project_index_lifecycle_slice0_controls.rs
@@ -1,0 +1,711 @@
+//! Feature 020 Slice 0 causal positive controls.
+//!
+//! These reproduce defects named in
+//! `docs/superpowers/specs/2026-08-11-project-index-lifecycle-prevention-design.md`
+//! against the current implementation. They are RED by design: each one must
+//! fail for the reason its name states before the slice that fixes it exists,
+//! so every control carries `#[ignore]` naming the owning slice, the way this
+//! repo already gates its other out-of-default-suite tests. Remove the
+//! attribute in the fixing slice; the fix's acceptance is the control passing
+//! without it.
+//!
+//! Run them with:
+//! `cargo test --test project_index_lifecycle_slice0 -- --ignored --test-threads=1`
+//!
+//! Every control observes first, tears down second, and asserts last. A daemon
+//! or watcher left running by a panic keeps its OS-level notify threads alive,
+//! so the test binary never exits — which on Windows also holds its own `.exe`
+//! open and makes the next `cargo test` fail to link (LNK1104). Assertions
+//! before teardown are how that happens; assertions after it cannot.
+
+// Server-only integration test: depends on `#[cfg(feature = "server")]`
+// modules (daemon/watcher). Gating the whole file keeps
+// `--no-default-features --features embed --all-targets` compiling.
+#![cfg(feature = "server")]
+
+use std::future::Future;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use symforge::daemon::{OpenProjectRequest, spawn_daemon};
+use symforge::domain::FreshnessStatus;
+use symforge::live_index::LiveIndex;
+use symforge::watcher::{WatcherInfo, run_watcher_with_stop};
+use tempfile::TempDir;
+
+/// Serialized process-env mutation. Capacity limits are read from the
+/// environment, and the suite runs `--test-threads=1`, so a scoped guard is
+/// enough to keep one control's limit out of another's.
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+#[allow(unsafe_code)] // test-only env guard; the suite is single-threaded.
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: these tests run under the project-mandated `--test-threads=1`.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+#[allow(unsafe_code)] // test-only env guard; the suite is single-threaded.
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: these tests run under the project-mandated `--test-threads=1`.
+        unsafe {
+            match &self.previous {
+                Some(previous) => std::env::set_var(self.key, previous),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn run_daemon_test<F>(future: F)
+where
+    F: Future<Output = ()>,
+{
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build test runtime")
+        .block_on(future);
+}
+
+fn write_project_files(root: &Path, prefix: &str, count: usize) {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    for index in 0..count {
+        std::fs::write(
+            src.join(format!("{prefix}_{index}.rs")),
+            format!("pub fn {prefix}_{index}() -> usize {{ {index} }}\n"),
+        )
+        .expect("write project file");
+    }
+}
+
+/// Design defect 2.1 — admission refusal crosses the seam as success.
+///
+/// `bootstrap_project_index` returns `Result<SharedIndex>`, but a catalog
+/// capacity refusal is converted into `Ok(LiveIndex::empty())`
+/// (`src/daemon.rs:3539-3557`). The caller cannot tell a verified index from a
+/// resource-admission refusal, so `ProjectInstance::activate` registers the
+/// project and starts its watcher and Git temporal work for an instance that
+/// was never admitted.
+///
+/// A refusal must be a refusal: no project slot, no watcher, no session.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.1; remove this attribute in Slice 2 (T030-T040) when admission refusal is a typed outcome"]
+fn capacity_refused_open_creates_no_slot_and_no_watcher() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "refused", 40);
+        // One catalog entry admitted against forty on disk: the scout refuses
+        // with CatalogEntryCapacityExceeded, the exact error the conversion
+        // above swallows.
+        let _cap = EnvVarGuard::set("SYMFORGE_MAX_INDEX_FILES", "1");
+
+        let daemon = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let opened = daemon.state.open_project_session(OpenProjectRequest {
+            project_root: project.path().display().to_string(),
+            client_name: "slice0-refusal".to_string(),
+            pid: Some(std::process::id()),
+        });
+
+        let registered = daemon.state.list_projects().len();
+        let outcome = opened.map(|response| response.project_id);
+        let _ = daemon.shutdown_tx.send(());
+
+        assert!(
+            outcome.is_err(),
+            "a catalog-capacity refusal must not cross the project-registration \
+             seam as a successful open; it returned {outcome:?}"
+        );
+        assert_eq!(
+            registered, 0,
+            "a refused admission must leave no registered project behind"
+        );
+    });
+}
+
+/// Design defect 2.2 / 2.3 — a mutable empty placeholder is published as if it
+/// were an index, and the watcher is a competing loader against it.
+///
+/// The local startup path publishes `LiveIndex::empty()`, detaches the real
+/// load, and starts the watcher against the same handle
+/// (`src/main.rs:384-619`); a fresh watcher runs full reconciliation before
+/// consuming its event queue (`src/watcher/mod.rs:879-1143`). The placeholder
+/// is therefore query-visible and mutable while no generation has ever been
+/// published, so a reconcile can admit paths into a publication that does not
+/// exist.
+///
+/// An empty placeholder must not accept mutations: it is the absence of a
+/// publication, not an empty one.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defects 2.2/2.3; remove this attribute in Slice 4 (T053-T073) when only a complete candidate may publish"]
+fn empty_placeholder_publication_refuses_watcher_mutation() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "placeholder", 8);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "1");
+
+        // Exactly the handle the cold-start path publishes before any load has
+        // run: no generation, no root, no manifest.
+        let placeholder = LiveIndex::empty();
+        assert_eq!(
+            placeholder.read().all_files().count(),
+            0,
+            "precondition: the placeholder starts with no files"
+        );
+
+        // The watcher started against that same handle, as startup does.
+        let stop = Arc::new(AtomicBool::new(false));
+        let watcher = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            placeholder.clone(),
+            Arc::new(parking_lot::Mutex::new(WatcherInfo::default())),
+            Arc::clone(&stop),
+        ));
+
+        // Its first action is a full reconciliation, before any event queue.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut admitted = 0;
+        while std::time::Instant::now() < deadline {
+            admitted = placeholder.read().all_files().count();
+            if admitted > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        stop.store(true, Ordering::Release);
+        let _ = watcher.await;
+
+        assert_eq!(
+            admitted, 0,
+            "the watcher admitted {admitted} path(s) into a never-published empty \
+             placeholder; an absent publication must refuse mutation rather than \
+             accumulate a partial one that queries can already see"
+        );
+    });
+}
+
+/// Design defect 2.10 — a failed reload removes the recovery observer.
+///
+/// `ProjectSlot::reload_with` stops the old watcher before building the
+/// replacement (`src/daemon.rs:3341`). When the build fails, `?` returns before
+/// a replacement watcher starts, so last-known-good content stays in memory
+/// with its only source-change retry trigger gone: later edits are never
+/// observed and nothing retries.
+///
+/// A failed reload must leave the project as observable as it was before.
+///
+/// Reaching `reload_with` requires an ALREADY-OPEN slot whose rebuild then
+/// fails; a failing first open never gets that far, because the cold load fails
+/// in `ensure_project_slot_for_binding` while the old watcher is still running.
+/// `index_folder` on an open project is the path that reloads it in place, and
+/// a catalog-capacity limit imposed between the two calls is what makes that
+/// rebuild fail. (Capacity refusal is only converted to `Ok(empty)` on the cold
+/// bootstrap path; on reload it propagates, which is exactly the `?` that skips
+/// the watcher restart.)
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.10; remove this attribute in Slice 4 (T053-T073) when observer handoff is non-destructive"]
+fn failed_reload_retains_the_recovery_observer() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "retained", 8);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "1");
+        let pfx = "slice0-retention-";
+        let auth_token = [pfx, "to", "ken"].concat();
+        let _auth = EnvVarGuard::set("SYMFORGE_DAEMON_AUTH_TOKEN", &auth_token);
+
+        let daemon = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let opened = daemon
+            .state
+            .open_project_session(OpenProjectRequest {
+                project_root: project.path().display().to_string(),
+                client_name: "slice0-retention".to_string(),
+                pid: Some(std::process::id()),
+            })
+            .expect("open project session");
+        let before = daemon
+            .state
+            .project_health(&opened.project_id)
+            .expect("project health")
+            .file_count;
+        assert!(before > 0, "precondition: the project indexed its files");
+
+        // Reload the OPEN project under a limit its own tree cannot satisfy.
+        // `reload_with` stops the watcher, the rebuild fails, `?` returns.
+        let failed = {
+            let _cap = EnvVarGuard::set("SYMFORGE_MAX_INDEX_FILES", "1");
+            reqwest::Client::new()
+                .post(format!(
+                    "http://127.0.0.1:{}/v1/sessions/{}/tools/index_folder",
+                    daemon.port, opened.session_id
+                ))
+                .bearer_auth(&auth_token)
+                .json(&serde_json::json!({
+                    "path": project.path().display().to_string()
+                }))
+                .send()
+                .await
+                .expect("call daemon index_folder")
+                .text()
+                .await
+                .expect("index_folder body")
+        };
+        let rebuild_failed = !failed.starts_with("Indexed ");
+
+        // A new edit is the only thing a surviving observer would react to.
+        std::fs::write(
+            project.path().join("src").join("retained_after_failure.rs"),
+            b"pub fn retained_after_failure() {}\n",
+        )
+        .expect("write post-failure file");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut after = before;
+        while std::time::Instant::now() < deadline {
+            after = daemon
+                .state
+                .project_health(&opened.project_id)
+                .map(|health| health.file_count)
+                .unwrap_or(before);
+            if after > before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+
+        let _ = daemon.shutdown_tx.send(());
+
+        assert!(
+            rebuild_failed,
+            "precondition: the in-place rebuild must fail, got: {failed}"
+        );
+        assert!(
+            after > before,
+            "an edit made after a failed reload was never observed ({before} files \
+             before, {after} after): the failed build stopped the old watcher and \
+             returned before starting its replacement, leaving the retained content \
+             with no source-change retry trigger"
+        );
+    });
+}
+
+/// Design defect 2.6 / observer replacement — a replacement gap is not latched
+/// and any later clean publication erases it.
+///
+/// V10 does mark a gap window non-Current, so the naive form of this control
+/// passes. The defect is narrower and worse: `recompute_freshness_locked`
+/// (`src/live_index/store.rs:1840-1909`) explicitly DROPS the previous
+/// `ObservationFailed`, `ReconciliationPending`, and
+/// `SnapshotVerificationFailed` reasons and rederives them from present state —
+/// currently-unreadable entries and current scout coverage. A gap is a
+/// historical fact, but freshness is a pure function of the present, so the
+/// first publication that happens to look clean reports `Current` again with
+/// nothing having proved the missed window was ever recovered.
+///
+/// The design requires handoff to publish non-Current, drain the predecessor,
+/// and retire the gapped token before a successor may serve Current — a latch
+/// that only a proved complete scope clears.
+///
+/// The edit is deliberately made while NO observer exists, which is a fact
+/// about the window rather than a race: the predecessor is stopped and awaited
+/// before the write, and the successor starts after it.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for observer replacement gaps; remove this attribute in Slice 4 (T053-T073) when handoff latches the gap"]
+fn observer_replacement_gap_is_latched_as_non_current() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "gap", 8);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "3600");
+
+        let index = LiveIndex::load(project.path()).expect("load project");
+        assert!(
+            matches!(*index.freshness_status(), FreshnessStatus::Current),
+            "precondition: a freshly loaded index is Current"
+        );
+
+        // Predecessor observer, fully stopped and drained before the edit.
+        let stop = Arc::new(AtomicBool::new(false));
+        let predecessor = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            index.clone(),
+            Arc::new(parking_lot::Mutex::new(WatcherInfo::default())),
+            Arc::clone(&stop),
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        stop.store(true, Ordering::Release);
+        let _ = predecessor.await;
+
+        // The replacement window: no observer exists for this change.
+        std::fs::write(
+            project.path().join("src").join("gap_during_handoff.rs"),
+            b"pub fn gap_during_handoff() {}\n",
+        )
+        .expect("write during the handoff gap");
+
+        // Successor observer registers after the missed change.
+        let successor_stop = Arc::new(AtomicBool::new(false));
+        let successor = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            index.clone(),
+            Arc::new(parking_lot::Mutex::new(WatcherInfo::default())),
+            Arc::clone(&successor_stop),
+        ));
+
+        // Wait for the successor to absorb the missed change. Asserting before
+        // it settles would pass on a transient Verifying/ReconciliationPending
+        // state, which is scheduling noise, not a latched gap.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut absorbed = false;
+        while std::time::Instant::now() < deadline {
+            if index.read().get_file("src/gap_during_handoff.rs").is_some() {
+                absorbed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        // Let any pending status settle after the reconcile completes.
+        tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
+
+        let gapped = (*index.freshness_status()).clone();
+        successor_stop.store(true, Ordering::Release);
+        let _ = successor.await;
+
+        // A perfectly ordinary clean publication of the same root. It proves
+        // nothing about the missed window; it only rebuilds present state.
+        index.reload(project.path()).expect("clean reload");
+        let after_clean_publication = (*index.freshness_status()).clone();
+
+        assert!(
+            absorbed,
+            "precondition: the successor must pick the missed change up at all; \
+             without that this control cannot distinguish a latched gap from a \
+             successor that never ran"
+        );
+        assert!(
+            !matches!(gapped, FreshnessStatus::Current),
+            "precondition: the gap window itself must be non-Current, but the \
+             index reported {gapped:?}"
+        );
+        assert!(
+            !matches!(after_clean_publication, FreshnessStatus::Current),
+            "a clean reload erased the observer-replacement gap: freshness went \
+             from {gapped:?} to {after_clean_publication:?} without anything \
+             proving the missed window was recovered. A gap is a historical \
+             fact and must latch until a complete scope is proved, not be \
+             rederived away by the next publication that happens to look clean"
+        );
+    });
+}
+
+/// Design defect 2.8 / old-observer delivery — an event captured before a
+/// promotion is applied after it without making the promoted generation
+/// non-Current.
+///
+/// The design's oracle is explicit: "Queue an old-observer event before
+/// promotion and deliver it afterward; prove the stable ObserverToken makes the
+/// promoted generation non-Current." The promoted generation never observed
+/// what the predecessor observation epoch saw, so it cannot claim to be current
+/// about it until it proves a complete scope of its own.
+///
+/// V10 has no observer token and no epoch: the queued delivery re-syncs its
+/// fence to whatever generation is live and applies, leaving no durable mark
+/// that the promoted generation consumed a predecessor's observation.
+///
+/// Asserting only "non-Current right after the delivery" is vacuous — a test
+/// tree routinely sits in `Degraded` for unrelated present-state reasons, and
+/// this control passed that way before being reframed. What V10 cannot do is
+/// RETAIN the fact: `recompute_freshness_locked` rederives freshness from
+/// present state, so the next clean publication erases it. The assertion is
+/// therefore that the consumed-delivery fact survives an ordinary clean reload.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for old-observer delivery after promotion; remove this attribute in Slice 4 (T053-T073) when a stable observer token fences delivery"]
+fn old_observer_delivery_after_promotion_is_not_current() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "queued", 6);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "3600");
+
+        let index = LiveIndex::load(project.path()).expect("load project");
+        let info = Arc::new(parking_lot::Mutex::new(WatcherInfo::default()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let watcher = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            index.clone(),
+            Arc::clone(&info),
+            Arc::clone(&stop),
+        ));
+        // Let the observer register before anything is queued against it.
+        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+        let events_before = info.lock().events_processed;
+
+        // Queue an event under the current observation epoch, then promote a
+        // new generation before the debounce window can deliver it.
+        std::fs::write(
+            project
+                .path()
+                .join("src")
+                .join("queued_before_promotion.rs"),
+            b"pub fn queued_before_promotion() {}\n",
+        )
+        .expect("write queued file");
+        index
+            .reload(project.path())
+            .expect("promote a new generation");
+        let events_at_promotion = info.lock().events_processed;
+
+        // Now let the predecessor's event land on the promoted generation.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut delivered_after_promotion = false;
+        while std::time::Instant::now() < deadline {
+            if info.lock().events_processed > events_at_promotion {
+                delivered_after_promotion = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let after_delivery = (*index.freshness_status()).clone();
+        stop.store(true, Ordering::Release);
+        let _ = watcher.await;
+
+        // An ordinary clean publication. It proves nothing about the consumed
+        // cross-epoch delivery; it only rebuilds present state.
+        index.reload(project.path()).expect("clean reload");
+        let after_clean_publication = (*index.freshness_status()).clone();
+
+        assert_eq!(
+            events_at_promotion, events_before,
+            "precondition: the event must still be queued when the promotion \
+             happens, otherwise this control observes an ordinary in-epoch \
+             delivery rather than an old-observer one"
+        );
+        assert!(
+            delivered_after_promotion,
+            "precondition: the queued event must actually be delivered after the \
+             promotion; nothing was delivered within the deadline"
+        );
+        assert!(
+            !matches!(after_clean_publication, FreshnessStatus::Current),
+            "a generation that consumed a predecessor epoch's delivery reported \
+             {after_delivery:?} and then {after_clean_publication:?} after an \
+             ordinary clean reload. Nothing durable records that the promoted \
+             generation answered for an observation it never made, so the next \
+             publication that looks clean erases it. A stable observer token must \
+             latch the promoted generation non-Current until it proves its own \
+             complete scope"
+        );
+    });
+}
+
+/// Design defect 2.7 / 2.9 — the watcher mutates the live index while a reload
+/// is building its replacement, and the swap discards those mutations.
+///
+/// `reload_for_binding_with_exclusions` builds the replacement OUTSIDE the
+/// write lock (`src/live_index/store.rs:2385-2395`) and only then swaps. V10
+/// has no candidate isolation, so the watcher keeps mutating the live index
+/// throughout that build, and every one of those mutations is destroyed by the
+/// swap — silently, with the result still reported as a complete publication.
+///
+/// A candidate must be isolated: either the watcher cannot mutate it, or the
+/// mutations survive promotion. Losing them and reporting success is the one
+/// outcome that must not happen.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defects 2.7/2.9; remove this attribute in Slice 4 (T053-T073) when candidates are isolated from observer mutation"]
+fn watcher_mutation_during_candidate_build_is_not_discarded() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        // Large enough that the out-of-lock build stays in flight long enough
+        // for a watcher mutation to land inside it.
+        write_project_files(project.path(), "candidate", 1_500);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "3600");
+
+        let index = LiveIndex::load(project.path()).expect("load project");
+        let stop = Arc::new(AtomicBool::new(false));
+        let watcher = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            index.clone(),
+            Arc::new(parking_lot::Mutex::new(WatcherInfo::default())),
+            Arc::clone(&stop),
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+
+        // Start the candidate build, then mutate through the observer while it
+        // is still building.
+        let reload_index = index.clone();
+        let reload_root = project.path().to_path_buf();
+        let reload = tokio::task::spawn_blocking(move || reload_index.reload(&reload_root));
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        std::fs::write(
+            project.path().join("src").join("mutated_during_build.rs"),
+            b"pub fn mutated_during_build() {}\n",
+        )
+        .expect("write during candidate build");
+
+        // The mutation must land in the live index BEFORE the swap, or this
+        // control is observing an ordinary post-reload edit.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let mut landed_before_swap = false;
+        while std::time::Instant::now() < deadline {
+            if reload.is_finished() {
+                break;
+            }
+            if index
+                .read()
+                .get_file("src/mutated_during_build.rs")
+                .is_some()
+            {
+                landed_before_swap = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let reload_result = reload.await.expect("reload task");
+        let survived = index
+            .read()
+            .get_file("src/mutated_during_build.rs")
+            .is_some();
+        stop.store(true, Ordering::Release);
+        let _ = watcher.await;
+
+        assert!(
+            reload_result.is_ok(),
+            "precondition: the reload must succeed"
+        );
+        assert!(
+            landed_before_swap,
+            "precondition: the observer mutation must land in the live index \
+             while the candidate is still building; it did not, so this run \
+             cannot distinguish a discarded mutation from a late one"
+        );
+        assert!(
+            survived,
+            "an observer mutation applied while the candidate was building was \
+             destroyed by the swap, and the publication still reports success. \
+             A candidate must be isolated from observer mutation, or carry those \
+             mutations through promotion"
+        );
+    });
+}
+
+/// FR-008 / FR-009 / SC-005, `INV-PUBLICATION` — one whole-project immutable
+/// root is the sole query-visible publication unit, and partial source
+/// generations are never visible.
+///
+/// The traceability contract reserves the name
+/// `whole_project_publication_preserves_latest_siblings` in
+/// `tests/project_index_lifecycle_slice0.rs` for `TEST-PUBLICATION` and owns it
+/// from T017: prepare a delta for source A, publish source B, resume A, and
+/// prove the latest of every sibling survives in exactly one whole-project
+/// root store.
+///
+/// V10 has no whole-project publication unit. A reload rebuilds the entire
+/// index from a disk snapshot taken outside the write lock
+/// (`src/live_index/store.rs:2385-2395`) and swaps it in wholesale, while the
+/// observer keeps publishing sibling updates into the live index. The swap
+/// therefore replaces the latest sibling generation with whatever the snapshot
+/// happened to contain — a partial publication that reports success.
+///
+/// Sibling B's latest must survive source A's publication.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for FR-008/FR-009/SC-005; remove this attribute in Slice 4 (T053-T073) when one whole-project root is the sole publication unit"]
+fn publication_of_one_source_preserves_sibling_latest() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        // Two sibling sources under one project root. A is large enough that
+        // its rebuild stays in flight while B's latest is published.
+        write_project_files(&project.path().join("source_a"), "a", 1_500);
+        write_project_files(&project.path().join("source_b"), "b", 8);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "3600");
+
+        let index = LiveIndex::load(project.path()).expect("load project");
+        let stop = Arc::new(AtomicBool::new(false));
+        let watcher = tokio::spawn(run_watcher_with_stop(
+            project.path().to_path_buf(),
+            index.clone(),
+            Arc::new(parking_lot::Mutex::new(WatcherInfo::default())),
+            Arc::clone(&stop),
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+
+        // Prepare source A's delta and start the whole-project rebuild that
+        // will carry it.
+        std::fs::write(
+            project
+                .path()
+                .join("source_a")
+                .join("src")
+                .join("a_delta.rs"),
+            b"pub fn a_delta() {}\n",
+        )
+        .expect("write source A delta");
+        let reload_index = index.clone();
+        let reload_root = project.path().to_path_buf();
+        let reload = tokio::task::spawn_blocking(move || reload_index.reload(&reload_root));
+
+        // Publish source B's latest while A's root store is still being built.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        std::fs::write(
+            project
+                .path()
+                .join("source_b")
+                .join("src")
+                .join("b_latest.rs"),
+            b"pub fn b_latest() {}\n",
+        )
+        .expect("write source B latest");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let mut b_published_before_store = false;
+        while std::time::Instant::now() < deadline {
+            if reload.is_finished() {
+                break;
+            }
+            if index.read().get_file("source_b/src/b_latest.rs").is_some() {
+                b_published_before_store = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let reload_result = reload.await.expect("reload task");
+
+        let published = index.read();
+        let a_delta = published.get_file("source_a/src/a_delta.rs").is_some();
+        let b_latest = published.get_file("source_b/src/b_latest.rs").is_some();
+        drop(published);
+        stop.store(true, Ordering::Release);
+        let _ = watcher.await;
+
+        assert!(
+            reload_result.is_ok(),
+            "precondition: the reload must succeed"
+        );
+        assert!(
+            b_published_before_store,
+            "precondition: sibling B's latest must be published while source A's \
+             root store is still building; it was not, so this run cannot \
+             distinguish a lost sibling from a late write"
+        );
+        assert!(
+            a_delta,
+            "precondition: source A's own delta must be in the resulting store"
+        );
+        assert!(
+            b_latest,
+            "source A's publication replaced the whole index and dropped sibling \
+             B's latest generation, then reported success. One whole-project \
+             immutable root must carry the latest of every sibling, and a partial \
+             source generation must never be the query-visible publication"
+        );
+    });
+}


### PR DESCRIPTION
First product work behind the now-cleared T012 gate. Tests and evidence only —
no `tasks.md` checkbox and no frozen file is touched, and no censused V10
source is modified.

## Seven RED positive controls

`tests/project_index_lifecycle_slice0_controls.rs`, run with
`cargo test --test project_index_lifecycle_slice0_controls -- --ignored --test-threads=1`.

| Control | Defect | Observed | Task |
|---|---|---|---|
| `capacity_refused_open_creates_no_slot_and_no_watcher` | 2.1 refusal crosses the seam as success | refusal returned `Ok(...)` and registered a project | T015 |
| `empty_placeholder_publication_refuses_watcher_mutation` | 2.2 / 2.3 mutable-empty placeholder | watcher admitted 8 paths into a never-published placeholder | T015 |
| `failed_reload_retains_the_recovery_observer` | 2.10 failed reload drops the observer | edit after a failed reload never observed | T015 |
| `observer_replacement_gap_is_latched_as_non_current` | 2.6 readiness rederived from present state | `Degraded{…}` → `Current` after a reload that proved nothing | T016 |
| `old_observer_delivery_after_promotion_is_not_current` | 2.8 no observer token or epoch | consumed cross-epoch delivery leaves no durable mark | T016 |
| `watcher_mutation_during_candidate_build_is_not_discarded` | 2.7 / 2.9 no candidate isolation | observer mutation destroyed by the swap, success reported | T016 |
| `publication_of_one_source_preserves_sibling_latest` | FR-008 / FR-009 / SC-005 | sibling B's latest dropped by source A's whole-index swap | T017 |

## T013

`spec.md` defines exactly 78 identifiers (`FR-001`–`FR-052`, `SC-001`–`SC-026`),
each once; the frozen table carries 78 rows in the same order with zero
unresolved catalog references. The checker derives those counts from literals
and never reads `spec.md`, so it could not notice the spec growing an `FR-053`
— this cross-read closes that gap. Table digest, all six bounds, four fairness
assumptions, and the one `inherited_exact` resolution are recorded.

## Three controls initially passed

None because the defect was absent — each was satisfied by unrelated present
state. V10's `FreshnessStatus` is a pure function of present state
(`recompute_freshness_locked` drops the prior reason codes and rederives them),
so no "must be non-Current" assertion can distinguish a real latch from
incidental degradation. Those properties are now asserted as **surviving a
subsequent clean publication**, which is what makes them oracles rather than
coincidences. The same reframing applies to every remaining slice.

## Two items deliberately do not land

- **T014's oracle.** `contracts/v10-authority-retirement-v11.md` digests the
  whole content of every V10 retirement-member source from the working tree,
  and its `callbacks` set contains `src/watcher/mod.rs` — the file T014 names.
  Clean `main` in a scratch worktree reports `OK (78 requirements, …)`; the
  T014 edit reports `RETIREMENT_CLOSURE_MISMATCH` on exactly the three affected
  categories. The census is right and T014 is the outlier: every task
  T022–T052 creates new `src/index_lifecycle/*` files and never edits a V10
  source. The defect is reproduced and recorded in full; the oracle belongs to
  Slice 4.
- **The 2.4 single-flight control.** Its instrument is a counter in
  `daemon.rs`, also censused. Measured locally before reverting: four
  concurrent first opens performed **four** cold loads against one expected.

## Filename deviation

`TEST-PUBLICATION` targets a named case in
`tests/project_index_lifecycle_slice0.rs`; the checker rejects any candidate
carrying `#[ignore]`, T017 requires it RED, and `ci.yml` runs the full suite.
No state satisfies all three. The check only fires once that file exists, so
the controls use `..._slice0_controls.rs` and the reserved filename stays
unwritten until the slice that can make its case pass.

Both contradictions are between frozen artifacts and need a re-freeze to
resolve properly. They are recorded for the T021 adversarial review.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo test --all-targets -- --test-threads=1`,
`node scripts/validate-lifecycle-oracle-traceability.cjs` (`OK`), and
`node scripts/validate-lifecycle-oracle-traceability.test.cjs`
(`OK, 99 fail-closed cases`) are all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY