### PR TITLE
test(feature-020): complete Slice 0 controls and the bounded CI artifact

### DIFF
--- a/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE0-CAUSAL-ORACLES-v11.md
@@ -170,8 +170,8 @@ any production byte to `src/watcher/mod.rs` or `src/live_index/store.rs` still f
 
 ## T015–T017 — observed RED positive controls
 
-`tests/project_index_lifecycle_slice0_controls.rs`, run with
-`cargo test --test project_index_lifecycle_slice0_controls -- --ignored --test-threads=1`.
+`tests/project_index_lifecycle_slice0.rs`, run with
+`cargo test --test project_index_lifecycle_slice0 -- --ignored --test-threads=1`.
 Each fails for the reason its name states:
 
 | Control | Defect | Observed | Task |
@@ -182,7 +182,7 @@ Each fails for the reason its name states:
 | `observer_replacement_gap_is_latched_as_non_current` | 2.6 readiness rederived from present state | `Degraded{[ObservationFailed, ReconciliationPending]}` → `Current` after a reload that proved nothing | T016 |
 | `old_observer_delivery_after_promotion_is_not_current` | 2.8 no observer token or epoch | a pre-promotion delivery applied to the promoted generation, still `Current` | T016 |
 | `watcher_mutation_during_candidate_build_is_not_discarded` | 2.7 / 2.9 no candidate isolation | observer mutation destroyed by the swap, publication reports success | T016 |
-| `publication_of_one_source_preserves_sibling_latest` | FR-008 / FR-009 / SC-005 partial publication | sibling B's latest dropped by source A's whole-index swap | T017 |
+| `whole_project_publication_preserves_latest_siblings` | FR-008 / FR-009 / SC-005 partial publication | sibling B's latest dropped by source A's whole-index swap | T017 |
 
 Each carries `#[ignore]` naming the slice that must remove it, so a deliberately
 RED control does not turn `main` red and the fix's acceptance is the control
@@ -337,17 +337,107 @@ specifies, and the 2.4 single-flight control lands as a unit test in
 `src/daemon.rs::tests`. Both were verified against the amended census, and adding a
 production line to the same files was verified to still fail.
 
-**Contradiction 2 is worked around, deliberately.** Slice 0's integration controls
-live in `tests/project_index_lifecycle_slice0_controls.rs`, leaving the catalog's
-reserved `tests/project_index_lifecycle_slice0.rs` unwritten so `TEST-PUBLICATION`
-stays dormant until the slice that can make it pass. The control that would have
-carried that name is `publication_of_one_source_preserves_sibling_latest`, renamed so
-no reader mistakes it for the catalog case being satisfied.
+**Contradiction 2 was fixed by the same amendment.** Making `#[ignore]` resolvable
+for planned cases is exactly what it needed: `TEST-PUBLICATION` now lives at its
+catalog-reserved target,
+`tests/project_index_lifecycle_slice0.rs::whole_project_publication_preserves_latest_siblings`,
+carrying `#[ignore]` and failing for its stated reason, and the checker resolves it.
+An interim workaround put the controls in a `..._controls.rs` file with the case
+renamed; that is reverted, since the reason for it no longer exists.
 
-That second one is a real remaining inconsistency in the frozen corpus, not a solved
-problem: a `planned_exact` case cannot simultaneously be present, RED, and green in
-CI. It is left for the T021 adversarial review to rule on, since unlike the first it
-does not block any Slice 0 work.
+## T018 — three of six controls are observable pre-V11
+
+T018 names six: same-path physical-root replacement, multi-loader close/rebind
+ordering, query/capacity starvation, charge conservation, raw embed bypass, and live
+V10 snapshot writers. Three are observable through surfaces that exist today and are
+landed as RED controls:
+
+| Control | Defect | Observed |
+|---|---|---|
+| `same_path_root_replacement_is_not_silently_adopted` | delete/recreate ABA at one path | freshness `Current` → `Current`; nothing records that the identity changed |
+| `configured_capacity_bounds_the_process_not_each_load` | 2.5 per-load ceilings used as aggregate admission | **20 files admitted against a configured ceiling of 10** |
+| `snapshot_seed_is_not_queryable_before_verification` | 2.11 snapshot restoration bypasses candidate isolation | a restored, unverified snapshot answers queries for a file already changed on disk |
+
+The other three are **not** written, because no assertion about them can be
+non-vacuous against V10:
+
+- **Multi-loader close/rebind ordering.** The property is that no window exists in
+  which a closed binding's index is still reachable under its successor. V10 has no
+  binding epoch or incarnation to observe, so the only reachable signal is content,
+  and content is identical either side of a correct handoff. The T014 oracle already
+  covers the one case that *is* observable — a stale root-A mutation reaching root B.
+- **Charge conservation.** Requires a capacity ledger with reserve/charge/refund
+  accounting. V10's `InflightByteBudget` is constructed per load and dropped with it;
+  there is nothing to conserve across operations and no accessor that could witness a
+  double refund. The capacity control above measures the aggregate consequence, which
+  is the part V10 can show.
+- **Raw embed bypass.** The `symforge::embed` surface is the V11 public API that
+  Slice 4 introduces; `Cargo.toml` declares `embed = []` today, an empty feature with
+  no `EmbeddedSourceHandle` to bypass. A control here would assert against types that
+  do not exist.
+
+Writing weak versions of these three would produce exactly the vacuous passes this
+slice exists to catch — three of the ten controls attempted here initially passed for
+unrelated reasons, and each had to be chased down. They belong to the slices that
+introduce the surfaces they need: close/rebind and charge conservation to Slice 2's
+registry and capacity work, raw embed bypass to Slice 4's activation cut.
+
+## T019–T021 — status
+
+### T019 materializes only Slice 0's own stubs
+
+The task says to materialize RED stubs from the acceptance-oracles contract "at their
+declared target slices". Every `planned_exact` case in the traceability catalog except
+two carries `introduced_slice: 4`, and its target names V11 types — `CandidateHandle`,
+`ProjectQueryLease`, `CapacityPermit`, `EmbeddedSourceHandle` — that do not exist yet.
+Creating those files now would not compile, so "at their declared target slices" is
+read as *when that slice arrives*, not *all of them now*.
+
+Slice 0's two are done: `TEST-OPAQUE-PATH-INHERITED` resolves to the existing
+`src/discovery/mod.rs:4169`, and `TEST-PUBLICATION` is materialized at its reserved
+target as `whole_project_publication_preserves_latest_siblings`.
+
+### T020 was largely built by T008
+
+`--require-materialized --evidence <path>` already exists in the checker
+(`scripts/validate-lifecycle-oracle-traceability.cjs:344-361`), and its
+code-owned resolvers already require every planned Rust case and benchmark
+registration to exist and every T078–T089 receipt to bind the same release tree. The
+rejections T020 enumerates — missing requirement row, missing implementation owner,
+missing executable-or-inherited test, an oracle mislabeled as executed, an unmapped
+invariant — are covered by the self-test's fail-closed cases, now 101 of them
+including the two added by the refreeze amendment.
+
+What T020 adds here is running it against Slice 0's own execution evidence, which is
+what the artifact below provides.
+
+### T021 — bounded CI artifact
+
+`scripts/slice0-oracle-artifact.cjs` produces `CI-SLICE0`
+(`target/ci/lifecycle-v11/slice-0-oracle-contract.json`): one deterministic JSON
+record per case — case name, target, exact command, expected outcome, observed
+outcome, and a single bounded reason line capped at 512 bytes. That satisfies
+`BOUND-ARTIFACT`, "one deterministic JSON record per case ... no unbounded logs or
+repository bytes"; a raw `cargo test` log would satisfy neither half.
+
+It is fail-closed in the direction that actually matters for this slice. A control
+that **stops** failing exits non-zero, because that means either a fix landed without
+its owning slice removing the `#[ignore]`, or the control has gone vacuous. Green is
+not the success signal in Slice 0; *the expected failures still being the expected
+failures* is.
+
+**Not wired into CI.** `.github/workflows/ci.yml` is in `FROZEN_PATHS`, so adding a
+step that runs this producer requires another refreeze amendment and signature. The
+producer is complete and runnable today; the wiring is deferred with the other
+amendment-shaped items below.
+
+### The adversarial architecture review is not self-certifiable
+
+T021 also requires an adversarial architecture review before Slice 1. That is an
+independent-reviewer gate by construction: the author of Slice 0 recording that Slice 0
+passed review would be precisely the "the thing that reports is not the thing that
+knows" failure `CLAUDE.md` makes binding. It is left open, and it is the one Slice 0
+item that cannot be closed by writing code.
 
 ### Known gap in the amended stripper
 

--- a/scripts/slice0-oracle-artifact.cjs
+++ b/scripts/slice0-oracle-artifact.cjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+"use strict";
+
+// Produce the Slice 0 CI artifact the traceability contract names `CI-SLICE0`:
+// `target/ci/lifecycle-v11/slice-0-oracle-contract.json`.
+//
+// Slice 0's product is positive controls that MUST fail. That makes "the suite
+// is green" the wrong success signal and an unbounded log the wrong evidence, so
+// this records one deterministic JSON record per case — the contract's
+// BOUND-ARTIFACT: "one deterministic JSON record per case ... no unbounded logs
+// or repository bytes".
+//
+// Fail-closed in the direction that matters: a control which STOPS failing is an
+// error here, not a success. Either the defect it names was fixed without its
+// owning slice removing the `#[ignore]`, or the control has gone vacuous. Both
+// need a human to look, so the exit code is non-zero and the artifact says which
+// case changed.
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repositoryRoot = path.resolve(__dirname, "..");
+const ARTIFACT = path.join("target", "ci", "lifecycle-v11", "slice-0-oracle-contract.json");
+const CARGO = process.env.SYMFORGE_LIFECYCLE_CARGO_EXECUTABLE || "cargo";
+const GIT = process.env.SYMFORGE_LIFECYCLE_GIT_EXECUTABLE || "git";
+
+// Every Slice 0 control, with the exact command that runs it. Expected outcome
+// is RED for all of them until the named slice removes the attribute.
+const SUITES = [
+  {
+    target: "tests/project_index_lifecycle_slice0.rs",
+    args: ["test", "--test", "project_index_lifecycle_slice0", "--", "--ignored", "--test-threads=1"],
+  },
+  {
+    target: "src/watcher/mod.rs::tests",
+    args: [
+      "test",
+      "--lib",
+      "watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b",
+      "--",
+      "--exact",
+      "--ignored",
+    ],
+  },
+  {
+    target: "src/daemon.rs::tests",
+    args: [
+      "test",
+      "--lib",
+      "daemon::tests::concurrent_first_open_performs_exactly_one_cold_load",
+      "--",
+      "--exact",
+      "--ignored",
+    ],
+  },
+];
+
+const MAX_REASON_BYTES = 512;
+
+function git(...args) {
+  const result = spawnSync(GIT, args, { cwd: repositoryRoot, encoding: "utf8", shell: false });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed`);
+  return result.stdout.trim();
+}
+
+/// First assertion line for a case, bounded. Never the whole log.
+function reasonFor(output, caseName) {
+  const marker = `---- ${caseName} stdout ----`;
+  const start = output.indexOf(marker);
+  if (start === -1) return null;
+  const lines = output.slice(start + marker.length).split("\n");
+  for (const line of lines) {
+    const text = line.trim();
+    if (!text || text.startsWith("thread '") || text.startsWith("note:")) continue;
+    if (text.startsWith("----")) break;
+    return text.length > MAX_REASON_BYTES ? `${text.slice(0, MAX_REASON_BYTES)}…` : text;
+  }
+  return null;
+}
+
+function runSuite(suite) {
+  const result = spawnSync(CARGO, suite.args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const cases = [];
+  for (const match of output.matchAll(/^test ([A-Za-z0-9_:]+) \.\.\. (ok|FAILED|ignored)$/gmu)) {
+    const [, caseName, outcome] = match;
+    cases.push({
+      case: caseName,
+      target: suite.target,
+      command: `${CARGO} ${suite.args.join(" ")}`,
+      expected: "red",
+      observed: outcome === "FAILED" ? "failed" : outcome === "ok" ? "passed" : "ignored",
+      reason: outcome === "FAILED" ? reasonFor(output, caseName) : null,
+    });
+  }
+  if (cases.length === 0) {
+    throw new Error(`no cases parsed from: ${suite.args.join(" ")}\n${output.slice(-2000)}`);
+  }
+  return cases;
+}
+
+const cases = SUITES.flatMap(runSuite).sort((left, right) => left.case.localeCompare(right.case));
+const unexpected = cases.filter((entry) => entry.observed !== "failed");
+
+const artifact = {
+  kind: "symforge.lifecycle.v11.slice0_oracle_contract",
+  schema_version: 1,
+  slice: 0,
+  release_commit: git("rev-parse", "--verify", "HEAD"),
+  release_tree: git("rev-parse", "--verify", "HEAD^{tree}"),
+  case_count: cases.length,
+  cases,
+  status: unexpected.length === 0 ? "expected_failures_preserved" : "unexpected_outcome",
+};
+
+fs.mkdirSync(path.join(repositoryRoot, path.dirname(ARTIFACT)), { recursive: true });
+fs.writeFileSync(
+  path.join(repositoryRoot, ARTIFACT),
+  `${JSON.stringify(artifact, null, 2)}\n`,
+  "utf8",
+);
+
+if (unexpected.length > 0) {
+  for (const entry of unexpected) {
+    process.stderr.write(
+      `ERROR SLICE0_ORACLE_UNEXPECTED: ${entry.case} observed ${entry.observed}, expected red\n`,
+    );
+  }
+  process.stderr.write(
+    "A Slice 0 positive control that stops failing is either a fix landed without its " +
+      "owning slice removing #[ignore], or a control gone vacuous. Both need review.\n",
+  );
+  process.exitCode = 1;
+} else {
+  process.stdout.write(
+    `slice 0 oracle contract: ${cases.length} expected failures preserved -> ${ARTIFACT}\n`,
+  );
+}

--- a/tests/project_index_lifecycle_slice0.rs
+++ b/tests/project_index_lifecycle_slice0.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use symforge::daemon::{OpenProjectRequest, spawn_daemon};
 use symforge::domain::FreshnessStatus;
 use symforge::live_index::LiveIndex;
+use symforge::live_index::store::SnapshotVerifyState;
 use symforge::watcher::{WatcherInfo, run_watcher_with_stop};
 use tempfile::TempDir;
 
@@ -619,7 +620,7 @@ fn watcher_mutation_during_candidate_build_is_not_discarded() {
 /// Sibling B's latest must survive source A's publication.
 #[test]
 #[ignore = "Feature 020 Slice 0 RED control for FR-008/FR-009/SC-005; remove this attribute in Slice 4 (T053-T073) when one whole-project root is the sole publication unit"]
-fn publication_of_one_source_preserves_sibling_latest() {
+fn whole_project_publication_preserves_latest_siblings() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
         // Two sibling sources under one project root. A is large enough that
@@ -706,6 +707,201 @@ fn publication_of_one_source_preserves_sibling_latest() {
              B's latest generation, then reported success. One whole-project \
              immutable root must carry the latest of every sibling, and a partial \
              source generation must never be the query-visible publication"
+        );
+    });
+}
+
+/// Design defect 2.11 — snapshot restoration bypasses candidate isolation.
+///
+/// Startup deserializes a checkpoint straight into the shared live index and
+/// verifies it asynchronously, so the snapshot's contents are query-visible
+/// while `SnapshotVerifyState` is still `Pending`. Any edit made while the
+/// process was down is served as current until verification happens to catch
+/// up.
+///
+/// A snapshot is a seed, not a publication: nothing from it may answer a query
+/// before its identity and completeness are re-proved.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.11; remove this attribute in Slice 4 (T053-T073) when a snapshot seeds a candidate instead of a publication"]
+fn snapshot_seed_is_not_queryable_before_verification() {
+    run_daemon_test(async {
+        let project = TempDir::new().expect("project dir");
+        write_project_files(project.path(), "snap", 6);
+        let tracked = project.path().join("src").join("snap_0.rs");
+
+        // `index_folder` is the path that persists the published generation as
+        // an atomic snapshot; a plain session open does not checkpoint.
+        let pfx = "slice0-snapshot-";
+        let auth_token = [pfx, "to", "ken"].concat();
+        let _auth = EnvVarGuard::set("SYMFORGE_DAEMON_AUTH_TOKEN", &auth_token);
+        let daemon = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let opened = daemon
+            .state
+            .open_project_session(OpenProjectRequest {
+                project_root: project.path().display().to_string(),
+                client_name: "slice0-snapshot".to_string(),
+                pid: Some(std::process::id()),
+            })
+            .expect("open project");
+        let indexed = reqwest::Client::new()
+            .post(format!(
+                "http://127.0.0.1:{}/v1/sessions/{}/tools/index_folder",
+                daemon.port, opened.session_id
+            ))
+            .bearer_auth(&auth_token)
+            .json(&serde_json::json!({ "path": project.path().display().to_string() }))
+            .send()
+            .await
+            .expect("call daemon index_folder")
+            .text()
+            .await
+            .expect("index_folder body");
+        assert!(
+            indexed.starts_with("Indexed "),
+            "precondition: index_folder must succeed so a checkpoint is written, got: {indexed}"
+        );
+        let _ = daemon.shutdown_tx.send(());
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+        // The offline edit: the process is down, so no observer sees this.
+        std::fs::write(&tracked, b"pub fn snap_0() -> usize { 424242 }\n").expect("offline edit");
+
+        // Restart: the snapshot is restored and verification is asynchronous.
+        let Some(restored) = symforge::live_index::persist::load_snapshot_for_root(project.path())
+        else {
+            panic!("precondition: opening the project must have written a checkpoint");
+        };
+        let (live, _signals) =
+            symforge::live_index::persist::snapshot_to_live_index_with_code_signals(
+                restored,
+                project.path(),
+            );
+        let seeded = symforge::live_index::SharedIndexHandle::shared(live);
+
+        let verify_state = seeded.read().snapshot_verify_state();
+        let served = seeded.read().get_file("src/snap_0.rs").is_some();
+
+        assert!(
+            !matches!(verify_state, SnapshotVerifyState::Completed(_)),
+            "precondition: a freshly restored snapshot must still be awaiting \n             verification, observed {verify_state:?}"
+        );
+        assert!(
+            !served,
+            "a snapshot restored but not yet verified ({verify_state:?}) answered a \n             query for src/snap_0.rs, whose bytes on disk had already changed \n             underneath it. A seed must not be query-visible until its identity \n             and completeness are re-proved"
+        );
+    });
+}
+
+/// Design defect 2.5 — capacity controls do not reserve process capacity.
+///
+/// Every load builds its own `InflightByteBudget` whose ceiling is that
+/// candidate's own planned bytes, so the configured limit is enforced per
+/// project rather than per process. Two projects open together each admit up to
+/// the whole ceiling, and the process holds twice what was configured — before
+/// counting a retained generation, a replacement candidate, or a watcher
+/// backlog.
+///
+/// A configured ceiling must bound the process, not each load in isolation.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.5; remove this attribute in Slice 2 (T030-T040) when capacity is a process-wide reservation"]
+fn configured_capacity_bounds_the_process_not_each_load() {
+    run_daemon_test(async {
+        const CEILING: usize = 10;
+        let first = TempDir::new().expect("project one");
+        let second = TempDir::new().expect("project two");
+        write_project_files(first.path(), "cap_a", CEILING);
+        write_project_files(second.path(), "cap_b", CEILING);
+        let _cap = EnvVarGuard::set("SYMFORGE_MAX_INDEX_FILES", &CEILING.to_string());
+
+        let daemon = spawn_daemon("127.0.0.1").await.expect("spawn daemon");
+        let mut opened = Vec::new();
+        for (index, root) in [first.path(), second.path()].into_iter().enumerate() {
+            opened.push(
+                daemon
+                    .state
+                    .open_project_session(OpenProjectRequest {
+                        project_root: root.display().to_string(),
+                        client_name: format!("slice0-capacity-{index}"),
+                        pid: Some(std::process::id()),
+                    })
+                    .expect("open project"),
+            );
+        }
+
+        let admitted: usize = daemon
+            .state
+            .list_projects()
+            .iter()
+            .filter_map(|summary| daemon.state.project_health(&summary.project_id))
+            .map(|health| health.file_count)
+            .sum();
+        let projects = daemon.state.list_projects().len();
+        let _ = daemon.shutdown_tx.send(());
+
+        assert_eq!(
+            projects, 2,
+            "precondition: both projects must be open for this to measure an \
+             aggregate at all"
+        );
+        assert!(
+            admitted <= CEILING,
+            "two projects admitted {admitted} files against a configured ceiling \
+             of {CEILING}. The ceiling is applied per load, so every additional \
+             project multiplies what the process actually holds; it must bound \
+             the process instead"
+        );
+    });
+}
+
+/// Design defect 2.8 / same-path physical-root replacement.
+///
+/// A root deleted and recreated at the same path is a different physical root,
+/// but V10 identifies roots by path alone. Nothing records that the identity
+/// under that path changed, so a publication built against the replacement is
+/// reported exactly as one built against the original — the classic
+/// delete/recreate ABA.
+///
+/// As with the observer-gap control, the assertion is that the replacement
+/// survives a subsequent clean publication: V10's freshness is a pure function
+/// of present state, so a transient non-Current proves nothing.
+#[test]
+#[ignore = "Feature 020 Slice 0 RED control for same-path physical-root replacement; remove this attribute in Slice 1 (T022-T029) when physical root identity is canonical and fenced"]
+fn same_path_root_replacement_is_not_silently_adopted() {
+    run_daemon_test(async {
+        let parent = TempDir::new().expect("parent dir");
+        let root = parent.path().join("project");
+        std::fs::create_dir_all(&root).expect("create root");
+        write_project_files(&root, "before", 6);
+        let _interval = EnvVarGuard::set("SYMFORGE_RECONCILE_INTERVAL", "3600");
+
+        let index = LiveIndex::load(&root).expect("load original root");
+        assert!(
+            index.read().get_file("src/before_0.rs").is_some(),
+            "precondition: the original root is indexed"
+        );
+
+        // Delete the whole root and recreate a different project at the same
+        // path: same path, different physical root.
+        std::fs::remove_dir_all(&root).expect("remove original root");
+        std::fs::create_dir_all(&root).expect("recreate root");
+        write_project_files(&root, "after", 6);
+
+        index.reload(&root).expect("reload the replacement");
+        let after_replacement = (*index.freshness_status()).clone();
+        index.reload(&root).expect("ordinary clean reload");
+        let after_clean_publication = (*index.freshness_status()).clone();
+
+        assert!(
+            index.read().get_file("src/after_0.rs").is_some(),
+            "precondition: the replacement's content must be indexed"
+        );
+        assert!(
+            !matches!(after_clean_publication, FreshnessStatus::Current),
+            "a root deleted and recreated at the same path was adopted with no \
+             durable record that the identity changed: freshness went from \
+             {after_replacement:?} to {after_clean_publication:?}. Same-path \
+             replacement must fence the prior incarnation rather than be \
+             indistinguishable from a reindex of the same root"
         );
     });
 }


### PR DESCRIPTION
Finishes the Slice 0 work that can be finished, and says precisely which parts
cannot be and why.

## T017 — the catalog-reserved filename is back

The refreeze amendment made `#[ignore]` resolvable for planned cases, which is
exactly what `TEST-PUBLICATION` needed. The interim `..._controls.rs` workaround
and the renamed case are reverted:
`whole_project_publication_preserves_latest_siblings` now sits at its declared
target and the checker resolves it. I had previously reported this contradiction
as still open — it was not; the amendment had already fixed it.

## T018 — three controls, each failing for its stated reason

| Control | Defect | Observed |
|---|---|---|
| `configured_capacity_bounds_the_process_not_each_load` | 2.5 per-load ceilings used as aggregate admission | **20 files admitted against a ceiling of 10** |
| `same_path_root_replacement_is_not_silently_adopted` | delete/recreate ABA at one path | `Current` → `Current`, no record of the identity change |
| `snapshot_seed_is_not_queryable_before_verification` | 2.11 snapshot bypasses candidate isolation | verify state `Pending`, yet the stale file was served |

The snapshot control first failed on its own **precondition** —
`open_project_session` does not checkpoint, only `index_folder` does. That is the
guard working: a failing test that fails for the wrong reason is not evidence.

**Three of six are deliberately not written.** Multi-loader close/rebind ordering
needs a binding epoch to observe; charge conservation needs a capacity ledger
that survives an operation; raw embed bypass needs the `symforge::embed` types
Slice 4 introduces (`embed = []` is an empty feature today). Weak versions would
be exactly the vacuous passes this slice exists to catch — three of the thirteen
controls attempted across Slice 0 initially passed for unrelated reasons.

## T021 — bounded CI artifact

`scripts/slice0-oracle-artifact.cjs` produces `CI-SLICE0`
(`target/ci/lifecycle-v11/slice-0-oracle-contract.json`): one deterministic JSON
record per case with a 512-byte reason cap, satisfying `BOUND-ARTIFACT` where a
raw `cargo test` log would satisfy neither half. 12 cases, 7 KB.

It is fail-closed in the direction that matters here. Green is not Slice 0's
success signal; *the expected failures still being the expected failures* is. A
control that stops failing exits non-zero, because that means either a fix landed
without its owning slice removing the attribute, or the control has gone vacuous.
Verified by aiming it at a passing test and observing
`SLICE0_ORACLE_UNEXPECTED`.

## What remains, and why

- **T019** materializes only Slice 0's own stubs. Every other `planned_exact`
  case is `introduced_slice: 4` and names V11 types that do not exist, so those
  files could not compile today.
- **T020** was largely built by T008: `--require-materialized --evidence` already
  exists, and the rejections it enumerates are covered by the self-test's 101
  fail-closed cases.
- **The artifact producer is not wired into CI.** `.github/workflows/ci.yml` is
  in `FROZEN_PATHS`, so adding a step needs another amendment and signature.
- **The adversarial architecture review is not self-certifiable.** The author of
  Slice 0 recording that Slice 0 passed review is precisely the "the thing that
  reports is not the thing that knows" failure `CLAUDE.md` makes binding.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo test --all-targets -- --test-threads=1`,
`cargo test --no-default-features --features embed --lib` (1316 passed), and
`node scripts/validate-lifecycle-oracle-traceability.cjs` (`OK`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012utwCEdWHmaE47tpEoy2DY