### PR TITLE
fix(read-gate): admit git-object reads in the symbol diff lane

### DIFF
--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -6502,11 +6502,18 @@ pub fn impact_footer(deps: usize, cochanges: &[String]) -> String {
 }
 
 /// Format symbol-level diff between two git refs.
-/// `live` is required because uncommitted mode reads the WORKING TREE, which is
-/// a disclosure lane: without it a security-demoted file's symbol names and
-/// signatures render straight into the diff. A refused file is reported as
-/// withheld rather than rendered as empty — rendering it empty would state,
-/// falsely, that every one of its symbols was removed.
+///
+/// `live` is required because EVERY content read in this function is a
+/// disclosure lane, not just the working-tree one. An earlier version of this
+/// comment scoped the hazard to "uncommitted mode reads the WORKING TREE",
+/// gated that single read, and left the two `file_at_ref` reads beside it
+/// ungated — so a security-demoted file's symbol names and signatures rendered
+/// straight into any committed-vs-committed diff. Both git-object reads now go
+/// through the same admission gate.
+///
+/// A refused file is reported as withheld rather than rendered as empty —
+/// rendering it empty would state, falsely, that every one of its symbols was
+/// removed.
 pub fn diff_symbols_result_view(
     base: &str,
     target: &str,
@@ -6534,17 +6541,12 @@ pub fn diff_symbols_result_view(
     let mut files_with_changes = 0usize;
 
     for file_path in changed_files {
-        // Get content at base and target refs
-        let base_content = repo
-            .file_at_ref(base, file_path)
-            .unwrap_or_default()
-            .unwrap_or_default();
-
-        // When target is empty, we're in uncommitted mode — read from the
-        // working tree instead of a git ref (file_at_ref("") returns None,
-        // which would make every symbol appear "removed").
-        let target_content = if target.is_empty() {
-            match crate::protocol::read_gate::admit_worktree_text(live, repo, file_path) {
+        // Content at the base ref. Git objects are a disclosure lane exactly
+        // like the working tree: an ungated read here rendered a demoted
+        // file's symbol names and signatures straight into the diff, on BOTH
+        // sides, whenever target was a real ref.
+        let base_content =
+            match crate::protocol::read_gate::admit_git_text(live, repo, base, file_path) {
                 Ok(text) => text.unwrap_or_default(),
                 Err(_) => {
                     // Withheld. Say so and move on: falling through with empty
@@ -6555,11 +6557,29 @@ pub fn diff_symbols_result_view(
                     lines.push(String::new());
                     continue;
                 }
+            };
+
+        // When target is empty, we're in uncommitted mode — read from the
+        // working tree instead of a git ref (an empty ref resolves to nothing,
+        // which would make every symbol appear "removed").
+        let target_content = if target.is_empty() {
+            match crate::protocol::read_gate::admit_worktree_text(live, repo, file_path) {
+                Ok(text) => text.unwrap_or_default(),
+                Err(_) => {
+                    lines.push(content_withheld_by_admission(file_path));
+                    lines.push(String::new());
+                    continue;
+                }
             }
         } else {
-            repo.file_at_ref(target, file_path)
-                .unwrap_or_default()
-                .unwrap_or_default()
+            match crate::protocol::read_gate::admit_git_text(live, repo, target, file_path) {
+                Ok(text) => text.unwrap_or_default(),
+                Err(_) => {
+                    lines.push(content_withheld_by_admission(file_path));
+                    lines.push(String::new());
+                    continue;
+                }
+            }
         };
 
         // Extract symbol names from both versions — prefer tree-sitter AST,

--- a/src/protocol/read_gate.rs
+++ b/src/protocol/read_gate.rs
@@ -1,10 +1,22 @@
-//! The single admission/disclosure gate for raw-disk content reads.
+//! The single admission/disclosure gate for repository CONTENT reads.
 //!
-//! Every protocol lane that reopens a repository file from disk — rather than
-//! serving bytes already held in the in-memory index — routes its read through
-//! [`admit_disk_read`]. The gate owns the read: it classifies the exact buffer
-//! it just read and hands that buffer back only on a permit verdict, so no
-//! caller can classify one set of bytes and then render another.
+//! Every protocol lane that fetches repository bytes from outside the in-memory
+//! index routes through this module. There are two such object stores, not one:
+//!
+//!   * the working tree, via [`admit_worktree_text`] / [`admit_disk_read`];
+//!   * git objects, via [`admit_git_text`].
+//!
+//! The gate OWNS the fetch in both cases. It classifies the exact buffer it
+//! just obtained and hands that buffer back only on a permit verdict, so no
+//! caller can classify one set of bytes and then render another. A lane that
+//! fetched its own bytes and promised to classify them afterwards would be
+//! indistinguishable from an ungated read, which is why the fetch lives here.
+//!
+//! This doc previously described the gate as disk-only, and that omission was
+//! load-bearing: `diff_symbols` gated its working-tree read while the two
+//! `file_at_ref` reads beside it stayed ungated, disclosing a demoted file's
+//! symbol names and signatures out of git objects. Policy and classification
+//! are shared by both lanes precisely so the next store added cannot repeat it.
 
 use std::path::Path;
 
@@ -89,19 +101,20 @@ pub(crate) fn disk_read_would_refuse(
 ///
 /// Returns `Err` with the caller-ready refusal or IO message; the caller
 /// returns it verbatim.
-pub(crate) fn admit_disk_read(
-    live: &LiveIndex,
-    relative_path: &str,
-    canon_path: &Path,
-) -> Result<Vec<u8>, String> {
+/// Policy refusals that need NO bytes: the current path rule and the recorded
+/// disposition on the publication that produced the miss.
+///
+/// Split out so both the disk lane and the git-object lane consult exactly the
+/// same policy, and so the disk lane can still refuse WITHOUT reading the file.
+fn refuse_by_policy(live: &LiveIndex, relative_path: &str) -> Option<String> {
     // Current path rule — no read needed.
     if crate::knowledge::sensitive_path_rule(relative_path).is_some() {
-        return Err(format::content_withheld_by_admission(relative_path));
+        return Some(format::content_withheld_by_admission(relative_path));
     }
 
     // Recorded disposition on the publication that produced the miss — no read
     // needed. A missing entry is not authorization: it means the manifest has
-    // nothing to say, and the current-bytes classification below still applies.
+    // nothing to say, and the current-bytes classification still applies.
     if let Some(FileDisposition::MetadataOnly { reason }) =
         live.capture_file_disposition(relative_path)
     {
@@ -113,14 +126,77 @@ pub(crate) fn admit_disk_read(
                     .iter()
                     .any(|id| id == crate::knowledge::INDETERMINATE_RULE_ID) =>
             {
-                return Err(format::content_withheld_unscanned(relative_path));
+                return Some(format::content_withheld_unscanned(relative_path));
             }
             MetadataOnlyReason::SensitivePath { .. }
             | MetadataOnlyReason::SensitiveContent { .. } => {
-                return Err(format::content_withheld_by_admission(relative_path));
+                return Some(format::content_withheld_by_admission(relative_path));
             }
             _ => {}
         }
+    }
+    None
+}
+
+/// Admit bytes the caller ALREADY HOLDS — a git blob, not a disk read.
+///
+/// The disk lane and the git-object lane differ in exactly one step: where the
+/// bytes come from. Policy (path rule, recorded disposition) and content
+/// classification are identical, so they live here and both lanes share them.
+///
+/// This exists because `diff_symbols` gated its working-tree read and left the
+/// two `file_at_ref` reads beside it ungated, which disclosed a demoted file's
+/// symbol names and signatures out of git objects. A lane that holds repository
+/// bytes must admit them, whatever object store they came from.
+pub(crate) fn admit_bytes(
+    live: &LiveIndex,
+    relative_path: &str,
+    bytes: Vec<u8>,
+) -> Result<Vec<u8>, String> {
+    if let Some(refusal) = refuse_by_policy(live, relative_path) {
+        return Err(refusal);
+    }
+    if let Some(refusal) = classify_admitted_bytes(relative_path, &bytes) {
+        return Err(refusal);
+    }
+    Ok(bytes)
+}
+
+/// Text for `relative_path` as of `git_ref`, admitted by [`admit_bytes`].
+///
+/// The gated replacement for a bare `GitRepo::file_at_ref` in a disclosure
+/// lane. Return shape MIRRORS `file_at_ref` so refusal stays distinguishable
+/// from absence at every call site:
+///   * `Ok(None)` — absent at that ref, binary, or not valid UTF-8;
+///   * `Ok(Some(text))` — admitted content, the only bytes a lane may use;
+///   * `Err(message)` — REFUSED, carrying the caller-ready refusal.
+pub(crate) fn admit_git_text(
+    live: &LiveIndex,
+    repo: &crate::git::GitRepo,
+    git_ref: &str,
+    relative_path: &str,
+) -> Result<Option<String>, String> {
+    // Policy first: a path-ruled file is refused without touching the object
+    // store at all.
+    if let Some(refusal) = refuse_by_policy(live, relative_path) {
+        return Err(refusal);
+    }
+    let Some(text) = repo.file_at_ref(git_ref, relative_path)? else {
+        return Ok(None);
+    };
+    let admitted = admit_bytes(live, relative_path, text.into_bytes())?;
+    Ok(String::from_utf8(admitted).ok())
+}
+
+pub(crate) fn admit_disk_read(
+    live: &LiveIndex,
+    relative_path: &str,
+    canon_path: &Path,
+) -> Result<Vec<u8>, String> {
+    // Policy refusals need no bytes, so they run BEFORE the read: a demoted
+    // file is never opened.
+    if let Some(refusal) = refuse_by_policy(live, relative_path) {
+        return Err(refusal);
     }
 
     // The one read, and the classification of exactly those bytes. Required
@@ -130,6 +206,14 @@ pub(crate) fn admit_disk_read(
         Ok(bytes) => bytes,
         Err(e) => return Err(format!("{relative_path} [error: could not read file: {e}]")),
     };
+    if let Some(refusal) = classify_admitted_bytes(relative_path, &bytes) {
+        return Err(refusal);
+    }
+    Ok(bytes)
+}
+
+/// Classify bytes the gate is holding. `None` admits them.
+fn classify_admitted_bytes(relative_path: &str, bytes: &[u8]) -> Option<String> {
     // Fail closed on bytes the detector cannot have inspected, and do it HERE so
     // the refusal MESSAGE can be honest. `classify_stable_content` demotes both
     // populations correctly on its own — it collapses the scan-budget refusal
@@ -140,9 +224,9 @@ pub(crate) fn admit_disk_read(
     // `detect_lfs_pointer` requires valid UTF-8 under 1 KiB, so no pointer is
     // swallowed here.
     if crate::knowledge::exceeds_scan_limit(bytes.len())
-        || crate::knowledge::decode_searchable_text(&bytes).is_err()
+        || crate::knowledge::decode_searchable_text(bytes).is_err()
     {
-        return Err(format::content_withheld_unscanned(relative_path));
+        return Some(format::content_withheld_unscanned(relative_path));
     }
     let language = Path::new(relative_path)
         .extension()
@@ -159,9 +243,9 @@ pub(crate) fn admit_disk_read(
     // advising a reindex.
     if let crate::knowledge::StableContentAdmission::MetadataOnly(
         MetadataOnlyReason::SensitiveContent { rule_ids, .. },
-    ) = crate::knowledge::classify_stable_content(relative_path, targets, &bytes)
+    ) = crate::knowledge::classify_stable_content(relative_path, targets, bytes)
     {
-        return Err(
+        return Some(
             if rule_ids
                 .iter()
                 .any(|id| id == crate::knowledge::INDETERMINATE_RULE_ID)
@@ -174,5 +258,5 @@ pub(crate) fn admit_disk_read(
     }
 
     // Permit. These are the only bytes any gated lane may render or parse.
-    Ok(bytes)
+    None
 }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -8413,7 +8413,7 @@ impl SymForgeServer {
                     .unwrap_or_default();
 
                 let base_content = repo
-                    .file_at_ref(seed_base_ref, path)
+                    .file_at_ref(seed_base_ref, path) // D8/PR2-ungated-git-read
                     .unwrap_or_default()
                     .unwrap_or_default();
                 // Gated: a refusal collapses to "no current content", which
@@ -31222,29 +31222,168 @@ mod tests {
         );
     }
 
-    /// GREEN-GUARD (FU-1). The structural half of the same property: no
-    /// protocol lane may reach the UNGATED working-tree read directly.
+    /// RED (D1). The working-tree read in `diff_symbols` is gated; the two
+    /// GIT-OBJECT reads beside it, in the same loop body, are not. In
+    /// committed-vs-committed mode BOTH sides come from `file_at_ref`, so the
+    /// admission gate is never consulted and a security-demoted file's symbol
+    /// names render straight into the diff.
     ///
-    /// Behavioural tests only cover the three lanes that exist today; this
-    /// fails the moment a FOURTH one is written, which is how the original
-    /// three came to share an ungated read in the first place.
+    /// `diff_symbols_result_view`'s own doc says `live` is needed "because
+    /// uncommitted mode reads the WORKING TREE, which is a disclosure lane".
+    /// That is true and incomplete: it scopes the hazard to one of three reads.
+    ///
+    /// The fixture demotes by PATH rule (`*.key` ->
+    /// `path.private-key-material`) because that is deterministic and needs no
+    /// content detector. The property under test is which AUTHORITY the lane
+    /// consults, not how likely a given filename is.
     #[test]
-    fn no_protocol_lane_reads_the_working_tree_ungated() {
+    fn committed_diff_does_not_disclose_symbols_of_a_demoted_file() {
+        let canary = runtime_canary();
+        let dir = init_git_repo();
+        let demoted = dir.path().join("deploy.key");
+        let admitted = dir.path().join("src.rs");
+
+        std::fs::write(
+            &demoted,
+            format!("function rotateMasterCredential() {{}}\n// {canary}\n"),
+        )
+        .expect("write demoted fixture");
+        std::fs::write(&admitted, "pub fn anchor() {}\n").expect("write admitted fixture");
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "base"]);
+
+        // Both files gain a symbol, so both have something to disclose.
+        std::fs::write(
+            &demoted,
+            format!(
+                "function rotateMasterCredential() {{}}\nfunction issueDeployToken() {{}}\n// {canary}\n"
+            ),
+        )
+        .expect("rewrite demoted fixture");
+        std::fs::write(&admitted, "pub fn anchor() {}\npub fn added_anchor() {}\n")
+            .expect("rewrite admitted fixture");
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "changes"]);
+
+        let shared = crate::live_index::LiveIndex::load(dir.path()).expect("load index");
+        let live = shared.read();
+        let repo = crate::git::GitRepo::open(dir.path()).expect("open git repo");
+
+        // Anti-vacuity: the gate really does refuse this path, so an absent
+        // symbol below is the gate acting rather than a fixture that never
+        // produced one.
+        assert!(
+            crate::protocol::read_gate::admit_disk_read(&live, "deploy.key", &demoted).is_err(),
+            "control: the admission gate must refuse deploy.key"
+        );
+
+        let result = super::format::diff_symbols_result_view(
+            "HEAD~1",
+            "HEAD",
+            &["deploy.key", "src.rs"],
+            &repo,
+            &live,
+            false,
+            false,
+        );
+
+        // GREEN-CONTROL: an admitted file is still diffed, so a passing test
+        // cannot be bought by refusing to render diffs at all.
+        assert!(
+            result.contains("added_anchor"),
+            "GREEN-CONTROL: an admitted file must still render its symbols, got {}",
+            refusal_shape(&result)
+        );
+
+        // The disclosure itself: symbol names read out of git objects.
+        assert!(
+            !result.contains("issueDeployToken"),
+            "a demoted file's symbol names must not be disclosed from git objects, got {}",
+            refusal_shape(&result)
+        );
+        assert!(
+            !result.contains("rotateMasterCredential"),
+            "a demoted file's existing symbols must not be disclosed either, got {}",
+            refusal_shape(&result)
+        );
+        assert!(
+            !result.contains(canary.as_str()),
+            "the diff must not echo withheld content"
+        );
+        assert!(
+            result.contains(WITHHELD_REFUSAL_PREFIX),
+            "the demoted file must be reported as withheld rather than silently skipped, got {}",
+            refusal_shape(&result)
+        );
+    }
+
+    /// GREEN-GUARD (FU-1, D2). The structural half of the same property: no
+    /// protocol lane may reach repository CONTENT through an ungated read.
+    ///
+    /// Behavioural tests only cover the lanes that exist today; this fails the
+    /// moment a new one is written, which is how the original three came to
+    /// share an ungated read in the first place.
+    ///
+    /// Two blind spots let D1 through and are closed here. The scan matched
+    /// only the working-tree read, so `file_at_ref` — a git-object read of the
+    /// same repository content — walked past it; and `read_dir` was not
+    /// recursive while its `.rs` check skipped directory entries, so
+    /// `src/protocol/format/` and `src/protocol/tools/` were never scanned at
+    /// all.
+    ///
+    /// The needle is the UNGATED call. A lane that wants repository bytes goes
+    /// through `read_gate`, which owns the fetch and classifies what it holds;
+    /// "call `file_at_ref` and classify afterwards" is indistinguishable from
+    /// the defect and is therefore not allowed.
+    #[test]
+    fn no_protocol_lane_reads_repository_content_ungated() {
         // Assembled at runtime so this scan does not match its OWN source, the
         // way the repository-wide detector tripwire avoids the same trap.
-        let needle = [".file_from_", "workdir("].concat();
+        let needles = [
+            [".file_from_", "workdir("].concat(),
+            [".file_at_", "ref("].concat(),
+        ];
+        // read_gate owns both fetches; it is the gate, not a bypass of it.
+        let gate_owner = ["read_", "gate.rs"].concat();
+        // D8/PR2: detect_impact still reaches git objects directly. It is
+        // production `tools.rs`, so fixing it regenerates the `writers`
+        // retirement-census digest and belongs with that batch. Allowlisted by
+        // an exact SENTINEL on the offending line — not by file and not by
+        // function, so a SECOND ungated read in the same function still fails.
+        // PR 2 deletes the sentinel and the call together.
+        let sentinel = ["D8", "/PR2-ungated-git-read"].concat();
         let protocol = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/protocol");
+
         let mut offenders: Vec<String> = Vec::new();
         let mut scanned = 0usize;
-        for entry in fs::read_dir(&protocol).expect("read src/protocol") {
-            let path = entry.expect("dir entry").path();
-            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
-                continue;
-            }
-            let text = fs::read_to_string(&path).expect("read protocol source");
-            scanned += 1;
-            for (number, line) in text.lines().enumerate() {
-                if line.contains(needle.as_str()) {
+        let mut allowlisted = 0usize;
+        let mut stack = vec![protocol];
+        while let Some(dir) = stack.pop() {
+            for entry in fs::read_dir(&dir).expect("read protocol dir") {
+                let path = entry.expect("dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let text = fs::read_to_string(&path).expect("read protocol source");
+                scanned += 1;
+                let is_gate = path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy() == gate_owner);
+                if is_gate {
+                    continue;
+                }
+                for (number, line) in text.lines().enumerate() {
+                    if !needles.iter().any(|needle| line.contains(needle.as_str())) {
+                        continue;
+                    }
+                    if line.contains(sentinel.as_str()) {
+                        allowlisted += 1;
+                        continue;
+                    }
                     offenders.push(format!(
                         "{}:{}",
                         path.file_name().unwrap_or_default().to_string_lossy(),
@@ -31253,10 +31392,20 @@ mod tests {
                 }
             }
         }
+
         assert!(scanned > 0, "control: the scan must actually read sources");
         assert!(
+            scanned > 20,
+            "control: the scan must recurse into protocol subdirectories, only saw {scanned} files"
+        );
+        assert_eq!(
+            allowlisted, 1,
+            "exactly one ungated read is allowlisted (D8/PR2 detect_impact); \
+             a changed count means the sentinel was added or removed without updating this guard"
+        );
+        assert!(
             offenders.is_empty(),
-            "these protocol lanes bypass the working-tree gate: {offenders:?}"
+            "these protocol lanes bypass the content gate: {offenders:?}"
         );
     }
 


### PR DESCRIPTION
## What leaked

`read_gate` was built and documented as a disk-only gate. `diff_symbols` routed its working-tree read through `admit_worktree_text` and left the two `file_at_ref` reads beside it — in the same loop body — ungated.

**Committed-vs-committed was the leak.** When `target` is a real ref, both sides come from `file_at_ref` and the gate is never consulted, so a security-demoted file's symbol names and signatures rendered straight into the diff out of git objects. Uncommitted mode was already correct: it reports withheld and continues. A test driving `target == ""` would have been green and proved nothing.

The gate exists because three lanes each disclosed a demoted file. This closes the object store it never covered.

## The fix

Shared policy and classification split off the disk path so both stores use one gate:

- `refuse_by_policy` runs before any fetch, so a path-ruled file is refused without touching the object store
- `classify_admitted_bytes` runs on the buffer in hand
- `admit_git_text` owns its `file_at_ref` fetch, so a lane cannot fetch its own bytes and promise to classify them later
- `admit_disk_read` keeps refusing before it opens a file

`format.rs` now contains no `file_at_ref` at all, and all three arms take the same withheld-and-continue path. This is deliberately not all of T044; T044 later splits generation versus disk authority on this same seam.

## The guard could not have caught it

The structural tripwire matched only the literal working-tree call, so a git-object read of the same content walked past it. Its directory scan was also not recursive, and the `.rs` extension check skipped directory entries, leaving `src/protocol/format` and `src/protocol/tools` unscanned entirely.

It now recurses, matches both calls, and controls on having scanned a plausible file count.

## Deferred, and machine-enforced

`detect_impact` still reaches git objects directly. That is production `tools.rs`, so fixing it regenerates the `writers` retirement-census digest and belongs with that batch.

It is allowlisted by a sentinel on the exact offending line — not by file, not by function — so a second ungated read in the same function still fails. **The tripwire asserts the allowlist holds exactly one entry**, so the deferral cannot quietly become permanent: adding a sentinel, or deleting the call without the sentinel, fails the guard.

## Census untouched

All five retirement-closure digests re-emitted byte-identical on this branch, gate reports OK. The only production hunk in `tools.rs` is a trailing comment on line 8416, which the census normalizer strips along with all `cfg`-test items.

## Verification

| Gate | Result |
|---|---|
| RED test pre-fix | FAILED on the disclosure assertion; control and green-control both passed |
| Same test post-fix | ok |
| `no_protocol_lane_reads_repository_content_ungated` | ok |
| `cargo test --all-targets` | 122 binaries, 0 failed |
| lib suite | 3162 passed, 0 failed |
| embed gate | 1329 passed, 0 failed |
| `clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
