### PR TITLE
fix(knowledge): report Unknown lifecycle when no evidence exists

### DIFF
--- a/src/live_index/knowledge_authority.rs
+++ b/src/live_index/knowledge_authority.rs
@@ -1095,7 +1095,15 @@ fn derive_native_lifecycle(
             },
         );
     }
-    (KnowledgeLifecycle::Active, LifecycleEvidence::None)
+    // No declared status, no archive path: nothing was observed, so nothing is
+    // claimed. This previously returned `Active` with `LifecycleEvidence::None`
+    // and the surface printed `lifecycle=active` as though it had been derived
+    // from evidence -- and `derive_voice` then consumed that invented `Active`
+    // to report `voice=current`. The hygiene contract is explicit that lifecycle
+    // always cites hash-valid policy or exact declared evidence and that code
+    // does not assign lifecycle, and `Unknown` is a legal value for exactly this
+    // case.
+    (KnowledgeLifecycle::Unknown, LifecycleEvidence::None)
 }
 
 fn derive_native_authority_domain(
@@ -2015,7 +2023,7 @@ content_hash = "hash"
         let (_root, shared) = fixture(&[
             (
                 "docs/mixed.md",
-                "# Current implementation\ncode_path = \"src/lib.rs\"\n\n# Broken current implementation\ncode_path = \"src/missing.rs\"\n\n# Intent\ncode_path = \"src/future.rs\"\n",
+                "# Current implementation\nstatus: active\ncode_path = \"src/lib.rs\"\n\n# Broken current implementation\nstatus: active\ncode_path = \"src/missing.rs\"\n\n# Intent\ncode_path = \"src/future.rs\"\n",
             ),
             ("src/lib.rs", "pub fn ready() {}\n"),
         ]);
@@ -2062,12 +2070,68 @@ content_hash = "hash"
         assert_eq!(view, build(&shared, AuthorityLimits::default()));
     }
 
+    /// A unit with no declared status and no archive path has no lifecycle
+    /// evidence, so the derived lifecycle must be `Unknown` rather than an
+    /// invented `Active`.
+    ///
+    /// Paired with the declared case in the same test: `status: active` still
+    /// yields `Active`, so this is not a guard that refuses everything. Without
+    /// that pairing, returning `Unknown` unconditionally would satisfy the
+    /// negative assertion perfectly.
+    #[test]
+    fn lifecycle_without_evidence_is_unknown_not_active() {
+        let (_root, shared) = fixture(&[
+            (
+                "docs/undeclared.md",
+                "# Current implementation\ncode_path = \"src/lib.rs\"\n",
+            ),
+            (
+                "docs/declared.md",
+                "# Current implementation\nstatus: active\ncode_path = \"src/lib.rs\"\n",
+            ),
+            ("src/lib.rs", "pub fn ready() {}\n"),
+        ]);
+
+        let view = build(&shared, AuthorityLimits::default());
+
+        let undeclared = view
+            .records
+            .iter()
+            .find(|record| record.unit.path.contains("undeclared"))
+            .expect("the undeclared unit is indexed");
+        assert_eq!(
+            undeclared.lifecycle,
+            KnowledgeLifecycle::Unknown,
+            "a unit with no declared status must not be reported as Active"
+        );
+        assert_eq!(
+            undeclared.voice,
+            KnowledgeVoice::Unknown,
+            "an unevidenced lifecycle must not be consumed as voice=current"
+        );
+        assert!(
+            matches!(undeclared.lifecycle_evidence, LifecycleEvidence::None),
+            "an Unknown lifecycle must not cite evidence it does not have"
+        );
+
+        let declared = view
+            .records
+            .iter()
+            .find(|record| record.unit.path.contains("declared.md"))
+            .expect("the declared unit is indexed");
+        assert_eq!(
+            declared.lifecycle,
+            KnowledgeLifecycle::Active,
+            "a declared status must still be honoured, or this guard is vacuous"
+        );
+    }
+
     #[test]
     fn code_authority_fixture_matrix_never_erases_intent_governance_operations_or_history() {
         let (_root, shared) = fixture(&[
             (
                 "docs/current.md",
-                "# Current implementation\ncode_path = \"src/lib.rs\"\n",
+                "# Current implementation\nstatus: active\ncode_path = \"src/lib.rs\"\n",
             ),
             (
                 "docs/current-broken.md",
@@ -2087,7 +2151,7 @@ content_hash = "hash"
             ),
             (
                 "docs/ops/runbook.md",
-                "# Runbook\ncode_path = \"src/missing.rs\"\n",
+                "# Runbook\nstatus: active\ncode_path = \"src/missing.rs\"\n",
             ),
             (
                 "docs/archive/history.md",

--- a/src/protocol/knowledge_search.rs
+++ b/src/protocol/knowledge_search.rs
@@ -1296,4 +1296,39 @@ mod tests {
             "no hit may be formatted under unsafe source provenance"
         );
     }
+
+    #[test]
+    fn unknown_lifecycle_units_remain_visible_at_default_authority_scope() {
+        let project = tempfile::tempdir().expect("project");
+        std::fs::create_dir_all(project.path().join("docs")).expect("docs");
+        std::fs::write(
+            project.path().join("docs").join("notes.md"),
+            "# Notes\nXylophone lifecycle canary with no declared status.\n",
+        )
+        .expect("undeclared document");
+        let shared = LiveIndex::load(project.path()).expect("load generation");
+        let current = shared.published_source_set().current_generation();
+
+        let default_output = search_current(&current, &input("xylophone lifecycle canary"));
+        assert!(
+            default_output.contains("docs/notes.md"),
+            "default authority_scope must still surface an unevidenced unit: {default_output}"
+        );
+        assert!(
+            default_output.contains("lifecycle=unknown"),
+            "the hit must report the lifecycle that was actually observed: {default_output}"
+        );
+        assert!(
+            default_output.contains("voice=unknown"),
+            "an unevidenced lifecycle must not be consumed as voice=current: {default_output}"
+        );
+
+        let mut history = input("xylophone lifecycle canary");
+        history.authority_scope = Some(KnowledgeAuthorityScope::History);
+        let history_output = search_current(&current, &history);
+        assert!(
+            !history_output.contains("docs/notes.md"),
+            "history scope must not surface an Unknown-voice unit, or the default-scope hit is unfiltered: {history_output}"
+        );
+    }
 }

--- a/tests/fixtures/verify-tools-real/snapshots/file_context.types.snap
+++ b/tests/fixtures/verify-tools-real/snapshots/file_context.types.snap
@@ -54,11 +54,11 @@ Knowledge evidence:
   source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e publication=<gen> content=<gen> target=file:src/types.rs
   counts total=6 shown=5 overflow=1 ambiguous=0 missing=0
   coverage bridge=complete authority=complete
-  1. cases.jsonl:7 bytes=1990..2002 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=1 resolution=resolved_exact lifecycle=active voice=unknown
-  2. cases.jsonl:8 bytes=2269..2281 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=2 resolution=resolved_exact lifecycle=active voice=unknown
-  3. snapshots/file_context.types.snap:2 bytes=58..70 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=10 resolution=resolved_exact lifecycle=active voice=unknown
-  4. snapshots/file_context.types.snap:3 bytes=109..121 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=11 resolution=resolved_exact lifecycle=active voice=unknown
-  5. snapshots/file_context.types.snap:5 bytes=131..143 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=12 resolution=resolved_exact lifecycle=active voice=unknown
+  1. cases.jsonl:7 bytes=1990..2002 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=1 resolution=resolved_exact lifecycle=unknown voice=unknown
+  2. cases.jsonl:8 bytes=2269..2281 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=2 resolution=resolved_exact lifecycle=unknown voice=unknown
+  3. snapshots/file_context.types.snap:2 bytes=58..70 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=10 resolution=resolved_exact lifecycle=unknown voice=unknown
+  4. snapshots/file_context.types.snap:3 bytes=109..121 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=11 resolution=resolved_exact lifecycle=unknown voice=unknown
+  5. snapshots/file_context.types.snap:5 bytes=131..143 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=12 resolution=resolved_exact lifecycle=unknown voice=unknown
 
 
 [truncated] Truncated at ~1000 tokens. Original output is ~<n> tokens; budget is 1000 tokens.

--- a/tests/fixtures/verify-tools-real/snapshots/get_symbol_context.tally.snap
+++ b/tests/fixtures/verify-tools-real/snapshots/get_symbol_context.tally.snap
@@ -20,6 +20,6 @@ Knowledge evidence:
   source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e publication=<gen> content=<gen> target=symbol:src/code_target.rs:tally:fn:6
   counts total=3 shown=3 overflow=0 ambiguous=0 missing=0
   coverage bridge=complete authority=complete
-  1. snapshots/batch_rename.tally.dryrun.snap:7 bytes=250..255 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=7 resolution=resolved_exact lifecycle=active voice=unknown
-  2. snapshots/find_references.tally.snap:2 bytes=249..254 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=14 resolution=resolved_exact lifecycle=active voice=unknown
-  3. snapshots/get_symbol_context.tally.snap:8 bytes=231..236 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=18 resolution=resolved_exact lifecycle=active voice=unknown
+  1. snapshots/batch_rename.tally.dryrun.snap:7 bytes=250..255 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=7 resolution=resolved_exact lifecycle=unknown voice=unknown
+  2. snapshots/find_references.tally.snap:2 bytes=249..254 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=14 resolution=resolved_exact lifecycle=unknown voice=unknown
+  3. snapshots/get_symbol_context.tally.snap:8 bytes=231..236 content_hash=<hash> source=5190313ba7f36ed7f2a148310f805650ab5bc2276e8cccba75a60a11334ffc5e generation=<gen> link_id=<id> bridge_index=18 resolution=resolved_exact lifecycle=unknown voice=unknown

--- a/tests/fixtures/verify-tools/snapshots/file_context.auth.snap
+++ b/tests/fixtures/verify-tools/snapshots/file_context.auth.snap
@@ -16,8 +16,8 @@ Knowledge evidence:
   source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab publication=<gen> content=<gen> target=file:src/auth.rs
   counts total=6 shown=5 overflow=1 ambiguous=0 missing=0
   coverage bridge=complete authority=complete
-  1. cases.jsonl:5 bytes=1302..1313 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=1 resolution=resolved_exact lifecycle=active voice=unknown
-  2. cases.jsonl:6 bytes=1540..1551 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=2 resolution=resolved_exact lifecycle=active voice=unknown
-  3. snapshots/file_context.auth.snap:2 bytes=58..69 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=11 resolution=resolved_exact lifecycle=active voice=unknown
-  4. snapshots/file_context.auth.snap:3 bytes=112..123 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=12 resolution=resolved_exact lifecycle=active voice=unknown
-  5. snapshots/file_context.auth.snap:5 bytes=133..144 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=13 resolution=resolved_exact lifecycle=active voice=unknown
+  1. cases.jsonl:5 bytes=1302..1313 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=1 resolution=resolved_exact lifecycle=unknown voice=unknown
+  2. cases.jsonl:6 bytes=1540..1551 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=2 resolution=resolved_exact lifecycle=unknown voice=unknown
+  3. snapshots/file_context.auth.snap:2 bytes=58..69 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=11 resolution=resolved_exact lifecycle=unknown voice=unknown
+  4. snapshots/file_context.auth.snap:3 bytes=112..123 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=12 resolution=resolved_exact lifecycle=unknown voice=unknown
+  5. snapshots/file_context.auth.snap:5 bytes=133..144 content_hash=<hash> source=23f0b55b77424cf55382590696f62d9e08008c99c4080cc8653ecab3af52ebab generation=<gen> link_id=<id> bridge_index=13 resolution=resolved_exact lifecycle=unknown voice=unknown

--- a/tests/search_knowledge.rs
+++ b/tests/search_knowledge.rs
@@ -156,6 +156,10 @@ async fn exact_hit_and_complete_no_match_preserve_captured_provenance() {
 
     assert!(hit.contains("docs/recovery.md:3"), "exact path/line: {hit}");
     assert!(
+        hit.contains("lifecycle=unknown") && hit.contains("voice=unknown"),
+        "an undeclared unit must stay visible at default scope as unknown, not as invented active/current: {hit}"
+    );
+    assert!(
         hit.contains("Recovery > Persistence boundaries"),
         "heading breadcrumb: {hit}"
     );


### PR DESCRIPTION
## Summary
- `derive_native_lifecycle` no longer assigns `Active` when nothing was observed. No `status:` line and no archive path now yields `Unknown` with `LifecycleEvidence::None`.
- Fixtures that meant to exercise `Active` now declare `status: active`. A paired test covers undeclared vs declared. Default `authority_scope` still surfaces those units as `voice=unknown`.
- Took the abandoned sift branch's fixture retargeting rather than weakening assertions.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib live_index::knowledge_authority -- --test-threads=1`
- [x] `cargo test --test search_knowledge -- --test-threads=1`
- [x] `cargo clippy --no-default-features --features embed --lib -- -D warnings`
- [x] `node scripts/validate-lifecycle-oracle-traceability.cjs`
- [x] `python execution/refreeze_v11.py verify-internal --target-ref HEAD`

## Gates (VERIFIED BY EXECUTION)

`cargo fmt --check` — exit 0, no diff.

`cargo clippy --all-targets -- -D warnings`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 23s
exit_code: 0  (outcome_trust=observed)
```

`cargo test --lib live_index::knowledge_authority -- --test-threads=1`
```
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 3129 filtered out; finished in 0.24s
exit_code: 0
```

`cargo test --test search_knowledge -- --test-threads=1`
```
test exact_hit_and_complete_no_match_preserve_captured_provenance ... ok
test result: ok. 22 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.52s
exit_code: 0
```
The exact-hit test now asserts `lifecycle=unknown` and `voice=unknown` on an undeclared recovery unit that remains visible at default scope.

`cargo clippy --no-default-features --features embed --lib -- -D warnings`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.19s
exit_code: 0
```

`node scripts/validate-lifecycle-oracle-traceability.cjs`
```
lifecycle oracle traceability v11: OK (78 requirements, 24 acceptance oracles, 13 retirement categories)
exit_code: 0
```

`python execution/refreeze_v11.py verify-internal --target-ref HEAD`
```
Feature 020 V11 internal refreeze verification passed.
exit_code: 0
```

Additional execution: `unknown_lifecycle_units_remain_visible_at_default_authority_scope` passed. History scope does not surface the same unit, so the default-scope hit is not an unfiltered pass.

## Inferred by reading
- Hygiene contract: lifecycle always cites hash-valid policy or exact declared evidence; code does not assign lifecycle. `unknown` is already a legal value.
- `derive_voice` maps `Unknown` lifecycle to `Unknown` voice unless an earlier arm wins. Default `authority_scope` includes `Unknown`.

Made with [Cursor](https://cursor.com)