### PR TITLE
test(feature-020): land T014 oracle and the 2.4 single-flight control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,18 @@
 `server`, `cli`, …) is absent. A `#[cfg(test)]` item whose only consumer lives behind
 `server` is therefore an unused import there, and `-D warnings` fails the build — while
 every default-feature gate above passes. Run that exact command before pushing
-anything that adds a `#[cfg(test)]` helper, and gate such helpers on
-`#[cfg(all(test, feature = "server"))]` when their consumer is server-only. Found the
-slow way on 2026-08-12: green locally and on the `rust` job, red on `embed-build`.
+anything that adds a `#[cfg(test)]` helper. Found the slow way on 2026-08-12: green
+locally and on the `rust` job, red on `embed-build`.
+
+When such a helper's consumer is server-only, gate it as two stacked attributes —
+`#[cfg(test)]` then `#[cfg(feature = "server")]` — **not** as
+`#[cfg(all(test, feature = "server"))]`. The two are identical to rustc but not to the
+Feature 020 retirement census: its stripper (`normalizeRetirementClosureSource` in
+`scripts/validate-lifecycle-oracle-traceability.cjs`) recognises a literal
+`#[cfg(test)]` and would read the `all` form as production code, failing
+`RETIREMENT_CLOSURE_MISMATCH`. Leading with `#[cfg(test)]` keeps the item test-only for
+both. That stripper limitation is a known gap, recorded for the next refreeze
+amendment; until then the stacked form is the supported spelling.
 
 ### Windows build cache (disk)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,17 @@
 - `npm/` only: `cd npm && npm test`
 - Mixed: run both before reporting success
 
+**The default-feature gates cannot catch a feature-gated `cfg` mistake.** CI's
+`embed-build` job runs `cargo test --no-default-features --features embed --lib --
+--test-threads=1`, where the lib tests still compile but every
+`#[cfg(feature = "server")]` module (`watcher`, `daemon`, `protocol`, `sidecar`,
+`server`, `cli`, …) is absent. A `#[cfg(test)]` item whose only consumer lives behind
+`server` is therefore an unused import there, and `-D warnings` fails the build — while
+every default-feature gate above passes. Run that exact command before pushing
+anything that adds a `#[cfg(test)]` helper, and gate such helpers on
+`#[cfg(all(test, feature = "server"))]` when their consumer is server-only. Found the
+slow way on 2026-08-12: green locally and on the `rust` job, red on `embed-build`.
+
 ### Windows build cache (disk)
 
 - Artifacts: repo `.cargo/config.toml` sets `target-dir = "target"`, i.e. artifacts land **beside the checkout, on whatever drive the repo is on** (gitignored). The comment in that file and this line both used to say "on **E:**", which was only ever true while the checkout lived there; as_of 2026-08-12 the repo is on **C:** with no E: drive present, and `target/` had reached **180 GB** on C:. Do **not** pass `CARGO_TARGET_DIR=...` on the command line (older handoffs suggested `C:/symforge-target` — that filled **C:**).

--- a/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
@@ -349,6 +349,30 @@ problem: a `planned_exact` case cannot simultaneously be present, RED, and green
 CI. It is left for the T021 adversarial review to rule on, since unlike the first it
 does not block any Slice 0 work.
 
+### Known gap in the amended stripper
+
+`normalizeRetirementClosureSource` recognises a literal `#[cfg(test)]` attribute. It
+does **not** recognise `#[cfg(all(test, feature = "…"))]`, which is equivalent to
+rustc and is the natural spelling when a test-only helper's consumer sits behind a
+feature gate — so the census reads such an item as production code and fails.
+
+Found immediately: the T014 hook's re-export has to be server-gated (its consumer is
+`src/watcher/mod.rs::tests`, and `watcher` is `#[cfg(feature = "server")]`, so under
+`--no-default-features --features embed` the bare `#[cfg(test)]` form is an unused
+import that `-D warnings` rejects). Writing that as `cfg(all(test, feature =
+"server"))` moved the `publication_roots` digest.
+
+The workaround is exact and costs nothing: two stacked attributes, `#[cfg(test)]`
+first, then `#[cfg(feature = "…")]`. The cut runs from the first attribute to the
+item's terminator, so the second is absorbed with it. `CLAUDE.md` records this as the
+supported spelling.
+
+The proper fix is for the stripper to evaluate test-only cfg predicates — `test`, and
+`all(...)` with `test` as a conjunct, while correctly *rejecting* `any(test, …)` and
+`not(test)`, which are not test-only. That needs another refreeze amendment and
+signature, so it is deferred rather than done here; it blocks nothing while the
+stacked spelling is used.
+
 Nothing was faked, weakened into a vacuous pass, or silently dropped.
 
 ## Scope note

--- a/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
@@ -116,13 +116,15 @@ slice silently skipped its artifact, the requirement table alone would not detec
 Slices 0–3 must therefore be checked against their task receipts, not against this
 table. The contract is frozen; this is noted for the reviewers of T020 and T090.
 
-## T014 — defect 2.8 reproduced; the oracle itself is blocked until Slice 4
+## T014 — observed RED oracle for design defect 2.8
 
-**Status: the defect is confirmed and reproduced. The oracle does not land.**
-`src/watcher/mod.rs` is byte-censused by the retirement contract for the whole
-pre-activation period, so the oracle T014 describes cannot be committed until Slice 4
-— see "Two contradictions inside the frozen corpus" below. What follows is the
-reproduction, performed locally and then reverted.
+**Status: landed.** This section first recorded the oracle as blocked, because the
+retirement census digested whole source bytes and so forbade the very edit T014
+requires. That contradiction was resolved by amending the refreeze (see "Two
+contradictions inside the frozen corpus" below): the census now digests a canonical
+release form, in which `#[cfg(test)]` items are invisible and production bytes are
+not. The oracle and its `cfg(test)` seam therefore land as T014 specifies, with the
+census reporting `OK` and still failing on any production edit to the same files.
 
 The design document's §2.8 says `effective_fence_generation`
 (`src/watcher/mod.rs:255`) assumes reload publishes the new root before advancing
@@ -159,12 +161,12 @@ The oracle asserts the consequence, not the intermediate fence value, so it stay
 valid under either fix — reordering the commit, or binding root and generation into
 one authority.
 
-**Why it cannot land now.** Both the oracle and its seam are edits to censused files
-(`src/watcher/mod.rs` in `callbacks`, `src/live_index/store.rs` in
-`publication_roots`). The reproduction above is preserved here as the evidence T014
-asks for; the executable oracle belongs to the slice that may legally edit those
-files. The exact code is recoverable from this document plus the two line references,
-and the reproduction takes minutes to repeat.
+**Gating.** The oracle carries `#[ignore]` naming Slice 1 (T022–T029) as the owner
+that must remove it, so a deliberately RED control does not turn `main` red. Append
+`--ignored` to the frozen command to reproduce the failure. Both the oracle and its
+seam live in `#[cfg(test)]` scope, which the amended census does not digest; adding
+any production byte to `src/watcher/mod.rs` or `src/live_index/store.rs` still fails
+`RETIREMENT_CLOSURE_MISMATCH`, and that was verified directly rather than assumed.
 
 ## T015–T017 — observed RED positive controls
 
@@ -186,8 +188,30 @@ Each carries `#[ignore]` naming the slice that must remove it, so a deliberately
 RED control does not turn `main` red and the fix's acceptance is the control
 passing without the attribute.
 
-The T015 single-flight control and the T014 oracle are **not** in this set; both need
-edits to censused sources. See the contradictions section below.
+The T015 single-flight control is not in this set because it needs crate-internal
+access; it lands as a unit test in `src/daemon.rs::tests` — see below.
+
+### The single-flight control counts production's own loader
+
+`ensure_project_slot_for_session_with` takes the loader as a closure parameter, so a
+unit test can pass `ProjectInstance::load` — exactly what
+`ensure_project_slot_for_session` supplies in production — wrapped in a counter. Four
+threads entering a shared barrier and racing one first open produce:
+
+```
+cargo test --lib daemon::tests::concurrent_first_open_performs_exactly_one_cold_load -- --exact --nocapture --ignored
+
+4 concurrent first opens of one root must perform exactly one cold load; every
+extra load is a complete project index built, paid for, and discarded by `or_insert`
+  left: 4
+ right: 1
+```
+
+An earlier attempt added a `cold_project_loads` counter to `DaemonState` to make the
+waste observable from an integration test. That was abandoned: it changed production
+code to observe a defect, and the injected loader counts the same real loads at the
+seam that owns them with no production change at all. Slice 2 (T030–T040) inherits an
+assertion that needs no instrument to keep working.
 
 ### The gap control had to be reframed before it meant anything
 
@@ -301,33 +325,31 @@ frozen.
 The check only fires when the target file exists (`isRegularFile(file)`), which is the
 only reason Slice 0 can land at all.
 
-## Deviations taken, and why
+## How each contradiction was resolved
 
-Both are deliberate and reversible, and both preserve every bit of engineering value
-that is reachable without breaking a frozen gate.
+**Contradiction 1 was fixed at the source.** The refreeze was amended so the census
+digests a canonical release form — `#[cfg(test)]` items removed, comments dropped,
+code whitespace collapsed, string and character literals verbatim — instead of raw
+source bytes. The census still freezes V10 authority, because any production byte
+moves the digest; test-only code, which the release build never compiles, no longer
+does. T014's oracle and its `cfg(test)` seam therefore land exactly as `tasks.md`
+specifies, and the 2.4 single-flight control lands as a unit test in
+`src/daemon.rs::tests`. Both were verified against the amended census, and adding a
+production line to the same files was verified to still fail.
 
-1. **Slice 0's controls live in `tests/project_index_lifecycle_slice0_controls.rs`,
-   not `tests/project_index_lifecycle_slice0.rs`.** The reserved filename stays
-   unwritten so `TEST-PUBLICATION` stays dormant until the slice that can make it pass.
-   The control that would have carried that name is
-   `publication_of_one_source_preserves_sibling_latest`, deliberately renamed so no
-   reader mistakes it for the catalog case being satisfied.
-2. **No censused V10 source is touched.** Two items are therefore blocked rather than
-   landed:
-   - **T014's oracle.** The deterministic pause needs a seam between the generation
-     advance and the root publication, both inside `store.rs`. No public or
-     crate-visible operation advances the generation without also publishing, so the
-     only alternative is a two-thread race — and a flaky oracle is worse than none.
-     The defect itself is confirmed and reproduced; see the T014 section above for the
-     exact interleaving and observed corruption.
-   - **The 2.4 single-flight control.** Its instrument (`cold_project_loads`, one
-     `AtomicU64` at the loader call site in `daemon.rs`) is a censused-file edit. With
-     the instrument applied locally, four concurrent first opens measured **four** cold
-     loads against an expected one. Nothing in the public surface counts index builds,
-     so the control cannot be written without it.
+**Contradiction 2 is worked around, deliberately.** Slice 0's integration controls
+live in `tests/project_index_lifecycle_slice0_controls.rs`, leaving the catalog's
+reserved `tests/project_index_lifecycle_slice0.rs` unwritten so `TEST-PUBLICATION`
+stays dormant until the slice that can make it pass. The control that would have
+carried that name is `publication_of_one_source_preserves_sibling_latest`, renamed so
+no reader mistakes it for the catalog case being satisfied.
 
-Both blocked items become legal in Slice 4. Neither was faked, weakened into a
-vacuous pass, or silently dropped.
+That second one is a real remaining inconsistency in the frozen corpus, not a solved
+problem: a `planned_exact` case cannot simultaneously be present, RED, and green in
+CI. It is left for the T021 adversarial review to rule on, since unlike the first it
+does not block any Slice 0 work.
+
+Nothing was faked, weakened into a vacuous pass, or silently dropped.
 
 ## Scope note
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5899,6 +5899,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
 
     use once_cell::sync::Lazy;
@@ -9211,6 +9212,80 @@ mod tests {
             .expect("A reload thread")
             .expect("A reload result");
         reader.join().expect("B reader thread");
+    }
+
+    /// Feature 020 Slice 0 causal control for design defect 2.4 — project
+    /// loading is not single-flight.
+    ///
+    /// `ensure_project_slot_for_session_with` reads the project map, runs the
+    /// complete load OUTSIDE the map lock, and only then calls
+    /// `entry.or_insert`. Concurrent first opens of one root therefore each
+    /// build a full `ProjectInstance`; `or_insert` keeps one and drops the rest
+    /// after they have already paid their I/O, parse, and memory cost.
+    ///
+    /// The waste leaves no other trace: the loser is never activated, so it
+    /// starts no watcher and appears in no listing or health response. That is
+    /// why the loader is counted here rather than asserted about indirectly.
+    /// The closure is production's own — `ProjectInstance::load`, exactly as
+    /// `ensure_project_slot_for_session` supplies it — so this counts real
+    /// loads, not a stand-in.
+    ///
+    /// One first open must cost exactly one cold load, however many sessions
+    /// race for it.
+    #[test]
+    #[ignore = "Feature 020 Slice 0 RED control for design defect 2.4; remove this attribute in Slice 2 (T030-T040) when project admission is single-flight"]
+    fn concurrent_first_open_performs_exactly_one_cold_load() {
+        let project = project_dir("symforge-slot-single-flight");
+        std::fs::write(
+            project.path().join("src").join("lib.rs"),
+            "pub fn single_flight() {}\n",
+        )
+        .expect("write source");
+        let canonical_root = project.path().to_path_buf();
+        let state = Arc::new(DaemonState::new());
+        let project_id = "project-single-flight";
+
+        const RACERS: usize = 4;
+        let loads = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(std::sync::Barrier::new(RACERS));
+        let racers: Vec<_> = (0..RACERS)
+            .map(|racer| {
+                let state = Arc::clone(&state);
+                let loads = Arc::clone(&loads);
+                let start = Arc::clone(&start);
+                let root = canonical_root.clone();
+                std::thread::spawn(move || {
+                    start.wait();
+                    state.ensure_project_slot_for_session_with(
+                        &format!("session-{racer}"),
+                        project_id,
+                        || {
+                            loads.fetch_add(1, Ordering::AcqRel);
+                            ProjectInstance::load(&root)
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        let slots: Vec<_> = racers
+            .into_iter()
+            .map(|racer| racer.join().expect("racer thread").expect("slot"))
+            .collect();
+
+        for slot in &slots {
+            assert!(
+                Arc::ptr_eq(slot, &slots[0]),
+                "precondition: every racer must join the one authoritative slot"
+            );
+        }
+        assert_eq!(
+            loads.load(Ordering::Acquire),
+            1,
+            "{RACERS} concurrent first opens of one root must perform exactly one \
+             cold load; every extra load is a complete project index built, paid \
+             for, and discarded by `or_insert`"
+        );
     }
 
     #[test]

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -2407,6 +2407,10 @@ impl SharedIndexHandle {
         self.project_state_dir
             .store(project_state_dir.map(Arc::new));
         self.project_generation.fetch_add(1, Ordering::AcqRel);
+        // Deterministic test observation point: the generation has advanced but
+        // the previous root is still published (no-op in release).
+        #[cfg(test)]
+        reload_mid_commit::fire();
         // Path-keyed pre-update snapshots belong to the previous project
         // generation. Clear them under the same writer lock as the retarget so
         // a late impact request cannot consume a replacement project's state.
@@ -3515,6 +3519,59 @@ impl Drop for SharedIndexWriteGuard<'_> {
         }
     }
 }
+
+/// Test-only interleave hook for the Feature 020 T014 root/generation split
+/// oracle.
+///
+/// Installed by the watcher oracle to observe the reload window that
+/// [`SharedIndexHandle::reload_for_binding_with_exclusions`] opens between
+/// advancing `project_generation` and publishing the new live root. It fires
+/// INSIDE the write lock, strictly AFTER the generation advance and strictly
+/// BEFORE the root publication, so an observer sees the new generation paired
+/// with the old root deterministically (no sleep, no extra thread). It is
+/// compiled out of release builds.
+#[cfg(test)]
+mod reload_mid_commit {
+    use std::cell::RefCell;
+
+    type Hook = Box<dyn Fn()>;
+
+    thread_local! {
+        static HOOK: RefCell<Option<Hook>> = const { RefCell::new(None) };
+    }
+
+    /// RAII guard that uninstalls the hook on drop so tests cannot leak it
+    /// across the thread-local into a sibling test on the same thread.
+    pub(crate) struct MidCommitGuard;
+
+    impl Drop for MidCommitGuard {
+        fn drop(&mut self) {
+            HOOK.with(|h| *h.borrow_mut() = None);
+        }
+    }
+
+    /// Install a callback fired at the next reload mid-commit point.
+    ///
+    /// The hook is consumed on first fire (see [`fire`]), so a later reload on
+    /// the same thread does not re-trigger it: exactly one observation lands in
+    /// the window.
+    pub(crate) fn install(hook: impl Fn() + 'static) -> MidCommitGuard {
+        HOOK.with(|h| *h.borrow_mut() = Some(Box::new(hook)));
+        MidCommitGuard
+    }
+
+    /// Fire the installed hook if one is present, consuming it first so a
+    /// re-entrant reload does not fire it again.
+    pub(crate) fn fire() {
+        let hook = HOOK.with(|h| h.borrow_mut().take());
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) use reload_mid_commit::install as install_reload_mid_commit_hook;
 
 /// Thread-safe shared handle to the index.
 pub type SharedIndex = Arc<SharedIndexHandle>;

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3575,7 +3575,14 @@ mod reload_mid_commit {
 // "server")]`. Under `--no-default-features --features embed` the lib tests
 // still compile, so a bare `#[cfg(test)]` here is an unused import and the
 // embed build denies warnings.
-#[cfg(all(test, feature = "server"))]
+//
+// Written as two stacked attributes rather than `cfg(all(test, feature =
+// "server"))`, which is equivalent to rustc but not to the retirement census:
+// its stripper recognises a literal `#[cfg(test)]` and would treat the `all`
+// form as production code. Leading with `#[cfg(test)]` keeps the whole item
+// test-only in the census's eyes as well as the compiler's.
+#[cfg(test)]
+#[cfg(feature = "server")]
 pub(crate) use reload_mid_commit::install as install_reload_mid_commit_hook;
 
 /// Thread-safe shared handle to the index.

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -3570,7 +3570,12 @@ mod reload_mid_commit {
     }
 }
 
-#[cfg(test)]
+// Gated on `server` as well as `test`: the only consumer is the watcher oracle
+// in `src/watcher/mod.rs::tests`, and `watcher` is itself `#[cfg(feature =
+// "server")]`. Under `--no-default-features --features embed` the lib tests
+// still compile, so a bare `#[cfg(test)]` here is an unused import and the
+// embed build denies warnings.
+#[cfg(all(test, feature = "server"))]
 pub(crate) use reload_mid_commit::install as install_reload_mid_commit_hook;
 
 /// Thread-safe shared handle to the index.

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -3327,6 +3327,104 @@ mod tests {
         );
     }
 
+    /// Feature 020 Slice 0 causal oracle (T014) for design defect 2.8, "root
+    /// and generation authority can split".
+    ///
+    /// [`effective_fence_generation`]'s contract comment asserts that reload
+    /// "publishes the new live index (with its new `indexed_root`) BEFORE
+    /// bumping the generation", which is what makes adopting an advanced
+    /// generation safe: a retarget would show a different `indexed_root` and be
+    /// kept stale. `reload_for_binding_with_exclusions` does the opposite —
+    /// `project_generation.fetch_add` runs first and `swap_and_publish` runs
+    /// after — so there is a window under the write lock where the generation
+    /// is already the new one and the published root is still A.
+    ///
+    /// A root-A watcher that samples the fence inside that window sees
+    /// `indexed_root == A`, concludes "same-project reload", and adopts the
+    /// advanced generation. Once root B is published that adopted value equals
+    /// the current generation, so the store's under-lock fence accepts the
+    /// mutation and the root-A reconcile removes root B's files.
+    ///
+    /// The oracle asserts the consequence rather than the intermediate value,
+    /// so it stays valid under either fix (reordering the commit, or binding
+    /// root and generation into one authority): whatever a mid-commit observer
+    /// walks away with must not authorize a root-A reindex against root B.
+    ///
+    /// RED by design and therefore ignored, like the other out-of-gate suites
+    /// in this repo: the defect it names is fixed in Slice 1, and the fix's
+    /// acceptance is this test passing without the attribute. Run it with
+    /// `cargo test --lib watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b -- --exact --nocapture --ignored`.
+    #[test]
+    #[ignore = "Feature 020 Slice 0 RED oracle for design defect 2.8; remove this attribute in Slice 1 (T022-T029) when one authority binds root and generation"]
+    fn generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b() {
+        let project_a = TempDir::new().unwrap();
+        let project_b = TempDir::new().unwrap();
+        let a_src = project_a.path().join("src");
+        let b_src = project_b.path().join("src");
+        std::fs::create_dir_all(&a_src).unwrap();
+        std::fs::create_dir_all(&b_src).unwrap();
+        std::fs::write(a_src.join("a.rs"), b"fn a() {}").unwrap();
+        std::fs::write(b_src.join("b.rs"), b"fn b() {}").unwrap();
+
+        let shared = crate::live_index::LiveIndex::load(project_a.path()).unwrap();
+        let spawn_gen = shared.current_project_generation();
+
+        // What a stale root-A watcher takes away from the mid-commit window.
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(None));
+        {
+            let sink = std::sync::Arc::clone(&observed);
+            let hook_shared = std::sync::Arc::clone(&shared);
+            let root_a = project_a.path().to_path_buf();
+            let _guard = crate::live_index::store::install_reload_mid_commit_hook(move || {
+                let fence = effective_fence_generation(&hook_shared, &root_a, spawn_gen);
+                let live_root = hook_shared.read().indexed_root.clone();
+                *sink.lock().unwrap() = Some((fence, live_root));
+            });
+            shared.reload(project_b.path()).unwrap();
+        }
+        let (fence_gen, mid_commit_root) = observed
+            .lock()
+            .unwrap()
+            .take()
+            .expect("reload must fire the mid-commit hook exactly once");
+
+        assert_ne!(
+            shared.current_project_generation(),
+            spawn_gen,
+            "precondition: the retarget must advance the project generation"
+        );
+
+        // Replay the watcher's own reconcile with the generation it captured.
+        let rejected_before = shared.current_rejected_stale_mutations();
+        let repairs =
+            reconcile_stale_files_with_stop(project_a.path(), &shared, || false, fence_gen);
+
+        let context = format!(
+            "observed fence {fence_gen}, spawn generation {spawn_gen}, root \
+             published at observation time {mid_commit_root:?}"
+        );
+        assert!(
+            shared.read().get_file("src/a.rs").is_none(),
+            "root A's file must not be written into root B's publication \
+             ({context}); a mid-commit observer must not be able to authorize a \
+             root-A reindex against root B"
+        );
+        assert!(
+            shared.read().get_file("src/b.rs").is_some(),
+            "root B's file must survive a root-A reconcile carrying the \
+             generation observed mid-commit ({context})"
+        );
+        assert_eq!(
+            repairs, 0,
+            "a foreign-root reconcile repairs zero bytes; it is a rejected \
+             mutation, not a repair ({context})"
+        );
+        assert!(
+            shared.current_rejected_stale_mutations() > rejected_before,
+            "the foreign-root mutation must be rejected by the store fence"
+        );
+    }
+
     /// Cold-start regression: a SAME-ROOT reload (the fire-and-forget
     /// `bg_index.reload(&bg_root)` main.rs runs when no snapshot exists) bumps
     /// the project generation AFTER the watcher captured `expected_gen` at spawn.


### PR DESCRIPTION
Closes the two Slice 0 items that the pre-amendment retirement census made
impossible. Both are tests only; no production code changes.

## Why they can land now

The census used to digest whole source bytes, so adding a `#[cfg(test)]` module
to `src/watcher/mod.rs` failed `RETIREMENT_CLOSURE_MISMATCH` — which is exactly
what `tasks.md` T014 instructs. #555 amended it to digest a canonical release
form instead, in which test-only scope is invisible and every production byte
still moves the digest.

Verified both directions rather than assumed:

| State | Census |
|---|---|
| T014 oracle + `cfg(test)` hook applied | `OK` |
| …plus one production line in the same files | `RETIREMENT_CLOSURE_MISMATCH` ×3 |

## T014 — design defect 2.8

`store.rs:2409` advances `project_generation`; `store.rs:2414` publishes the new
root — the reverse of what `watcher/mod.rs:249-251` claims. A one-shot
thread-local hook in that window (same shape as the existing `write_interleave`
hook in `protocol/edit.rs:208`, compiled out of release builds) lets an observer
read generation `1` while root A is still published. It adopts that generation,
and the resulting reconcile writes root A's file into root B's publication.

The oracle asserts the consequence rather than the intermediate fence value, so
it stays valid under either fix — reordering the commit, or binding root and
generation into one authority.

## The 2.4 single-flight control

Lands as a unit test in `src/daemon.rs::tests`, because it needs crate-internal
access. `ensure_project_slot_for_session_with` takes the loader as a closure
parameter, so the test passes `ProjectInstance::load` — production's own loader,
exactly as `ensure_project_slot_for_session` supplies it — wrapped in a counter.
Four threads entering a shared barrier and racing one first open:

```
4 concurrent first opens of one root must perform exactly one cold load; every
extra load is a complete project index built, paid for, and discarded by `or_insert`
  left: 4
 right: 1
```

**An earlier version of this control added a `cold_project_loads` counter to
`DaemonState`** so an integration test could observe the waste. That is deleted.
Changing production code to observe a defect was the wrong trade when the
injected loader counts the same real loads at the seam that owns them with
nothing added to the shipped binary. Slice 2 (T030–T040) inherits an assertion
that needs no instrument to keep working.

## Gating

Both carry `#[ignore]` naming the slice that must remove them, so deliberately
RED controls do not turn `main` red. The fix's acceptance is each control
passing without its attribute.

## Still open

The evidence document is updated to record what happened rather than the earlier
"blocked" status. It also states plainly that the **second** frozen-corpus
contradiction is unresolved: a `planned_exact` case cannot be simultaneously
present, `#[ignore]`d, and green in CI. Slice 0 works around it by leaving the
catalog's reserved filename unwritten. That is left for the T021 adversarial
review, since unlike the first contradiction it blocks no work.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo test --all-targets -- --test-threads=1`, and
`node scripts/validate-lifecycle-oracle-traceability.cjs` (`OK`) are all clean
locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY