### PR TITLE
fix(feature-020): amend the V11 refreeze so Slice 0 is executable

### DIFF
--- a/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
+++ b/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
@@ -26,7 +26,7 @@ This detached attestation binds the refreeze manifest to the exact baseline, des
   "kind": "symforge-feature-020-refreeze-attestation",
   "manifest": {
     "path": "specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md",
-    "sha256": "a1915ce1bcd1f769fd0e1da7296bd2ce5b364eb2f4775798b7e8c71d75436671"
+    "sha256": "1858b4c5ea334216f248820aabff9851d1ac1945896611b1a2500c11b96a730e"
   },
   "public_api": {
     "canonical_sha256": "c45f3cd3f77e5690ad1dcd2e5fc7e39e30d52df38fa564d7b663e1c95823a7da",

--- a/scripts/validate-lifecycle-oracle-traceability.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.cjs
@@ -308,7 +308,7 @@ const FROZEN_DIGESTS = {
   },
   retirement_records: {
     domain: "symforge.lifecycle.v11.retirement.records",
-    hash: "3310ec039003c6ac3c441dc73ac59f5f77d2137ce532eca06d3766abd9b931fe",
+    hash: "35d27c8785291b156de2967100417115c09862e073e1404a72f00cf96269f1cb",
   },
   retirement_edges: {
     domain: "symforge.lifecycle.v11.retirement.edges",
@@ -775,27 +775,32 @@ function seamPath(seam) {
   return typeof seam === "string" ? seam.split("::", 1)[0] : "";
 }
 
-function maskRustCommentsAndLiterals(source) {
-  const chars = source.split("");
+/// Classify every character as `code`, `comment`, or `literal`.
+///
+/// One walker, two consumers: the mask below and the canonical release form.
+/// Duplicating this state machine is how a subtle lexer bug gets fixed in one
+/// place and not the other.
+function rustCharacterKinds(source) {
+  const kinds = new Array(source.length).fill("code");
   let index = 0;
   let state = "code";
   let blockDepth = 0;
   let rawTerminator = "";
-  const mask = (at) => {
-    if (chars[at] !== "\n" && chars[at] !== "\r") chars[at] = " ";
+  const set = (at, kind) => {
+    if (at < kinds.length) kinds[at] = kind;
   };
   while (index < source.length) {
     if (state === "code") {
       if (source.startsWith("//", index)) {
-        mask(index);
-        mask(index + 1);
+        set(index, "comment");
+        set(index + 1, "comment");
         index += 2;
         state = "line_comment";
         continue;
       }
       if (source.startsWith("/*", index)) {
-        mask(index);
-        mask(index + 1);
+        set(index, "comment");
+        set(index + 1, "comment");
         index += 2;
         blockDepth = 1;
         state = "block_comment";
@@ -803,21 +808,21 @@ function maskRustCommentsAndLiterals(source) {
       }
       const raw = /^(?:br|r)(#*)"/u.exec(source.slice(index));
       if (raw) {
-        for (let offset = 0; offset < raw[0].length; offset += 1) mask(index + offset);
+        for (let offset = 0; offset < raw[0].length; offset += 1) set(index + offset, "literal");
         index += raw[0].length;
         rawTerminator = `"${raw[1]}`;
         state = "raw_string";
         continue;
       }
       if (source[index] === '"') {
-        mask(index);
+        set(index, "literal");
         index += 1;
         state = "string";
         continue;
       }
       const character = /^'(?:\\.|[^'\\\r\n])'/u.exec(source.slice(index));
       if (character) {
-        for (let offset = 0; offset < character[0].length; offset += 1) mask(index + offset);
+        for (let offset = 0; offset < character[0].length; offset += 1) set(index + offset, "literal");
         index += character[0].length;
         continue;
       }
@@ -825,55 +830,62 @@ function maskRustCommentsAndLiterals(source) {
       continue;
     }
     if (state === "line_comment") {
-      if (source[index] === "\n" || source[index] === "\r") {
-        state = "code";
-      } else {
-        mask(index);
-      }
+      if (source[index] === "\n" || source[index] === "\r") state = "code";
+      else set(index, "comment");
       index += 1;
       continue;
     }
     if (state === "block_comment") {
       if (source.startsWith("/*", index)) {
-        mask(index);
-        mask(index + 1);
+        set(index, "comment");
+        set(index + 1, "comment");
         blockDepth += 1;
         index += 2;
       } else if (source.startsWith("*/", index)) {
-        mask(index);
-        mask(index + 1);
+        set(index, "comment");
+        set(index + 1, "comment");
         blockDepth -= 1;
         index += 2;
         if (blockDepth === 0) state = "code";
       } else {
-        mask(index);
+        set(index, "comment");
         index += 1;
       }
       continue;
     }
     if (state === "raw_string") {
       if (source.startsWith(rawTerminator, index)) {
-        for (let offset = 0; offset < rawTerminator.length; offset += 1) mask(index + offset);
+        for (let offset = 0; offset < rawTerminator.length; offset += 1) set(index + offset, "literal");
         index += rawTerminator.length;
         state = "code";
       } else {
-        mask(index);
+        set(index, "literal");
         index += 1;
       }
       continue;
     }
     if (source[index] === "\\") {
-      mask(index);
-      if (index + 1 < source.length) mask(index + 1);
+      set(index, "literal");
+      if (index + 1 < source.length) set(index + 1, "literal");
       index += 2;
     } else if (source[index] === '"') {
-      mask(index);
+      set(index, "literal");
       index += 1;
       state = "code";
     } else {
-      mask(index);
+      set(index, "literal");
       index += 1;
     }
+  }
+  return kinds;
+}
+
+function maskRustCommentsAndLiterals(source) {
+  const kinds = rustCharacterKinds(source);
+  const chars = source.split("");
+  for (let index = 0; index < chars.length; index += 1) {
+    if (kinds[index] === "code") continue;
+    if (chars[index] !== "\n" && chars[index] !== "\r") chars[index] = " ";
   }
   return chars.join("");
 }
@@ -1015,7 +1027,7 @@ function sourceAnchorResolves(anchor) {
   return sourceAnchorResolvesText(anchor, source);
 }
 
-function rustNamedCaseBodyInSource(symbolPath, source) {
+function rustNamedCaseBodyInSource(symbolPath, source, allowIgnored = false) {
   if (typeof symbolPath !== "string" || typeof source !== "string") return null;
   const code = maskRustCommentsAndLiterals(source);
   const caseName = symbolPath.split("::").at(-1);
@@ -1030,7 +1042,13 @@ function rustNamedCaseBodyInSource(symbolPath, source) {
     const attributes = /(?:#\s*\[[^\]]*\]\s*)+$/u.exec(prefix);
     if (attributes &&
         /#\s*\[\s*(?:test\b|(?:tokio|async_std|actix_rt)::test\b)/u.test(attributes[0]) &&
-        !/#\s*\[\s*(?:ignore\b|cfg_attr\b)/u.test(attributes[0]) &&
+        // `cfg_attr` can add `ignore` conditionally, so it is never resolvable.
+        // A literal `ignore` is resolvable only where the case is PLANNED: a
+        // Slice 0 positive control is RED by construction and must be kept out
+        // of the default suite, but an executed receipt claiming `passed` can
+        // never come from an ignored case, so that path stays strict.
+        !/#\s*\[\s*cfg_attr\b/u.test(attributes[0]) &&
+        (allowIgnored || !/#\s*\[\s*ignore\b/u.test(attributes[0])) &&
         ![...attributes[0].matchAll(/#\s*\[\s*cfg\s*\(([^)]*)\)\s*\]/gu)].some((cfg) => cfg[1].trim() !== "test")) {
       const modules = moduleIntervals
         .filter((interval) => interval.open < match.index && match.index < interval.close)
@@ -1042,12 +1060,12 @@ function rustNamedCaseBodyInSource(symbolPath, source) {
   return null;
 }
 
-function rustNamedCaseExistsInSource(symbolPath, source) {
-  return rustNamedCaseBodyInSource(symbolPath, source) !== null;
+function rustNamedCaseExistsInSource(symbolPath, source, allowIgnored = false) {
+  return rustNamedCaseBodyInSource(symbolPath, source, allowIgnored) !== null;
 }
 
-function rustNamedCaseIsNonEmptyInSource(symbolPath, source) {
-  const body = rustNamedCaseBodyInSource(symbolPath, source);
+function rustNamedCaseIsNonEmptyInSource(symbolPath, source, allowIgnored = false) {
+  const body = rustNamedCaseBodyInSource(symbolPath, source, allowIgnored);
   return typeof body === "string" && /[A-Za-z0-9_]/u.test(body);
 }
 
@@ -1279,9 +1297,9 @@ function validateTrace(trace, taskCatalog) {
       } catch {
         plannedSource = null;
       }
-      if (typeof plannedSource === "string" && !rustNamedCaseExistsInSource(target.symbolPath, plannedSource)) {
+      if (typeof plannedSource === "string" && !rustNamedCaseExistsInSource(target.symbolPath, plannedSource, true)) {
         fail("PLANNED_TEST_CASE_MISSING", `${context}: ${test.target}`);
-      } else if (typeof plannedSource === "string" && !rustNamedCaseIsNonEmptyInSource(target.symbolPath, plannedSource)) {
+      } else if (typeof plannedSource === "string" && !rustNamedCaseIsNonEmptyInSource(target.symbolPath, plannedSource, true)) {
         fail("PLANNED_TEST_CASE_EMPTY", `${context}: ${test.target}`);
       }
     }
@@ -2174,8 +2192,103 @@ function validateRetirementSourceInventory(retirement, sourceMap) {
   }
 }
 
+/// Remove every `#[cfg(test)]`-attributed item or statement.
+///
+/// The census exists to freeze V10 *authority* while V11 is built beside it, so
+/// what it must pin is the source as the release build sees it. Test-only code
+/// is compiled out and changes no shipped behaviour, and freezing it as well
+/// made the retirement contract forbid the very edits `tasks.md` T014 requires.
+/// Production additions to a censused file still move the digest, which is the
+/// property the two closure self-tests assert.
+///
+/// Offsets come from the masked source so a `;` or brace inside a comment or
+/// string literal cannot terminate an item early; the cut is applied to the
+/// original bytes at those same offsets.
+function stripCfgTestItems(source) {
+  const masked = maskRustCommentsAndLiterals(source);
+  const cuts = [];
+  for (const match of masked.matchAll(/#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/gu)) {
+    const start = match.index;
+    let index = start + match[0].length;
+    let nesting = 0;
+    let end = -1;
+    while (index < masked.length) {
+      const character = masked[index];
+      if (character === "(" || character === "[") nesting += 1;
+      else if (character === ")" || character === "]") nesting -= 1;
+      else if (nesting === 0 && character === ";") {
+        end = index + 1;
+        break;
+      } else if (nesting === 0 && character === "{") {
+        let depth = 0;
+        let scan = index;
+        for (; scan < masked.length; scan += 1) {
+          if (masked[scan] === "{") depth += 1;
+          else if (masked[scan] === "}") {
+            depth -= 1;
+            if (depth === 0) {
+              scan += 1;
+              break;
+            }
+          }
+        }
+        end = scan;
+        break;
+      }
+      index += 1;
+    }
+    // No line-framing heuristics: whatever whitespace the cut leaves behind is
+    // erased by `canonicalReleaseSource`, so where a removed item's blank lines
+    // went is not observable in the digest.
+    cuts.push([start, end === -1 ? masked.length : end]);
+  }
+  if (cuts.length === 0) return source;
+  cuts.sort((left, right) => left[0] - right[0]);
+  let result = "";
+  let cursor = 0;
+  for (const [start, end] of cuts) {
+    // A nested attribute inside an already-cut item is already removed.
+    if (start < cursor) {
+      cursor = Math.max(cursor, end);
+      continue;
+    }
+    result += source.slice(cursor, start);
+    cursor = end;
+  }
+  return result + source.slice(cursor);
+}
+
+/// Reduce source to the code a release build compiles, in a canonical form.
+///
+/// Comments are dropped and runs of code whitespace collapse to a single space,
+/// while string and character literals are emitted verbatim: their contents are
+/// behaviour, so a change inside one must still move the digest. A comment
+/// between two tokens becomes a separator rather than vanishing, so `a/*x*/b`
+/// cannot canonicalize to `ab`.
+///
+/// Digesting this form rather than edited text is what makes the census
+/// position-independent. Reformatting, re-wrapping a doc comment, or moving a
+/// stripped test item's surrounding blank lines are all invisible; adding,
+/// removing, or altering a single production token is not.
+function canonicalReleaseSource(source) {
+  const kinds = rustCharacterKinds(source);
+  let result = "";
+  let pendingSeparator = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const kind = kinds[index];
+    if (kind === "comment" || (kind === "code" && /\s/u.test(source[index]))) {
+      pendingSeparator = true;
+      continue;
+    }
+    if (pendingSeparator && result.length > 0) result += " ";
+    pendingSeparator = false;
+    result += source[index];
+  }
+  return result;
+}
+
 function normalizeRetirementClosureSource(source) {
-  return source.replace(/\r\n/gu, "\n");
+  return canonicalReleaseSource(stripCfgTestItems(source.replace(/\r\n/gu, "\n")));
 }
 
 function validateRetirementClosure(retirement, sourceMap) {

--- a/scripts/validate-lifecycle-oracle-traceability.test.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.test.cjs
@@ -641,6 +641,28 @@ const cases = [
     },
   },
   {
+    name: "ignored case is still rejected where the catalog requires it to have run",
+    expected: "ERROR INHERITED_TEST_CASE_MISSING:",
+    mutate(root) {
+      const file = path.join(root, "src/discovery/mod.rs");
+      const text = fs.readFileSync(file, "utf8");
+      const marker = "        fn non_utf8_path_is_opaque_catalog_only_without_lossy_collision() {";
+      if (!text.includes(marker)) throw new Error("inherited opaque-path case not found in fixture");
+      fs.writeFileSync(file, text.replace(marker, `        #[ignore = "self-test"]\n${marker}`), "utf8");
+    },
+  },
+  {
+    name: "string literal content changed in a retirement-owned source file",
+    expected: "ERROR RETIREMENT_CLOSURE_MISMATCH:",
+    mutate(root) {
+      const file = path.join(root, "src/protocol/edit.rs");
+      const text = fs.readFileSync(file, "utf8");
+      const match = /"[A-Za-z0-9 _.:-]{6,}"/u.exec(text);
+      if (!match) throw new Error("no string literal available in the censused writer source");
+      fs.writeFileSync(file, text.replace(match[0], match[0].slice(0, -1) + 'X"'), "utf8");
+    },
+  },
+  {
     name: "new CCR path in its retirement-owned source file",
     expected: "ERROR RETIREMENT_CLOSURE_MISMATCH:",
     mutate(root) {
@@ -1683,6 +1705,47 @@ try {
   else if (closureLineEnding.status !== 0) failures.push(`closure line-ending equivalence: checker failed (${`${closureLineEnding.stdout || ""}${closureLineEnding.stderr || ""}`.trim()})`);
 } finally {
   safeRemoveFixture(closureLineEndingRoot);
+}
+const closureCfgTestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "symforge-lifecycle-oracle-"));
+try {
+  copyFixture(closureCfgTestRoot);
+  // The census freezes V10 authority, which is what the release build contains.
+  // Test-only code is compiled out, so adding it must NOT move the digest --
+  // otherwise the retirement contract forbids the very edits tasks.md requires.
+  // The two RETIREMENT_CLOSURE_MISMATCH cases above still cover the converse:
+  // production code added to the same file does move it.
+  fs.appendFileSync(
+    path.join(closureCfgTestRoot, "src/protocol/edit.rs"),
+    [
+      "",
+      "/// Test-only helper documented above its attribute, which is the",
+      "/// idiomatic placement and must not move the census either.",
+      "#[cfg(test)]",
+      "mod census_equivalence_probe {",
+      "    #[test]",
+      "    fn probe() { assert!(true); }",
+      "}",
+      "",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  // Prose and layout are not authority either: rewording a comment and
+  // re-indenting must be invisible to the census for the same reason.
+  const censusProse = path.join(closureCfgTestRoot, "src/protocol/ccr.rs");
+  const proseText = fs.readFileSync(censusProse, "utf8");
+  const proseLine = /^([ \t]*)\/\/[^\n]*$/mu.exec(proseText);
+  if (!proseLine) throw new Error("no line comment available in the censused CCR source");
+  fs.writeFileSync(
+    censusProse,
+    proseText.replace(proseLine[0], `${proseLine[1]}//   reworded for the census equivalence probe`),
+    "utf8",
+  );
+  const closureCfgTest = runChecker(closureCfgTestRoot);
+  if (closureCfgTest.error) failures.push(`closure cfg(test) equivalence: spawn failed (${closureCfgTest.error.code || closureCfgTest.error.message})`);
+  else if (closureCfgTest.status !== 0) failures.push(`closure cfg(test) equivalence: checker failed (${`${closureCfgTest.stdout || ""}${closureCfgTest.stderr || ""}`.trim()})`);
+} finally {
+  safeRemoveFixture(closureCfgTestRoot);
 }
 const postactivationOrdinaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "symforge-lifecycle-oracle-"));
 try {

--- a/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
+++ b/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
@@ -1097,7 +1097,7 @@ This machine-verifiable manifest binds the complete Feature 020 corpus, its V11 
       "hash_policy": "raw_bytes",
       "path": "specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md",
       "scope": "feature",
-      "sha256": "a0bf95a53741423de4018519d2058761888347369b3b6ca3557bca16c80aaf97",
+      "sha256": "c681e0a8dbd2bfb7ec4958ee575ed8327886016fb27b0aaccbec39b76e43d4cf",
       "superseded_by": []
     },
     {

--- a/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
+++ b/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
@@ -14,38 +14,17 @@ planned and unexecuted.
 <!-- SYMFORGE V10 AUTHORITY RETIREMENT V11 JSON START -->
 ```json
 {
-  "kind": "symforge.v10_authority_retirement.v11",
-  "schema_version": 1,
-  "status": "planned_not_executed",
-  "slice4_owner": {
-    "slice": 4,
-    "tasks": ["T064", "T065", "T066", "T067"]
-  },
-  "preactivation_closure": {
-    "writers": {
-      "paths": ["src/cli/init.rs", "src/gitignore_hygiene.rs", "src/live_index/persist.rs", "src/live_index/single_file.rs", "src/protocol/edit.rs", "src/protocol/edit_tools.rs", "src/protocol/knowledge_curation.rs", "src/protocol/tools.rs"],
-      "digest": "e2e4120433514d9c0ea3ad366c26ef14a50bac5950ec7fe4f361c8e3a5ac00ae"
-    },
-    "callbacks": {
-      "paths": ["src/daemon.rs", "src/live_index/git_temporal.rs", "src/live_index/persist.rs", "src/main.rs", "src/protocol/edit_hooks.rs", "src/protocol/knowledge_curation.rs", "src/server/serve.rs", "src/watcher/mod.rs"],
-      "digest": "0338146c8ee23d07abc28a2bae09aee740d854ec1a24370e22b77bc83bb80216"
-    },
-    "publication_roots": {
-      "paths": ["src/daemon.rs", "src/live_index/store.rs", "src/protocol/mod.rs", "src/server/mod.rs", "src/sidecar/mod.rs"],
-      "digest": "6f2e24f4c15e6fd58d97b5ebaefff228700e7ca7d52bfa87451e71acbd47cf1d"
-    },
-    "cache": {
-      "paths": ["src/daemon.rs", "src/protocol/knowledge_curation.rs", "src/protocol/session.rs", "src/sidecar/mod.rs", "src/worktree.rs"],
-      "digest": "554deb77a982c03738e20f22a3d43424a05500367226b9de28bf75fc084cdd99"
-    },
-    "ccr": {
-      "paths": ["src/protocol/ccr.rs"],
-      "digest": "d6bb6ecb8e64f955f796d0851901f21cfe8b96b99f83b1d7c7f392f08afff9e8"
-    }
-  },
   "entries": [
     {
+      "assertions": [
+        "Every repository-source byte writer obtains a current SourceMutationPermit before I/O",
+        "No writer mutates a V10 SharedIndex or publishes directly",
+        "Gitignore hygiene is source-authorized while ProjectStateDir and post-image team-artifact state writes remain permit-free"
+      ],
       "category": "writers",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "route_all_repository-source writes through mutation intent and V11 reconciliation; remove direct index publication",
+      "executed": false,
       "members": [
         "src/cli/init.rs::run_init_with_paths",
         "src/gitignore_hygiene.rs::atomic_replace",
@@ -73,17 +52,28 @@ planned and unexecuted.
         "src/protocol/knowledge_curation.rs::durable_replace_io",
         "src/protocol/tools.rs::SymForgeServer::curate_knowledge"
       ],
-      "production_seams": ["src/index_lifecycle/mutation.rs::SourceMutationPermit", "src/index_lifecycle/runtime.rs::ProjectIndexRuntime"],
-      "slice4_owner_tasks": ["T064", "T065", "T067"],
-      "disposition": "route_all_repository-source writes through mutation intent and V11 reconciliation; remove direct index publication",
+      "production_seams": [
+        "src/index_lifecycle/mutation.rs::SourceMutationPermit",
+        "src/index_lifecycle/runtime.rs::ProjectIndexRuntime"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Every repository-source byte writer obtains a current SourceMutationPermit before I/O", "No writer mutates a V10 SharedIndex or publishes directly", "Gitignore hygiene is source-authorized while ProjectStateDir and post-image team-artifact state writes remain permit-free"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T064",
+        "T065",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "No callback holds publication authority",
+        "Every callback carries current project and source incarnations",
+        "Late V10 callbacks are unreachable after the activation cut"
+      ],
       "category": "callbacks",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "register callbacks with a source-slot incarnation and revoke them before tombstone retirement",
+      "executed": false,
       "members": [
         "src/daemon.rs::bootstrap_project_index::background_verify spawn",
         "src/daemon.rs::spawn_local_ref_reconcile",
@@ -100,17 +90,28 @@ planned and unexecuted.
         "src/watcher/mod.rs::restart_watcher",
         "src/watcher/mod.rs::start_watcher"
       ],
-      "production_seams": ["src/index_lifecycle/observer.rs::ObserverHandoff", "src/index_lifecycle/supervisor.rs::SourceSupervisor"],
-      "slice4_owner_tasks": ["T064", "T065", "T067"],
-      "disposition": "register callbacks with a source-slot incarnation and revoke them before tombstone retirement",
+      "production_seams": [
+        "src/index_lifecycle/observer.rs::ObserverHandoff",
+        "src/index_lifecycle/supervisor.rs::SourceSupervisor"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["No callback holds publication authority", "Every callback carries current project and source incarnations", "Late V10 callbacks are unreachable after the activation cut"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T064",
+        "T065",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Only ProjectPublicationRoot is query-visible",
+        "No bare SharedIndex is stored in daemon, protocol, server, sidecar, or embed state",
+        "Partial source generations cannot be published"
+      ],
       "category": "publication_roots",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "replace every V10 root with the sole immutable whole-project publication root",
+      "executed": false,
       "members": [
         "src/daemon.rs::ProjectInstance::index",
         "src/daemon.rs::SessionRuntime::index",
@@ -122,17 +123,27 @@ planned and unexecuted.
         "src/server/mod.rs::ServerRuntime::index",
         "src/sidecar/mod.rs::SidecarState::index"
       ],
-      "production_seams": ["src/index_lifecycle/runtime.rs::ProjectIndexRuntime", "src/index_lifecycle/runtime.rs::ProjectPublicationRoot"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "replace every V10 root with the sole immutable whole-project publication root",
+      "production_seams": [
+        "src/index_lifecycle/runtime.rs::ProjectIndexRuntime",
+        "src/index_lifecycle/runtime.rs::ProjectPublicationRoot"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Only ProjectPublicationRoot is query-visible", "No bare SharedIndex is stored in daemon, protocol, server, sidecar, or embed state", "Partial source generations cannot be published"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "A cache miss never falls back to a V10 authority",
+        "A cache hit is fenced to the leased publication",
+        "Retarget and publication swap invalidate stale cache entries deterministically"
+      ],
       "category": "cache",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "make caches generation-keyed, non-authoritative projections of a pinned V11 publication or remove them",
+      "executed": false,
       "members": [
         "src/daemon.rs::DaemonState::bases",
         "src/daemon.rs::ProjectInstance::symbol_cache",
@@ -144,34 +155,55 @@ planned and unexecuted.
         "src/sidecar/mod.rs::SidecarState::symbol_cache",
         "src/worktree.rs::WorktreeCache"
       ],
-      "production_seams": ["src/index_lifecycle/query.rs::ProjectQueryLease", "src/index_lifecycle/runtime.rs::ProjectPublicationRoot"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "make caches generation-keyed, non-authoritative projections of a pinned V11 publication or remove them",
+      "production_seams": [
+        "src/index_lifecycle/query.rs::ProjectQueryLease",
+        "src/index_lifecycle/runtime.rs::ProjectPublicationRoot"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["A cache miss never falls back to a V10 authority", "A cache hit is fenced to the leased publication", "Retarget and publication swap invalidate stale cache entries deterministically"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "CCR cannot originate truth or extend a lease",
+        "CCR handles encode the source publication identity",
+        "Evicted or foreign generations return typed unavailability"
+      ],
       "category": "ccr",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "retain CCR only as a generation-bound rendering cache downstream of a V11 query lease",
+      "executed": false,
       "members": [
         "src/protocol/ccr.rs::CcrStore",
         "src/protocol/ccr.rs::apply_ccr_overflow",
         "src/protocol/ccr.rs::enforce_token_budget_with_ccr",
         "src/protocol/ccr.rs::rewrite_footer_for_symforge_facade"
       ],
-      "production_seams": ["src/index_lifecycle/query.rs::ProjectQueryLease", "src/protocol/read_gate.rs::ReadGate"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "retain CCR only as a generation-bound rendering cache downstream of a V11 query lease",
+      "production_seams": [
+        "src/index_lifecycle/query.rs::ProjectQueryLease",
+        "src/protocol/read_gate.rs::ReadGate"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["CCR cannot originate truth or extend a lease", "CCR handles encode the source publication identity", "Evicted or foreign generations return typed unavailability"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Snapshot load never publishes directly",
+        "Compatibility and source identity are re-proved before promotion",
+        "Protected placement first selects deterministic user-local state fallback",
+        "Only memory-only placement or failed user-local fallback produces typed checkpoint unavailability"
+      ],
       "category": "snapshot",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "demote restore to private candidate seed and route checkpointing through the typed V11 state owner with protected-root user-local fallback",
+      "executed": false,
       "members": [
         "src/live_index/persist.rs::IndexSnapshot",
         "src/live_index/persist.rs::background_verify",
@@ -187,17 +219,30 @@ planned and unexecuted.
         "src/live_index/persist.rs::snapshot_to_live_index",
         "src/live_index/persist.rs::snapshot_to_live_index_with_code_signals"
       ],
-      "production_seams": ["src/index_lifecycle/verification.rs::VerificationRecord", "src/live_index/persist.rs::IndexSnapshot"],
-      "slice4_owner_tasks": ["T065", "T067"],
-      "disposition": "demote restore to private candidate seed and route checkpointing through the typed V11 state owner with protected-root user-local fallback",
+      "production_seams": [
+        "src/index_lifecycle/verification.rs::VerificationRecord",
+        "src/live_index/persist.rs::IndexSnapshot"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Snapshot load never publishes directly", "Compatibility and source identity are re-proved before promotion", "Protected placement first selects deterministic user-local state fallback", "Only memory-only placement or failed user-local fallback produces typed checkpoint unavailability"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T065",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Every source-derived union member selects exactly one of GenerationLeased, DiskObserved, WorktreeScopeObserved, GitObserved, RuntimeHealthObserved, MutationPermitted, StateWriteAuthorized, or Refused",
+        "Full contains exactly 39 tools, Compact contains exactly status, symforge, and symforge_edit, and their unique union contains exactly 40",
+        "Only GenerationLeased acquires a ProjectQueryLease and only repository-source MutationPermitted operations acquire a SourceMutationPermit",
+        "RuntimeHealthObserved keeps committed-generation fields separate from bounded attempt and runtime-work fields",
+        "No tool retains direct V10 index access",
+        "The compact facade does not weaken authority checks"
+      ],
       "category": "tools",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "route the source-derived full-39 and compact-3 profiles, whose unique union is 40 tools, through exactly one typed V11 authority branch",
+      "executed": false,
       "members": [
         "analyze_file_impact",
         "ask",
@@ -240,17 +285,30 @@ planned and unexecuted.
         "validate_file_syntax",
         "what_changed"
       ],
-      "production_seams": ["src/index_lifecycle/mutation.rs::SourceMutationPermit", "src/index_lifecycle/public_api.rs::V11PublicApi", "src/index_lifecycle/query.rs::ProjectQueryLease"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "route the source-derived full-39 and compact-3 profiles, whose unique union is 40 tools, through exactly one typed V11 authority branch",
+      "production_seams": [
+        "src/index_lifecycle/mutation.rs::SourceMutationPermit",
+        "src/index_lifecycle/public_api.rs::V11PublicApi",
+        "src/index_lifecycle/query.rs::ProjectQueryLease"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Every source-derived union member selects exactly one of GenerationLeased, DiskObserved, WorktreeScopeObserved, GitObserved, RuntimeHealthObserved, MutationPermitted, StateWriteAuthorized, or Refused", "Full contains exactly 39 tools, Compact contains exactly status, symforge, and symforge_edit, and their unique union contains exactly 40", "Only GenerationLeased acquires a ProjectQueryLease and only repository-source MutationPermitted operations acquire a SourceMutationPermit", "RuntimeHealthObserved keeps committed-generation fields separate from bounded attempt and runtime-work fields", "No tool retains direct V10 index access", "The compact facade does not weaken authority checks"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Generation-backed resources use GenerationLeased and pin one V11 publication",
+        "Pure disk, worktree-scope, git, and runtime-health resources use their lease-free observed branches with typed provenance",
+        "RuntimeHealthObserved resources cannot mix attempt-only fields into committed-generation truth",
+        "Static catalog resources cannot disclose raw runtime state",
+        "Template expansion preserves the selected branch and never upgrades an observation into Current"
+      ],
       "category": "resources",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "classify every static resource and resource template into its exact V11 generation, disk, worktree, git, state, or refusal branch",
+      "executed": false,
       "members": [
         "symforge://file/content",
         "symforge://file/context",
@@ -263,17 +321,27 @@ planned and unexecuted.
         "symforge://symbol/detail",
         "symforge://tools/catalog"
       ],
-      "production_seams": ["src/index_lifecycle/query.rs::ProjectQueryLease", "src/protocol/read_gate.rs::ReadGate"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "classify every static resource and resource template into its exact V11 generation, disk, worktree, git, state, or refusal branch",
+      "production_seams": [
+        "src/index_lifecycle/query.rs::ProjectQueryLease",
+        "src/protocol/read_gate.rs::ReadGate"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Generation-backed resources use GenerationLeased and pin one V11 publication", "Pure disk, worktree-scope, git, and runtime-health resources use their lease-free observed branches with typed provenance", "RuntimeHealthObserved resources cannot mix attempt-only fields into committed-generation truth", "Static catalog resources cannot disclose raw runtime state", "Template expansion preserves the selected branch and never upgrades an observation into Current"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Generation-backed prompt context uses GenerationLeased while pure observation context remains lease-free",
+        "Prompt aliases cannot reach V10 caches or upgrade observations into Current",
+        "Unavailable context selects Refused rather than silently empty success"
+      ],
       "category": "prompts",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "route prompt context through the exact typed V11 branch; static prompt text carries no publication authority",
+      "executed": false,
       "members": [
         "symforge-admin",
         "symforge-architecture",
@@ -284,17 +352,28 @@ planned and unexecuted.
         "symforge-review",
         "symforge-triage"
       ],
-      "production_seams": ["src/index_lifecycle/query.rs::ProjectQueryLease", "src/protocol/read_gate.rs::ReadGate"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "route prompt context through the exact typed V11 branch; static prompt text carries no publication authority",
+      "production_seams": [
+        "src/index_lifecycle/query.rs::ProjectQueryLease",
+        "src/protocol/read_gate.rs::ReadGate"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Generation-backed prompt context uses GenerationLeased while pure observation context remains lease-free", "Prompt aliases cannot reach V10 caches or upgrade observations into Current", "Unavailable context selects Refused rather than silently empty success"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Generation-backed endpoints use GenerationLeased; disk, worktree-scope, git, runtime-health, mutation, and state endpoints use only their matching typed branch",
+        "RuntimeHealthObserved endpoints separate committed-generation fields from attempt and work state",
+        "Caller-root mismatch selects Refused and cannot fall through to V10",
+        "Workflow aliases are thin aliases over the same branch selector"
+      ],
       "category": "sidecar",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "route standalone and daemon-proxied sidecar endpoints through the same typed V11 branch selector and root guard",
+      "executed": false,
       "members": [
         "GET /health",
         "GET /impact",
@@ -321,41 +400,86 @@ planned and unexecuted.
         "GET /workflows/search-hit-expansion",
         "GET /workflows/source-read"
       ],
-      "production_seams": ["src/index_lifecycle/public_api.rs::V11PublicApi", "src/index_lifecycle/query.rs::ProjectQueryLease"],
-      "slice4_owner_tasks": ["T064", "T066", "T067"],
-      "disposition": "route standalone and daemon-proxied sidecar endpoints through the same typed V11 branch selector and root guard",
+      "production_seams": [
+        "src/index_lifecycle/public_api.rs::V11PublicApi",
+        "src/index_lifecycle/query.rs::ProjectQueryLease"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Generation-backed endpoints use GenerationLeased; disk, worktree-scope, git, runtime-health, mutation, and state endpoints use only their matching typed branch", "RuntimeHealthObserved endpoints separate committed-generation fields from attempt and work state", "Caller-root mismatch selects Refused and cannot fall through to V10", "Workflow aliases are thin aliases over the same branch selector"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T064",
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Read, Grep, SessionStart, PromptSubmit, and PreTool select GenerationLeased only for generation-backed context and otherwise retain their exact disk, worktree, git, runtime-health, state, or refusal branch",
+        "Edit and Write notifications cannot publish, mint a SourceMutationPermit, or bypass mutation authority",
+        "Fallback output carries no false Current claim and cannot upgrade a pure observation"
+      ],
       "category": "hooks",
-      "members": ["hook:Edit", "hook:Grep", "hook:PreTool", "hook:PromptSubmit", "hook:Read", "hook:SessionStart", "hook:Write"],
-      "production_seams": ["src/index_lifecycle/activation.rs::ActivationCut", "src/index_lifecycle/mutation.rs::SourceMutationPermit", "src/index_lifecycle/query.rs::ProjectQueryLease"],
-      "slice4_owner_tasks": ["T064", "T066", "T067"],
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
       "disposition": "route all seven hook classes through root-bound typed V11 sidecar or daemon ingress; fail open only without claiming Current evidence",
+      "executed": false,
+      "members": [
+        "hook:Edit",
+        "hook:Grep",
+        "hook:PreTool",
+        "hook:PromptSubmit",
+        "hook:Read",
+        "hook:SessionStart",
+        "hook:Write"
+      ],
+      "production_seams": [
+        "src/index_lifecycle/activation.rs::ActivationCut",
+        "src/index_lifecycle/mutation.rs::SourceMutationPermit",
+        "src/index_lifecycle/query.rs::ProjectQueryLease"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Read, Grep, SessionStart, PromptSubmit, and PreTool select GenerationLeased only for generation-backed context and otherwise retain their exact disk, worktree, git, runtime-health, state, or refusal branch", "Edit and Write notifications cannot publish, mint a SourceMutationPermit, or bypass mutation authority", "Fallback output carries no false Current claim and cannot upgrade a pure observation"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T064",
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "Neither alias is advertised as an additional tool",
+        "detect_changes delegates to detect_impact and returns GitObserved for committed-ref diffs or WorktreeScopeObserved for worktree diffs",
+        "detect_changes never acquires a ProjectQueryLease or upgrades observation evidence to GenerationLeased",
+        "trace_symbol cannot reach V10 symbol caches and uses GenerationLeased only for a complete Current publication"
+      ],
       "category": "compatibility_aliases",
-      "members": ["detect_changes", "trace_symbol"],
-      "production_seams": ["src/index_lifecycle/activation.rs::ActivationCut", "src/index_lifecycle/public_api.rs::V11PublicApi"],
-      "slice4_owner_tasks": ["T066", "T067"],
-      "disposition": "route trace_symbol through V11 generation authority and route detect_changes to detect_impact as typed Git/worktree observation, or retire either alias",
-      "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
       "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["Neither alias is advertised as an additional tool", "detect_changes delegates to detect_impact and returns GitObserved for committed-ref diffs or WorktreeScopeObserved for worktree diffs", "detect_changes never acquires a ProjectQueryLease or upgrades observation evidence to GenerationLeased", "trace_symbol cannot reach V10 symbol caches and uses GenerationLeased only for a complete Current publication"],
-      "status": "planned_not_executed",
-      "executed": false
+      "disposition": "route trace_symbol through V11 generation authority and route detect_changes to detect_impact as typed Git/worktree observation, or retire either alias",
+      "executed": false,
+      "members": [
+        "detect_changes",
+        "trace_symbol"
+      ],
+      "production_seams": [
+        "src/index_lifecycle/activation.rs::ActivationCut",
+        "src/index_lifecycle/public_api.rs::V11PublicApi"
+      ],
+      "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
+      "slice4_owner_tasks": [
+        "T066",
+        "T067"
+      ],
+      "status": "planned_not_executed"
     },
     {
+      "assertions": [
+        "The member set exactly equals all remove/replace V10 migration atoms",
+        "No forbidden raw module, state, parser, snapshot, search, mutation, STEL, Git, or deep re-export remains public",
+        "The observed public graph equals the frozen V11 graph in every supported configuration cell"
+      ],
       "category": "raw_embed",
+      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
+      "disposition": "remove or replace exactly as frozen by every migration_v10 category whose decision is remove or replace",
+      "executed": false,
       "members": [
         "symforge::analytics",
         "symforge::capability",
@@ -437,16 +561,84 @@ planned and unexecuted.
         "symforge::watcher_state",
         "symforge::worktree"
       ],
-      "production_seams": ["src/index_lifecycle/embedded.rs::EmbeddedSourceHandle", "src/index_lifecycle/process_runtime.rs::ProcessIndexRuntime", "src/index_lifecycle/public_api.rs::V11PublicApi"],
-      "slice4_owner_tasks": ["T067"],
-      "disposition": "remove or replace exactly as frozen by every migration_v10 category whose decision is remove or replace",
+      "production_seams": [
+        "src/index_lifecycle/embedded.rs::EmbeddedSourceHandle",
+        "src/index_lifecycle/process_runtime.rs::ProcessIndexRuntime",
+        "src/index_lifecycle/public_api.rs::V11PublicApi"
+      ],
       "retirement_test": "tests/activation_cut_v11.rs::all_ingress_uses_exact_typed_authority_branch",
-      "command": "cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact",
-      "assertions": ["The member set exactly equals all remove/replace V10 migration atoms", "No forbidden raw module, state, parser, snapshot, search, mutation, STEL, Git, or deep re-export remains public", "The observed public graph equals the frozen V11 graph in every supported configuration cell"],
-      "status": "planned_not_executed",
-      "executed": false
+      "slice4_owner_tasks": [
+        "T067"
+      ],
+      "status": "planned_not_executed"
     }
-  ]
+  ],
+  "kind": "symforge.v10_authority_retirement.v11",
+  "preactivation_closure": {
+    "cache": {
+      "digest": "19eb9a74bf4de8c6ff2c2d6aeb3e1ada24597491fd24856b02f5794f5e41e061",
+      "paths": [
+        "src/daemon.rs",
+        "src/protocol/knowledge_curation.rs",
+        "src/protocol/session.rs",
+        "src/sidecar/mod.rs",
+        "src/worktree.rs"
+      ]
+    },
+    "callbacks": {
+      "digest": "4b6a5fc9cc3d37df50cf25287c36c4330742d6ebb5a2fd327a95196a2507b124",
+      "paths": [
+        "src/daemon.rs",
+        "src/live_index/git_temporal.rs",
+        "src/live_index/persist.rs",
+        "src/main.rs",
+        "src/protocol/edit_hooks.rs",
+        "src/protocol/knowledge_curation.rs",
+        "src/server/serve.rs",
+        "src/watcher/mod.rs"
+      ]
+    },
+    "ccr": {
+      "digest": "8ad77748b8fd9e6eb31853cc9615730fc632a890898321deb915546e384ad246",
+      "paths": [
+        "src/protocol/ccr.rs"
+      ]
+    },
+    "publication_roots": {
+      "digest": "f09e746dd8b3a5354284d5fd1c403b1ee962005d96bb9c749d58fbce0fb7ce90",
+      "paths": [
+        "src/daemon.rs",
+        "src/live_index/store.rs",
+        "src/protocol/mod.rs",
+        "src/server/mod.rs",
+        "src/sidecar/mod.rs"
+      ]
+    },
+    "writers": {
+      "digest": "4d5a2dbbcff42cf673bb4e1baf555d6c25dfb17ee851a5a9a085cf92c53e03f5",
+      "paths": [
+        "src/cli/init.rs",
+        "src/gitignore_hygiene.rs",
+        "src/live_index/persist.rs",
+        "src/live_index/single_file.rs",
+        "src/protocol/edit.rs",
+        "src/protocol/edit_tools.rs",
+        "src/protocol/knowledge_curation.rs",
+        "src/protocol/tools.rs"
+      ]
+    }
+  },
+  "schema_version": 1,
+  "slice4_owner": {
+    "slice": 4,
+    "tasks": [
+      "T064",
+      "T065",
+      "T066",
+      "T067"
+    ]
+  },
+  "status": "planned_not_executed"
 }
 ```
 <!-- SYMFORGE V10 AUTHORITY RETIREMENT V11 JSON END -->


### PR DESCRIPTION
Two frozen artifacts contradicted each other. Both contradictions were found by
**running** the frozen gates, not by reading them, and neither could be resolved
by a code change because every artifact involved is byte-pinned.

## What was broken

**1. T014 required an edit the retirement contract forbids.** `tasks.md` T014
asks for a RED oracle in `src/watcher/mod.rs::tests`. The retirement contract's
`preactivation_closure` digests every V10 retirement-member source, and its
`callbacks` set contains that exact file. Measured: clean `main` in a scratch
worktree verifies `OK`; the T014 edit reports `RETIREMENT_CLOSURE_MISMATCH` on
precisely the three categories containing the touched files.

**2. A catalog-named case could be present or RED, never both.**
`TEST-PUBLICATION` is `planned_exact`, and `rustNamedCaseBodyInSource` refused to
resolve any candidate carrying `#[ignore]`. T017 requires it RED and `ci.yml`
runs `cargo test --all-targets`. No state satisfied all three.

## The fix: digest a canonical form, not edited text

The census now digests **the code a release build compiles**: `#[cfg(test)]`
items removed, comments dropped, code whitespace collapsed — while string and
character literals are emitted verbatim, because their contents are behaviour.

This matters beyond convenience. An earlier text-splicing approach needed three
successive corrections for whitespace boundaries (leftover newlines, an
off-by-one that ate a line break belonging to surviving code, doc comments above
the attribute) and *still* left a blind spot: a comment directly above a
`#[cfg(test)]` item was silently absorbed, so editing it could not move the
digest. Digesting a canonical form makes the census position-independent, so the
whole bug class and the blind spot are gone rather than patched.

`rustCharacterKinds` is extracted so the mask and the canonical form share one
lexer instead of duplicating a subtle state machine. **Proven
behaviour-preserving: mask output is byte-identical across 307 Rust files
(~10 MB).**

## `#[ignore]` is resolvable only where the case is PLANNED

A Slice 0 positive control is RED by construction and must stay out of the
default suite. An executed receipt claiming `passed` can never come from an
ignored case, so `inherited_exact`, `executed_exact`, and the materialized
receipt path all stay strict. `cfg_attr` remains rejected everywhere, since it
can add `ignore` conditionally.

## Guards

- **fail-closed**: an `#[ignore]` on the inherited opaque-path case still fails
  with `INHERITED_TEST_CASE_MISSING`
- **fail-closed**: a string-literal change in a censused file still trips
  `RETIREMENT_CLOSURE_MISMATCH`
- **positive**: a `#[cfg(test)]` module — with the idiomatic doc comment above
  its attribute — plus a reworded comment elsewhere must not move the census
- the two pre-existing closure cases append *production* code and are untouched

The positive check earned its keep immediately by catching the first stripper
leaving removed items' newlines behind.

## Acceptance

With T014's oracle and its doc-commented `cfg(test)` hook applied, the checker
reports `OK`. Adding the production counter on top reports
`RETIREMENT_CLOSURE_MISMATCH` on all three categories — test-only edits
invisible, production edits caught.

## Verification

- `validate-lifecycle-oracle-traceability.cjs` → `OK (78 requirements, 24 acceptance oracles, 13 retirement categories)`
- `validate-lifecycle-oracle-traceability.test.cjs` → `OK (101 fail-closed cases)`
- `execution/test_refreeze_v11.py` → `Ran 164 tests ... OK`
- `refreeze_v11.py verify-internal --target-ref HEAD` → passed
- 16-case normalization matrix, including literal-whitespace sensitivity and
  `a/*x*/b` not collapsing to `ab`

## Digest chain

closures → `retirement_records` → contract `c681e0a8…` → manifest `1858b4c5…` →
attestation `4708da8e…`. The other seven frozen digests are unchanged.

## This needs a new signature

The attestation digest changed, so the existing approval record no longer binds
this tree. A new signed `RefreezeApprovalRecordV11` over the post-merge commit is
required before the release gate will accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY