### PR TITLE
fix(release): do not treat an untagged release merge as a silent skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1997,32 +1997,18 @@ jobs:
           manifest-file: .github/.release-please-manifest.json
 
       # release-please skipping is silent and indistinguishable from "nothing to
-      # release". It has now bitten this repo three times: two merge-strategy
-      # variants recorded in CLAUDE.md, and a `fix:` whose BODY the conventional
-      # parser rejected, which dropped the commit entirely and cut no version.
-      # Every one of them left this job green. A job may not report success for a
-      # release it did not observe, so prove the absence instead of assuming it.
+      # release". It has now bitten this repo four times: two merge-strategy
+      # variants recorded in CLAUDE.md, a `fix:` whose BODY the conventional
+      # parser rejected (dropped the commit, cut no version, job still green),
+      # and counting feat/fix since the previous tag after a release PR merged
+      # (release-please aborted "untagged, merged release PRs outstanding";
+      # this step then blocked Create GitHub release, so v10.2.0 never tagged).
+      # A job may not report success for a release it did not observe, so prove
+      # the absence — but an untagged merged release PR is the tagging path,
+      # not a silent skip. See execution/prove_release_owed.py.
       - name: Prove that no release was owed
         if: ${{ steps.release.outputs.prs_created != 'true' && (github.event_name != 'workflow_dispatch' || inputs.tag == '') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          LAST_TAG="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
-          if [[ -z "$LAST_TAG" ]]; then
-            echo "No release tag yet; nothing to prove."
-            exit 0
-          fi
-          OWED="$(git log --no-merges --format=%s "${LAST_TAG}..HEAD" \
-            | grep -cE '^(feat|fix)(\([^)]*\))?!?: ' || true)"
-          if [[ "$OWED" -gt 0 ]]; then
-            echo "::error::${OWED} user-facing commit(s) since ${LAST_TAG} produced no release PR."
-            echo "::error::release-please parsed them away silently. Inspect the step log above for"
-            echo "::error::'commit could not be parsed' before assuming there was nothing to release."
-            git log --no-merges --format='  %h %s' "${LAST_TAG}..HEAD" \
-              | grep -E '(feat|fix)(\([^)]*\))?!?: ' || true
-            exit 1
-          fi
-          echo "No user-facing commits since ${LAST_TAG}; skipping is correct."
+        run: python -I execution/prove_release_owed.py
 
       - name: Auto-merge release PR
         if: ${{ steps.release.outputs.prs_created == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,16 @@ reliable — but it does not fully eliminate the double-count risk above if
 history later happens to also sweep in that PR's inner commits, so prefer
 squash unless there's a specific reason not to.
 
+Release PRs themselves stay `--merge` (the workflow's auto-merge). With
+`skip-github-release: true`, release-please then aborts with "untagged,
+merged release PRs outstanding" until this workflow creates the tag. The
+"Prove that no release was owed" step must not treat that abort as a silent
+parse-away: counting feat/fix since the *previous* tag blocks tagging.
+That is how v10.2.0 never landed after #561 merged (as_of 2026-08-13).
+If HEAD has already moved past the untagged release commit, create `vX.Y.Z`
+at that merge SHA and label the PR `autorelease: tagged` — do not tag HEAD.
+Helper: `execution/prove_release_owed.py`.
+
 ## Architecture
 
 Rust MCP server providing symbol-aware code and repository-knowledge navigation, review, curation, and editing tools. The **default** MCP `tools/list` surface **advertises 39 tools** while **40 are registered** (as_of 2026-08-07). Registration count: `#[tool(` attribute sites — 33 in `tools.rs` + 7 in `edit_tools.rs` — equal to the 40 names in `SYMFORGE_TOOL_NAMES` (including `health_compact`, `search_knowledge`, `review_knowledge`, and `curate_knowledge`), pinned by `test_client_allow_lists_match_registered_tool_surface`. The advertised count is one lower because `list_tools_for_profile` filters the compact-only `symforge` facade out of the full profile (`src/protocol/surface_probe.rs:173`) — `symforge_retrieve` is its full-surface equivalent. Do not "fix" a client reporting 39; that is correct. the compact-3 surface (`symforge`, `symforge_edit`, `status`) is a documented opt-in escape hatch via `SYMFORGE_SURFACE=compact`, with backward-compat aliases for removed tools in `src/daemon.rs`. Resources and prompts are first-class protocol surfaces, not side notes.

--- a/execution/prove_release_owed.py
+++ b/execution/prove_release_owed.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+"""Prove that a release-please skip was not a silent drop of feat/fix commits.
+
+release-please skipping is silent. This repo now fails the prepare-release job
+when user-facing commits since the last *completed* release produced no PR.
+
+A merged release PR with no git tag yet is not that failure. With
+`skip-github-release: true`, release-please opens the version PR, then aborts
+with "untagged, merged release PRs outstanding" until this workflow creates
+the tag. Counting feat/fix since the *previous* tag on that path blocks
+tagging. That is how v10.2.0 never landed after #561 merged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+USER_FACING_SUBJECT = re.compile(r"^(feat|fix)(\([^)]*\))?!?: ")
+RELEASE_SUBJECT = re.compile(
+    r"^chore\([^)]*\): release (\d+\.\d+\.\d+)(?:\s+\(#\d+\))?\s*$"
+)
+MANIFEST_RELATIVE = Path(".github") / ".release-please-manifest.json"
+
+
+class ProveError(RuntimeError):
+    """Raised when the skip cannot be proven safe."""
+
+
+def repo_root(path: str | None = None) -> Path:
+    if path is not None:
+        return Path(path).resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+def run_git(root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def git_text(root: Path, args: Sequence[str]) -> str:
+    result = run_git(root, args)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise ProveError(detail)
+    return result.stdout
+
+
+def list_v_tags(root: Path) -> list[str]:
+    result = run_git(root, ["tag", "-l", "v*"])
+    if result.returncode != 0:
+        raise ProveError(result.stderr.strip() or "git tag failed")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def tag_exists(root: Path, tag: str) -> bool:
+    result = run_git(root, ["rev-parse", "-q", "--verify", f"refs/tags/{tag}"])
+    return result.returncode == 0
+
+
+def commit_subject(root: Path, rev: str) -> str:
+    return git_text(root, ["log", "-1", "--format=%s", rev]).strip()
+
+
+def has_second_parent(root: Path, rev: str) -> bool:
+    result = run_git(root, ["rev-parse", "-q", "--verify", f"{rev}^2"])
+    return result.returncode == 0
+
+
+def release_subject_version(subject: str) -> str | None:
+    match = RELEASE_SUBJECT.match(subject.strip())
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def is_release_head(root: Path, version: str, head: str = "HEAD") -> bool:
+    if release_subject_version(commit_subject(root, head)) == version:
+        return True
+    if not has_second_parent(root, head):
+        return False
+    return release_subject_version(commit_subject(root, f"{head}^2")) == version
+
+
+def find_release_commit(root: Path, version: str) -> str | None:
+    log = git_text(root, ["log", "--format=%H\t%s"])
+    for line in log.splitlines():
+        sha, separator, subject = line.partition("\t")
+        if not separator:
+            continue
+        if release_subject_version(subject) == version:
+            return sha
+    return None
+
+
+def find_release_tag_commit(root: Path, version: str, head: str = "HEAD") -> str | None:
+    """SHA a GitHub release tag should point at: the merge onto main, else the chore."""
+    chore = find_release_commit(root, version)
+    if chore is None:
+        return None
+    first_parent = git_text(root, ["log", "--first-parent", "--format=%H", head])
+    for sha in (line.strip() for line in first_parent.splitlines()):
+        if not sha:
+            continue
+        if sha == chore:
+            return chore
+        if has_second_parent(root, sha):
+            second = git_text(root, ["rev-parse", f"{sha}^2"]).strip()
+            if second == chore:
+                return sha
+    return chore
+
+
+def manifest_version(root: Path) -> str:
+    path = root / MANIFEST_RELATIVE
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise ProveError("release manifest is unavailable or not JSON") from error
+    value = payload.get(".") if isinstance(payload, dict) else None
+    if not isinstance(value, str) or not value:
+        raise ProveError("release manifest version is unavailable")
+    return value
+
+
+def owed_subjects(root: Path, since: str, head: str = "HEAD") -> list[str]:
+    log = git_text(root, ["log", "--no-merges", "--format=%s", f"{since}..{head}"])
+    return [
+        subject
+        for subject in (line.strip() for line in log.splitlines())
+        if subject and USER_FACING_SUBJECT.match(subject)
+    ]
+
+
+def owed_lines(root: Path, since: str, head: str = "HEAD") -> list[str]:
+    log = git_text(root, ["log", "--no-merges", "--format=%h %s", f"{since}..{head}"])
+    lines = []
+    for line in log.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        _, separator, subject = stripped.partition(" ")
+        if separator and USER_FACING_SUBJECT.match(subject):
+            lines.append(stripped)
+    return lines
+
+
+def prove(root: Path, head: str = "HEAD") -> str:
+    """Return a success message, or raise ProveError if a skip is not proven."""
+    if not list_v_tags(root):
+        return "No release tag yet; nothing to prove."
+
+    version = manifest_version(root)
+    expected_tag = f"v{version}"
+    if not tag_exists(root, expected_tag):
+        if is_release_head(root, version, head):
+            return (
+                f"Manifest is {version} with no tag {expected_tag}; "
+                "HEAD is that release commit. Tagging is the next step."
+            )
+        release_sha = find_release_tag_commit(root, version, head)
+        where = f" at {release_sha}" if release_sha is not None else ""
+        raise ProveError(
+            f"Manifest is {version} with no tag {expected_tag}, but HEAD is not "
+            f"that release commit.\n"
+            f"Create GitHub release {expected_tag}{where} "
+            f"(chore(main): release {version}) and label the merged release PR "
+            "autorelease: tagged.\n"
+            "Do not tag HEAD; it has moved past the untagged release."
+        )
+
+    owed = owed_subjects(root, expected_tag, head)
+    if owed:
+        listed = "\n".join(f"  {line}" for line in owed_lines(root, expected_tag, head))
+        raise ProveError(
+            f"{len(owed)} user-facing commit(s) since {expected_tag} produced no "
+            "release PR.\n"
+            "release-please parsed them away silently. Inspect the step log above "
+            "for 'commit could not be parsed' before assuming there was nothing "
+            "to release.\n"
+            f"{listed}"
+        )
+    return f"No user-facing commits since {expected_tag}; skipping is correct."
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail when a release-please skip dropped feat/fix commits, but allow "
+            "the untagged merged release-PR tagging path."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root. Defaults to the current repository.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = repo_root(args.root)
+    try:
+        message = prove(root)
+    except ProveError as error:
+        for line in str(error).splitlines():
+            print(f"::error::{line}", file=sys.stderr)
+            print(line, file=sys.stderr)
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/execution/test_prove_release_owed.py
+++ b/execution/test_prove_release_owed.py
@@ -1,0 +1,146 @@
+"""The 10.2.0 tagging stall: prove must not treat an untagged release merge as a skip."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import prove_release_owed
+
+
+def _run(root: Path, args: list[str]) -> None:
+    subprocess.run(args, cwd=root, check=True, capture_output=True, text=True)
+
+
+def _git(root: Path, *args: str) -> None:
+    _run(root, ["git", *args])
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "prove@example.test")
+    _git(root, "config", "user.name", "Prove Test")
+    _git(root, "config", "commit.gpgsign", "false")
+
+
+def _write_manifest(root: Path, version: str) -> None:
+    path = root / ".github" / ".release-please-manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({".": version}, indent=2) + "\n", encoding="utf-8")
+
+
+def _commit(root: Path, message: str, filename: str, content: str) -> None:
+    (root / filename).write_text(content, encoding="utf-8")
+    _git(root, "add", filename)
+    _git(root, "commit", "-m", message)
+
+
+class ProveReleaseOwedTests(unittest.TestCase):
+    def test_no_tags_is_vacuous_success(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="prove-release-") as temp:
+            root = Path(temp)
+            _init_repo(root)
+            _write_manifest(root, "1.0.0")
+            _commit(root, "feat: first", "a.txt", "a\n")
+            self.assertEqual(
+                prove_release_owed.prove(root),
+                "No release tag yet; nothing to prove.",
+            )
+
+    def test_untagged_release_merge_is_tagging_not_a_silent_skip(self) -> None:
+        """The 10.2.0 shape: last tag is 1.0.0, manifest is 1.1.0, HEAD is the merge."""
+        with tempfile.TemporaryDirectory(prefix="prove-release-") as temp:
+            root = Path(temp)
+            _init_repo(root)
+            _write_manifest(root, "1.0.0")
+            _commit(root, "feat: initial", "a.txt", "a\n")
+            _git(root, "tag", "v1.0.0")
+            _commit(root, "feat(feature-020): Slice 1", "b.txt", "b\n")
+            _git(root, "checkout", "-b", "release-please")
+            _write_manifest(root, "1.1.0")
+            _commit(root, "chore(main): release 1.1.0", "changelog.txt", "1.1.0\n")
+            _git(root, "checkout", "main")
+            _git(
+                root,
+                "merge",
+                "--no-ff",
+                "-m",
+                "Merge pull request #561 from org/release-please",
+                "release-please",
+            )
+
+            message = prove_release_owed.prove(root)
+            self.assertIn("Tagging is the next step", message)
+            self.assertIn("1.1.0", message)
+
+    def test_head_past_untagged_release_refuses_to_tag_head(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="prove-release-") as temp:
+            root = Path(temp)
+            _init_repo(root)
+            _write_manifest(root, "1.0.0")
+            _commit(root, "feat: initial", "a.txt", "a\n")
+            _git(root, "tag", "v1.0.0")
+            _commit(root, "feat: owed", "b.txt", "b\n")
+            _git(root, "checkout", "-b", "release-please")
+            _write_manifest(root, "1.1.0")
+            _commit(root, "chore(main): release 1.1.0", "changelog.txt", "1.1.0\n")
+            _git(root, "checkout", "main")
+            _git(
+                root,
+                "merge",
+                "--no-ff",
+                "-m",
+                "Merge pull request #561 from org/release-please",
+                "release-please",
+            )
+            merge_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            _commit(root, "feat(knowledge): later", "c.txt", "c\n")
+
+            with self.assertRaises(prove_release_owed.ProveError) as raised:
+                prove_release_owed.prove(root)
+            text = str(raised.exception)
+            self.assertIn("Do not tag HEAD", text)
+            self.assertIn(merge_sha, text)
+            self.assertIn("v1.1.0", text)
+
+    def test_feat_since_manifest_tag_is_owed(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="prove-release-") as temp:
+            root = Path(temp)
+            _init_repo(root)
+            _write_manifest(root, "1.1.0")
+            _commit(root, "chore(main): release 1.1.0", "a.txt", "a\n")
+            _git(root, "tag", "v1.1.0")
+            _commit(root, "feat(knowledge): answer-first", "b.txt", "b\n")
+
+            with self.assertRaises(prove_release_owed.ProveError) as raised:
+                prove_release_owed.prove(root)
+            text = str(raised.exception)
+            self.assertIn("1 user-facing commit", text)
+            self.assertIn("v1.1.0", text)
+            self.assertIn("feat(knowledge): answer-first", text)
+
+    def test_docs_since_manifest_tag_is_not_owed(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="prove-release-") as temp:
+            root = Path(temp)
+            _init_repo(root)
+            _write_manifest(root, "1.1.0")
+            _commit(root, "chore(main): release 1.1.0", "a.txt", "a\n")
+            _git(root, "tag", "v1.1.0")
+            _commit(root, "docs: note", "b.txt", "b\n")
+            self.assertIn(
+                "skipping is correct",
+                prove_release_owed.prove(root),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/execution/test_release_ops.py
+++ b/execution/test_release_ops.py
@@ -185,6 +185,14 @@ class ReleaseOpsTests(unittest.TestCase):
         self.assertIn("Publish platform packages to npm", workflow)
         self.assertIn("Publish root package to npm", workflow)
 
+    def test_release_workflow_proves_skips_via_untagged_aware_helper(self) -> None:
+        root = release_ops.repo_root()
+        workflow = (root / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("python -I execution/prove_release_owed.py", workflow)
+        self.assertNotIn("LAST_TAG=\"$(git describe --tags --abbrev=0 --match 'v*'", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- The prove step counted feat/fix since the previous git tag after a release PR merged. release-please had already aborted with untagged merged release PRs outstanding; the prove then failed the job before Create GitHub release, so v10.2.0 never tagged.
- Prove now uses the manifest version tag. An untagged merged release at HEAD is the tagging path. If HEAD has moved, it names the merge SHA to tag and refuses to tag HEAD.
- Operator recovery already done on the repo: GitHub release v10.2.0 points at 6d21a16b; #561 is labeled autorelease: tagged.

## Test plan
- [x] `python -m unittest test_prove_release_owed test_release_ops` from `execution/`
- [ ] Merge this before re-running Release on main, or the next cut will stick the same way
- [ ] After merge, Release should open 10.3.0 for #562 and #563 plus this fix
- [ ] Rebuild 10.2.0 assets: workflow run 31698193392 dispatched with tag=v10.2.0
