### PR TITLE
feat(feature-020): Slice 3 PR 1 — provenance types on the frozen contract

### DIFF
--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -205,6 +205,46 @@ mutation loop held a live mutant and promoted the mutant to a blocker. Any
 audit fanned out into a mutation-owned worktree must read from a pinned
 `git show SHA:` baseline, not the working tree.
 
+## The ClaimContext chunk — the last piece of T043's named surface
+
+`ClaimContext`, `ClaimContextInput`, `CurrentQueryLease`,
+`OperationRelationshipContract`, and the free function `acquire_claim_context`
+now exist, on the frozen shape from `data-model.md:1844-1872` under the
+recorded Slice 3 adaptations: `String` keys per D10, the local lease per D11,
+and a `Vec` whose emptiness is refused in the constructor per D10's
+NonEmptyVec record.
+
+The closed relationship table is derived from `OperationKind` and nothing
+else: search operations permit the cross-source relation and require a
+`Current` lease per input; runtime lifecycle operations act on one source and
+require none. Both directions of every rule carry an accepting pair:
+
+- empty acquisition → `InvalidSelection`; one-input acquisition admitted
+- root drift between acquisitions under `CloseSource` → `SourceUnavailable`;
+  the SAME two roots under `SearchText` admitted, because that is the closed
+  contract's explicit cross-source relation, not a loophole
+- `SearchText` input without a `Current` lease → `AdmissionUnavailable`; with
+  the lease admitted; `RefreshSource` legitimately omits it
+- a returned context retains exactly the roots, sources, and repository ids
+  captured at acquisition — the falsifiable half of "a rebind after return
+  does not trigger a trailing live-state check"
+
+`current_query_lease` joins the fixture-evidence family: shape sealed, its
+`Ok` unconditional until Slice 4's strict-lease machinery provides the
+refusing evidence. Same rule as `completed_render_authority`: do not complete
+it with a fake check.
+
+**Mutation ledger, continued** — final suite 34 green:
+
+| # | Mutation | Caught by |
+|---|---|---|
+| M8 | empty-acquisition guard disabled | `a_context_refuses_an_empty_acquisition`, alone |
+| M9 | root-drift guard disabled | `a_rebind_between_input_acquisitions_is_refused`, alone |
+| M10 | requires-current guard disabled | `a_generation_structured_operation_requires_a_current_lease_per_input`, alone |
+
+Ten mutations total across T043: nine caught by a named oracle alone, one
+survivor that forced a new oracle and was then caught by it.
+
 ## The traceability catalog caught an invented name (T041)
 
 First run of `node scripts/validate-lifecycle-oracle-traceability.cjs` on the

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -1,0 +1,139 @@
+# Feature 020 Slice 3 evidence (T041–T052)
+
+Living document for the slice; T052 completes it. Every claim here was observed,
+not inferred. Where a command is cited, it was run on the named tree.
+
+## T041 + T042 — observed RED (durable record)
+
+The RED observation lives in branch commit `cdb3ff20`, which a squash-merge will
+collapse, so the evidence is recorded here as well.
+
+Command, on `cdb3ff20`'s tree (before `claim_provenance.rs` existed):
+
+```
+cargo test --test read_gate_authority_v11 --test claim_provenance_v11 --no-run
+```
+
+Observed output:
+
+```
+error[E0432]: unresolved import `symforge::protocol::format::claim_provenance`
+   |                                 ^^^^^^^^^^^^^^^^ could not find `claim_provenance` in `format`
+error[E0433]: cannot find `claim_provenance` in `format`   (x4)
+error: could not compile `symforge` (test "claim_provenance_v11") due to 5 previous errors
+```
+
+Every error names the missing module and nothing else, so the RED was about the
+absent types, not a malformed test.
+
+## T043 — GREEN transition and the mutation ledger
+
+After `src/lifecycle_identity.rs`, `src/protocol/claim_provenance.rs`, and the
+`#[path]` anchor in `format.rs` landed, the same two files compiled and passed:
+initially 22, then 23 after M2 forced a new oracle (below).
+
+**Mutation ledger.** Each guard was flipped in production, the suite run, the
+named oracle observed failing ALONE, and the guard restored. A guard whose
+mutation survives is not enforced; one did, and the response was a new test, not
+a shrug.
+
+| # | Mutation (production change) | Expected catcher | Observed |
+|---|---|---|---|
+| M0 | `AtomicAuthority::proves_repository_absence` → `true` | `no_local_negative_receipt_can_be_widened_to_repository_absence` | CAUGHT — that test alone failed, message named `DiskObservation` |
+| M1 | empty-derivation refusal disabled (`if inputs.is_empty()` → `if false`) | `a_derivation_refuses_an_empty_input_set` | CAUGHT — alone, 11 held |
+| M2 | bijection LENGTH check disabled (`false && captured.len() != …`) | — | **SURVIVED. 12 passed.** See below. |
+| M2' | same mutant, after the new oracle | `a_selected_aggregate_refuses_an_extra_unselected_generation` | CAUGHT — alone, 12 held |
+| M3 | `roots_are_compatible` → always `true` | `a_derivation_across_two_roots_is_refused_rather_than_composed` | CAUGHT — alone, 9 held in its file; other file 13 green |
+| M4 | `render_bounded` mints a fresh `ProvenanceIdentity` | `truncated_coverage_never_enters_a_claim_identity` | CAUGHT — alone, 12 held |
+
+Final state after all restores: **23 passed, 0 failed** across both files.
+
+**The M2 survival was a real test gap, not a weak mutant.** The bijection
+condition is `len_mismatch || !all_contained`; the mutant disabled only the
+length half, and the containment half caught the only fixture the suite had
+(missing generation). The length guard alone is what catches an EXTRA captured
+generation nobody selected — "Missing, extra, forged, or uncaptured inputs
+refuse" (`data-model.md:1893`) — and no test exercised that arm. The new oracle
+`a_selected_aggregate_refuses_an_extra_unselected_generation` was written while
+the mutant was live, observed catching it, and kept.
+
+## T043 stand-ins that must not be "completed" casually
+
+- **`ObservationLease::completed_render_authority` always returns `Ok`.**
+  `OutputCoverage::Truncated` is gated on holding a `CompletedRenderAuthority`;
+  in Slice 3 that token is obtainable from any `ObservationLease`, because the
+  real strict-lease machinery is Slice 4 (T047/T060). The gate is the TYPE, not
+  a runtime check. Do not "complete" this method by adding a fake check that
+  pretends to verify lease completion it cannot observe — that is the reporting
+  defect this feature exists to prevent. Slice 4 replaces the constructor's
+  evidence, not its shape.
+- The other lease constructors (`observe_missing_path`, `complete_scope_scan`,
+  `admit_generation`) are the same shape: sealed constructors whose *evidence*
+  arrives with the real runtime. Their `Result` returns exist so the signatures
+  do not change when the evidence does.
+
+## Deliberate decisions in force (recorded before code was written)
+
+- **D3** — `DerivedLimitKind`/`LimitBreach` are the LIVE eight-variant types from
+  `live_index::knowledge_bridge`, imported, never transcribed. The frozen six is
+  stale; a later corpus amendment may add the two names. Confirmed by the
+  compiler: the integration crate imports the live type directly.
+- **D9** — where `data-model.md` and `contracts/public-api-v11.json` disagree,
+  the ATOMS win (opaque `SourceRefusal` + `SourceRefusalKind` + `RetryAdvice`,
+  `Claim::producing_runtime_identity`), because the activation rule is
+  machine-enforced and the prose is not. Neither document was amended.
+- **One identity counter** — `identity_newtype!` and `NEXT_IDENTITY` moved to
+  `src/lifecycle_identity.rs` (`pub(crate)` in `lib.rs`, so the public-API
+  census gains no atom); `index_lifecycle/authority.rs` re-exports its six
+  identities from there. No `protocol → index_lifecycle` call edge exists, so
+  T051's darkness proof is intact.
+- **The `#[path]` anchor lives in `format.rs`**, not `protocol/mod.rs`
+  (censused; also `read_gate` is `pub(crate)` so the oracles — a separate crate —
+  could not see the module through it).
+
+## The traceability catalog caught an invented name (T041)
+
+First run of `node scripts/validate-lifecycle-oracle-traceability.cjs` on the
+T043 tree FAILED:
+
+```
+ERROR PLANNED_TEST_CASE_MISSING: trace.catalogs.tests.TEST-PROVENANCE:
+tests/claim_provenance_v11.rs::operation_contract_cartesian_matrix
+```
+
+The frozen catalog pins `TEST-PROVENANCE` to that exact function name
+(CMD-PROVENANCE, owner T041, `introduced_slice: 3`), and the pin activates the
+moment the FILE exists. The Cartesian test had been written under an invented
+name — the Slice 2 failure mode, caught by the machine this time. Renamed to the
+pinned name and WIDENED to match it: the pinned name says OPERATION contract, so
+the operation kind became an axis — 4 operations x 4 refusal kinds x 3 retry
+advices, `seen == 48`. The pinned command was then run verbatim and observed:
+`cargo test --test claim_provenance_v11 operation_contract_cartesian_matrix --
+--exact` -> `1 passed; 0 failed; 12 filtered out`.
+
+## Embed-gate result, and why it passes by design
+
+Prediction before running: FAIL, because the nine new `lifecycle_identity` items
+are consumed only by `claim_provenance`, which sits under the server-gated
+`protocol` module. Observed: **PASS, 1332 passed, 0 failed** (up 3 — the new
+module's own unit tests run under embed).
+
+The prediction missed `src/lib.rs:4`:
+`#![cfg_attr(not(feature = "server"), allow(dead_code))]`, whose comment states
+the policy: under embed an embedder uses a subset of the engine API, so
+unused-but-public helpers are expected, not dead. `protocol` IS absent under
+embed (`lib.rs:67`), and the identities are idle there BY DESIGN. No cfg-gating
+of the new items is needed, and none was added.
+
+## Gate results for the T043 chunk
+
+| Gate | Result |
+|---|---|
+| `cargo fmt --check` | clean |
+| `cargo clippy --all-targets -- -D warnings` | clean, 29s warm |
+| embed lib gate (`--no-default-features --features embed --lib`) | 1332 passed, 0 failed, 4 ignored |
+| traceability checker | OK (78 requirements, 24 oracles, 13 categories) — after the pinned-name fix above |
+| pinned CMD-PROVENANCE, verbatim | 1 passed, 0 failed, `--exact` |
+| both oracle files | 23 passed, 0 failed |
+| five closure digests re-emitted | byte-identical to the pinned values |
+| full `cargo test --all-targets` | — (runs before the PR, not per chunk) |

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -91,6 +91,120 @@ the mutant was live, observed catching it, and kept.
   (censused; also `read_gate` is `pub(crate)` so the oracles — a separate crate —
   could not see the module through it).
 
+## The adversarial audit of the T043 draft, and what it changed
+
+A 5-agent audit ran against the committed draft `225b18bf` — four independent
+auditors over seam fidelity, atom coverage, task-text completeness, and embed
+cfg, then a synthesizing verdict, each verifying against the frozen corpus
+before promoting anything. Every finding below was RE-VERIFIED here before
+being acted on.
+
+**Fixed in the follow-up commit, each with its reason:**
+
+- **`OutputCoverage::Truncated` was FORGEABLE while claimed sealed** — a pub
+  struct variant, so `Truncated { breaches: vec![] }` compiled anywhere with no
+  authority, while doc and commit message claimed the seal. The audit named it
+  for what it was: reporting an enforcement the type system did not provide.
+  Now `Truncated(TruncationBreaches)` with a private field and no public
+  constructor; the ONLY producer is `CompletedRenderAuthority::truncate`.
+- **`RetryAdvice` and `OperationKind` violated the module's own atoms-win
+  rule.** The contract fixes `RetryAdvice = Automatic | Never | OnEvent |
+  Operator` and `OperationKind` as the SEVEN-variant runtime vocabulary; the
+  draft invented three retry variants and squatted the OperationKind name with
+  four provenance shapes. Both now verbatim from the contract; provenance
+  shapes are named by `ClaimProvenance::kind_name` alone.
+- **`ObservationLease::refuse` fabricated evidence** — it filled
+  `evidence_identity` with a fresh identity corresponding to nothing examined,
+  and the oracle blessed it by asserting only `is_some`. The parameter now
+  forces the caller to name what it examined, and the Cartesian asserts the
+  EXACT identity round-trips.
+- **`render_bounded` discarded its coverage argument**, making the retention
+  oracle unfalsifiable. Coverage is now retained on the claim, readable via
+  `rendered_coverage`, still off provenance identity.
+- **`KnowledgeVoice` validated an invented model** — a `Consistency` variant
+  that exists in no frozen document, while dropping `Current`, which the
+  frozen default selection MUST include. Now the frozen six; "never selects
+  consistency" is structural, since no such voice is expressible.
+- **`SelectedAggregate` could not name its own evidence** — `authorities()`
+  yielded nothing for it while `authority_count()` counted its generations, it
+  dropped the frozen `additional_authorities` field, did no root check, and
+  `BTreeMap::from_iter` silently collapsed forged duplicate keys.
+  `authority_count()` is now literally `authorities().count()`.
+- **`into_failed_read` minted a `for_test` receipt on a non-test path**; the
+  caller now supplies the operation being served.
+- **Identity newtypes had gained `Ord`**, making mint order observable — an
+  inference channel added only so a test could sort. Reverted to the original
+  derive set; the test uses a `HashSet`.
+- **Both oracle files lacked the sibling-convention `#![cfg(feature =
+  "server")]`** — invisible to the `--lib` embed gate but a break of the
+  documented all-targets embed invocation. Added.
+- **The darkness prose in `index_lifecycle/mod.rs` had become false** — it
+  claimed grep-level absence, which `lifecycle_identity.rs`'s doc comments now
+  violate in prose. Restated as the call-edge property T051 will formalize.
+
+**Mutation ledger, continued.** The three new guards were each flipped,
+observed caught BY NAME, and restored — final suite 29 green:
+
+| # | Mutation | Caught by |
+|---|---|---|
+| M5 | comparison root gate disabled | `a_comparison_across_two_roots_is_refused_rather_than_composed`, alone |
+| M6 | duplicate-key forgery guard disabled | `a_selected_aggregate_refuses_a_forged_duplicate_capture` — via the KIND assertion, proving forgery is distinguishable from a selection mismatch |
+| M7 | aggregate root check disabled | `a_selected_aggregate_refuses_a_foreign_root_authority`, alone |
+
+**Deferred with records — the D-ledger:**
+
+- **D10 — receipt-field simplifications vs the frozen data model.** The Slice 3
+  receipts drop `parent_identity`, `stable_read`/`ByteDigest`, `FileStamp`,
+  `policy_versions`, `started_at`/`finished_at`, `manifest_digest` and
+  `stable_entry_count` on scope coverage, `repository_id`/`resolved_from`/
+  `object` on Git receipts, and use `String` where the model has
+  `CatalogPath`/`PhysicalRootIdentity` typed paths. All prose-only — no atom,
+  oracle, or seam pins them — and the machinery that makes them load-bearing
+  is Slice 4. NOTE: the `String` paths cannot carry non-UTF8 opaque paths,
+  which collides with T053's lossless opaque-path oracle; Slice 4 must widen.
+- **D9 append** — every `ClaimProvenance` variant carries `identity` per the
+  atom `ClaimProvenance::identity`, which the data-model prose lacks.
+- **D11 — duplicate `PhysicalRootLease` name.** The provenance fixture
+  coexists with the real `index_lifecycle/physical_root.rs` type the data
+  model references. The recon census wrongly listed it as nonexistent, which
+  caused the duplication. Reconciliation belongs to the Slice 4 wiring that
+  connects provenance to the real lease; no enforced check breaks today.
+- **D12 — activation-time surface unwind.** The module is mounted at
+  `symforge::protocol::format::claim_provenance`, and `OutputCoverage`
+  publicly exposes `live_index::LimitBreach` — both forbidden by negative
+  assertions AT ACTIVATION, both legal today because `observed_graph.status`
+  is `pre_activation_required`. T048's embed boundary must wrap or unwind.
+- **D13 — atom accessor shapes are the EMBED boundary's problem.** The
+  contract fixes `&str` identity returns, reference returns, `Display` +
+  `Error` on `SourceRefusal`, and opaque structs where this module has enums.
+  The atoms describe `symforge::embed::*`; T048's re-export layer wraps the
+  internal types into contract shapes, and T049's dependent-positive fixture
+  is the enforcement. Recorded so T048 does not assume a 1:1 re-export.
+- **D14 — one T042 clause is currently unfalsifiable.** The
+  preserving-Current half compares an immutable local identity to itself; it
+  becomes falsifiable when T047's runtime exists. T052's review must not count
+  it as coverage until then.
+- **D15 — compile-fail harness sequencing.** `cases.json`'s T043-era subjects
+  resolve only after T048's re-exports; T049 must not run before T048. The
+  harness has zero `OutputCoverage` cases; the seal fix above is what makes
+  them writable.
+- **ClaimContext / `acquire_claim_context` are still absent** — named by
+  T043's task text, needed by T042's rebind clauses. They are the NEXT chunk
+  of T043, not a deferral.
+
+**Dogfood catch — a symforge defect observed by an auditor.** `get_symbol` for
+`LimitBreach` returned `Decision: cache_hit` with "Reuse the content already
+loaded in this session" and `session_age_secs=5402` — in a subagent session
+that had never loaded that content. A cache voucher pointing at content the
+requesting context never observed is symforge's own reporting-invariant
+failure class; `force_refresh=true` was the workaround. Reported separately;
+not a campaign item.
+
+**Audit-environment lesson.** Two auditors read this worktree WHILE the
+mutation loop held a live mutant and promoted the mutant to a blocker. Any
+audit fanned out into a mutation-owned worktree must read from a pinned
+`git show SHA:` baseline, not the working tree.
+
 ## The traceability catalog caught an invented name (T041)
 
 First run of `node scripts/validate-lifecycle-oracle-traceability.cjs` on the

--- a/docs/reviews/FEATURE-020-SLICE3-PLAN-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-PLAN-v11.md
@@ -1,0 +1,337 @@
+# Slice 3 plan — behavior-neutral seams, provenance, and a dark runtime
+
+Slice 3 is T041–T052. Production stays on V10 authority for the whole slice. The
+deliverable is typed seams that Slice 4 can activate in one cut, plus a runtime that
+compiles, is tested, and is provably unreachable from every production entry point.
+
+## PROGRESS LEDGER — durable, does not depend on session state
+
+| Task | State |
+|---|---|
+| T041 RED provenance/contract negatives | not started |
+| T042 RED cross-authority | not started |
+| T043 sealed provenance types | not started |
+| T044 read_gate authority split | not started |
+| T045 protocol lane migration | not started |
+| T046 published-source-set consolidation | not started |
+| T047 dark runtime | not started |
+| T048 dark public API + export delta | not started |
+| T049 AAP migration receipt | not started |
+| T050 activation-cut matrix | not started |
+| T051 dark unreachability | not started |
+| T052 gates + adversarial review | not started |
+
+Entry state, verified at `10e036b5` (not inherited):
+
+- `python execution/refreeze_v11.py verify-internal --target-ref HEAD` — passed.
+- `node scripts/validate-lifecycle-oracle-traceability.cjs` — OK, 78 requirements,
+  24 acceptance oracles, 13 retirement categories.
+- Slices 0–2 are on `main`; Slice 2 landed as `6c3794f3` with all eight PR checks green.
+- External approval sequences 1–3 are signed and archived; sequence 4 is an UNSIGNED
+  DRAFT bound to `95f24cb1`, a commit the squash-merge replaced. `verify-approval` is
+  invoked only by `.github/workflows/release.yml` (T089), so this is a release-closure
+  item, not a Slice 2→3 gap. The draft gets re-targeted at the release commit;
+  `scripts/prepare-refreeze-approval.py` replaces an unsigned draft in place and keeps
+  its chain position, so no orphan signature exists.
+
+## Reality-fit findings from the investigation
+
+These change how the slice is built. Each is a measurement, not a reading of intent.
+
+**1. The 64 V11 atoms must NOT be exported in this slice, and the contract agrees.**
+`contracts/public-api-v11.json` lists 64 `introduced_v11_atoms`, every one under
+`symforge::embed::`. Its `observed_graph.status` is `pre_activation_required` and
+`crate.identity_status` is likewise `pre_activation_required`. The
+`activation_rule` ("missing and extra atoms both refuse activation") therefore binds
+at ACTIVATION, not now. T048's phrase "generate the exact future export delta" means
+compute and record the delta — not apply it. The live `src/lib.rs` census stays byte-
+frozen for the whole preactivation period. This is the same constraint Slice 2 hit,
+where a top-level `pub mod index_lifecycle;` would have widened the census and the
+`#[path]` re-anchor avoided it; the same discipline applies here.
+
+**2. The compile-fail harness already exists and is Python-driven, not `trybuild`.**
+`tests/fixtures/public-api-v11-consumer/` already has `all-cfg/`, `compile-fail/`
+(with `cases.json` and three `.rs.in` templates: `impl_family_absent`, `path_absent`,
+`trait_absent`), and `dependent-positive/`, all driven from `execution/refreeze_v11.py`.
+There is no `trybuild` dev-dependency and adding one would be redundant. T041's
+"compile-fail/private-constructor cases" extend `cases.json` and the templates; they do
+not introduce a second harness. `public-api-v11.json` carries 12 `negative_assertions`
+to satisfy.
+
+**3. T050 is a 244-member matrix, and the inventory is frozen.**
+`contracts/v10-authority-retirement-v11.md` closes 13 categories totalling 244 members
+— writers 25, callbacks 14, publication_roots 9, cache 9, ccr 4, snapshot 13, tools 40,
+resources 10, prompts 8, sidecar 24, hooks 7, compatibility_aliases 2, raw_embed 79 —
+all `executed: false`. Every member needs an exact Slice 4 owner across eight branches
+(`GenerationLeased`, `DiskObserved`, `WorktreeScopeObserved`, `GitObserved`,
+`RuntimeHealthObserved`, `MutationPermitted`, `StateWriteAuthorized`, `Refused`). The
+inventory itself must not be edited to make the matrix pass.
+
+**4. T044 is small, and T046 is much smaller than the task text implies.**
+`src/protocol/read_gate.rs` is 178 lines with three functions
+(`admit_worktree_text`, `disk_read_would_refuse`, `admit_disk_read`). Splitting
+generation-byte resolution from beneath-confined disk observation is a contained
+change.
+
+T046 reads as though the captured published source set must be built. It already
+exists: `src/live_index/store.rs:1309` holds `published_source_set:
+ArcSwap<PublishedSourceSet>`, and `store.rs:6668`
+(`published_source_set_is_the_single_atomic_root_for_current_source`) already pins it
+as the single atomic root for current source. So T046 is a MIGRATION of the remaining
+legacy readers onto an existing atomic root, not a new consolidation.
+
+Note the task names `src/live_index/view.rs`, but the ~10 independent `ArcSwap` fields
+that produce sequential reads live in `store.rs` (`live`, `published_source_set`,
+`project_state_dir`, `source_exclusions`, `scout_plan`, `freshness_status`,
+`published_state`, `published_repo_outline`, `git_temporal`). `view.rs` is a consumer.
+The work therefore spans both files; the task's named file is where the consumer-side
+change lands, and that is worth stating in the evidence rather than silently widening
+scope.
+
+**5. "Dark" has a precedent and a mechanical definition: no production call edge.**
+`src/index_lifecycle/mod.rs` states it as "`grep -rn index_lifecycle src/` returns no
+hit outside it other than its own declaration in `live_index/mod.rs` — a `#[path]`
+attribute and the `pub mod` line it decorates. Neither is a call edge." T051 formalizes
+exactly that into an executing test rather than inventing a second notion of darkness.
+That same doc comment also records a prior correction where an integration was claimed
+that did not exist — the reporting defect this feature exists to prevent. T047/T048
+must not repeat it: the module doc states what has no caller, and the test proves it.
+
+**6b. BINDING — one identity counter, shared through a new non-lifecycle module.**
+
+`GenerationIdentity` and its siblings are MACRO-GENERATED by `identity_newtype!`
+(`src/index_lifecycle/authority.rs:21-34`), which mints from a process-wide
+`NEXT_IDENTITY: AtomicU64`. A plain declaration search finds no `struct
+GenerationIdentity` at all, and an earlier census of mine reported it MISSING — which
+would have had T043 redeclare it.
+
+T043 must NOT redeclare it. A second `fresh()` on a second counter is TWO IDENTITY
+SPACES, which is strictly worse than the Slice 2 name mismatch: identities from the two
+spaces would compare unequal while both claiming to be fresh.
+
+It also must not import from `src/index_lifecycle/`. `claim_provenance` lives under
+`protocol`, and a `protocol -> index_lifecycle` reference is exactly the call edge
+T051's darkness proof forbids — `index_lifecycle/mod.rs` states its darkness as
+"`grep -rn index_lifecycle src/` returns no hit outside it".
+
+Resolution: move `identity_newtype!` and `NEXT_IDENTITY` into a small module that is
+under NEITHER tree — `src/lifecycle_identity.rs`. `authority.rs` and
+`claim_provenance.rs` both use it. One counter, no protocol-to-lifecycle edge.
+
+Three constraints hold at once, each verified rather than assumed:
+
+1. **Census (retirement closure).** `src/lib.rs`, `src/lifecycle_identity.rs`,
+   `src/index_lifecycle/authority.rs`, `src/protocol/format.rs` and
+   `src/protocol/claim_provenance.rs` are in NONE of the five closure path lists.
+2. **Public-API census.** `derivePublicApiAtoms`
+   (`validate-lifecycle-oracle-traceability.cjs:1998`) reads ONLY `src/lib.rs`
+   `^\s*pub\s+mod\s+NAME\s*;` lines plus `src/embed.rs` items and ITS `pub use crate::`
+   re-exports. So the declaration in `lib.rs` is `pub(crate) mod lifecycle_identity;` —
+   `pub(crate)` does not match `pub\s+mod`, so no atom is added. A plain `pub mod` WOULD
+   add `symforge::lifecycle_identity` and widen the frozen surface. Nothing under
+   `src/protocol/` is read by that function at all.
+3. **Visibility.** The crate runs `-D warnings`, so a `pub` field typed by a merely
+   crate-visible type trips `private_interfaces`. `claim_provenance` therefore
+   re-exports the identities it exposes with `pub use crate::lifecycle_identity::...`.
+   A `pub use` outside `embed.rs` is not counted by the census.
+
+**6a. BINDING — `DerivedLimitKind` and `LimitBreach` are the LIVE types, not the frozen ones.**
+
+The frozen `data-model.md:1007-1014` declares `DerivedLimitKind` with SIX variants.
+`src/live_index/knowledge_bridge.rs:179-189` ships EIGHT: the frozen six plus
+`OwnershipSelectors` and `AmbiguousSamples`, both of which production actively records
+and tests. `LimitBreach` at `:191-195` is already byte-identical to the frozen shape.
+
+T043 uses the LIVE eight. It does not transcribe the frozen six, because a six-variant
+second enum would silently drop two limit kinds that production reports — the exact
+reporting defect this feature exists to prevent, rebuilt on purpose.
+
+T043 also does NOT amend the corpus. An amendment to `data-model.md` is documentation
+catching up with shipping code; it is not required to write the types, and a drive-by
+frozen-corpus edit is the one path this campaign forbids. The staleness is recorded in
+the Slice 3 evidence document so a later amendment can add the two names deliberately,
+with its own manifest hash and approval chain.
+
+**6. The provenance model is fully frozen and is ~15 types.**
+`data-model.md:1683–1899` fixes `DiskObservationReceipt`, `WorktreeScopeObservationReceipt`,
+`GitObservationReceipt`, `AtomicAuthority`, `ClaimInput`, `ClaimProvenance`, `Claim<T>`,
+`SourceRefusal`, `ClaimContext`/`ClaimContextInput`, `OutputCoverage`, `LimitBreach`,
+`DerivedLimitKind`, `WorktreeObservationCut`, `WorktreeScopeCoverage`, `GitResolvedFrom`.
+T043 transcribes these names verbatim — Slice 2 lost time to four seam-name mismatches
+invented rather than copied, and that must not repeat.
+
+## T045 and T046 MUST regenerate the retirement census. This is designed, not a blocker.
+
+`contracts/v10-authority-retirement-v11.md` carries a `preactivation_closure` with five
+live SHA-256 digests over the NORMALIZED RELEASE FORM of named file sets. Slice 3's
+edit targets sit inside four of the five:
+
+| category | pinned digest covers | touched by |
+|---|---|---|
+| `ccr` | `src/protocol/ccr.rs` — that file alone | T045 |
+| `cache` | `session.rs`, `knowledge_curation.rs`, `daemon.rs`, `sidecar/mod.rs`, `worktree.rs` | T045 |
+| `writers` | `tools.rs`, `edit.rs`, `edit_tools.rs`, `knowledge_curation.rs`, … | T045 |
+| `publication_roots` | `store.rs`, `protocol/mod.rs`, `daemon.rs`, `server/mod.rs`, `sidecar/mod.rs` | T046 |
+| `callbacks` | `persist.rs`, `edit_hooks.rs`, `git_temporal.rs`, `watcher/mod.rs`, … | T045, if it reaches `knowledge_curation.rs` |
+
+**It is probably five, not four, and that is decided in PR 2's FIRST commit — not at
+gate time.** `src/protocol/knowledge_curation.rs` sits in THREE categories at once
+(`cache`, `callbacks`, `writers`). If T045's lane walk touches it, `callbacks` moves too
+and all five digests regenerate. The lane census answers whether it does; the answer is
+recorded before the first line of T045 is written, because discovering a fifth
+regeneration while trying to make a red gate green is precisely how a deliberate act
+turns into a silent fixup.
+
+The census rule is that ANY change to code a release build compiles moves the digest.
+So T045 and T046 necessarily break these. That is expected. The gate
+(`scripts/validate-lifecycle-oracle-traceability.cjs:2458` `validateRetirementClosure`)
+fails them as `RETIREMENT_CLOSURE_MISMATCH`, and its own comment at :2493 states the
+intent: "every slice that legitimately edits a censused file has to regenerate it, and
+the gate deliberately refuses to print it so a mismatch cannot be papered over by
+copying the number out of the failure."
+
+**The procedure, verified on this tree, not read off the comment:**
+
+```
+SYMFORGE_LIFECYCLE_EMIT_CLOSURE=1 node scripts/validate-lifecycle-oracle-traceability.cjs
+```
+
+emits `CLOSURE <category> <digest>` for all five WITHOUT relaxing the comparison. Run
+at `10e036b5` it emitted values identical to the five pinned digests and still reported
+OK, so both the emitter and the current tree are consistent.
+
+Consequences the plan binds:
+
+- Regenerating a closure digest is a DELIBERATE, reviewed act, recorded in the evidence
+  document with the before/after digest and the reason the censused file changed. It is
+  never a silent fixup to make a red gate green.
+- `record.paths` must equal every member-owned `src/` path derived from that category's
+  `entries[].members` (:2468). Adding or removing an inventory member changes `paths`
+  too, and the inventory itself stays frozen — so T045/T046 must not add members.
+- Normalization drops comments and test-only `cfg` items, so T041/T042/T051's test files
+  do NOT move any digest by themselves. But that alone does NOT make PR 1 census-clean:
+  PR 1 must also carry T043's production module, because the tests cannot compile
+  without it. PR 1 is census-clean only because that module is declared from an
+  UNCENSUSED parent — see the PR 1 section. Add the `mod` line to
+  `src/protocol/mod.rs` and PR 1 moves `publication_roots`.
+
+## Two risks, both now measured rather than assumed
+
+**RISK-A — cache identity under T045. SETTLED, and it is benign.**
+The concern was that a claim's `OperationReceipt` would leak into a cache key and move
+cache identity inside a slice that promises no behavior change. Measured: the CCR key
+is built at `src/protocol/ccr.rs:225–228` and hashes exactly two things — `tool_name`
+and `formatted`, the rendered output. Provenance is not an input. Therefore behavior-
+neutrality of the RENDERED OUTPUT is identical to cache-key neutrality: if T045 changes
+no byte of any lane's output, no CCR key moves, by construction rather than by hope.
+
+This converts RISK-A into one falsifiable assertion, which T045 must carry as a test:
+the CCR key input set remains `(tool_name, formatted)`. If a later task needs
+provenance in the key, that is a deliberate amendment with its own evidence, not a
+silent absorption.
+
+**RISK-B — T046 changes read tearing, which is an observable behavior change.**
+Migrating the remaining legacy readers onto the existing atomic `PublishedSourceSet`
+converts a torn multi-read into a consistent one. That is the task's purpose, but it is
+observable, and a test that pins today's torn interleaving would break. Breaking it
+would be correct — but only if it is FOUND first and named, not discovered at gate
+time and quietly adjusted. The affected tests are identified before `store.rs` or
+`view.rs` is touched, and each one that changes is listed in the evidence document with
+the reason it changed.
+
+## Order of work, and why
+
+The task order in `tasks.md` is already dependency-correct; the only addition is
+grouping into four reviewable landings, because Slice 2's unrefuted external criticism
+was change size, not correctness.
+
+**PR 1 — provenance core (T041, T042, T043), and it must not move a digest.**
+RED first: both test files written and OBSERVED failing before `claim_provenance.rs`
+exists. Then the sealed types, verbatim from the data model. Ends green with zero
+production call sites migrated.
+
+T041/T042 cannot ship WITHOUT T043. A Rust test that names a type which does not exist
+does not compile, so a "RED tests only" PR fails `cargo test --all-targets` and cannot
+merge. RED is a LOCAL observation recorded in the evidence document, not an
+independently mergeable commit. The three tasks therefore land together.
+
+That creates the trap this PR has to dodge. `src/protocol/claim_provenance.rs` is itself
+uncensused, but the obvious declaration — `mod claim_provenance;` in
+`src/protocol/mod.rs` — is a release-compiled edit to a file inside the
+`publication_roots` path set, so it WOULD move that digest and break this PR's whole
+claim to be census-clean.
+
+**Binding decision: the `mod` line does not go in `src/protocol/mod.rs`.** It is declared
+from a parent that is in NONE of the five path sets. Verified against the closure on this
+tree: `src/protocol/read_gate.rs` — NOT CENSUSED; `src/protocol/format.rs` — NOT
+CENSUSED; `src/live_index/mod.rs` — NOT CENSUSED (which is exactly why Slice 2's
+`#[path]` re-anchor was free). `read_gate.rs` is the right parent: T044 edits it anyway
+and it already owns the read-authority seam.
+
+The file stays at the contract-mandated path `src/protocol/claim_provenance.rs`; only
+the declaring parent moves. This is the Slice 2 `#[path]` move again — contract file
+location, uncensused parent — and it must be written down IN THE CODE, because the next
+agent's instinct will be to "tidy" that `mod` line back into `protocol/mod.rs` and
+silently move a frozen digest.
+
+**The exact spelling, resolved by compiling rather than asserted.** An earlier draft of
+this plan guessed that `#[path]` inside a non-`mod.rs` file resolves relative to that
+file's own module directory (`src/protocol/read_gate/`). That guess was WRONG, and a
+throwaway crate mirroring this layout proved it: `#[path = "../claim_provenance.rs"]`
+made rustc report
+
+```
+error: couldn't read `src\protocol\..\claim_provenance.rs`
+```
+
+naming its base directory as `src/protocol/` — the directory CONTAINING `read_gate.rs`,
+not `read_gate/`. The spelling that compiles and links is therefore the bare one:
+
+```rust
+// src/protocol/read_gate.rs
+#[path = "claim_provenance.rs"]
+pub(crate) mod claim_provenance;
+```
+
+which resolves to `src/protocol/claim_provenance.rs` and exposes the module as
+`crate::protocol::read_gate::claim_provenance`. Confirmed compiling and passing a
+linkage test in an isolated crate before any symforge file was touched.
+
+**PR 2 — authority split and lane migration (T044, T045, T046).** RISK-A settled
+before the first lane moves; RISK-B's affected tests identified before `view.rs` is
+touched. Every step keeps V10 output identical, proven by the existing suite, not by
+assertion.
+
+**PR 3 — dark runtime and dark API (T047, T048, T049, T051).** New modules
+`src/index_lifecycle/runtime.rs` and `src/index_lifecycle/public_api.rs`, reachable
+only from a dark factory; T051's unreachability proof lands in the SAME PR as the code
+it constrains, so the constraint can never be merged later than the thing it guards.
+
+**PR 4 — activation matrix and slice closure (T050, T052).** The 244-member matrix,
+then the full gate set and independent adversarial review.
+
+## Binding constraints for this slice
+
+- **Run the embed gate on the FIRST commit that adds a file.** `cargo test
+  --no-default-features --features embed --lib -- --test-threads=1`. Default-feature
+  gates cannot catch a feature-gated `cfg` mistake, and this campaign has already paid
+  for that lesson once.
+- **Long cargo runs go through Terminal Commander**, never the Bash tool — the 600 s
+  ceiling kills a cold `--all-targets` mid-write and corrupts `target/`.
+- **Do not edit the frozen corpus** to make a check pass. A frozen-clause change is an
+  amendment with a manifest hash, an `EXPECTED_AMENDMENT_MAPPINGS` entry, and a
+  regenerated digest chain.
+- **Every negative test pairs with its accepting case**, and each guard is
+  mutation-tested — remove the guard, prove the specific test fails, restore it.
+- **No known gap crosses the Slice 3 → Slice 4 boundary.** Documenting a hazard is not
+  fixing it.
+- **Do not start Slice 4 early.** Slice 4 is the single indivisible activation cut.
+- Keep nested parentheses out of commit bodies; release-please silently drops the commit.
+
+## Claims inherited, not verified
+
+- That Slice 4 can actually own all 244 inventory members. Slice 3 only proves each has
+  a named owner; whether the owner is correct is Slice 4's evidence.
+- Grok's five smoke findings against 10.3.0 (tools catalog, path-as-project correction,
+  `index_folder` parent refusal, `broken_anchor` vs `exact:symbol`, outline dropped
+  under budget) are a separate product pass, not observed by me, and not Slice 3 work.

--- a/docs/reviews/SLICE3-RECON-FINDINGS-v11.md
+++ b/docs/reviews/SLICE3-RECON-FINDINGS-v11.md
@@ -1,0 +1,229 @@
+# Slice 3 reconnaissance findings
+
+Produced by four independent read-only censuses plus one adversarial critique, run
+against `10e036b5`. Every item below was RE-VERIFIED by hand before being written down;
+the agent report was treated as input, not as evidence.
+
+Critique verdict: **plan-needs-amendment** (6 blockers, 8 corrections, 8 defect
+candidates).
+
+## D1 — SECURITY: ungated git-object content disclosure (confirmed)
+
+`src/protocol/format.rs:6537-6564`, inside one loop body of the `diff_symbols` renderer:
+
+- `base_content` = `repo.file_at_ref(base, file_path)` — **no admission gate**, both modes.
+- `target_content`, uncommitted mode — routed through `read_gate::admit_worktree_text`,
+  and on refusal it emits `content_withheld_by_admission` and `continue`s.
+- `target_content`, committed mode — `repo.file_at_ref(target, file_path)` — **no gate**.
+
+Both ungated buffers flow into `extract_symbols_for_diff` / `extract_symbol_signatures`
+and are rendered as symbol names and signatures.
+
+`read_gate.rs:1-7` states it is "the single admission/disclosure gate for raw-disk
+content reads", and its own doc records that it exists BECAUSE three lanes — including
+`diff_symbols` in uncommitted mode — each disclosed a security-demoted file. The
+worktree read in that lane was fixed. The git-object reads beside it were not, so a file
+the gate withholds on the worktree side is still fully disclosed through git objects.
+
+The gated branch carries a comment explaining that falling through with empty content
+"would render every symbol in the file as REMOVED, which is a false claim about the file
+rather than a refusal to describe it." The two ungated branches do exactly that
+`.unwrap_or_default().unwrap_or_default()` fallthrough.
+
+Same shape reported in `detect_impact` (`src/protocol/tools.rs:8422-8425`), where
+`admit_worktree_text(...).unwrap_or_default().unwrap_or_default()` erases `Err` and
+`None` alike — see D8.
+
+## D2 — the tripwire for D1 has two blind spots (confirmed)
+
+`src/protocol/tools.rs:31232-31258`,
+`no_protocol_lane_reads_the_working_tree_ungated`, whose own doc comment says it "fails
+the moment a FOURTH one is written, which is how the original three came to share an
+ungated read in the first place."
+
+1. `let needle = [".file_from_", "workdir("].concat();` matches ONLY
+   `.file_from_workdir(`. D1 reaches content through `file_at_ref`, so it passes clean.
+2. `fs::read_dir(&protocol)` is non-recursive, and the
+   `path.extension() != Some("rs")` guard skips directory entries — so
+   `src/protocol/format/` and `src/protocol/tools/` are never scanned at all.
+
+The guard against the next ungated lane would not have caught the one that already
+exists.
+
+## D3 — frozen-corpus discrepancy: `DerivedLimitKind` is 8 live vs 6 frozen (confirmed)
+
+`src/live_index/knowledge_bridge.rs:179-189` declares eight variants: `Cards`,
+`BridgeLinks`, `OwnershipSelectors`, `AmbiguousSamples`, `AuthorityRecords`, `Findings`,
+`MetadataBytes`, `Output`. `specs/020-repository-knowledge-index/data-model.md:1007-1014`
+declares six — omitting `OwnershipSelectors` and `AmbiguousSamples`, both of which
+production actively records.
+
+`LimitBreach` already exists at `knowledge_bridge.rs:191-195`, byte-identical to the
+frozen shape.
+
+This is NOT an implementation choice. T043 is instructed to transcribe the frozen types
+verbatim, which would create a second, conflicting, lossy `DerivedLimitKind` in one
+crate. **Do not edit the frozen corpus to resolve this.** It needs an explicit decision
+recorded before T043 is written: reuse the live 8-variant type, or amend the corpus
+through the manifest/approval chain.
+
+## D4 — `introduced_v11_atoms` is 60 embed + 4 `server_api` (confirmed)
+
+`contracts/public-api-v11.json` `migration_v10.introduced_v11_atoms` is not uniformly
+under `symforge::embed`. Four atoms are `symforge::server_api`,
+`::ServerBootstrapError`, `::ServerExit`, `::run`, and `grep -rn server_api src/`
+returns nothing — the module does not exist.
+
+Consequence for T048: the export delta includes a genuinely NEW top-level
+`pub mod server_api;` in `src/lib.rs`. That is the single case where the Slice 2
+`#[path]` re-anchor trick cannot apply, because a top-level public module is exactly
+what the atom demands at activation.
+
+## D5 — `published_repo_outline` is write-only state (confirmed by the reporter)
+
+`src/live_index/store.rs:1329` declares it; it is stored at `:3211`, `:3299`, `:3311`
+and never loaded. The public accessor at `:2317` reads
+`published_generation().outline` from the captured set instead. Dead state carried
+through the hot publish path.
+
+## D6 — `health_for_runtime` renders one report from four independent lock-free loads
+
+`src/protocol/tools.rs:6978`, `:7048`, `:7054`, `:7075` — `published_state()`,
+`git_temporal()`, `read()`, `published_source_set()` all load separately inside one
+function body, so a publication landing mid-render mixes generations within a single
+user-visible health report. `health_compact_for_runtime` has the identical shape.
+
+This is the CLAUDE.md reporting invariant in its literal form: the thing that reports is
+not the thing that knows.
+
+## D7 — `get_symbol`'s session cache key carries no generation identity
+
+`src/protocol/session.rs:452-470` hashes only `kind`, `symbol_line`, `max_tokens`
+(used at `tools.rs:4302`). Its two siblings do include generation identity —
+`get_file_content` at `tools.rs:8743-8749` hashes `project_generation`, `source_id`,
+`publication_generation`. So a symbol body served before a publication can be replayed
+from cache after it, because nothing in the key changes when the index does.
+
+**This also re-opens RISK-A**, which the plan had declared settled on `ccr.rs` evidence
+alone. The `cache` closure category is a different lane from `ccr`, and it hashes
+provenance-adjacent identity directly.
+
+## D8 — `detect_impact` collapses a gate refusal into an empty seed (likely)
+
+`src/protocol/tools.rs:8422-8425`:
+`admit_worktree_text(...).unwrap_or_default().unwrap_or_default()` erases both `Err`
+and `None`. For a supported language, empty content yields an empty current-symbol map
+rather than the documented "seed every indexed symbol" fallback, because the fallback at
+`:8433` fires only when the extractor returns `None`, which empty content does not
+produce.
+
+## D9 — the two frozen documents disagree about T043's own API (confirmed)
+
+`data-model.md` gives the DATA shape; `contracts/public-api-v11.json`
+`introduced_v11_atoms` gives the ACTIVATION surface. They conflict, and T043 cannot
+satisfy both.
+
+1. **`Claim`'s last member has two frozen names.** `data-model.md:1809` declares
+   `pub producing_publication: ProducingPublicationIdentity`. The atom is
+   `symforge::embed::Claim::producing_runtime_identity`. Same member, two spellings.
+2. **`SourceRefusal` has two frozen SHAPES.** `data-model.md:1812-1831` is an enum of
+   four variants with `pub` fields. The atoms give it ACCESSORS instead — `::kind`,
+   `::operation`, `::retry`, `::evidence_identity` — plus `SourceRefusalKind` and
+   `RetryAdvice`, two types `data-model.md` never mentions. An accessor surface implies
+   opaque internals, which is the opposite of pub-field variants.
+3. **`OperationReceipt` likewise** is not spelled in `data-model.md` at all, but the
+   atoms fix four members: `::identity`, `::operation_kind`, `::schema_version`,
+   `::canonical_argument_hash`.
+
+**Proposed resolution, needs a decision before T043 is written.** The API contract wins
+for API NAMES and VISIBILITY, because `expected_graph.activation_rule` is enforced
+exactly at activation — "missing and extra atoms both refuse activation" — whereas
+`data-model.md` is descriptive prose that no checker compares against code. So: opaque
+types with the atom-named accessors, `producing_runtime_identity`, and
+`SourceRefusalKind` / `RetryAdvice` as real types.
+
+Same handling as D3: do NOT amend either document inside T043. Record the divergence and
+let a later amendment reconcile them deliberately.
+
+Note the atoms also cover T047's runtime surface, not just T043's:
+`ProcessIndexRuntime`, `EmbeddedSourceHandle`, `RefreshTicket`, `ShutdownReceipt`,
+`SourceCloseReceipt`, `SourceRuntimeView`, and the search request/result types. T043
+owns only the provenance subset.
+
+## T043 support-type census — what exists, what T043 must create
+
+Verified by declaration search on `10e036b5`. Slice 2 lost real time to inventing seam
+names that already existed, so this is the list T043 works from.
+
+**Already exist — import, do not redeclare:**
+
+| Type | Where |
+|---|---|
+| `BindingAuthority` | `src/index_lifecycle/authority.rs:94` |
+| `PhysicalRootIdentity` | `src/index_lifecycle/physical_root.rs:46` |
+| `GenerationIdentity` | `authority.rs:50`, MACRO-GENERATED |
+| `PublicationIdentity`, `BindingIdentity`, `ObserverToken`, `CandidateIdentity`, `SnapshotIdentity` | `authority.rs:36-59`, macro-generated |
+| `CatalogPath` | `src/domain/index.rs:804` |
+| `PlatformFileId` | `src/domain/index.rs:860` |
+| `FileStamp` | `src/domain/index.rs:864` |
+| `RepositoryId` | `src/domain/index.rs:479` |
+| `LimitBreach`, `DerivedLimitKind` | `src/live_index/knowledge_bridge.rs:179-195` — the LIVE EIGHT, see 6a |
+
+**A plain declaration search MISSES the macro-generated identities.** `GenerationIdentity`
+has no `struct GenerationIdentity` anywhere; `authority.rs:21-34` defines
+`identity_newtype!`, which emits `pub struct $name(NonZeroU64)` with a `fresh()`
+constructor off a process-wide `AtomicU64`. Any new Slice 3 identity uses that macro
+rather than a hand-rolled newtype — but note the macro is currently PRIVATE to
+`authority.rs`, so T043 either shares it deliberately or repeats the shape knowingly.
+
+**Do not exist — T043 creates them:** `ObservationTime`, `StableReadReceipt`,
+`ByteDigest`, `GitObjectId`, `ObserverEpoch`, `InvalidationSequence`, `ManifestDigest`,
+`NonEmptyVec`, `NonEmptyMap`, `ProjectSourceKey`, `GenerationAuthority`,
+`WorktreeObservationScope`, `ScopeAndPolicyVersions`, `WorktreeScanId`,
+`SourceSelectionReceipt`, `ComparisonRelation`, `OperationReceipt`, `OperationKind`,
+`EvaluationProvenance`, `ProducingPublicationIdentity`, `CanonicalArgumentHash`,
+`AdmissionSubject`, `UnavailableCause`, `ResolvedSourceReceipt`, `ResolvedSelectionSet`,
+`CurrentQueryLease`, `PhysicalRootLease`, `OperationRelationshipContract`,
+`GitIndexChecksum`.
+
+That is ~29 new types against ~10 reused ones, which is the real size of T043 and is
+larger than the plan's "~15 types" implied. The frozen definitions name them; none of
+the names are open to invention.
+
+## Corrections to the Slice 3 plan itself
+
+Each verified by hand; all six critique blockers stand.
+
+1. **`view.rs` consumes nothing.** The plan claimed the nine `ArcSwap` fields live in
+   `store.rs` with "`view.rs` a consumer". `view.rs` contains zero reads of any of the
+   nine and zero `ArcSwap` code — five hits, all prose comments (`:3`, `:92`, `:94`,
+   `:1195`, `:1217`). `tasks.md:923` names the wrong file for T046; that is a task-text
+   correction to record with evidence, not a scope widening to invent.
+2. **Nine fields, not ~10**, and five of the nine already resolve through
+   `published_source_set` on the public read surface. The residual problem is how many
+   times ONE caller loads the set, not which field it reads.
+3. **T046 needs a read-MUTATE-read exclusion rule.** At least ten production sites load,
+   mutate, then load again — `store.rs` 2494/2495, 2551/2552, 2660/2661, 2798/2799,
+   2813/2814, 3025/3027, 3104-3111, 3142/3143 and `watcher/mod.rs` 703 vs 853, 433 vs
+   491. `store.rs:2660` `swap_and_publish(live)` is followed at `:2661` by
+   `published_generation()`, whose value becomes `IndexedFilePublicationReceipt.published`
+   (`:2665-2668`). Hoisting that to an entry-time capture makes every publication receipt
+   one generation stale. These are deliberate before/after samples and are OUT of T046's
+   scope by construction; they must be enumerated as exclusions before any edit.
+4. **All five closure digests regenerate regardless**, because T046 alone reaches four
+   of the five path sets. The `knowledge_curation.rs` contingency the plan staked the
+   decision on is not the deciding factor.
+5. **PR 1's anchor must be `format.rs`, not `read_gate.rs`.** `protocol/mod.rs:16`
+   declares `pub(crate) mod read_gate;`, so anchoring there makes the whole provenance
+   module crate-private — and `tests/claim_provenance_v11.rs` is a SEPARATE CRATE that
+   cannot see it. `protocol/mod.rs:9` declares `pub mod format;`, and `format.rs` is
+   uncensused and is not a T044 target. Verified: `read_gate.rs`, `format.rs` and
+   `live_index/mod.rs` are in none of the five closure path sets.
+6. **"Provenance is not a CCR input" is misleading.** Provenance is already rendered
+   into `formatted` today, so it is a transitive input. The conditional conclusion
+   survives; the sentence does not.
+7. **T044 is not "small" in the sense the plan meant.** The 178-line count is right but
+   is the wrong measure: `read_gate.rs` performs no confinement at all today, so
+   "beneath-confined disk observation" means ADDING containment the gate does not have.
+8. **The frozen corpus specifies two layers with the same type names and incompatible
+   shapes, and gives no precedence rule.** T043 alone cannot satisfy both — see D3.

--- a/src/index_lifecycle/authority.rs
+++ b/src/index_lifecycle/authority.rs
@@ -7,56 +7,18 @@
 //! sealed [`CurrentMutationGrantAuthority`] that was consumed from an exact live
 //! `Current` publication, or it is refused.
 
-use std::num::NonZeroU64;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Process-global monotonic identity source. Never restarts, never reuses.
-static NEXT_IDENTITY: AtomicU64 = AtomicU64::new(1);
-
-fn next_identity() -> NonZeroU64 {
-    let raw = NEXT_IDENTITY.fetch_add(1, Ordering::Relaxed);
-    NonZeroU64::new(raw).expect("identity counter starts at 1 and only increases")
-}
-
-macro_rules! identity_newtype {
-    ($(#[$meta:meta])* $name:ident) => {
-        $(#[$meta])*
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-        pub struct $name(NonZeroU64);
-
-        impl $name {
-            /// Mint a fresh never-reused identity.
-            pub fn fresh() -> Self {
-                Self(next_identity())
-            }
-        }
-    };
-}
-
-identity_newtype!(
-    /// Identity of a source binding to one physical root.
-    BindingIdentity
-);
-identity_newtype!(
-    /// Stable identity of a filesystem observer registration.
-    ObserverToken
-);
-identity_newtype!(
-    /// Identity of an in-progress candidate build.
-    CandidateIdentity
-);
-identity_newtype!(
-    /// Identity of a promoted generation's authority.
-    GenerationIdentity
-);
-identity_newtype!(
-    /// Identity of one publication of source runtime state.
-    PublicationIdentity
-);
-identity_newtype!(
-    /// Identity of an untrusted on-disk snapshot seed.
-    SnapshotIdentity
-);
+// The identity newtypes and their counter moved to `crate::lifecycle_identity`
+// so the V11 provenance types under `protocol` can mint from the SAME counter
+// without importing this dark module. Re-exported here so every existing path
+// through `authority::` keeps resolving.
+//
+// Do not reintroduce a local counter: two counters means two identity spaces,
+// and two identities minted "fresh" could then compare unequal while both
+// claiming uniqueness.
+pub use crate::lifecycle_identity::{
+    BindingIdentity, CandidateIdentity, GenerationIdentity, ObserverToken, PublicationIdentity,
+    SnapshotIdentity,
+};
 
 /// Monotonic per-source mutation epoch. An ordering aid, never an authorization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/index_lifecycle/mod.rs
+++ b/src/index_lifecycle/mod.rs
@@ -5,10 +5,14 @@
 //! this module samples separate fields to infer permission: a mutation is
 //! authorized by one whole, exact, consumed authority or it is refused.
 //!
-//! **Nothing in production calls this module.** `grep -rn index_lifecycle src/`
-//! returns no hit outside it other than its own declaration in
-//! `live_index/mod.rs` — a `#[path]` attribute and the `pub mod` line it
-//! decorates. Neither is a call edge.
+//! **Nothing in production calls this module.** The darkness property is about
+//! CALL EDGES, not grep hits: no code outside this directory names an item in
+//! it. The module's declaration in `live_index/mod.rs` — a `#[path]` attribute
+//! and the `pub mod` line it decorates — is not a call edge, and since T043 the
+//! doc comments of `src/lifecycle_identity.rs` mention this directory by name
+//! in prose, which is not one either. An earlier version of this paragraph
+//! stated the property as "grep returns no hit outside", which prose alone now
+//! falsifies; T051 formalizes the call-edge form into an executing test.
 //!
 //! An earlier version of this comment said "production integration is limited to
 //! the watcher/store mutation seam (T028)", which read as though T028 had wired

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,14 @@ pub mod domain;
 pub mod git;
 pub mod hash;
 pub mod knowledge;
+// Feature 020 V11 identity minting, shared by the dark lifecycle runtime and the
+// protocol provenance types so both draw from ONE process-wide counter.
+//
+// `pub(crate)` is load-bearing, not a style choice: the frozen public-API census
+// adds one atom per `pub mod NAME;` line in THIS file, so a plain `pub mod` here
+// would widen a surface Slice 3 must leave frozen. Modules that expose one of
+// these types publicly re-export it instead.
+pub(crate) mod lifecycle_identity;
 pub mod live_index;
 pub mod parsing;
 pub mod paths;

--- a/src/lifecycle_identity.rs
+++ b/src/lifecycle_identity.rs
@@ -1,0 +1,207 @@
+//! Process-wide identity minting, shared by the lifecycle runtime and the
+//! protocol provenance types.
+//!
+//! **Why this module exists at all.** `identity_newtype!` and its counter began
+//! in `src/index_lifecycle/authority.rs`, and Feature 020 V11's provenance types
+//! (`src/protocol/claim_provenance.rs`) need the SAME identities. Two options
+//! were rejected:
+//!
+//!   * Redeclaring the macro under `protocol` would create a SECOND counter, so
+//!     two identities minted "fresh" could compare unequal while both claiming
+//!     to be unique. Two identity spaces is a worse defect than a name mismatch,
+//!     because nothing about it is visible at the call site.
+//!   * Importing from `src/index_lifecycle/` would create a
+//!     `protocol -> index_lifecycle` call edge. That directory is DARK for the
+//!     whole preactivation period, and `index_lifecycle/mod.rs` states its
+//!     darkness as "`grep -rn index_lifecycle src/` returns no hit outside it".
+//!     T051 proves that property; a protocol import would end it.
+//!
+//! So the primitives live HERE, under neither tree. `authority.rs` and
+//! `claim_provenance.rs` both use them, one counter, no call edge between them.
+//!
+//! **This module is `pub(crate)`, deliberately.** The frozen public-API census
+//! (`derivePublicApiAtoms`, `scripts/validate-lifecycle-oracle-traceability.cjs`)
+//! adds one atom per `^\s*pub\s+mod\s+NAME\s*;` line in `src/lib.rs`. A
+//! `pub mod lifecycle_identity;` there would add `symforge::lifecycle_identity`
+//! and WIDEN the surface that Slice 3 must leave frozen. `pub(crate) mod` does
+//! not match that pattern, so it adds nothing. Modules that need to expose one
+//! of these types publicly re-export it; a `pub use` outside `src/embed.rs` is
+//! not counted either.
+
+use std::num::NonZeroU64;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The one counter. Every identity in the process is drawn from it, so an
+/// identity minted by the lifecycle runtime can never collide with one minted
+/// by a provenance receipt.
+static NEXT_IDENTITY: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn next_identity() -> NonZeroU64 {
+    let raw = NEXT_IDENTITY.fetch_add(1, Ordering::Relaxed);
+    NonZeroU64::new(raw).expect("identity counter starts at 1 and only increases")
+}
+
+macro_rules! identity_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(NonZeroU64);
+
+        impl $name {
+            /// Mint a fresh never-reused identity.
+            pub fn fresh() -> Self {
+                Self($crate::lifecycle_identity::next_identity())
+            }
+        }
+    };
+}
+
+identity_newtype!(
+    /// Identity of a source binding to one physical root.
+    BindingIdentity
+);
+identity_newtype!(
+    /// Stable identity of a filesystem observer registration.
+    ObserverToken
+);
+identity_newtype!(
+    /// Identity of an in-progress candidate build.
+    CandidateIdentity
+);
+identity_newtype!(
+    /// Identity of a promoted generation's authority.
+    GenerationIdentity
+);
+identity_newtype!(
+    /// Identity of one publication of source runtime state.
+    PublicationIdentity
+);
+identity_newtype!(
+    /// Identity of an untrusted on-disk snapshot seed.
+    SnapshotIdentity
+);
+
+// ── Feature 020 V11 provenance identities (T043) ───────────────────────────
+
+identity_newtype!(
+    /// Identity of one atomic authority: a generation, or a single disk,
+    /// worktree-scope, or Git observation.
+    AuthorityIdentity
+);
+identity_newtype!(
+    /// Identity of one claim's provenance structure. Caches, CCR, and
+    /// persistence key on this, so bounded rendering must never move it.
+    ProvenanceIdentity
+);
+identity_newtype!(
+    /// Identity of one normalized operation request.
+    OperationIdentity
+);
+identity_newtype!(
+    /// Identity of one immutable ranking snapshot.
+    EvaluationIdentity
+);
+identity_newtype!(
+    /// Identity of one sealed worktree traversal.
+    WorktreeScanId
+);
+identity_newtype!(
+    /// Identity of the runtime publication that produced a claim.
+    ProducingRuntimeIdentity
+);
+
+/// A monotonic observation instant.
+///
+/// Deliberately NOT a wall clock. Absence proofs are scoped to "the instant this
+/// was observed", and a wall clock can repeat, jump backwards across a
+/// resync, or tie between two observations. A monotonic counter cannot, so
+/// `observed_at` orders and compares exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObservationTime(NonZeroU64);
+
+impl ObservationTime {
+    /// Take a fresh observation instant.
+    pub fn fresh() -> Self {
+        Self(next_identity())
+    }
+}
+
+/// Monotonic epoch of a filesystem observer registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObserverEpoch(u64);
+
+impl ObserverEpoch {
+    /// The epoch an observer occupies before it has seen any invalidation.
+    pub const fn initial() -> Self {
+        Self(0)
+    }
+
+    /// The next epoch. Never rewinds.
+    pub const fn advanced(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    /// Diagnostic value. Callers must not derive permission from it.
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Position in an observer's invalidation stream. Seals the interval a
+/// worktree-scope observation may speak for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InvalidationSequence(u64);
+
+impl InvalidationSequence {
+    /// The sequence before any invalidation has been recorded.
+    pub const fn initial() -> Self {
+        Self(0)
+    }
+
+    /// The next position. Never rewinds.
+    pub const fn advanced(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    /// Diagnostic value. Callers must not derive permission from it.
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_counter_serves_every_identity_kind() {
+        // The property this module exists for: identities minted through
+        // DIFFERENT newtypes still come from one space, so their raw values
+        // never collide. A second counter under `protocol` would break this
+        // silently, which is why the macro is not duplicated there.
+        let a = GenerationIdentity::fresh().0;
+        let b = AuthorityIdentity::fresh().0;
+        let c = OperationIdentity::fresh().0;
+        let d = ObservationTime::fresh().0;
+
+        let mut raws = vec![a, b, c, d];
+        raws.sort_unstable();
+        raws.dedup();
+        assert_eq!(raws.len(), 4, "one shared counter must not repeat a value");
+    }
+
+    #[test]
+    fn a_fresh_identity_never_repeats_within_its_own_kind() {
+        let first = GenerationIdentity::fresh();
+        let second = GenerationIdentity::fresh();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn monotonic_positions_never_rewind() {
+        let epoch = ObserverEpoch::initial();
+        assert!(epoch.advanced() > epoch);
+        let sequence = InvalidationSequence::initial();
+        assert!(sequence.advanced() > sequence);
+    }
+}

--- a/src/lifecycle_identity.rs
+++ b/src/lifecycle_identity.rs
@@ -42,9 +42,13 @@ pub(crate) fn next_identity() -> NonZeroU64 {
 }
 
 macro_rules! identity_newtype {
+    // No PartialOrd/Ord: with a monotonic counter, ordering identities exposes
+    // MINT ORDER, an inference channel nothing should read. An earlier draft
+    // added Ord so a test could sort identities; the test uses a HashSet now
+    // and the derive set matches the original authority.rs newtypes exactly.
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub struct $name(NonZeroU64);
 
         impl $name {

--- a/src/protocol/claim_provenance.rs
+++ b/src/protocol/claim_provenance.rs
@@ -1,0 +1,1107 @@
+//! Feature 020 V11 claim attribution (T043).
+//!
+//! Every generation-backed result is a `Result<Claim<T>, SourceRefusal>`. A
+//! claim carries the authority it was derived from, so "what proves this?" is
+//! answered by the value itself rather than by convention.
+//!
+//! **Absence is scoped to its authority.** This is the rule the whole module
+//! exists to enforce, from `data-model.md` lines 1874 to 1881: a missing path is
+//! path-local at its own observation instant, a complete worktree scan speaks
+//! only for its sealed scope and interval, a Git miss is local to one immutable
+//! tree, and a generation miss covers one captured generation. None of them may
+//! be widened into repository-wide absence. Only [`ClaimProvenance::SelectedAggregate`],
+//! which proves an exact selection-to-generation bijection, may do that.
+//!
+//! **API names follow `contracts/public-api-v11.json`, not `data-model.md`.**
+//! The two frozen documents disagree: the data model spells a pub-field `Claim`
+//! with `producing_publication` and a four-variant `SourceRefusal` enum, while
+//! `introduced_v11_atoms` fixes `Claim::producing_runtime_identity` and an
+//! OPAQUE `SourceRefusal` carrying `kind` / `operation` / `retry` /
+//! `evidence_identity`, plus `SourceRefusalKind` and `RetryAdvice`. The atoms
+//! win because `expected_graph.activation_rule` refuses activation on a missing
+//! or extra atom, while no checker compares the prose to code. The four refusal
+//! KIND NAMES are identical in both documents. Recorded as D9 in
+//! `docs/reviews/SLICE3-RECON-FINDINGS-v11.md`; neither document is amended here.
+//!
+//! **This module is production-unreachable in Slice 3.** Nothing calls it. The
+//! lanes that will consume it are Slice 4 activation work.
+
+use std::collections::BTreeMap;
+
+use crate::live_index::knowledge_bridge::{DerivedLimitKind, LimitBreach};
+
+// The identities come from the ONE process-wide counter in
+// `crate::lifecycle_identity`, never from a second one declared here. They are
+// re-exported because they appear in this module's public signatures, and a
+// `pub` item typed by a merely crate-visible type trips `private_interfaces`
+// under `-D warnings`. A `pub use` outside `src/embed.rs` adds no census atom.
+pub use crate::lifecycle_identity::{
+    AuthorityIdentity, EvaluationIdentity, GenerationIdentity, InvalidationSequence,
+    ObservationTime, ObserverEpoch, OperationIdentity, ProducingRuntimeIdentity,
+    ProvenanceIdentity, WorktreeScanId,
+};
+
+// ── Operations ─────────────────────────────────────────────────────────────
+
+/// The closed set of operation shapes. Transport mapping derives from this one
+/// table, so a new operation cannot acquire a bespoke refusal vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OperationKind {
+    Retrieval,
+    Comparison,
+    Derivation,
+    SelectedAggregate,
+}
+
+impl OperationKind {
+    /// Stable display name. Part of the closed contract, not a debug string.
+    pub fn kind_name(self) -> &'static str {
+        match self {
+            Self::Retrieval => "Retrieval",
+            Self::Comparison => "Comparison",
+            Self::Derivation => "Derivation",
+            Self::SelectedAggregate => "SelectedAggregate",
+        }
+    }
+}
+
+/// Hash of the normalized request arguments. Binds a claim to the exact
+/// question asked, so a cached answer cannot be replayed for a different one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CanonicalArgumentHash(u64);
+
+impl CanonicalArgumentHash {
+    /// Build from already-normalized argument bytes.
+    pub fn of_normalized(bytes: &[u8]) -> Self {
+        // FNV-1a. Deterministic across runs, which a DefaultHasher is not.
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x1000_0000_01b3);
+        }
+        Self(hash)
+    }
+
+    /// Diagnostic value.
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// One normalized operation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OperationReceipt {
+    identity: OperationIdentity,
+    operation_kind: OperationKind,
+    schema_version: u32,
+    canonical_argument_hash: CanonicalArgumentHash,
+}
+
+impl OperationReceipt {
+    /// The schema version every V11 receipt is minted at.
+    pub const SCHEMA_VERSION: u32 = 1;
+
+    /// Bind a normalized request.
+    pub fn normalized(operation_kind: OperationKind, normalized_arguments: &[u8]) -> Self {
+        Self {
+            identity: OperationIdentity::fresh(),
+            operation_kind,
+            schema_version: Self::SCHEMA_VERSION,
+            canonical_argument_hash: CanonicalArgumentHash::of_normalized(normalized_arguments),
+        }
+    }
+
+    /// Fixture constructor for oracles that do not vary the arguments.
+    pub fn for_test(operation_kind: OperationKind) -> Self {
+        Self::normalized(operation_kind, operation_kind.kind_name().as_bytes())
+    }
+
+    pub fn identity(&self) -> OperationIdentity {
+        self.identity
+    }
+
+    pub fn operation_kind(&self) -> OperationKind {
+        self.operation_kind
+    }
+
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    pub fn canonical_argument_hash(&self) -> CanonicalArgumentHash {
+        self.canonical_argument_hash
+    }
+}
+
+// ── Refusals ───────────────────────────────────────────────────────────────
+
+/// The closed refusal algebra. Identical names in both frozen documents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SourceRefusalKind {
+    AdmissionUnavailable,
+    InvalidSelection,
+    SelectionUnavailable,
+    SourceUnavailable,
+}
+
+/// What, if anything, would make a retry worth attempting. Advice only: it
+/// never authorizes the retry it describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RetryAdvice {
+    /// The request is wrong in a way repetition cannot fix.
+    Never,
+    /// A rebind to the correct root could succeed.
+    AfterRebind,
+    /// A completed refresh could succeed.
+    AfterRefresh,
+}
+
+/// A typed refusal. Opaque by construction: callers read it through the
+/// accessors the activation contract names, and cannot assemble one themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceRefusal {
+    kind: SourceRefusalKind,
+    operation: OperationReceipt,
+    retry: RetryAdvice,
+    evidence_identity: Option<AuthorityIdentity>,
+}
+
+impl SourceRefusal {
+    fn new(
+        kind: SourceRefusalKind,
+        operation: OperationReceipt,
+        retry: RetryAdvice,
+        evidence_identity: Option<AuthorityIdentity>,
+    ) -> Self {
+        Self {
+            kind,
+            operation,
+            retry,
+            evidence_identity,
+        }
+    }
+
+    pub fn kind(&self) -> SourceRefusalKind {
+        self.kind
+    }
+
+    pub fn operation(&self) -> OperationReceipt {
+        self.operation
+    }
+
+    pub fn retry(&self) -> RetryAdvice {
+        self.retry
+    }
+
+    /// Identity of the evidence the refusal was decided on. Present whenever a
+    /// refusal was reached by examining an authority rather than by rejecting a
+    /// malformed request outright.
+    pub fn evidence_identity(&self) -> Option<AuthorityIdentity> {
+        self.evidence_identity
+    }
+}
+
+// ── Physical root and observation leases ───────────────────────────────────
+
+/// Identity of one physical root a lease owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhysicalRootLease {
+    root: String,
+}
+
+impl PhysicalRootLease {
+    /// Fixture constructor. The real lease is acquired from the lifecycle
+    /// runtime in Slice 4; nothing in production reaches this today.
+    pub fn for_test_root(root: &str) -> Self {
+        Self {
+            root: root.to_string(),
+        }
+    }
+
+    pub fn root(&self) -> &str {
+        &self.root
+    }
+}
+
+/// Holds a physical root open for the duration of an observation.
+///
+/// Every observation receipt is minted THROUGH a lease, which is what "sealed
+/// constructor" means here: a receipt cannot exist without something having held
+/// the root while the observation was taken.
+#[derive(Debug, Clone)]
+pub struct ObservationLease {
+    root: PhysicalRootLease,
+    observer_epoch: ObserverEpoch,
+}
+
+impl ObservationLease {
+    /// Fixture constructor for the Slice 3 oracles.
+    pub fn for_test_root(root: PhysicalRootLease) -> Self {
+        Self {
+            root,
+            observer_epoch: ObserverEpoch::initial(),
+        }
+    }
+
+    pub fn root(&self) -> &PhysicalRootLease {
+        &self.root
+    }
+
+    /// Record that a path was absent, under this lease, at this instant.
+    pub fn observe_missing_path(
+        &self,
+        path: &str,
+        observed_at: ObservationTime,
+    ) -> Result<DiskObservationReceipt, SourceRefusal> {
+        Ok(DiskObservationReceipt::PathMissing {
+            identity: AuthorityIdentity::fresh(),
+            physical_root: self.root.root().to_string(),
+            path: path.to_string(),
+            observed_at,
+        })
+    }
+
+    /// Seal a COMPLETE traversal of `scope`. There is no partial variant:
+    /// an incomplete traversal refuses instead of constructing a receipt.
+    pub fn complete_scope_scan(
+        &self,
+        scope: WorktreeObservationScope,
+    ) -> Result<WorktreeScopeObservationReceipt, SourceRefusal> {
+        let start = InvalidationSequence::initial();
+        Ok(WorktreeScopeObservationReceipt {
+            identity: AuthorityIdentity::fresh(),
+            physical_root: self.root.root().to_string(),
+            scope,
+            scan_id: WorktreeScanId::fresh(),
+            observation_cut: WorktreeObservationCut {
+                observer_epoch: self.observer_epoch,
+                start_seq: start,
+                end_seq: start.advanced(),
+            },
+            coverage: WorktreeScopeCoverage::Complete,
+        })
+    }
+
+    /// Capture one complete generation under this lease.
+    pub fn admit_generation(&self) -> Result<GenerationAuthority, SourceRefusal> {
+        Ok(GenerationAuthority {
+            identity: AuthorityIdentity::fresh(),
+            generation: GenerationIdentity::fresh(),
+            physical_root: self.root.root().to_string(),
+        })
+    }
+
+    /// A receipt naming one selected project source.
+    pub fn selection_receipt(&self, project_source: &str) -> SourceSelectionReceipt {
+        SourceSelectionReceipt {
+            project_source: project_source.to_string(),
+            physical_root: self.root.root().to_string(),
+        }
+    }
+
+    /// Build a typed refusal against this lease's evidence.
+    pub fn refuse(
+        &self,
+        operation: OperationReceipt,
+        kind: SourceRefusalKind,
+        retry: RetryAdvice,
+    ) -> SourceRefusal {
+        SourceRefusal::new(kind, operation, retry, Some(AuthorityIdentity::fresh()))
+    }
+
+    /// Authority to bound the rendering of an ALREADY complete leased result.
+    ///
+    /// `OutputCoverage::Truncated` cannot be constructed without one of these,
+    /// which is what "post-lease only" means: truncation describes a response,
+    /// never a generation.
+    pub fn completed_render_authority(&self) -> Result<CompletedRenderAuthority, SourceRefusal> {
+        Ok(CompletedRenderAuthority { _sealed: () })
+    }
+}
+
+// ── Observation receipts ───────────────────────────────────────────────────
+
+/// What a disk observation actually saw.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiskObservationReceipt {
+    Bytes {
+        identity: AuthorityIdentity,
+        physical_root: String,
+        path: String,
+        observed_at: ObservationTime,
+        byte_digest: u64,
+    },
+    Metadata {
+        identity: AuthorityIdentity,
+        physical_root: String,
+        path: String,
+        observed_at: ObservationTime,
+        size: u64,
+    },
+    PathMissing {
+        identity: AuthorityIdentity,
+        physical_root: String,
+        path: String,
+        observed_at: ObservationTime,
+    },
+}
+
+impl DiskObservationReceipt {
+    pub fn identity(&self) -> AuthorityIdentity {
+        match self {
+            Self::Bytes { identity, .. }
+            | Self::Metadata { identity, .. }
+            | Self::PathMissing { identity, .. } => *identity,
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        match self {
+            Self::Bytes { path, .. }
+            | Self::Metadata { path, .. }
+            | Self::PathMissing { path, .. } => path,
+        }
+    }
+
+    pub fn observed_at(&self) -> ObservationTime {
+        match self {
+            Self::Bytes { observed_at, .. }
+            | Self::Metadata { observed_at, .. }
+            | Self::PathMissing { observed_at, .. } => *observed_at,
+        }
+    }
+
+    pub fn physical_root(&self) -> &str {
+        match self {
+            Self::Bytes { physical_root, .. }
+            | Self::Metadata { physical_root, .. }
+            | Self::PathMissing { physical_root, .. } => physical_root,
+        }
+    }
+
+    /// True only for `PathMissing`, and only about THIS path at THIS instant.
+    pub fn proves_path_local_absence(&self) -> bool {
+        matches!(self, Self::PathMissing { .. })
+    }
+
+    /// Always false. A path-local miss is not a statement about a generation.
+    pub fn proves_generation_absence(&self) -> bool {
+        false
+    }
+
+    /// Always false. A path-local miss is not a statement about a repository.
+    pub fn proves_repository_absence(&self) -> bool {
+        false
+    }
+
+    /// A read that failed is a typed refusal, never an absence. Reporting it as
+    /// absence would let an I/O error masquerade as proof that a file is gone.
+    pub fn into_failed_read(self) -> Result<Self, SourceRefusal> {
+        Err(SourceRefusal::new(
+            SourceRefusalKind::SourceUnavailable,
+            OperationReceipt::for_test(OperationKind::Retrieval),
+            RetryAdvice::AfterRefresh,
+            Some(self.identity()),
+        ))
+    }
+}
+
+/// The scope a worktree traversal sealed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeObservationScope {
+    prefix: String,
+}
+
+impl WorktreeObservationScope {
+    /// Everything beneath `prefix`.
+    pub fn beneath(prefix: &str) -> Self {
+        Self {
+            prefix: prefix.to_string(),
+        }
+    }
+
+    pub fn contains(&self, path: &str) -> bool {
+        path.starts_with(&self.prefix)
+    }
+
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+/// The interval a scope observation speaks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorktreeObservationCut {
+    observer_epoch: ObserverEpoch,
+    start_seq: InvalidationSequence,
+    end_seq: InvalidationSequence,
+}
+
+impl WorktreeObservationCut {
+    pub fn observer_epoch(&self) -> ObserverEpoch {
+        self.observer_epoch
+    }
+
+    pub fn start_seq(&self) -> InvalidationSequence {
+        self.start_seq
+    }
+
+    pub fn end_seq(&self) -> InvalidationSequence {
+        self.end_seq
+    }
+}
+
+/// Coverage of a worktree scan. There is deliberately NO partial variant:
+/// an incomplete traversal refuses rather than describing itself as partial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeScopeCoverage {
+    Complete,
+}
+
+/// A sealed, complete traversal of one scope over one interval.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeScopeObservationReceipt {
+    identity: AuthorityIdentity,
+    physical_root: String,
+    scope: WorktreeObservationScope,
+    scan_id: WorktreeScanId,
+    observation_cut: WorktreeObservationCut,
+    coverage: WorktreeScopeCoverage,
+}
+
+impl WorktreeScopeObservationReceipt {
+    pub fn identity(&self) -> AuthorityIdentity {
+        self.identity
+    }
+
+    pub fn scope(&self) -> &WorktreeObservationScope {
+        &self.scope
+    }
+
+    pub fn scan_id(&self) -> WorktreeScanId {
+        self.scan_id
+    }
+
+    pub fn observation_cut(&self) -> WorktreeObservationCut {
+        self.observation_cut
+    }
+
+    pub fn coverage(&self) -> WorktreeScopeCoverage {
+        self.coverage
+    }
+
+    pub fn physical_root(&self) -> &str {
+        &self.physical_root
+    }
+
+    /// Absence inside the sealed scope, and nowhere else.
+    pub fn proves_absence_within_scope(&self, path: &str) -> bool {
+        matches!(self.coverage, WorktreeScopeCoverage::Complete) && self.scope.contains(path)
+    }
+
+    /// The scan speaks only up to the end of its interval.
+    pub fn proves_absence_after(&self, sequence: InvalidationSequence) -> bool {
+        sequence < self.observation_cut.end_seq
+    }
+
+    /// The scan speaks only from the start of its interval.
+    pub fn proves_absence_before(&self, sequence: InvalidationSequence) -> bool {
+        sequence > self.observation_cut.start_seq
+    }
+
+    /// Always false. A sealed scope is not a generation.
+    pub fn proves_generation_absence(&self) -> bool {
+        false
+    }
+
+    /// Always false. A sealed scope is not the repository.
+    pub fn proves_repository_absence(&self) -> bool {
+        false
+    }
+}
+
+/// What a Git observation proves, for one exact immutable object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitObservationReceipt {
+    Present {
+        identity: AuthorityIdentity,
+        object_id: String,
+        path: String,
+    },
+    NotInTree {
+        identity: AuthorityIdentity,
+        tree_id: String,
+        path: String,
+    },
+}
+
+impl GitObservationReceipt {
+    /// Non-membership of one exact path in one exact immutable tree.
+    pub fn not_in_tree(tree_id: &str, path: &str) -> Self {
+        Self::NotInTree {
+            identity: AuthorityIdentity::fresh(),
+            tree_id: tree_id.to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    /// Membership of one exact path in one exact immutable object.
+    pub fn present(object_id: &str, path: &str) -> Self {
+        Self::Present {
+            identity: AuthorityIdentity::fresh(),
+            object_id: object_id.to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    pub fn identity(&self) -> AuthorityIdentity {
+        match self {
+            Self::Present { identity, .. } | Self::NotInTree { identity, .. } => *identity,
+        }
+    }
+
+    /// True only for the exact tree this receipt names.
+    pub fn proves_absence_in_tree(&self, tree_id: &str) -> bool {
+        matches!(self, Self::NotInTree { tree_id: named, .. } if named == tree_id)
+    }
+
+    /// Always false. One tree is not a generation.
+    pub fn proves_generation_absence(&self) -> bool {
+        false
+    }
+
+    /// Always false. One tree is not the repository across all of its history.
+    pub fn proves_repository_absence(&self) -> bool {
+        false
+    }
+}
+
+/// One complete captured generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationAuthority {
+    identity: AuthorityIdentity,
+    generation: GenerationIdentity,
+    physical_root: String,
+}
+
+impl GenerationAuthority {
+    pub fn identity(&self) -> AuthorityIdentity {
+        self.identity
+    }
+
+    pub fn generation(&self) -> GenerationIdentity {
+        self.generation
+    }
+
+    pub fn physical_root(&self) -> &str {
+        &self.physical_root
+    }
+
+    /// A generation miss covers ONE captured generation, not the repository.
+    pub fn proves_generation_absence(&self) -> bool {
+        true
+    }
+
+    pub fn proves_repository_absence(&self) -> bool {
+        false
+    }
+
+    /// Promote to the one authority that may speak for the whole selection.
+    pub fn into_selected_aggregate(self) -> SelectedAggregateAuthority {
+        SelectedAggregateAuthority {
+            _generation: self.generation,
+        }
+    }
+}
+
+/// The ONLY authority that may prove repository-wide absence, and only because
+/// its constructor proved an exact selection-to-generation bijection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedAggregateAuthority {
+    _generation: GenerationIdentity,
+}
+
+impl SelectedAggregateAuthority {
+    pub fn proves_repository_absence(&self) -> bool {
+        true
+    }
+}
+
+/// One selected project source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSelectionReceipt {
+    project_source: String,
+    physical_root: String,
+}
+
+impl SourceSelectionReceipt {
+    pub fn project_source(&self) -> &str {
+        &self.project_source
+    }
+
+    pub fn physical_root(&self) -> &str {
+        &self.physical_root
+    }
+}
+
+// ── Atomic authority ───────────────────────────────────────────────────────
+
+/// One indivisible piece of evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtomicAuthority {
+    Generation(GenerationAuthority),
+    DiskObservation(DiskObservationReceipt),
+    WorktreeScopeObservation(WorktreeScopeObservationReceipt),
+    GitObservation(GitObservationReceipt),
+}
+
+impl AtomicAuthority {
+    pub fn identity(&self) -> AuthorityIdentity {
+        match self {
+            Self::Generation(authority) => authority.identity(),
+            Self::DiskObservation(receipt) => receipt.identity(),
+            Self::WorktreeScopeObservation(receipt) => receipt.identity(),
+            Self::GitObservation(receipt) => receipt.identity(),
+        }
+    }
+
+    /// Stable name, part of the contract rather than a debug rendering.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Generation(_) => "Generation",
+            Self::DiskObservation(_) => "DiskObservation",
+            Self::WorktreeScopeObservation(_) => "WorktreeScopeObservation",
+            Self::GitObservation(_) => "GitObservation",
+        }
+    }
+
+    /// The physical root this evidence was taken under, when it has one.
+    /// Git objects are content-addressed and belong to a repository rather than
+    /// to a checkout, so they carry none.
+    pub fn physical_root(&self) -> Option<&str> {
+        match self {
+            Self::Generation(authority) => Some(authority.physical_root()),
+            Self::DiskObservation(receipt) => Some(receipt.physical_root()),
+            Self::WorktreeScopeObservation(receipt) => Some(receipt.physical_root()),
+            Self::GitObservation(_) => None,
+        }
+    }
+
+    pub fn proves_generation_absence(&self) -> bool {
+        match self {
+            Self::Generation(authority) => authority.proves_generation_absence(),
+            Self::DiskObservation(receipt) => receipt.proves_generation_absence(),
+            Self::WorktreeScopeObservation(receipt) => receipt.proves_generation_absence(),
+            Self::GitObservation(receipt) => receipt.proves_generation_absence(),
+        }
+    }
+
+    /// Never true for any atomic authority. Repository-wide absence is legal
+    /// only through `SelectedAggregate`.
+    pub fn proves_repository_absence(&self) -> bool {
+        false
+    }
+}
+
+/// An input to a derivation: evidence, or a selection of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimInput {
+    Authority(AtomicAuthority),
+    Selection(SourceSelectionReceipt),
+}
+
+/// How two authorities were compared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonRelation {
+    SameContent,
+    DifferentContent,
+}
+
+// ── Provenance ─────────────────────────────────────────────────────────────
+
+/// The shape of the evidence behind a claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimProvenance {
+    Single {
+        identity: ProvenanceIdentity,
+        authority: AtomicAuthority,
+    },
+    Comparison {
+        identity: ProvenanceIdentity,
+        operation: OperationReceipt,
+        relation: ComparisonRelation,
+        left: AtomicAuthority,
+        right: AtomicAuthority,
+    },
+    Derivation {
+        identity: ProvenanceIdentity,
+        operation: OperationReceipt,
+        nonempty_inputs: Vec<ClaimInput>,
+    },
+    SelectedAggregate {
+        identity: ProvenanceIdentity,
+        operation: OperationReceipt,
+        selections: Vec<SourceSelectionReceipt>,
+        generations: BTreeMap<String, GenerationAuthority>,
+    },
+}
+
+impl ClaimProvenance {
+    /// One authority, standing alone.
+    pub fn single(authority: AtomicAuthority) -> Self {
+        Self::Single {
+            identity: ProvenanceIdentity::fresh(),
+            authority,
+        }
+    }
+
+    /// Exactly two authorities, and they must share a physical root: composing
+    /// evidence across roots would state a relation neither side observed.
+    pub fn comparison(
+        operation: OperationReceipt,
+        relation: ComparisonRelation,
+        left: AtomicAuthority,
+        right: AtomicAuthority,
+    ) -> Result<Self, SourceRefusal> {
+        if !roots_are_compatible(&left, &right) {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::SourceUnavailable,
+                operation,
+                RetryAdvice::AfterRebind,
+                Some(left.identity()),
+            ));
+        }
+        Ok(Self::Comparison {
+            identity: ProvenanceIdentity::fresh(),
+            operation,
+            relation,
+            left,
+            right,
+        })
+    }
+
+    /// N-ary, and never empty: a derivation from nothing proves nothing.
+    /// Every authority input must share one physical root.
+    pub fn derivation(
+        operation: OperationReceipt,
+        inputs: Vec<ClaimInput>,
+    ) -> Result<Self, SourceRefusal> {
+        if inputs.is_empty() {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::InvalidSelection,
+                operation,
+                RetryAdvice::Never,
+                None,
+            ));
+        }
+        let authorities: Vec<&AtomicAuthority> = inputs
+            .iter()
+            .filter_map(|input| match input {
+                ClaimInput::Authority(authority) => Some(authority),
+                ClaimInput::Selection(_) => None,
+            })
+            .collect();
+        if let Some(first) = authorities.first() {
+            for other in &authorities[1..] {
+                if !roots_are_compatible(first, other) {
+                    return Err(SourceRefusal::new(
+                        SourceRefusalKind::SourceUnavailable,
+                        operation,
+                        RetryAdvice::AfterRebind,
+                        Some(first.identity()),
+                    ));
+                }
+            }
+        }
+        Ok(Self::Derivation {
+            identity: ProvenanceIdentity::fresh(),
+            operation,
+            nonempty_inputs: inputs,
+        })
+    }
+
+    /// The only constructor for repository-wide absence. Requires an EXACT
+    /// bijection between selections and captured generations: a missing, extra,
+    /// or unmatched entry refuses.
+    pub fn selected_aggregate(
+        operation: OperationReceipt,
+        selections: Vec<SourceSelectionReceipt>,
+        generations: Vec<(String, GenerationAuthority)>,
+    ) -> Result<Self, SourceRefusal> {
+        if selections.is_empty() {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::InvalidSelection,
+                operation,
+                RetryAdvice::Never,
+                None,
+            ));
+        }
+        let captured: BTreeMap<String, GenerationAuthority> = generations.into_iter().collect();
+        if captured.len() != selections.len()
+            || !selections
+                .iter()
+                .all(|selection| captured.contains_key(selection.project_source()))
+        {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::SelectionUnavailable,
+                operation,
+                RetryAdvice::AfterRefresh,
+                None,
+            ));
+        }
+        Ok(Self::SelectedAggregate {
+            identity: ProvenanceIdentity::fresh(),
+            operation,
+            selections,
+            generations: captured,
+        })
+    }
+
+    pub fn identity(&self) -> ProvenanceIdentity {
+        match self {
+            Self::Single { identity, .. }
+            | Self::Comparison { identity, .. }
+            | Self::Derivation { identity, .. }
+            | Self::SelectedAggregate { identity, .. } => *identity,
+        }
+    }
+
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Single { .. } => "Single",
+            Self::Comparison { .. } => "Comparison",
+            Self::Derivation { .. } => "Derivation",
+            Self::SelectedAggregate { .. } => "SelectedAggregate",
+        }
+    }
+
+    /// Every atomic authority retained, in order. Inputs are never collapsed:
+    /// a claim must be able to name each thing it was derived from.
+    pub fn authorities(&self) -> impl Iterator<Item = &AtomicAuthority> + '_ {
+        let items: Vec<&AtomicAuthority> = match self {
+            Self::Single { authority, .. } => vec![authority],
+            Self::Comparison { left, right, .. } => vec![left, right],
+            Self::Derivation {
+                nonempty_inputs, ..
+            } => nonempty_inputs
+                .iter()
+                .filter_map(|input| match input {
+                    ClaimInput::Authority(authority) => Some(authority),
+                    ClaimInput::Selection(_) => None,
+                })
+                .collect(),
+            Self::SelectedAggregate { .. } => Vec::new(),
+        };
+        items.into_iter()
+    }
+
+    pub fn authority_count(&self) -> usize {
+        match self {
+            Self::Single { .. } => 1,
+            Self::Comparison { .. } => 2,
+            Self::Derivation {
+                nonempty_inputs, ..
+            } => nonempty_inputs.len(),
+            Self::SelectedAggregate { generations, .. } => generations.len(),
+        }
+    }
+}
+
+/// Two authorities may compose only if they were taken under the same physical
+/// root. Git observations are content-addressed and carry no root, so they
+/// compose with anything.
+fn roots_are_compatible(left: &AtomicAuthority, right: &AtomicAuthority) -> bool {
+    match (left.physical_root(), right.physical_root()) {
+        (Some(left_root), Some(right_root)) => left_root == right_root,
+        _ => true,
+    }
+}
+
+// ── Ranking ────────────────────────────────────────────────────────────────
+
+/// An immutable ranking snapshot. Attached whenever order or scores are
+/// observable, so a result's ordering is attributable rather than incidental.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvaluationProvenance {
+    identity: EvaluationIdentity,
+}
+
+impl EvaluationProvenance {
+    pub fn fresh() -> Self {
+        Self {
+            identity: EvaluationIdentity::fresh(),
+        }
+    }
+
+    /// Fixture constructor for the Slice 3 oracles.
+    pub fn for_test() -> Self {
+        Self::fresh()
+    }
+
+    pub fn identity(&self) -> EvaluationIdentity {
+        self.identity
+    }
+}
+
+// ── Output coverage ────────────────────────────────────────────────────────
+
+/// Whether a RESPONSE was rendered whole. Never a statement about a generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputCoverage {
+    Complete,
+    Truncated { breaches: Vec<LimitBreach> },
+}
+
+/// Proof that a strict lease COMPLETED. Required to construct
+/// `OutputCoverage::Truncated`, which is what keeps truncation a property of
+/// rendering rather than of the index.
+#[derive(Debug)]
+pub struct CompletedRenderAuthority {
+    _sealed: (),
+}
+
+impl CompletedRenderAuthority {
+    /// Report the limits this response hit.
+    ///
+    /// `DerivedLimitKind` is the LIVE eight-variant type from
+    /// `live_index::knowledge_bridge`, not a transcription of the frozen six.
+    /// The data model omits `OwnershipSelectors` and `AmbiguousSamples`, which
+    /// production actively records; a six-variant copy here would silently drop
+    /// two real truncation reasons. Recorded as D3.
+    pub fn truncate(&self, breaches: Vec<(DerivedLimitKind, u64)>) -> OutputCoverage {
+        if breaches.is_empty() {
+            return OutputCoverage::Complete;
+        }
+        OutputCoverage::Truncated {
+            breaches: breaches
+                .into_iter()
+                .map(|(kind, omitted)| LimitBreach { kind, omitted })
+                .collect(),
+        }
+    }
+}
+
+// ── Claims ─────────────────────────────────────────────────────────────────
+
+/// A value and the evidence that proves it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Claim<T> {
+    value: T,
+    operation: OperationReceipt,
+    provenance: ClaimProvenance,
+    evaluation: Option<EvaluationProvenance>,
+    producing_runtime_identity: ProducingRuntimeIdentity,
+}
+
+impl<T> Claim<T> {
+    /// One authority, no observable ordering.
+    pub fn single(operation: OperationReceipt, authority: AtomicAuthority, value: T) -> Self {
+        Self {
+            value,
+            operation,
+            provenance: ClaimProvenance::single(authority),
+            evaluation: None,
+            producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+        }
+    }
+
+    /// One authority whose ORDER is observable, so the ranking is attributed.
+    pub fn single_ranked(
+        operation: OperationReceipt,
+        authority: AtomicAuthority,
+        value: T,
+        evaluation: EvaluationProvenance,
+    ) -> Self {
+        Self {
+            value,
+            operation,
+            provenance: ClaimProvenance::single(authority),
+            evaluation: Some(evaluation),
+            producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+        }
+    }
+
+    /// Derive from many inputs. Refuses rather than composing across roots.
+    pub fn derive(
+        operation: OperationReceipt,
+        inputs: impl IntoIterator<Item = ClaimInput>,
+        value: T,
+    ) -> Result<Self, SourceRefusal> {
+        let provenance = ClaimProvenance::derivation(operation, inputs.into_iter().collect())?;
+        Ok(Self {
+            value,
+            operation,
+            provenance,
+            evaluation: None,
+            producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+        })
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn operation(&self) -> OperationReceipt {
+        self.operation
+    }
+
+    pub fn provenance(&self) -> &ClaimProvenance {
+        &self.provenance
+    }
+
+    pub fn evaluation(&self) -> Option<EvaluationProvenance> {
+        self.evaluation
+    }
+
+    /// Named per `contracts/public-api-v11.json`, which spells this
+    /// `producing_runtime_identity`. `data-model.md` calls the same member
+    /// `producing_publication`; the atoms are what activation refuses on.
+    pub fn producing_runtime_identity(&self) -> ProducingRuntimeIdentity {
+        self.producing_runtime_identity
+    }
+
+    /// Bound this claim's RENDERING. Deliberately does not touch provenance
+    /// identity: truncation describes a response, and caches, CCR, and
+    /// persistence key on provenance identity. Moving it here would make a
+    /// bounded render look like different evidence.
+    pub fn render_bounded(self, _coverage: OutputCoverage) -> Self {
+        self
+    }
+}
+
+// ── Retrieval voice ────────────────────────────────────────────────────────
+
+/// A knowledge voice a retrieval may select.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KnowledgeVoice {
+    Intent,
+    NeedsReview,
+    Unknown,
+    HistoryOnly,
+    Suppressed,
+    /// Consistency is an AUTHORITY HYGIENE verdict, never a retrieval filter.
+    Consistency,
+}
+
+impl KnowledgeVoice {
+    pub fn is_consistency(self) -> bool {
+        matches!(self, Self::Consistency)
+    }
+}
+
+/// Which voices retrieval may select.
+#[derive(Debug)]
+pub struct KnowledgeVoiceFilter;
+
+impl KnowledgeVoiceFilter {
+    /// Consistency is absent by construction, not by filtering after the fact.
+    /// A stale document must not be able to acquire generation authority by
+    /// being selected as a consistency voice.
+    pub fn selectable_voices() -> Vec<KnowledgeVoice> {
+        vec![
+            KnowledgeVoice::Intent,
+            KnowledgeVoice::NeedsReview,
+            KnowledgeVoice::Unknown,
+        ]
+    }
+}

--- a/src/protocol/claim_provenance.rs
+++ b/src/protocol/claim_provenance.rs
@@ -353,6 +353,32 @@ impl ObservationLease {
         SourceRefusal::new(kind, operation, retry, evidence)
     }
 
+    /// A strict `Current` query lease for this source. Sealed constructor;
+    /// like the other lease constructors its EVIDENCE is a Slice 4 stand-in —
+    /// see the evidence document — while its shape is what Slice 4 keeps.
+    pub fn current_query_lease(&self) -> Result<CurrentQueryLease, SourceRefusal> {
+        Ok(CurrentQueryLease {
+            generation: GenerationIdentity::fresh(),
+        })
+    }
+
+    /// Capture one context input under this lease. The root is captured HERE,
+    /// at build time, which is what lets `acquire_claim_context` detect a
+    /// rebind between input acquisitions.
+    pub fn context_input(
+        &self,
+        project_source: &str,
+        repository_id: &str,
+        current: Option<CurrentQueryLease>,
+    ) -> ClaimContextInput {
+        ClaimContextInput {
+            project_source: project_source.to_string(),
+            repository_id: repository_id.to_string(),
+            root: self.root.root().to_string(),
+            current,
+        }
+    }
+
     /// Authority to bound the rendering of an ALREADY complete leased result.
     ///
     /// The SEAL is real and type-level: `OutputCoverage::Truncated` carries an
@@ -694,6 +720,164 @@ impl SourceSelectionReceipt {
     pub fn physical_root(&self) -> &str {
         &self.physical_root
     }
+}
+
+// ── Claim contexts: the one coherent acquisition ───────────────────────────
+
+/// A strict lease on one project's `Current` generation, minted through an
+/// [`ObservationLease`]. Sealed: holding one is the proof that a `Current`
+/// was captured for the query, and a generation-structured operation can
+/// never substitute a retained non-Current generation for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentQueryLease {
+    generation: GenerationIdentity,
+}
+
+impl CurrentQueryLease {
+    pub fn generation(&self) -> GenerationIdentity {
+        self.generation
+    }
+}
+
+/// One input to a claim context, captured THROUGH a lease at build time.
+/// Sealed: [`ObservationLease::context_input`] is the only constructor, so an
+/// input cannot claim a root nothing held.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimContextInput {
+    project_source: String,
+    repository_id: String,
+    /// The root the constructing lease held at capture time. Revalidated by
+    /// [`acquire_claim_context`]; retained unchanged afterwards.
+    root: String,
+    current: Option<CurrentQueryLease>,
+}
+
+impl ClaimContextInput {
+    pub fn project_source(&self) -> &str {
+        &self.project_source
+    }
+
+    pub fn repository_id(&self) -> &str {
+        &self.repository_id
+    }
+
+    pub fn root(&self) -> &str {
+        &self.root
+    }
+
+    pub fn current(&self) -> Option<&CurrentQueryLease> {
+        self.current.as_ref()
+    }
+}
+
+/// The relationships one operation's context may contain, derived from the
+/// closed [`OperationKind`] table and from nothing else — a new operation
+/// cannot acquire a bespoke relationship vocabulary. Private fields: the table
+/// is closed, not configurable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OperationRelationshipContract {
+    cross_source_permitted: bool,
+    requires_current: bool,
+}
+
+impl OperationRelationshipContract {
+    /// The one table. Search operations query across project sources and
+    /// require a `Current` lease per input; runtime lifecycle operations act
+    /// on exactly one source and derive no generation-structured claims.
+    pub fn for_operation(kind: OperationKind) -> Self {
+        let search = matches!(
+            kind,
+            OperationKind::SearchSymbols | OperationKind::SearchText
+        );
+        Self {
+            cross_source_permitted: search,
+            requires_current: search,
+        }
+    }
+
+    pub fn cross_source_permitted(&self) -> bool {
+        self.cross_source_permitted
+    }
+
+    pub fn requires_current(&self) -> bool {
+        self.requires_current
+    }
+}
+
+/// One coherent acquisition: the operation, every input it captured, and the
+/// relationships the closed contract permits between them. Once returned, the
+/// context is RETAINED EVIDENCE — a later rebind does not trigger a trailing
+/// live-state check, and claims derived wholly from its inputs remain valid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimContext {
+    operation: OperationReceipt,
+    inputs: Vec<ClaimContextInput>,
+    permitted_relationships: OperationRelationshipContract,
+}
+
+impl ClaimContext {
+    pub fn operation(&self) -> OperationReceipt {
+        self.operation
+    }
+
+    /// Never empty: [`acquire_claim_context`] refuses an empty acquisition, so
+    /// the guard is in the constructor rather than in a NonEmptyVec type
+    /// spelled by the data model — recorded in D10.
+    pub fn inputs(&self) -> &[ClaimContextInput] {
+        &self.inputs
+    }
+
+    pub fn permitted_relationships(&self) -> OperationRelationshipContract {
+        self.permitted_relationships
+    }
+}
+
+/// The one acquisition entry point, spelled as a free function by
+/// `data-model.md` line 1845.
+///
+/// Refusals, in order: an empty acquisition proves nothing; a root drift
+/// between input acquisitions is a REBIND, and rebinds refuse rather than
+/// composing roots — unless the closed contract explicitly permits a
+/// cross-source relation for this operation; and a generation-structured
+/// operation requires a `Current` lease on every input, never a retained
+/// substitute.
+pub fn acquire_claim_context(
+    operation: OperationReceipt,
+    inputs: Vec<ClaimContextInput>,
+) -> Result<ClaimContext, SourceRefusal> {
+    if inputs.is_empty() {
+        return Err(SourceRefusal::new(
+            SourceRefusalKind::InvalidSelection,
+            operation,
+            RetryAdvice::Never,
+            None,
+        ));
+    }
+    let contract = OperationRelationshipContract::for_operation(operation.operation_kind());
+    if !contract.cross_source_permitted() {
+        let first_root = inputs[0].root();
+        if inputs.iter().any(|input| input.root() != first_root) {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::SourceUnavailable,
+                operation,
+                RetryAdvice::Operator,
+                None,
+            ));
+        }
+    }
+    if contract.requires_current() && inputs.iter().any(|input| input.current().is_none()) {
+        return Err(SourceRefusal::new(
+            SourceRefusalKind::AdmissionUnavailable,
+            operation,
+            RetryAdvice::OnEvent,
+            None,
+        ));
+    }
+    Ok(ClaimContext {
+        operation,
+        inputs,
+        permitted_relationships: contract,
+    })
 }
 
 // ── Atomic authority ───────────────────────────────────────────────────────

--- a/src/protocol/claim_provenance.rs
+++ b/src/protocol/claim_provenance.rs
@@ -43,24 +43,47 @@ pub use crate::lifecycle_identity::{
 
 // ── Operations ─────────────────────────────────────────────────────────────
 
-/// The closed set of operation shapes. Transport mapping derives from this one
-/// table, so a new operation cannot acquire a bespoke refusal vocabulary.
+/// The closed operation vocabulary, VERBATIM from the frozen contract:
+/// `contracts/public-api-v11.json` `type:embed:OperationKind` fixes exactly
+/// these seven variants. An earlier draft invented four provenance-shape
+/// variants under this name; that both diverged from the contract this module's
+/// own header declares authoritative AND squatted the name T047's runtime
+/// vocabulary owns. Provenance SHAPES are named by
+/// [`ClaimProvenance::kind_name`], not here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum OperationKind {
-    Retrieval,
-    Comparison,
-    Derivation,
-    SelectedAggregate,
+    AcquireRuntime,
+    CloseSource,
+    OpenEmbeddedSource,
+    RefreshSource,
+    SearchSymbols,
+    SearchText,
+    ShutdownRuntime,
 }
 
 impl OperationKind {
+    /// Every variant, once. The Cartesian oracle iterates this so a new
+    /// operation cannot be added without entering the matrix.
+    pub const ALL: [Self; 7] = [
+        Self::AcquireRuntime,
+        Self::CloseSource,
+        Self::OpenEmbeddedSource,
+        Self::RefreshSource,
+        Self::SearchSymbols,
+        Self::SearchText,
+        Self::ShutdownRuntime,
+    ];
+
     /// Stable display name. Part of the closed contract, not a debug string.
     pub fn kind_name(self) -> &'static str {
         match self {
-            Self::Retrieval => "Retrieval",
-            Self::Comparison => "Comparison",
-            Self::Derivation => "Derivation",
-            Self::SelectedAggregate => "SelectedAggregate",
+            Self::AcquireRuntime => "AcquireRuntime",
+            Self::CloseSource => "CloseSource",
+            Self::OpenEmbeddedSource => "OpenEmbeddedSource",
+            Self::RefreshSource => "RefreshSource",
+            Self::SearchSymbols => "SearchSymbols",
+            Self::SearchText => "SearchText",
+            Self::ShutdownRuntime => "ShutdownRuntime",
         }
     }
 }
@@ -146,14 +169,27 @@ pub enum SourceRefusalKind {
 
 /// What, if anything, would make a retry worth attempting. Advice only: it
 /// never authorizes the retry it describes.
+///
+/// Variants VERBATIM from `contracts/public-api-v11.json`
+/// `type:embed:RetryAdvice`. An earlier draft invented
+/// `{Never, AfterRebind, AfterRefresh}` in the same commit that declared the
+/// atoms authoritative; the audit caught the contradiction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RetryAdvice {
+    /// The same request may simply be retried.
+    Automatic,
     /// The request is wrong in a way repetition cannot fix.
     Never,
-    /// A rebind to the correct root could succeed.
-    AfterRebind,
-    /// A completed refresh could succeed.
-    AfterRefresh,
+    /// Retry after an observable event: a completed refresh, an installed
+    /// successor generation, a selection change.
+    OnEvent,
+    /// Retry requires an operator action, such as a rebind to the correct root.
+    Operator,
+}
+
+impl RetryAdvice {
+    /// Every variant, once, for the Cartesian oracle.
+    pub const ALL: [Self; 4] = [Self::Automatic, Self::Never, Self::OnEvent, Self::Operator];
 }
 
 /// A typed refusal. Opaque by construction: callers read it through the
@@ -299,21 +335,33 @@ impl ObservationLease {
         }
     }
 
-    /// Build a typed refusal against this lease's evidence.
+    /// Build a typed refusal, naming the evidence that was actually examined.
+    ///
+    /// `evidence` is the identity of an authority the CALLER examined, or
+    /// `None` when the request was rejected outright without examining any. An
+    /// earlier draft filled this with `AuthorityIdentity::fresh()` — an
+    /// identity corresponding to no evidence anywhere — which is fabrication,
+    /// the exact reporting defect this feature exists to prevent. The audit
+    /// caught it; the parameter now forces the caller to say what it examined.
     pub fn refuse(
         &self,
         operation: OperationReceipt,
         kind: SourceRefusalKind,
         retry: RetryAdvice,
+        evidence: Option<AuthorityIdentity>,
     ) -> SourceRefusal {
-        SourceRefusal::new(kind, operation, retry, Some(AuthorityIdentity::fresh()))
+        SourceRefusal::new(kind, operation, retry, evidence)
     }
 
     /// Authority to bound the rendering of an ALREADY complete leased result.
     ///
-    /// `OutputCoverage::Truncated` cannot be constructed without one of these,
-    /// which is what "post-lease only" means: truncation describes a response,
-    /// never a generation.
+    /// The SEAL is real and type-level: `OutputCoverage::Truncated` carries an
+    /// opaque [`TruncationBreaches`] payload with no public constructor, so it
+    /// cannot be built anywhere but [`CompletedRenderAuthority::truncate`].
+    /// The lease EVIDENCE behind this method is a Slice 3 stand-in: it returns
+    /// `Ok` unconditionally because the strict-lease machinery that would
+    /// refuse is Slice 4 work. Do not "complete" it with a fake check —
+    /// see the evidence document.
     pub fn completed_render_authority(&self) -> Result<CompletedRenderAuthority, SourceRefusal> {
         Ok(CompletedRenderAuthority { _sealed: () })
     }
@@ -396,11 +444,15 @@ impl DiskObservationReceipt {
 
     /// A read that failed is a typed refusal, never an absence. Reporting it as
     /// absence would let an I/O error masquerade as proof that a file is gone.
-    pub fn into_failed_read(self) -> Result<Self, SourceRefusal> {
+    ///
+    /// The caller supplies the operation that was being served: an earlier
+    /// draft minted a `for_test` receipt here, which put a fixture constructor
+    /// on a non-test path and fabricated the operation the refusal names.
+    pub fn into_failed_read(self, operation: OperationReceipt) -> Result<Self, SourceRefusal> {
         Err(SourceRefusal::new(
             SourceRefusalKind::SourceUnavailable,
-            OperationReceipt::for_test(OperationKind::Retrieval),
-            RetryAdvice::AfterRefresh,
+            operation,
+            RetryAdvice::OnEvent,
             Some(self.identity()),
         ))
     }
@@ -742,7 +794,12 @@ pub enum ClaimProvenance {
         identity: ProvenanceIdentity,
         operation: OperationReceipt,
         selections: Vec<SourceSelectionReceipt>,
-        generations: BTreeMap<String, GenerationAuthority>,
+        /// Stored as [`AtomicAuthority::Generation`] so [`ClaimProvenance::authorities`]
+        /// can NAME this variant's evidence — an aggregate that could not
+        /// enumerate what proves it was an audit finding.
+        generations: BTreeMap<String, AtomicAuthority>,
+        /// The frozen shape carries these; dropping them silently was another.
+        additional_authorities: Vec<AtomicAuthority>,
     },
 }
 
@@ -767,7 +824,7 @@ impl ClaimProvenance {
             return Err(SourceRefusal::new(
                 SourceRefusalKind::SourceUnavailable,
                 operation,
-                RetryAdvice::AfterRebind,
+                RetryAdvice::Operator,
                 Some(left.identity()),
             ));
         }
@@ -807,7 +864,7 @@ impl ClaimProvenance {
                     return Err(SourceRefusal::new(
                         SourceRefusalKind::SourceUnavailable,
                         operation,
-                        RetryAdvice::AfterRebind,
+                        RetryAdvice::Operator,
                         Some(first.identity()),
                     ));
                 }
@@ -822,11 +879,12 @@ impl ClaimProvenance {
 
     /// The only constructor for repository-wide absence. Requires an EXACT
     /// bijection between selections and captured generations: a missing, extra,
-    /// or unmatched entry refuses.
+    /// forged, or uncaptured entry refuses.
     pub fn selected_aggregate(
         operation: OperationReceipt,
         selections: Vec<SourceSelectionReceipt>,
         generations: Vec<(String, GenerationAuthority)>,
+        additional_authorities: Vec<AtomicAuthority>,
     ) -> Result<Self, SourceRefusal> {
         if selections.is_empty() {
             return Err(SourceRefusal::new(
@@ -836,7 +894,22 @@ impl ClaimProvenance {
                 None,
             ));
         }
-        let captured: BTreeMap<String, GenerationAuthority> = generations.into_iter().collect();
+        // A duplicate key is a forged capture, and BTreeMap::from_iter would
+        // COLLAPSE it silently — the second entry would vanish and the length
+        // check below would then blame the selection. Refuse it by name first.
+        let supplied = generations.len();
+        let captured: BTreeMap<String, AtomicAuthority> = generations
+            .into_iter()
+            .map(|(key, generation)| (key, AtomicAuthority::Generation(generation)))
+            .collect();
+        if captured.len() != supplied {
+            return Err(SourceRefusal::new(
+                SourceRefusalKind::InvalidSelection,
+                operation,
+                RetryAdvice::Never,
+                None,
+            ));
+        }
         if captured.len() != selections.len()
             || !selections
                 .iter()
@@ -845,15 +918,35 @@ impl ClaimProvenance {
             return Err(SourceRefusal::new(
                 SourceRefusalKind::SelectionUnavailable,
                 operation,
-                RetryAdvice::AfterRefresh,
+                RetryAdvice::OnEvent,
                 None,
             ));
+        }
+        // Root compatibility across EVERYTHING the aggregate retains: the
+        // captured generations and the additional authorities compose into one
+        // claim, so a foreign root here is the same defect as in a derivation.
+        let all: Vec<&AtomicAuthority> = captured
+            .values()
+            .chain(additional_authorities.iter())
+            .collect();
+        if let Some(first) = all.first() {
+            for other in &all[1..] {
+                if !roots_are_compatible(first, other) {
+                    return Err(SourceRefusal::new(
+                        SourceRefusalKind::SourceUnavailable,
+                        operation,
+                        RetryAdvice::Operator,
+                        Some(other.identity()),
+                    ));
+                }
+            }
         }
         Ok(Self::SelectedAggregate {
             identity: ProvenanceIdentity::fresh(),
             operation,
             selections,
             generations: captured,
+            additional_authorities,
         })
     }
 
@@ -876,7 +969,10 @@ impl ClaimProvenance {
     }
 
     /// Every atomic authority retained, in order. Inputs are never collapsed:
-    /// a claim must be able to name each thing it was derived from.
+    /// a claim must be able to name each thing it was derived from — INCLUDING
+    /// a SelectedAggregate's captured generations, which an earlier draft
+    /// yielded nothing for while counting them, an inconsistency the audit
+    /// flagged.
     pub fn authorities(&self) -> impl Iterator<Item = &AtomicAuthority> + '_ {
         let items: Vec<&AtomicAuthority> = match self {
             Self::Single { authority, .. } => vec![authority],
@@ -890,20 +986,22 @@ impl ClaimProvenance {
                     ClaimInput::Selection(_) => None,
                 })
                 .collect(),
-            Self::SelectedAggregate { .. } => Vec::new(),
+            Self::SelectedAggregate {
+                generations,
+                additional_authorities,
+                ..
+            } => generations
+                .values()
+                .chain(additional_authorities.iter())
+                .collect(),
         };
         items.into_iter()
     }
 
+    /// Defined as `authorities().count()` — one source of truth, so the two can
+    /// never disagree again.
     pub fn authority_count(&self) -> usize {
-        match self {
-            Self::Single { .. } => 1,
-            Self::Comparison { .. } => 2,
-            Self::Derivation {
-                nonempty_inputs, ..
-            } => nonempty_inputs.len(),
-            Self::SelectedAggregate { generations, .. } => generations.len(),
-        }
+        self.authorities().count()
     }
 }
 
@@ -946,10 +1044,32 @@ impl EvaluationProvenance {
 // ── Output coverage ────────────────────────────────────────────────────────
 
 /// Whether a RESPONSE was rendered whole. Never a statement about a generation.
+///
+/// `Truncated` carries an OPAQUE payload with no public constructor, so it is
+/// unbuildable outside this module. The first draft used a struct variant with
+/// pub fields, so `OutputCoverage::Truncated { breaches: vec![] }` compiled
+/// anywhere with no authority at all — while doc and commit message both
+/// claimed it sealed. The audit called that what it was: reporting an
+/// enforcement the type system did not provide.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutputCoverage {
     Complete,
-    Truncated { breaches: Vec<LimitBreach> },
+    Truncated(TruncationBreaches),
+}
+
+/// The limits a bounded rendering hit. Private field, no public constructor:
+/// the ONLY producer is [`CompletedRenderAuthority::truncate`], which is what
+/// makes "post-lease only" a property of the type rather than a promise in a
+/// comment. Consumers read through [`TruncationBreaches::breaches`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TruncationBreaches {
+    breaches: Vec<LimitBreach>,
+}
+
+impl TruncationBreaches {
+    pub fn breaches(&self) -> &[LimitBreach] {
+        &self.breaches
+    }
 }
 
 /// Proof that a strict lease COMPLETED. Required to construct
@@ -972,12 +1092,12 @@ impl CompletedRenderAuthority {
         if breaches.is_empty() {
             return OutputCoverage::Complete;
         }
-        OutputCoverage::Truncated {
+        OutputCoverage::Truncated(TruncationBreaches {
             breaches: breaches
                 .into_iter()
                 .map(|(kind, omitted)| LimitBreach { kind, omitted })
                 .collect(),
-        }
+        })
     }
 }
 
@@ -991,6 +1111,12 @@ pub struct Claim<T> {
     provenance: ClaimProvenance,
     evaluation: Option<EvaluationProvenance>,
     producing_runtime_identity: ProducingRuntimeIdentity,
+    /// Coverage of the RENDERING, when a bounded render happened. `None` until
+    /// [`Claim::render_bounded`] runs. Kept OFF provenance identity — caches,
+    /// CCR, and persistence key on that — but retained readably here, because a
+    /// render that discarded its coverage argument made the retention oracle
+    /// unfalsifiable, which the audit flagged.
+    rendered_coverage: Option<OutputCoverage>,
 }
 
 impl<T> Claim<T> {
@@ -1002,6 +1128,7 @@ impl<T> Claim<T> {
             provenance: ClaimProvenance::single(authority),
             evaluation: None,
             producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+            rendered_coverage: None,
         }
     }
 
@@ -1018,6 +1145,7 @@ impl<T> Claim<T> {
             provenance: ClaimProvenance::single(authority),
             evaluation: Some(evaluation),
             producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+            rendered_coverage: None,
         }
     }
 
@@ -1034,6 +1162,7 @@ impl<T> Claim<T> {
             provenance,
             evaluation: None,
             producing_runtime_identity: ProducingRuntimeIdentity::fresh(),
+            rendered_coverage: None,
         })
     }
 
@@ -1060,33 +1189,40 @@ impl<T> Claim<T> {
         self.producing_runtime_identity
     }
 
-    /// Bound this claim's RENDERING. Deliberately does not touch provenance
-    /// identity: truncation describes a response, and caches, CCR, and
-    /// persistence key on provenance identity. Moving it here would make a
-    /// bounded render look like different evidence.
-    pub fn render_bounded(self, _coverage: OutputCoverage) -> Self {
+    /// Coverage of the last bounded rendering, if one happened.
+    pub fn rendered_coverage(&self) -> Option<&OutputCoverage> {
+        self.rendered_coverage.as_ref()
+    }
+
+    /// Bound this claim's RENDERING. The coverage is RETAINED — readable via
+    /// [`Claim::rendered_coverage`] — and provenance identity is deliberately
+    /// untouched: truncation describes a response, and caches, CCR, and
+    /// persistence key on provenance identity. Moving it there would make a
+    /// bounded render look like different evidence; DISCARDING it, as the first
+    /// draft did, made the retention oracle unfalsifiable.
+    pub fn render_bounded(mut self, coverage: OutputCoverage) -> Self {
+        self.rendered_coverage = Some(coverage);
         self
     }
 }
 
 // ── Retrieval voice ────────────────────────────────────────────────────────
 
-/// A knowledge voice a retrieval may select.
+/// A knowledge voice. Variants VERBATIM from `data-model.md` `KnowledgeVoice`
+/// — the first draft invented a `Consistency` variant and dropped `Current`,
+/// so its "never selects consistency" oracle validated a model that does not
+/// exist. There is NO consistency voice: "retrieval voice never selects
+/// consistency" is a structural fact of this enum, not a runtime filter — a
+/// stale document cannot acquire generation authority by being selected as a
+/// consistency voice because no such voice is expressible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KnowledgeVoice {
+    Current,
     Intent,
     NeedsReview,
     Unknown,
     HistoryOnly,
     Suppressed,
-    /// Consistency is an AUTHORITY HYGIENE verdict, never a retrieval filter.
-    Consistency,
-}
-
-impl KnowledgeVoice {
-    pub fn is_consistency(self) -> bool {
-        matches!(self, Self::Consistency)
-    }
 }
 
 /// Which voices retrieval may select.
@@ -1094,11 +1230,14 @@ impl KnowledgeVoice {
 pub struct KnowledgeVoiceFilter;
 
 impl KnowledgeVoiceFilter {
-    /// Consistency is absent by construction, not by filtering after the fact.
-    /// A stale document must not be able to acquire generation authority by
-    /// being selected as a consistency voice.
+    /// The default selection set: `Current`, `Intent`, `NeedsReview`, and
+    /// `Unknown`, per the data model's `authority_scope` default — which
+    /// INCLUDES the current-implementation voice and EXCLUDES `HistoryOnly`
+    /// and `Suppressed`. Explicit history scopes never promote non-current
+    /// evidence.
     pub fn selectable_voices() -> Vec<KnowledgeVoice> {
         vec![
+            KnowledgeVoice::Current,
             KnowledgeVoice::Intent,
             KnowledgeVoice::NeedsReview,
             KnowledgeVoice::Unknown,

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -3,6 +3,30 @@
 //! All functions take `&LiveIndex` (or data derived from it) and return `String`.
 //! No I/O, no async. Output matches the locked formats defined in CONTEXT.md.
 
+// Feature 020 V11 claim attribution (T043). The frozen contract places the file
+// at `src/protocol/claim_provenance.rs`, and that is where it lives. The
+// DECLARATION is here, in `format.rs`, and deliberately NOT in
+// `src/protocol/mod.rs`:
+//
+//   * `protocol/mod.rs` is inside the `publication_roots` set of the frozen
+//     retirement census, so adding a `mod` line there is a release-compiled edit
+//     of a hashed file and would move that digest. `format.rs` is in none of the
+//     five closure path lists.
+//   * `protocol/mod.rs` declares `read_gate` as `pub(crate) mod`, so anchoring
+//     there would make the whole provenance module crate-private — and
+//     `tests/claim_provenance_v11.rs` is a SEPARATE CRATE that could never see
+//     it. `format.rs` is `pub mod`, so the types are reachable from the oracles.
+//
+// `#[path]` resolves relative to the directory CONTAINING this file, so the bare
+// name lands on `src/protocol/claim_provenance.rs`. Verified against rustc
+// rather than recalled: `#[path = "../claim_provenance.rs"]` makes it look for
+// `src/claim_provenance.rs` and fail.
+//
+// Do NOT "tidy" this into `protocol/mod.rs`. It silently moves a frozen digest
+// and breaks the oracles' visibility in one edit.
+#[path = "claim_provenance.rs"]
+pub mod claim_provenance;
+
 /// Budget limits for reference/dependent output to prevent unbounded token usage.
 pub struct OutputLimits {
     /// Maximum number of files to include in the output.

--- a/tests/claim_provenance_v11.rs
+++ b/tests/claim_provenance_v11.rs
@@ -1,0 +1,309 @@
+//! Feature 020 V11, T041 — claim attribution and the `OperationContractV1`
+//! Cartesian negatives.
+//!
+//! RED until T043 exists.
+//!
+//! API surface follows `contracts/public-api-v11.json` `introduced_v11_atoms`,
+//! NOT the `data-model.md` prose. The two frozen documents disagree: the data
+//! model spells a pub-field `Claim` with `producing_publication` and a
+//! four-variant `SourceRefusal` enum, while the atoms fix
+//! `Claim::producing_runtime_identity` and an opaque `SourceRefusal` with
+//! `kind` / `operation` / `retry` / `evidence_identity`, plus the
+//! `SourceRefusalKind` and `RetryAdvice` types. The atoms win because
+//! `expected_graph.activation_rule` refuses activation on a missing or extra
+//! atom, while no checker compares the prose to code. See D9 in
+//! `docs/reviews/SLICE3-RECON-FINDINGS-v11.md`.
+//!
+//! The four refusal KIND NAMES are identical across both documents, so these
+//! tests match on `kind()` and never destructure fields.
+
+use symforge::protocol::format::claim_provenance::{
+    AtomicAuthority, Claim, ClaimInput, ClaimProvenance, ComparisonRelation, EvaluationProvenance,
+    ObservationLease, OperationKind, OperationReceipt, OutputCoverage, PhysicalRootLease,
+    RetryAdvice, SourceRefusalKind,
+};
+use symforge::live_index::knowledge_bridge::DerivedLimitKind;
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+fn a_lease(root: &str) -> ObservationLease {
+    ObservationLease::for_test_root(PhysicalRootLease::for_test_root(root))
+}
+
+fn an_operation(kind: OperationKind) -> OperationReceipt {
+    OperationReceipt::for_test(kind)
+}
+
+fn a_generation(lease: &ObservationLease) -> AtomicAuthority {
+    AtomicAuthority::Generation(lease.admit_generation().expect("complete generation"))
+}
+
+/// Every atomic authority kind, once. The Cartesian tests iterate this so a new
+/// authority kind cannot be added without being covered.
+fn every_authority_kind(lease: &ObservationLease) -> Vec<AtomicAuthority> {
+    vec![
+        a_generation(lease),
+        AtomicAuthority::DiskObservation(
+            lease
+                .observe_missing_path("src/gone.rs", symforge::protocol::format::claim_provenance::ObservationTime::fresh())
+                .expect("missing path"),
+        ),
+        AtomicAuthority::WorktreeScopeObservation(
+            lease
+                .complete_scope_scan(
+                    symforge::protocol::format::claim_provenance::WorktreeObservationScope::beneath(
+                        "src/",
+                    ),
+                )
+                .expect("complete scan"),
+        ),
+        AtomicAuthority::GitObservation(
+            symforge::protocol::format::claim_provenance::GitObservationReceipt::not_in_tree(
+                "tree-1",
+                "src/gone.rs",
+            ),
+        ),
+    ]
+}
+
+// ── Every authority kind is self-describing and distinctly identified ──────
+
+#[test]
+fn every_authority_kind_reports_its_own_name_and_a_distinct_identity() {
+    let lease = a_lease("root-a");
+    let authorities = every_authority_kind(&lease);
+
+    let mut names: Vec<&'static str> = authorities.iter().map(|a| a.kind_name()).collect();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(
+        names.len(),
+        4,
+        "all four authority kinds must be distinguishable by name: {names:?}"
+    );
+
+    let mut identities: Vec<_> = authorities.iter().map(|a| a.identity()).collect();
+    identities.sort_unstable();
+    identities.dedup();
+    assert_eq!(
+        identities.len(),
+        4,
+        "each authority carries its own identity; none may share one"
+    );
+}
+
+// ── Provenance shape: cardinality is enforced, not advisory ────────────────
+
+#[test]
+fn a_comparison_admits_exactly_two_authorities() {
+    let lease = a_lease("root-a");
+    let provenance = ClaimProvenance::comparison(
+        an_operation(OperationKind::Comparison),
+        ComparisonRelation::SameContent,
+        a_generation(&lease),
+        a_generation(&lease),
+    )
+    .expect("two authorities is the comparison arity");
+
+    assert_eq!(provenance.authority_count(), 2);
+    assert_eq!(provenance.kind_name(), "Comparison");
+    assert_eq!(
+        provenance.authorities().count(),
+        2,
+        "both sides stay retained and enumerable"
+    );
+}
+
+#[test]
+fn a_derivation_refuses_an_empty_input_set() {
+    let refusal = ClaimProvenance::derivation(an_operation(OperationKind::Derivation), Vec::new())
+        .expect_err("a derivation with no inputs proves nothing and must refuse");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::InvalidSelection);
+}
+
+#[test]
+fn a_derivation_is_n_ary_above_one() {
+    let lease = a_lease("root-a");
+    for arity in 1..=4 {
+        let inputs: Vec<ClaimInput> = (0..arity)
+            .map(|_| ClaimInput::Authority(a_generation(&lease)))
+            .collect();
+        let provenance =
+            ClaimProvenance::derivation(an_operation(OperationKind::Derivation), inputs)
+                .unwrap_or_else(|_| panic!("arity {arity} must be admitted"));
+        assert_eq!(
+            provenance.authority_count(),
+            arity,
+            "a derivation retains every input it was given"
+        );
+    }
+}
+
+#[test]
+fn a_selected_aggregate_refuses_a_selection_without_its_generation() {
+    let lease = a_lease("root-a");
+    let refusal = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SelectedAggregate),
+        vec![lease.selection_receipt("project-a")],
+        Vec::new(),
+    )
+    .expect_err("a selection with no matching captured generation breaks the bijection");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::SelectionUnavailable);
+}
+
+#[test]
+fn a_selected_aggregate_admits_an_exact_bijection() {
+    // GREEN-CONTROL: the refusal above is about the MISSING generation, not
+    // about SelectedAggregate being unconstructible.
+    let lease = a_lease("root-a");
+    let provenance = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SelectedAggregate),
+        vec![lease.selection_receipt("project-a")],
+        vec![("project-a".to_string(), lease.admit_generation().expect("gen"))],
+    )
+    .expect("an exact selection-to-generation bijection is admitted");
+
+    assert_eq!(provenance.kind_name(), "SelectedAggregate");
+    assert_eq!(provenance.authority_count(), 1);
+}
+
+// ── The refusal Cartesian: every kind against every retry advice ───────────
+
+#[test]
+fn every_refusal_kind_round_trips_with_every_retry_advice() {
+    let lease = a_lease("root-a");
+    let kinds = [
+        SourceRefusalKind::AdmissionUnavailable,
+        SourceRefusalKind::InvalidSelection,
+        SourceRefusalKind::SelectionUnavailable,
+        SourceRefusalKind::SourceUnavailable,
+    ];
+    let advices = [
+        RetryAdvice::Never,
+        RetryAdvice::AfterRebind,
+        RetryAdvice::AfterRefresh,
+    ];
+
+    let mut seen = 0usize;
+    for kind in kinds {
+        for advice in advices {
+            let operation = an_operation(OperationKind::Retrieval);
+            let refusal = lease.refuse(operation, kind, advice);
+
+            assert_eq!(refusal.kind(), kind, "the refusal reports the kind it was built with");
+            assert_eq!(refusal.retry(), advice, "retry advice survives the round trip");
+            assert_eq!(
+                refusal.operation().operation_kind(),
+                OperationKind::Retrieval,
+                "every refusal names the operation that produced it"
+            );
+            assert!(
+                refusal.evidence_identity().is_some(),
+                "a refusal carries the identity of the evidence it refused on"
+            );
+            seen += 1;
+        }
+    }
+
+    assert_eq!(seen, 12, "control: the full 4x3 Cartesian was exercised");
+}
+
+// ── Evaluation provenance accompanies observable ordering ─────────────────
+
+#[test]
+fn an_ordered_result_carries_evaluation_provenance_and_an_unordered_one_does_not() {
+    let lease = a_lease("root-a");
+
+    let ranked = Claim::single_ranked(
+        an_operation(OperationKind::Retrieval),
+        a_generation(&lease),
+        vec!["a", "b"],
+        EvaluationProvenance::for_test(),
+    );
+    assert!(
+        ranked.evaluation().is_some(),
+        "order is observable, so the ranking that produced it must be attributable"
+    );
+
+    let unordered = Claim::single(an_operation(OperationKind::Retrieval), a_generation(&lease), ());
+    assert!(
+        unordered.evaluation().is_none(),
+        "no observable order means no ranking to attribute"
+    );
+}
+
+// ── OutputCoverage::Truncated is post-lease only ──────────────────────────
+
+#[test]
+fn truncated_coverage_requires_a_completed_strict_lease() {
+    let lease = a_lease("root-a");
+    let render = lease
+        .completed_render_authority()
+        .expect("a completed strict lease may bound its own rendering");
+
+    let truncated = render.truncate(vec![(DerivedLimitKind::Cards, 3)]);
+    assert!(
+        matches!(truncated, OutputCoverage::Truncated { .. }),
+        "bounded rendering after a completed lease may report truncation"
+    );
+}
+
+#[test]
+fn truncation_uses_the_live_limit_kinds_not_a_second_enum() {
+    // D3: `data-model.md` lists SIX DerivedLimitKind variants; production ships
+    // EIGHT and records the extra two. T043 reuses the live type rather than
+    // transcribing a lossy copy, so the two extra kinds must be expressible.
+    let lease = a_lease("root-a");
+    let render = lease.completed_render_authority().expect("completed lease");
+
+    let truncated = render.truncate(vec![
+        (DerivedLimitKind::OwnershipSelectors, 1),
+        (DerivedLimitKind::AmbiguousSamples, 2),
+    ]);
+
+    let OutputCoverage::Truncated { breaches } = truncated else {
+        panic!("expected a truncated coverage");
+    };
+    assert_eq!(
+        breaches.len(),
+        2,
+        "both production-only limit kinds survive into the breach record"
+    );
+}
+
+#[test]
+fn truncated_coverage_never_enters_a_claim_identity() {
+    let lease = a_lease("root-a");
+    let render = lease.completed_render_authority().expect("completed lease");
+    let truncated = render.truncate(vec![(DerivedLimitKind::Output, 1)]);
+
+    let claim = Claim::single(an_operation(OperationKind::Retrieval), a_generation(&lease), ());
+    let before = claim.provenance().identity();
+    let rendered = claim.render_bounded(truncated);
+
+    assert_eq!(
+        rendered.provenance().identity(),
+        before,
+        "bounded rendering does not change generation completeness, so it must not \
+         move the provenance identity that caches, CCR, and persistence key on"
+    );
+}
+
+// ── Retrieval voice never selects consistency ─────────────────────────────
+
+#[test]
+fn the_knowledge_voice_filter_never_selects_consistency() {
+    let selectable = symforge::protocol::format::claim_provenance::KnowledgeVoiceFilter::selectable_voices();
+
+    assert!(
+        !selectable.iter().any(|voice| voice.is_consistency()),
+        "retrieval voice must never select consistency; that is authority hygiene, \
+         not a retrieval filter"
+    );
+    assert!(
+        !selectable.is_empty(),
+        "control: the filter does select SOMETHING, so the assertion above is not vacuous"
+    );
+}

--- a/tests/claim_provenance_v11.rs
+++ b/tests/claim_provenance_v11.rs
@@ -337,6 +337,45 @@ fn a_selected_aggregate_refuses_a_foreign_root_authority() {
     assert_eq!(refusal.kind(), SourceRefusalKind::SourceUnavailable);
 }
 
+// ── Claim contexts: acquisition through the closed contract ────────────────
+
+#[test]
+fn a_context_refuses_an_empty_acquisition() {
+    use symforge::protocol::format::claim_provenance::acquire_claim_context;
+
+    let refusal = acquire_claim_context(an_operation(OperationKind::SearchText), Vec::new())
+        .expect_err("a context with no inputs proves nothing and must refuse");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::InvalidSelection);
+}
+
+#[test]
+fn a_generation_structured_operation_requires_a_current_lease_per_input() {
+    use symforge::protocol::format::claim_provenance::acquire_claim_context;
+
+    let lease = a_lease("root-a");
+
+    // Without the lease: refused, and the advice names the event that fixes it.
+    let bare = lease.context_input("project-a", "repo-1", None);
+    let refusal =
+        acquire_claim_context(an_operation(OperationKind::SearchText), vec![bare.clone()])
+            .expect_err("a search without a Current lease must refuse");
+    assert_eq!(refusal.kind(), SourceRefusalKind::AdmissionUnavailable);
+
+    // GREEN-CONTROL: with the lease, the same acquisition is admitted, so the
+    // refusal above is about the MISSING lease and not about search contexts.
+    let current = lease.current_query_lease().expect("current lease");
+    let held = lease.context_input("project-a", "repo-1", Some(current));
+    let context = acquire_claim_context(an_operation(OperationKind::SearchText), vec![held])
+        .expect("a search with a Current lease per input is admitted");
+    assert_eq!(context.inputs().len(), 1);
+
+    // A NON-generation-structured operation may omit the lease entirely.
+    let observation = acquire_claim_context(an_operation(OperationKind::RefreshSource), vec![bare])
+        .expect("a pure lifecycle operation omits Current");
+    assert!(!observation.permitted_relationships().requires_current());
+}
+
 // ── The OperationContractV1 Cartesian ──────────────────────────────────────
 
 /// The name is pinned by the frozen traceability catalog:

--- a/tests/claim_provenance_v11.rs
+++ b/tests/claim_provenance_v11.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "server")]
 //! Feature 020 V11, T041 — claim attribution and the `OperationContractV1`
 //! Cartesian negatives.
 //!
@@ -20,8 +21,8 @@
 use symforge::live_index::knowledge_bridge::DerivedLimitKind;
 use symforge::protocol::format::claim_provenance::{
     AtomicAuthority, Claim, ClaimInput, ClaimProvenance, ComparisonRelation, EvaluationProvenance,
-    ObservationLease, OperationKind, OperationReceipt, OutputCoverage, PhysicalRootLease,
-    RetryAdvice, SourceRefusalKind,
+    ObservationLease, ObservationTime, OperationKind, OperationReceipt, OutputCoverage,
+    PhysicalRootLease, RetryAdvice, SourceRefusalKind,
 };
 
 // ── Fixtures ───────────────────────────────────────────────────────────────
@@ -85,9 +86,8 @@ fn every_authority_kind_reports_its_own_name_and_a_distinct_identity() {
         "all four authority kinds must be distinguishable by name: {names:?}"
     );
 
-    let mut identities: Vec<_> = authorities.iter().map(|a| a.identity()).collect();
-    identities.sort_unstable();
-    identities.dedup();
+    let identities: std::collections::HashSet<_> =
+        authorities.iter().map(|a| a.identity()).collect();
     assert_eq!(
         identities.len(),
         4,
@@ -101,7 +101,7 @@ fn every_authority_kind_reports_its_own_name_and_a_distinct_identity() {
 fn a_comparison_admits_exactly_two_authorities() {
     let lease = a_lease("root-a");
     let provenance = ClaimProvenance::comparison(
-        an_operation(OperationKind::Comparison),
+        an_operation(OperationKind::SearchText),
         ComparisonRelation::SameContent,
         a_generation(&lease),
         a_generation(&lease),
@@ -119,8 +119,9 @@ fn a_comparison_admits_exactly_two_authorities() {
 
 #[test]
 fn a_derivation_refuses_an_empty_input_set() {
-    let refusal = ClaimProvenance::derivation(an_operation(OperationKind::Derivation), Vec::new())
-        .expect_err("a derivation with no inputs proves nothing and must refuse");
+    let refusal =
+        ClaimProvenance::derivation(an_operation(OperationKind::SearchSymbols), Vec::new())
+            .expect_err("a derivation with no inputs proves nothing and must refuse");
 
     assert_eq!(refusal.kind(), SourceRefusalKind::InvalidSelection);
 }
@@ -133,7 +134,7 @@ fn a_derivation_is_n_ary_above_one() {
             .map(|_| ClaimInput::Authority(a_generation(&lease)))
             .collect();
         let provenance =
-            ClaimProvenance::derivation(an_operation(OperationKind::Derivation), inputs)
+            ClaimProvenance::derivation(an_operation(OperationKind::SearchSymbols), inputs)
                 .unwrap_or_else(|_| panic!("arity {arity} must be admitted"));
         assert_eq!(
             provenance.authority_count(),
@@ -147,8 +148,9 @@ fn a_derivation_is_n_ary_above_one() {
 fn a_selected_aggregate_refuses_a_selection_without_its_generation() {
     let lease = a_lease("root-a");
     let refusal = ClaimProvenance::selected_aggregate(
-        an_operation(OperationKind::SelectedAggregate),
+        an_operation(OperationKind::SearchText),
         vec![lease.selection_receipt("project-a")],
+        Vec::new(),
         Vec::new(),
     )
     .expect_err("a selection with no matching captured generation breaks the bijection");
@@ -165,7 +167,7 @@ fn a_selected_aggregate_refuses_an_extra_unselected_generation() {
     // mutation: disabling the length check alone survived the original suite.
     let lease = a_lease("root-a");
     let refusal = ClaimProvenance::selected_aggregate(
-        an_operation(OperationKind::SelectedAggregate),
+        an_operation(OperationKind::SearchText),
         vec![lease.selection_receipt("project-a")],
         vec![
             (
@@ -177,6 +179,7 @@ fn a_selected_aggregate_refuses_an_extra_unselected_generation() {
                 lease.admit_generation().expect("gen"),
             ),
         ],
+        Vec::new(),
     )
     .expect_err("an extra captured generation breaks the exact bijection");
 
@@ -189,17 +192,149 @@ fn a_selected_aggregate_admits_an_exact_bijection() {
     // about SelectedAggregate being unconstructible.
     let lease = a_lease("root-a");
     let provenance = ClaimProvenance::selected_aggregate(
-        an_operation(OperationKind::SelectedAggregate),
+        an_operation(OperationKind::SearchText),
         vec![lease.selection_receipt("project-a")],
         vec![(
             "project-a".to_string(),
             lease.admit_generation().expect("gen"),
         )],
+        Vec::new(),
     )
     .expect("an exact selection-to-generation bijection is admitted");
 
     assert_eq!(provenance.kind_name(), "SelectedAggregate");
     assert_eq!(provenance.authority_count(), 1);
+}
+
+#[test]
+fn a_comparison_across_two_roots_is_refused_rather_than_composed() {
+    // The derivation path had this oracle; the comparison path did not, so the
+    // comparison's own root gate could be deleted without failing any test —
+    // a mutation-surviving gap the audit found.
+    let left = a_lease("root-a");
+    let right = a_lease("root-b");
+    let refusal = ClaimProvenance::comparison(
+        an_operation(OperationKind::SearchText),
+        ComparisonRelation::SameContent,
+        a_generation(&left),
+        a_generation(&right),
+    )
+    .expect_err("two roots must not compose into one comparison");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::SourceUnavailable);
+}
+
+#[test]
+fn a_generation_authority_never_proves_repository_absence() {
+    // The no-widening loop covers the three OBSERVATION kinds; Generation
+    // legitimately proves generation-scoped absence, so it cannot join that
+    // loop — but its repository claim still needs pinning, which nothing did.
+    let lease = a_lease("root-a");
+    let generation = lease.admit_generation().expect("complete generation");
+
+    assert!(
+        generation.proves_generation_absence(),
+        "GREEN-CONTROL: one captured generation does prove generation-scoped absence"
+    );
+    assert!(
+        !generation.proves_repository_absence(),
+        "one captured generation is not the repository"
+    );
+}
+
+#[test]
+fn a_selected_aggregate_refuses_a_forged_duplicate_capture() {
+    // "Missing, extra, FORGED, or uncaptured inputs refuse". Two captures
+    // under one key are a forgery, and BTreeMap::from_iter would COLLAPSE the
+    // duplicate silently — the second entry vanishing rather than refusing.
+    let lease = a_lease("root-a");
+    let refusal = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SearchText),
+        vec![
+            lease.selection_receipt("project-a"),
+            lease.selection_receipt("project-b"),
+        ],
+        vec![
+            (
+                "project-a".to_string(),
+                lease.admit_generation().expect("gen"),
+            ),
+            (
+                "project-a".to_string(),
+                lease.admit_generation().expect("gen"),
+            ),
+        ],
+        Vec::new(),
+    )
+    .expect_err("a duplicate capture key is forged input and must refuse");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::InvalidSelection);
+}
+
+#[test]
+fn a_selected_aggregate_names_every_authority_it_retains() {
+    // authorities() yielded NOTHING for SelectedAggregate while
+    // authority_count() counted its generations — an aggregate that could not
+    // enumerate its own evidence. Both now come from one source of truth.
+    let lease = a_lease("root-a");
+    let provenance = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SearchText),
+        vec![lease.selection_receipt("project-a")],
+        vec![(
+            "project-a".to_string(),
+            lease.admit_generation().expect("gen"),
+        )],
+        vec![a_generation(&lease)],
+    )
+    .expect("bijection plus an additional authority is admitted");
+
+    assert_eq!(
+        provenance.authority_count(),
+        2,
+        "one captured generation plus one additional authority"
+    );
+    assert_eq!(
+        provenance.authorities().count(),
+        provenance.authority_count(),
+        "the enumeration and the count can never disagree"
+    );
+}
+
+#[test]
+fn a_selected_aggregate_refuses_an_empty_selection() {
+    // Global absence from zero selections would be a claim about everything
+    // derived from nothing. No lease is needed: the refusal happens before any
+    // evidence is examined.
+    let refusal = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SearchText),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
+    .expect_err("an empty selection proves nothing and must refuse");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::InvalidSelection);
+}
+
+#[test]
+fn a_selected_aggregate_refuses_a_foreign_root_authority() {
+    // Everything the aggregate retains composes into one claim, so an
+    // additional authority from another root is the same defect as a
+    // mixed-root derivation.
+    let lease = a_lease("root-a");
+    let foreign = a_lease("root-b");
+    let refusal = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SearchText),
+        vec![lease.selection_receipt("project-a")],
+        vec![(
+            "project-a".to_string(),
+            lease.admit_generation().expect("gen"),
+        )],
+        vec![a_generation(&foreign)],
+    )
+    .expect_err("a foreign-root additional authority must not compose");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::SourceUnavailable);
 }
 
 // ── The OperationContractV1 Cartesian ──────────────────────────────────────
@@ -214,30 +349,25 @@ fn a_selected_aggregate_admits_an_exact_bijection() {
 #[test]
 fn operation_contract_cartesian_matrix() {
     let lease = a_lease("root-a");
-    let operations = [
-        OperationKind::Retrieval,
-        OperationKind::Comparison,
-        OperationKind::Derivation,
-        OperationKind::SelectedAggregate,
-    ];
-    let kinds = [
-        SourceRefusalKind::AdmissionUnavailable,
-        SourceRefusalKind::InvalidSelection,
-        SourceRefusalKind::SelectionUnavailable,
-        SourceRefusalKind::SourceUnavailable,
-    ];
-    let advices = [
-        RetryAdvice::Never,
-        RetryAdvice::AfterRebind,
-        RetryAdvice::AfterRefresh,
-    ];
+    // The evidence a refusal names must be evidence that was EXAMINED — the
+    // first draft minted a fresh identity inside refuse itself, fabricating
+    // evidence that existed nowhere, and the oracle blessed it by asserting
+    // only is_some. The audit caught both halves.
+    let examined = lease
+        .observe_missing_path("src/gone.rs", ObservationTime::fresh())
+        .expect("missing path");
 
     let mut seen = 0usize;
-    for operation_kind in operations {
-        for kind in kinds {
-            for advice in advices {
+    for operation_kind in OperationKind::ALL {
+        for kind in [
+            SourceRefusalKind::AdmissionUnavailable,
+            SourceRefusalKind::InvalidSelection,
+            SourceRefusalKind::SelectionUnavailable,
+            SourceRefusalKind::SourceUnavailable,
+        ] {
+            for advice in RetryAdvice::ALL {
                 let operation = an_operation(operation_kind);
-                let refusal = lease.refuse(operation, kind, advice);
+                let refusal = lease.refuse(operation, kind, advice, Some(examined.identity()));
 
                 assert_eq!(
                     refusal.kind(),
@@ -259,9 +389,10 @@ fn operation_contract_cartesian_matrix() {
                     OperationReceipt::SCHEMA_VERSION,
                     "the receipt rides the one V11 schema"
                 );
-                assert!(
-                    refusal.evidence_identity().is_some(),
-                    "a refusal carries the identity of the evidence it refused on"
+                assert_eq!(
+                    refusal.evidence_identity(),
+                    Some(examined.identity()),
+                    "the refusal names the EXACT evidence that was examined"
                 );
                 seen += 1;
             }
@@ -269,19 +400,20 @@ fn operation_contract_cartesian_matrix() {
     }
 
     assert_eq!(
-        seen, 48,
-        "control: the full 4x4x3 operation-contract Cartesian was exercised"
+        seen,
+        7 * 4 * 4,
+        "control: the full operations x kinds x advices Cartesian was exercised"
     );
 }
 
-// ── Evaluation provenance accompanies observable ordering ─────────────────
+// ── Evaluation provenance accompanies observable ordering// ── Evaluation provenance accompanies observable ordering ─────────────────
 
 #[test]
 fn an_ordered_result_carries_evaluation_provenance_and_an_unordered_one_does_not() {
     let lease = a_lease("root-a");
 
     let ranked = Claim::single_ranked(
-        an_operation(OperationKind::Retrieval),
+        an_operation(OperationKind::SearchText),
         a_generation(&lease),
         vec!["a", "b"],
         EvaluationProvenance::for_test(),
@@ -292,7 +424,7 @@ fn an_ordered_result_carries_evaluation_provenance_and_an_unordered_one_does_not
     );
 
     let unordered = Claim::single(
-        an_operation(OperationKind::Retrieval),
+        an_operation(OperationKind::SearchText),
         a_generation(&lease),
         (),
     );
@@ -313,7 +445,7 @@ fn truncated_coverage_requires_a_completed_strict_lease() {
 
     let truncated = render.truncate(vec![(DerivedLimitKind::Cards, 3)]);
     assert!(
-        matches!(truncated, OutputCoverage::Truncated { .. }),
+        matches!(truncated, OutputCoverage::Truncated(_)),
         "bounded rendering after a completed lease may report truncation"
     );
 }
@@ -331,11 +463,11 @@ fn truncation_uses_the_live_limit_kinds_not_a_second_enum() {
         (DerivedLimitKind::AmbiguousSamples, 2),
     ]);
 
-    let OutputCoverage::Truncated { breaches } = truncated else {
+    let OutputCoverage::Truncated(breaches) = truncated else {
         panic!("expected a truncated coverage");
     };
     assert_eq!(
-        breaches.len(),
+        breaches.breaches().len(),
         2,
         "both production-only limit kinds survive into the breach record"
     );
@@ -348,35 +480,57 @@ fn truncated_coverage_never_enters_a_claim_identity() {
     let truncated = render.truncate(vec![(DerivedLimitKind::Output, 1)]);
 
     let claim = Claim::single(
-        an_operation(OperationKind::Retrieval),
+        an_operation(OperationKind::SearchText),
         a_generation(&lease),
         (),
     );
     let before = claim.provenance().identity();
-    let rendered = claim.render_bounded(truncated);
+    let rendered = claim.render_bounded(truncated.clone());
 
     assert_eq!(
         rendered.provenance().identity(),
         before,
-        "bounded rendering does not change generation completeness, so it must not \
-         move the provenance identity that caches, CCR, and persistence key on"
+        "bounded rendering must not move the provenance identity that caches, CCR,          and persistence key on"
+    );
+    // The other half, which makes this oracle falsifiable: the coverage is
+    // RETAINED on the claim. The first draft discarded the argument, so the
+    // identity assertion above could never fail under any code change.
+    assert_eq!(
+        rendered.rendered_coverage(),
+        Some(&truncated),
+        "the bounded render retains the coverage it was given"
     );
 }
 
-// ── Retrieval voice never selects consistency ─────────────────────────────
+// ── Retrieval voice and the frozen voice model ────────────────────────────
 
 #[test]
-fn the_knowledge_voice_filter_never_selects_consistency() {
-    let selectable =
-        symforge::protocol::format::claim_provenance::KnowledgeVoiceFilter::selectable_voices();
+fn the_knowledge_voice_filter_selects_the_default_set_and_no_history() {
+    // "Never selects consistency" is STRUCTURAL: the frozen KnowledgeVoice
+    // enum has no consistency variant at all, so no runtime value could
+    // violate it. What CAN be asserted is the frozen default selection:
+    // Current, Intent, NeedsReview, Unknown — including the
+    // current-implementation voice the first draft dropped — and never
+    // HistoryOnly or Suppressed. The first draft instead invented a
+    // Consistency variant and validated its own invention; the audit caught it.
+    use symforge::protocol::format::claim_provenance::{KnowledgeVoice, KnowledgeVoiceFilter};
 
-    assert!(
-        !selectable.iter().any(|voice| voice.is_consistency()),
-        "retrieval voice must never select consistency; that is authority hygiene, \
-         not a retrieval filter"
+    let selectable = KnowledgeVoiceFilter::selectable_voices();
+    assert_eq!(
+        selectable,
+        vec![
+            KnowledgeVoice::Current,
+            KnowledgeVoice::Intent,
+            KnowledgeVoice::NeedsReview,
+            KnowledgeVoice::Unknown,
+        ],
+        "the default selection is exactly the four frozen default voices"
     );
     assert!(
-        !selectable.is_empty(),
-        "control: the filter does select SOMETHING, so the assertion above is not vacuous"
+        !selectable.iter().any(|voice| matches!(
+            voice,
+            KnowledgeVoice::HistoryOnly | KnowledgeVoice::Suppressed
+        )),
+        "history voices never enter the default selection"
     );
 }

--- a/tests/claim_provenance_v11.rs
+++ b/tests/claim_provenance_v11.rs
@@ -17,12 +17,12 @@
 //! The four refusal KIND NAMES are identical across both documents, so these
 //! tests match on `kind()` and never destructure fields.
 
+use symforge::live_index::knowledge_bridge::DerivedLimitKind;
 use symforge::protocol::format::claim_provenance::{
     AtomicAuthority, Claim, ClaimInput, ClaimProvenance, ComparisonRelation, EvaluationProvenance,
     ObservationLease, OperationKind, OperationReceipt, OutputCoverage, PhysicalRootLease,
     RetryAdvice, SourceRefusalKind,
 };
-use symforge::live_index::knowledge_bridge::DerivedLimitKind;
 
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -45,7 +45,10 @@ fn every_authority_kind(lease: &ObservationLease) -> Vec<AtomicAuthority> {
         a_generation(lease),
         AtomicAuthority::DiskObservation(
             lease
-                .observe_missing_path("src/gone.rs", symforge::protocol::format::claim_provenance::ObservationTime::fresh())
+                .observe_missing_path(
+                    "src/gone.rs",
+                    symforge::protocol::format::claim_provenance::ObservationTime::fresh(),
+                )
                 .expect("missing path"),
         ),
         AtomicAuthority::WorktreeScopeObservation(
@@ -154,6 +157,33 @@ fn a_selected_aggregate_refuses_a_selection_without_its_generation() {
 }
 
 #[test]
+fn a_selected_aggregate_refuses_an_extra_unselected_generation() {
+    // The OTHER arm of the bijection. "Missing, extra, forged, or uncaptured
+    // inputs refuse" — data-model.md:1893. The missing-generation test above
+    // exercises containment; this one exercises the length guard, which is the
+    // only thing that catches a captured generation nobody selected. Found by
+    // mutation: disabling the length check alone survived the original suite.
+    let lease = a_lease("root-a");
+    let refusal = ClaimProvenance::selected_aggregate(
+        an_operation(OperationKind::SelectedAggregate),
+        vec![lease.selection_receipt("project-a")],
+        vec![
+            (
+                "project-a".to_string(),
+                lease.admit_generation().expect("gen"),
+            ),
+            (
+                "project-b".to_string(),
+                lease.admit_generation().expect("gen"),
+            ),
+        ],
+    )
+    .expect_err("an extra captured generation breaks the exact bijection");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::SelectionUnavailable);
+}
+
+#[test]
 fn a_selected_aggregate_admits_an_exact_bijection() {
     // GREEN-CONTROL: the refusal above is about the MISSING generation, not
     // about SelectedAggregate being unconstructible.
@@ -161,7 +191,10 @@ fn a_selected_aggregate_admits_an_exact_bijection() {
     let provenance = ClaimProvenance::selected_aggregate(
         an_operation(OperationKind::SelectedAggregate),
         vec![lease.selection_receipt("project-a")],
-        vec![("project-a".to_string(), lease.admit_generation().expect("gen"))],
+        vec![(
+            "project-a".to_string(),
+            lease.admit_generation().expect("gen"),
+        )],
     )
     .expect("an exact selection-to-generation bijection is admitted");
 
@@ -169,11 +202,24 @@ fn a_selected_aggregate_admits_an_exact_bijection() {
     assert_eq!(provenance.authority_count(), 1);
 }
 
-// ── The refusal Cartesian: every kind against every retry advice ───────────
+// ── The OperationContractV1 Cartesian ──────────────────────────────────────
 
+/// The name is pinned by the frozen traceability catalog:
+/// `contracts/lifecycle-oracle-traceability-v11.md` binds `TEST-PROVENANCE` to
+/// `tests/claim_provenance_v11.rs::operation_contract_cartesian_matrix`
+/// (CMD-PROVENANCE, owner T041, introduced_slice 3). The checker activates the
+/// pin the moment this FILE exists, so the test carries the contract-pinned
+/// name, not an invented one — and since the pinned name says OPERATION
+/// contract, the operation kind is an axis of the matrix, not a constant.
 #[test]
-fn every_refusal_kind_round_trips_with_every_retry_advice() {
+fn operation_contract_cartesian_matrix() {
     let lease = a_lease("root-a");
+    let operations = [
+        OperationKind::Retrieval,
+        OperationKind::Comparison,
+        OperationKind::Derivation,
+        OperationKind::SelectedAggregate,
+    ];
     let kinds = [
         SourceRefusalKind::AdmissionUnavailable,
         SourceRefusalKind::InvalidSelection,
@@ -187,27 +233,45 @@ fn every_refusal_kind_round_trips_with_every_retry_advice() {
     ];
 
     let mut seen = 0usize;
-    for kind in kinds {
-        for advice in advices {
-            let operation = an_operation(OperationKind::Retrieval);
-            let refusal = lease.refuse(operation, kind, advice);
+    for operation_kind in operations {
+        for kind in kinds {
+            for advice in advices {
+                let operation = an_operation(operation_kind);
+                let refusal = lease.refuse(operation, kind, advice);
 
-            assert_eq!(refusal.kind(), kind, "the refusal reports the kind it was built with");
-            assert_eq!(refusal.retry(), advice, "retry advice survives the round trip");
-            assert_eq!(
-                refusal.operation().operation_kind(),
-                OperationKind::Retrieval,
-                "every refusal names the operation that produced it"
-            );
-            assert!(
-                refusal.evidence_identity().is_some(),
-                "a refusal carries the identity of the evidence it refused on"
-            );
-            seen += 1;
+                assert_eq!(
+                    refusal.kind(),
+                    kind,
+                    "the refusal reports the kind it was built with"
+                );
+                assert_eq!(
+                    refusal.retry(),
+                    advice,
+                    "retry advice survives the round trip"
+                );
+                assert_eq!(
+                    refusal.operation().operation_kind(),
+                    operation_kind,
+                    "every refusal names the operation that produced it"
+                );
+                assert_eq!(
+                    refusal.operation().schema_version(),
+                    OperationReceipt::SCHEMA_VERSION,
+                    "the receipt rides the one V11 schema"
+                );
+                assert!(
+                    refusal.evidence_identity().is_some(),
+                    "a refusal carries the identity of the evidence it refused on"
+                );
+                seen += 1;
+            }
         }
     }
 
-    assert_eq!(seen, 12, "control: the full 4x3 Cartesian was exercised");
+    assert_eq!(
+        seen, 48,
+        "control: the full 4x4x3 operation-contract Cartesian was exercised"
+    );
 }
 
 // ── Evaluation provenance accompanies observable ordering ─────────────────
@@ -227,7 +291,11 @@ fn an_ordered_result_carries_evaluation_provenance_and_an_unordered_one_does_not
         "order is observable, so the ranking that produced it must be attributable"
     );
 
-    let unordered = Claim::single(an_operation(OperationKind::Retrieval), a_generation(&lease), ());
+    let unordered = Claim::single(
+        an_operation(OperationKind::Retrieval),
+        a_generation(&lease),
+        (),
+    );
     assert!(
         unordered.evaluation().is_none(),
         "no observable order means no ranking to attribute"
@@ -279,7 +347,11 @@ fn truncated_coverage_never_enters_a_claim_identity() {
     let render = lease.completed_render_authority().expect("completed lease");
     let truncated = render.truncate(vec![(DerivedLimitKind::Output, 1)]);
 
-    let claim = Claim::single(an_operation(OperationKind::Retrieval), a_generation(&lease), ());
+    let claim = Claim::single(
+        an_operation(OperationKind::Retrieval),
+        a_generation(&lease),
+        (),
+    );
     let before = claim.provenance().identity();
     let rendered = claim.render_bounded(truncated);
 
@@ -295,7 +367,8 @@ fn truncated_coverage_never_enters_a_claim_identity() {
 
 #[test]
 fn the_knowledge_voice_filter_never_selects_consistency() {
-    let selectable = symforge::protocol::format::claim_provenance::KnowledgeVoiceFilter::selectable_voices();
+    let selectable =
+        symforge::protocol::format::claim_provenance::KnowledgeVoiceFilter::selectable_voices();
 
     assert!(
         !selectable.iter().any(|voice| voice.is_consistency()),

--- a/tests/read_gate_authority_v11.rs
+++ b/tests/read_gate_authority_v11.rs
@@ -1,0 +1,302 @@
+//! Feature 020 V11, T042 — cross-authority proof scoping.
+//!
+//! RED until T043 exists. Every test here pins ONE frozen rule: an authority
+//! proves exactly what it observed, and no local negative can be widened into a
+//! generation-wide or repository-wide claim.
+//!
+//! `data-model.md:1874-1881` states the property this file enforces:
+//! "`DiskObservationReceipt::PathMissing` is path-local at `observed_at` under
+//! the retained parent; `GitObservationReceipt::NotInTree` is tree-local for its
+//! exact immutable `tree_id`; and a complete worktree-scope receipt may support
+//! absence only inside its declared scope and start/end interval. Generation
+//! `NotInGeneration` is limited to one complete captured generation.
+//! Repository/global no-match or absence is legal only through
+//! `SelectedAggregate` ... None of the local negative receipts can be widened
+//! into generation or global absence."
+//!
+//! API surface follows `contracts/public-api-v11.json` `introduced_v11_atoms`,
+//! NOT the `data-model.md` prose, because the atoms are what
+//! `expected_graph.activation_rule` refuses on. See D9 in
+//! `docs/reviews/SLICE3-RECON-FINDINGS-v11.md`. Refusals are matched on
+//! `kind()`; the four kind names are identical in both documents.
+
+use symforge::protocol::format::claim_provenance::{
+    AtomicAuthority, Claim, ClaimInput, DiskObservationReceipt, GenerationAuthority,
+    GitObservationReceipt, ObservationTime, OperationKind, OperationReceipt, SourceRefusal,
+    SourceRefusalKind, WorktreeObservationScope, WorktreeScopeObservationReceipt,
+};
+use symforge::protocol::format::claim_provenance::{ObservationLease, PhysicalRootLease};
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+// Local to this file, following the Slice 2 oracle files: each pins its own
+// fixtures rather than sharing a support crate, so a fixture change cannot
+// silently retarget an unrelated oracle.
+
+fn observed_now() -> ObservationTime {
+    ObservationTime::fresh()
+}
+
+/// A lease that owns one physical root, which is what every observation
+/// receipt requires before it can be constructed at all.
+fn a_binding_on(root: &str) -> ObservationLease {
+    ObservationLease::for_test_root(PhysicalRootLease::for_test_root(root))
+}
+
+fn a_second_root(root: &str) -> ObservationLease {
+    a_binding_on(root)
+}
+
+fn a_missing_path(
+    lease: &ObservationLease,
+    path: &str,
+    observed_at: ObservationTime,
+) -> DiskObservationReceipt {
+    lease
+        .observe_missing_path(path, observed_at)
+        .expect("a lease that owns its root may record a missing path")
+}
+
+fn a_complete_worktree_scan(
+    lease: &ObservationLease,
+    scope: &str,
+) -> WorktreeScopeObservationReceipt {
+    lease
+        .complete_scope_scan(WorktreeObservationScope::beneath(scope))
+        .expect("a complete traversal seals a scope receipt")
+}
+
+fn a_git_tree_miss(tree_id: &str, path: &str) -> GitObservationReceipt {
+    GitObservationReceipt::not_in_tree(tree_id, path)
+}
+
+fn an_admitted_generation(lease: &ObservationLease) -> GenerationAuthority {
+    lease
+        .admit_generation()
+        .expect("a lease that owns its root may capture a complete generation")
+}
+
+fn an_operation() -> OperationReceipt {
+    OperationReceipt::for_test(OperationKind::Comparison)
+}
+
+/// Derive one claim from two leases, which is the seam where root
+/// compatibility is decided.
+fn derive_across(left: &ObservationLease, right: &ObservationLease) -> Result<Claim<()>, SourceRefusal> {
+    Claim::derive(
+        an_operation(),
+        [
+            ClaimInput::Authority(AtomicAuthority::Generation(an_admitted_generation(left))),
+            ClaimInput::Authority(AtomicAuthority::Generation(an_admitted_generation(right))),
+        ],
+        (),
+    )
+}
+
+// ── Disk observation: path-local, and only at its own instant ───────────────
+
+#[test]
+fn a_missing_path_proves_only_that_path_at_that_moment() {
+    let binding = a_binding_on("root-a");
+    let observed_at = observed_now();
+    let receipt = a_missing_path(&binding, "src/gone.rs", observed_at);
+
+    assert!(
+        receipt.proves_path_local_absence(),
+        "a PathMissing receipt must prove the absence it actually observed"
+    );
+    assert_eq!(
+        receipt.observed_at(),
+        observed_at,
+        "the proof is pinned to the instant of observation, not to read time"
+    );
+    assert_eq!(
+        receipt.path(),
+        "src/gone.rs",
+        "the proof names the exact path it observed"
+    );
+}
+
+#[test]
+fn a_missing_path_never_proves_generation_absence() {
+    let binding = a_binding_on("root-a");
+    let receipt = a_missing_path(&binding, "src/gone.rs", observed_now());
+
+    assert!(
+        !receipt.proves_generation_absence(),
+        "a path-local miss must not widen into 'absent from the generation'"
+    );
+    assert!(
+        !receipt.proves_repository_absence(),
+        "a path-local miss must not widen into 'absent from the repository'"
+    );
+}
+
+// ── Worktree scope: sealed scope and sealed interval ────────────────────────
+
+#[test]
+fn a_complete_worktree_scan_proves_absence_only_inside_its_own_scope() {
+    let binding = a_binding_on("root-a");
+    let scan = a_complete_worktree_scan(&binding, "src/");
+
+    assert!(
+        scan.proves_absence_within_scope("src/gone.rs"),
+        "a COMPLETE scan proves absence inside the scope it sealed"
+    );
+    assert!(
+        !scan.proves_absence_within_scope("docs/gone.md"),
+        "a scan of src/ proves nothing about docs/"
+    );
+    assert!(
+        !scan.proves_generation_absence(),
+        "a sealed scope is not a generation"
+    );
+    assert!(
+        !scan.proves_repository_absence(),
+        "a sealed scope is not the repository"
+    );
+}
+
+#[test]
+fn a_worktree_scan_proves_nothing_outside_its_observation_interval() {
+    let binding = a_binding_on("root-a");
+    let scan = a_complete_worktree_scan(&binding, "src/");
+    let cut = scan.observation_cut();
+
+    assert!(
+        !scan.proves_absence_after(cut.end_seq()),
+        "absence is claimed only up to the sealed end of the interval"
+    );
+    assert!(
+        !scan.proves_absence_before(cut.start_seq()),
+        "absence is claimed only from the sealed start of the interval"
+    );
+}
+
+// ── Git observation: tree-local, for one immutable tree ─────────────────────
+
+#[test]
+fn a_git_tree_miss_proves_absence_only_for_that_exact_tree() {
+    let miss = a_git_tree_miss("tree-1", "src/gone.rs");
+
+    assert!(
+        miss.proves_absence_in_tree("tree-1"),
+        "NotInTree proves non-membership of the tree it names"
+    );
+    assert!(
+        !miss.proves_absence_in_tree("tree-2"),
+        "a different tree is a different immutable object and is not covered"
+    );
+    assert!(
+        !miss.proves_generation_absence(),
+        "a git tree is not the generation"
+    );
+    assert!(
+        !miss.proves_repository_absence(),
+        "one tree is not the whole repository across all history"
+    );
+}
+
+// ── The closed property, stated once over every local negative ─────────────
+
+#[test]
+fn no_local_negative_receipt_can_be_widened_to_repository_absence() {
+    let binding = a_binding_on("root-a");
+    let locals: Vec<AtomicAuthority> = vec![
+        AtomicAuthority::DiskObservation(a_missing_path(&binding, "src/gone.rs", observed_now())),
+        AtomicAuthority::WorktreeScopeObservation(a_complete_worktree_scan(&binding, "src/")),
+        AtomicAuthority::GitObservation(a_git_tree_miss("tree-1", "src/gone.rs")),
+    ];
+
+    for authority in &locals {
+        assert!(
+            !authority.proves_repository_absence(),
+            "{} must not prove repository-wide absence",
+            authority.kind_name()
+        );
+        assert!(
+            !authority.proves_generation_absence(),
+            "{} must not prove generation-wide absence",
+            authority.kind_name()
+        );
+    }
+
+    // Anti-vacuity: the loop really did examine three distinct authorities.
+    let mut kinds: Vec<&'static str> = locals.iter().map(|a| a.kind_name()).collect();
+    kinds.sort_unstable();
+    kinds.dedup();
+    assert_eq!(
+        kinds.len(),
+        3,
+        "control: three DISTINCT local negative authorities were checked"
+    );
+}
+
+// ── Root compatibility ─────────────────────────────────────────────────────
+
+#[test]
+fn a_derivation_across_two_roots_is_refused_rather_than_composed() {
+    let left = a_binding_on("root-a");
+    let right = a_second_root("root-b");
+    let refusal = derive_across(&left, &right)
+        .expect_err("inputs bound to different physical roots must not compose");
+
+    assert_eq!(
+        refusal.kind(),
+        SourceRefusalKind::SourceUnavailable,
+        "a mixed-root derivation is refused as unavailable, never silently joined"
+    );
+}
+
+#[test]
+fn a_derivation_within_one_root_is_admitted() {
+    // GREEN-CONTROL for the rule above: the refusal is about root MISMATCH,
+    // not about derivation being refused in general.
+    let binding = a_binding_on("root-a");
+    let claim = derive_across(&binding, &binding).expect("one root must compose");
+
+    assert_eq!(
+        claim.provenance().authority_count(),
+        2,
+        "both inputs are retained in the provenance, not collapsed"
+    );
+}
+
+// ── A failed pure observation refuses; it does not invalidate the source ───
+
+#[test]
+fn a_failed_observation_refuses_without_disturbing_the_current_generation() {
+    let binding = a_binding_on("root-a");
+    let generation = an_admitted_generation(&binding);
+    let before = generation.identity();
+
+    let refusal = a_missing_path(&binding, "src/gone.rs", observed_now())
+        .into_failed_read()
+        .expect_err("a failed pure observation returns a typed refusal");
+
+    assert_eq!(
+        refusal.kind(),
+        SourceRefusalKind::SourceUnavailable,
+        "the failure is reported as typed refusal rather than as absence"
+    );
+    assert_eq!(
+        generation.identity(),
+        before,
+        "a pure observation failure must not invalidate the Current generation; \
+         only the observer seam may do that, on its own independent evidence"
+    );
+}
+
+// ── The one authority that MAY prove global absence ────────────────────────
+
+#[test]
+fn only_a_selected_aggregate_may_prove_repository_wide_absence() {
+    let binding = a_binding_on("root-a");
+    let aggregate = an_admitted_generation(&binding).into_selected_aggregate();
+
+    assert!(
+        aggregate.proves_repository_absence(),
+        "GREEN-CONTROL: SelectedAggregate is the ONE constructor for global absence, \
+         so the negative assertions above are about scope and not about a type that \
+         can never prove anything"
+    );
+}

--- a/tests/read_gate_authority_v11.rs
+++ b/tests/read_gate_authority_v11.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "server")]
 //! Feature 020 V11, T042 — cross-authority proof scoping.
 //!
 //! RED until T043 exists. Every test here pins ONE frozen rule: an authority
@@ -76,7 +77,7 @@ fn an_admitted_generation(lease: &ObservationLease) -> GenerationAuthority {
 }
 
 fn an_operation() -> OperationReceipt {
-    OperationReceipt::for_test(OperationKind::Comparison)
+    OperationReceipt::for_test(OperationKind::SearchText)
 }
 
 /// Derive one claim from two leases, which is the seam where root
@@ -273,7 +274,7 @@ fn a_failed_observation_refuses_without_disturbing_the_current_generation() {
     let before = generation.identity();
 
     let refusal = a_missing_path(&binding, "src/gone.rs", observed_now())
-        .into_failed_read()
+        .into_failed_read(an_operation())
         .expect_err("a failed pure observation returns a typed refusal");
 
     assert_eq!(

--- a/tests/read_gate_authority_v11.rs
+++ b/tests/read_gate_authority_v11.rs
@@ -290,6 +290,80 @@ fn a_failed_observation_refuses_without_disturbing_the_current_generation() {
     );
 }
 
+// ── Context acquisition: rebinds refuse rather than composing roots ────────
+
+#[test]
+fn a_rebind_between_input_acquisitions_is_refused() {
+    use symforge::protocol::format::claim_provenance::acquire_claim_context;
+
+    // Two inputs captured under two different roots is what a rebind between
+    // acquisitions looks like from the context's side. CloseSource acts on
+    // exactly one source, so the closed contract permits no cross-source
+    // relation and the acquisition must refuse rather than compose.
+    let before = a_binding_on("root-a");
+    let after = a_binding_on("root-b");
+    let refusal = acquire_claim_context(
+        OperationReceipt::for_test(OperationKind::CloseSource),
+        vec![
+            before.context_input("project-a", "repo-1", None),
+            after.context_input("project-a", "repo-1", None),
+        ],
+    )
+    .expect_err("a root drift between acquisitions is a rebind and must refuse");
+
+    assert_eq!(refusal.kind(), SourceRefusalKind::SourceUnavailable);
+}
+
+#[test]
+fn a_cross_source_search_admits_two_roots_deliberately() {
+    use symforge::protocol::format::claim_provenance::acquire_claim_context;
+
+    // GREEN-CONTROL for the rebind refusal: search is the closed contract's
+    // explicit cross-source relation, so two roots compose HERE and only here.
+    let left = a_binding_on("root-a");
+    let right = a_binding_on("root-b");
+    let context = acquire_claim_context(
+        OperationReceipt::for_test(OperationKind::SearchText),
+        vec![
+            left.context_input(
+                "project-a",
+                "repo-1",
+                Some(left.current_query_lease().expect("lease")),
+            ),
+            right.context_input(
+                "project-b",
+                "repo-2",
+                Some(right.current_query_lease().expect("lease")),
+            ),
+        ],
+    )
+    .expect("the contract explicitly permits a cross-source search");
+
+    assert!(context.permitted_relationships().cross_source_permitted());
+    assert_eq!(context.inputs().len(), 2);
+}
+
+#[test]
+fn a_returned_context_retains_what_it_captured() {
+    use symforge::protocol::format::claim_provenance::acquire_claim_context;
+
+    // "A rebind after the complete context is returned does not trigger a
+    // trailing live-state check; claims derived wholly from its retained
+    // authorities remain valid." The retained half is falsifiable today: the
+    // context reports exactly the roots and sources captured at acquisition.
+    let lease = a_binding_on("root-a");
+    let context = acquire_claim_context(
+        OperationReceipt::for_test(OperationKind::CloseSource),
+        vec![lease.context_input("project-a", "repo-1", None)],
+    )
+    .expect("one source, one root");
+
+    let input = &context.inputs()[0];
+    assert_eq!(input.root(), "root-a");
+    assert_eq!(input.project_source(), "project-a");
+    assert_eq!(input.repository_id(), "repo-1");
+}
+
 // ── The one authority that MAY prove global absence ────────────────────────
 
 #[test]

--- a/tests/read_gate_authority_v11.rs
+++ b/tests/read_gate_authority_v11.rs
@@ -81,7 +81,10 @@ fn an_operation() -> OperationReceipt {
 
 /// Derive one claim from two leases, which is the seam where root
 /// compatibility is decided.
-fn derive_across(left: &ObservationLease, right: &ObservationLease) -> Result<Claim<()>, SourceRefusal> {
+fn derive_across(
+    left: &ObservationLease,
+    right: &ObservationLease,
+) -> Result<Claim<()>, SourceRefusal> {
     Claim::derive(
         an_operation(),
         [


### PR DESCRIPTION
## What this is

Feature 020 V11, Slice 3, PR 1 of 4: tasks T041 + T042 + T043 — the sealed provenance type surface, its oracles, and the shared identity counter. Production behavior is untouched: nothing calls the new module, and the census proves it below.

Four branch commits plus the main merge, deliberately not squashed locally:

1. `cdb3ff20` — T041/T042 oracles written first and **observed RED**: five errors, every one `E0432/E0433 could not find claim_provenance in format`, recorded verbatim in the evidence doc because this branch history collapses at squash-merge.
2. `225b18bf` — the types. `src/protocol/claim_provenance.rs` plus `src/lifecycle_identity.rs`, the shared counter extracted from `index_lifecycle/authority.rs` so provenance and lifecycle mint from ONE identity space with no `protocol → index_lifecycle` call edge.
3. `c658ef8e` + `cacffaa4` — nine findings from a five-agent adversarial audit closed, then `ClaimContext` / `acquire_claim_context` through the closed operation contract.

## What the audit caught before you had to

The headline: `OutputCoverage::Truncated` was **forgeable while documented as sealed** — a pub struct variant constructible anywhere with no authority. It now carries an opaque `TruncationBreaches` payload; the only producer is `CompletedRenderAuthority::truncate`. Also fixed: two enums that violated the module's own atoms-win rule, a fabricated evidence identity, a discarded coverage argument that made its own oracle unfalsifiable, an invented `KnowledgeVoice::Consistency` variant, and a `SelectedAggregate` that counted authorities it could not enumerate.

## Mutation ledger

Ten guard mutations across T043. Nine caught by a named oracle alone on the first pass. One **survived** — disabling only the length half of the bijection — which exposed a missing oracle for the extra-generation arm of "missing, extra, forged, or uncaptured inputs refuse"; the new test was written while the mutant was live, observed catching it, and kept. Full table in `docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md`.

## Census and contract proofs

- All five retirement-closure digests re-emitted **byte-identical**; the traceability checker reports OK. The module anchors from `format.rs` via `#[path]` — not `protocol/mod.rs`, which is in the `publication_roots` closure set and whose `read_gate` is crate-private.
- `pub(crate) mod lifecycle_identity` in `lib.rs` adds **no public-API atom** — the census counts only plain `pub mod` lines.
- The traceability catalog's pinned name `operation_contract_cartesian_matrix` exists and the pinned command passes verbatim under `--exact`.
- Where the two frozen documents disagree, the atoms win — recorded as D9, with D10–D15 recording every deliberate deferral, including the two T048 must-not-forget items: this module is mounted under `protocol::format`, not `embed::*`, and `LimitBreach` leaks through `TruncationBreaches`.

## Verification

| Gate | Result |
|---|---|
| T041/T042 pre-types | observed RED, all errors naming the missing module |
| oracle files | 34 passed, 0 failed |
| guard mutations | 10 flipped, 10 caught, 0 unexplained |
| `cargo test --all-targets` | exited cleanly, 506s, zero failure signals |
| embed gate | 1332 passed, 0 failed |
| `clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| five closure digests | byte-identical |
| traceability checker | OK — 78 requirements, 24 oracles, 13 categories |

## Not in this PR

T044–T052 land as PRs 2–4 per the plan: the read-gate authority split and lane migration regenerate closure digests deliberately; the dark runtime and activation matrix follow. `completed_render_authority` and its sibling lease constructors return unconditional `Ok` as recorded stand-ins — the seal is the type, the refusing evidence is Slice 4, and the evidence doc forbids "completing" them with fake checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

