### PR TITLE
feat(feature-020): Slice 3 PR 2 — named read stores and single-capture seams

### DIFF
--- a/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
+++ b/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
@@ -26,7 +26,7 @@ This detached attestation binds the refreeze manifest to the exact baseline, des
   "kind": "symforge-feature-020-refreeze-attestation",
   "manifest": {
     "path": "specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md",
-    "sha256": "54bb000e7e64940b4e2db4257e67efea4ebe29570d53e491ae5a921ad0101003"
+    "sha256": "60f33e09dfa8678c049411d96db998ad55d76eb25e54516ef8eff69ad599feee"
   },
   "public_api": {
     "canonical_sha256": "c45f3cd3f77e5690ad1dcd2e5fc7e39e30d52df38fa564d7b663e1c95823a7da",

--- a/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
+++ b/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
@@ -26,7 +26,7 @@ This detached attestation binds the refreeze manifest to the exact baseline, des
   "kind": "symforge-feature-020-refreeze-attestation",
   "manifest": {
     "path": "specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md",
-    "sha256": "60f33e09dfa8678c049411d96db998ad55d76eb25e54516ef8eff69ad599feee"
+    "sha256": "e1d083d338d4bae9dd3ff9a110acd1ed5fd83030480eaff822af04f0ae1bc9a9"
   },
   "public_api": {
     "canonical_sha256": "c45f3cd3f77e5690ad1dcd2e5fc7e39e30d52df38fa564d7b663e1c95823a7da",

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -46,7 +46,58 @@ envelope oracle; clippy all targets denied warnings clean; embed 1332 passed
 0 failed; fmt clean. The checker still reports the expected `writers`-only
 mismatch; the single regeneration waits for PR 2's end.
 
-## T044 — the authority choice is explicit (PR 2)
+## T046 — per-caller single capture, and the one regeneration (PR 2)
+
+Every approved site now takes ONE `published_generation()` capture at entry and
+reads every axis — live rows, freshness, health counts, temporal, outline —
+off that capture, which is possible because every accessor already resolves
+through the bundle; the defect was per-call re-loading, not field scatter.
+
+Migrated: `health_for_runtime` and `health_compact_for_runtime` (four loads
+each → one), daemon `project_health` (freshness now describes the same
+publication as the counts beside it), the daemon call-evidence block and
+`local_project_evidence` (generation number, load_source, counts, and state
+all off `current_generation()`; the atomic counter is no longer a side
+channel), `search_symbols`, `search_text` (handler + renderer share the
+caller's capture through a new parameter), `search_files` (13 loads → 1),
+`find_references` (11 → 1), `append_impact_footer`, `edit_plan`, and
+`analyze_file_impact`, whose capture is taken BEFORE the sidecar await so the
+co-change footer describes a publication the impact result actually saw.
+`terminal_dispositions` was re-rooted from the raw `live` field onto the
+bundle, closing the store-order window where new content could pair with the
+old publication. The write-only `published_repo_outline` ArcSwap field was
+deleted after re-verifying zero loads on the current HEAD; the accessor and
+both its tests read the bundle and keep working.
+
+Left alone, by prior agreement: the read-MUTATE-read publish paths, watcher
+reconcile, Tier-3 mutex-held store functions, `what_changed` — same class as
+the search tools, recorded as OUT of this PR rather than silently expanded —
+and the `scout_plan` / `source_exclusions` / `project_state_dir` ArcSwaps,
+which the bundle has no fields for.
+
+Behavior neutrality: the full library suite passed 3166 to 0 with ZERO test
+adjustments — the RISK-B worry that tests pinned torn interleavings did not
+materialize, and the Slice-0 root-split oracle got strictly stronger and
+stayed green.
+
+**The one regeneration — prediction versus measurement.** The PR 2
+first-commit decision predicted FIVE categories dirty. Measured at the end:
+FOUR moved, `ccr` byte-identical, because CCR was trimmed out of T045 batch
+two by review. The regen updates exactly the four that moved:
+
+| category | before | after |
+|---|---|---|
+| writers | `5137cd7b…3af7dd` | `bafa517a…daeee1` |
+| callbacks | `48938137…97e8b22` | `026c548b…fe577b` |
+| publication_roots | `e37555ad…61e82d` | `b90b8d88…190b54` |
+| cache | `4eb220e8…5c18a38` | `6fb4cace…14fa095` |
+| ccr | `8ad77748…84ad246` | UNCHANGED |
+
+The checker's own second-order pin (`FROZEN_DIGESTS.retirement_records`) was
+regenerated through its emit opt-in the same way: old `4c118fab…76a6fb`, new
+`313dceda…9c21bf`. Checker reports OK after both.
+
+## T044 — the authority choice is explicit (PR 2)## T044 — the authority choice is explicit (PR 2)
 
 Observed RED first: both oracles failed `E0432` naming exactly the three new
 seam items and nothing else. Then the seam, in `src/protocol/read_gate.rs`,

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -1,5 +1,51 @@
 # Feature 020 Slice 3 evidence (T041–T052)
 
+## T045 — the lanes and the measured envelope (PR 2)
+
+**Batch one** routed the three disk lanes through `observe_disk_beneath` and
+closed D8 by routing `detect_impact`'s base seed through `admit_git_text`,
+deleting the tripwire's sentinel allowlist outright. The `writers` drift was
+OBSERVED, not assumed: the checker was run after the first `tools.rs` edit and
+reported `RETIREMENT_CLOSURE_MISMATCH` for `writers` and for `writers` alone.
+
+**Batch two — the forgeable envelope axis.** `format_search_envelope` collapsed
+to the compact `Trust:` banner on `source_authority == "current index"` — a
+string equality any caller could satisfy by assertion. Two lanes did exactly
+that: the context bundle passed the literal whenever it had not disk-refreshed,
+and `what_changed`'s Timestamp arm passed it unconditionally — both collapsing
+the envelope while the index could be Verifying or Degraded. The second lane
+was found by the COMPILER during the migration, not by the census.
+
+The collapse now rides on `SourceAuthority`, a type honest by construction:
+`from_freshness` is the only constructor that can produce a collapsible value
+and it takes the index's measured `FreshnessStatus`; `never_collapse` covers
+disk-refreshed, composite, and git authorities whose labels are display only.
+A lying literal is UNREPRESENTABLE — no constructor accepts a caller-chosen
+string and marks it collapsible. Behavior is byte-identical for measured
+Current and for every already-loud lane; the sanctioned change is that the two
+asserting lanes now go loud with the honest label when freshness is not
+Current. Composite labels keep their existing text, including the recorded
+wart that they say "current" unconditionally — a text change was not in scope.
+
+Mutation M13 flipped the Degraded arm to collapsible and was caught by
+`a_measured_degraded_authority_never_collapses_however_clean_the_rest_is`
+alone, then restored. Twelve mutations across the slice: eleven caught by
+name, one survivor that forced its oracle, one guard proven structural.
+
+**D16 — `ProjectEvidence` and the structured `_meta` surface stay untyped in
+this PR, deliberately.** The MCP `_meta` object already carries an untyped
+provenance record with `generation` / `load_source` / `index_state`. Replacing
+it with `Claim`/`ClaimProvenance` is a client-visible schema change, not a
+read-gate migration, and no frozen atom requires it preactivation. Recorded
+here next to D12/D13 as T048/structured-activation work: the competitor is
+untyped strings versus the provenance types, and the swap belongs to the
+activation surface, not to T045's task-text word "structured".
+
+Gates on the batch-two tree: lib suite 3166 passed 0 failed including the new
+envelope oracle; clippy all targets denied warnings clean; embed 1332 passed
+0 failed; fmt clean. The checker still reports the expected `writers`-only
+mismatch; the single regeneration waits for PR 2's end.
+
 ## T044 — the authority choice is explicit (PR 2)
 
 Observed RED first: both oracles failed `E0432` naming exactly the three new

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -89,17 +89,26 @@ first-commit decision predicted FIVE categories dirty. Measured at the end:
 FOUR moved, `ccr` byte-identical, because CCR was trimmed out of T045 batch
 two by review. The regen updates exactly the four that moved:
 
-| category | before | after |
-|---|---|---|
-| writers | `5137cd7b…3af7dd` | `bafa517a…daeee1` |
-| callbacks | `48938137…97e8b22` | `026c548b…fe577b` |
-| publication_roots | `e37555ad…61e82d` | `b90b8d88…190b54` |
-| cache | `4eb220e8…5c18a38` | `6fb4cace…14fa095` |
-| ccr | `8ad77748…84ad246` | UNCHANGED |
+| category | before | first regen | after re-crank (HEAD) |
+|---|---|---|---|
+| writers | `5137cd7b…3af7dd` | `bafa517a…daeee1` | `565e4227…bf3e31` |
+| callbacks | `48938137…97e8b22` | `026c548b…fe577b` | unchanged |
+| publication_roots | `e37555ad…61e82d` | `b90b8d88…190b54` | unchanged |
+| cache | `4eb220e8…5c18a38` | `6fb4cace…14fa095` | unchanged |
+| ccr | `8ad77748…84ad246` | UNCHANGED | unchanged |
 
 The checker's own second-order pin (`FROZEN_DIGESTS.retirement_records`) was
-regenerated through its emit opt-in the same way: old `4c118fab…76a6fb`, new
-`313dceda…9c21bf`. Checker reports OK after both.
+regenerated through its emit opt-in the same way: `4c118fab…76a6fb` →
+`313dceda…9c21bf` at the first regen, → `d86bd17b…e5ce29` after the
+re-crank. Checker reports OK after each.
+
+**Correction, on review.** The re-crank commit's message claimed "the
+evidence table now carries the final writers value" while touching only the
+contract and the checker — the table had NOT been updated, which is the same
+reporting class as a stale pin: the thing that reported was not the thing
+that knew. This row-level history is the repair, added as a docs-only commit
+after the full suite went green on the re-cranked tree, so the receipt and
+the table describe the same HEAD.
 
 ## T044 — the authority choice is explicit (PR 2)
 

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -1,5 +1,41 @@
 # Feature 020 Slice 3 evidence (T041–T052)
 
+## T044 — the authority choice is explicit (PR 2)
+
+Observed RED first: both oracles failed `E0432` naming exactly the three new
+seam items and nothing else. Then the seam, in `src/protocol/read_gate.rs`,
+on the policy/bytes/git/disk split #571 carved:
+
+- `resolve_generation_bytes` — serves `IndexedFile.content`, the bytes the
+  generation PUBLISHED. **The defect it exists to prevent is structurally
+  unrepresentable in it**: the function takes no workspace root, so an
+  in-function disk backfill cannot even locate a file, and its return borrows
+  from the index, so owned disk bytes cannot be returned without a deliberate
+  leak. This is recorded INSTEAD of a mutation for the never-reads-disk
+  guard, because the only writable mutant is one whose `fs::read` cannot find
+  the fixture and therefore survives for reasons unrelated to the property —
+  a theatrical mutant would be evidence-shaped noise. The oracle still pins
+  the behavior: published bytes survive a disk rewrite, and an unindexed
+  file resolves `NotInGeneration`, never disk content.
+- `observe_disk_beneath` — the deliberate lane, lexically confined beneath
+  the workspace root, refusing absolute paths, prefixes, and `..` components
+  BEFORE any read; the refusal never carries escaped content. Symlink policy
+  deliberately remains the crate's existing never-follow walk; the ceiling
+  and upgrade path are marked in the code.
+- Both re-exported through `claim_provenance` the same way as the identities,
+  because `read_gate` is crate-private and the oracles are a separate crate.
+  No `protocol/mod.rs` edit; no census atom.
+
+Mutation M12 — confinement disabled — caught by
+`a_disk_observation_is_confined_beneath_its_root` alone, restored. Eleven
+mutations across the slice so far: ten caught by name, one survivor that
+forced a new oracle, plus one guard proven structural rather than mutated.
+
+Gates on the T044 tree: oracle files 36 passed 0 failed; clippy all targets
+denied warnings clean; embed 1332 passed 0 failed; fmt clean; traceability
+OK; all five closure digests byte-identical — T044 touched only uncensused
+files, per the PR 2 first-commit decision.
+
 Living document for the slice; T052 completes it. Every claim here was observed,
 not inferred. Where a command is cited, it was run on the named tree.
 

--- a/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md
@@ -43,8 +43,9 @@ activation surface, not to T045's task-text word "structured".
 
 Gates on the batch-two tree: lib suite 3166 passed 0 failed including the new
 envelope oracle; clippy all targets denied warnings clean; embed 1332 passed
-0 failed; fmt clean. The checker still reports the expected `writers`-only
-mismatch; the single regeneration waits for PR 2's end.
+0 failed; fmt clean. At the time batch two landed, the checker reported the
+expected `writers`-only mismatch; the regeneration has since HAPPENED — the
+T046 section's before/after table is the truth, and the pins are clean.
 
 ## T046 — per-caller single capture, and the one regeneration (PR 2)
 
@@ -58,7 +59,10 @@ each → one), daemon `project_health` (freshness now describes the same
 publication as the counts beside it), the daemon call-evidence block and
 `local_project_evidence` (generation number, load_source, counts, and state
 all off `current_generation()`; the atomic counter is no longer a side
-channel), `search_symbols`, `search_text` (handler + renderer share the
+channel — including `runtime_status_for`, whose reported project-generation
+is now a caller-supplied parameter: the health pair passes its captured
+bundle's value, and the two capture-less callers pass the atomic EXPLICITLY,
+named at the site), `search_symbols`, `search_text` (handler + renderer share the
 caller's capture through a new parameter), `search_files` (13 loads → 1),
 `find_references` (11 → 1), `append_impact_footer`, `edit_plan`, and
 `analyze_file_impact`, whose capture is taken BEFORE the sidecar await so the
@@ -97,7 +101,7 @@ The checker's own second-order pin (`FROZEN_DIGESTS.retirement_records`) was
 regenerated through its emit opt-in the same way: old `4c118fab…76a6fb`, new
 `313dceda…9c21bf`. Checker reports OK after both.
 
-## T044 — the authority choice is explicit (PR 2)## T044 — the authority choice is explicit (PR 2)
+## T044 — the authority choice is explicit (PR 2)
 
 Observed RED first: both oracles failed `E0432` naming exactly the three new
 seam items and nothing else. Then the seam, in `src/protocol/read_gate.rs`,

--- a/docs/reviews/FEATURE-020-SLICE3-PLAN-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE3-PLAN-v11.md
@@ -215,6 +215,48 @@ Consequences the plan binds:
   UNCENSUSED parent — see the PR 1 section. Add the `mod` line to
   `src/protocol/mod.rs` and PR 1 moves `publication_roots`.
 
+## PR 2 FIRST-COMMIT DECISION — five digests regenerate, not four
+
+Made here, before any PR 2 code, per the rule that a digest regeneration is a
+deliberate act and never a gate-time discovery. Grounds are the two recon
+censuses, both verified against code at the time they ran:
+
+**The answer is FIVE.** T046's read-site migration necessarily spills beyond
+`store.rs` into `src/daemon.rs`, `src/watcher/mod.rs`, `src/live_index/persist.rs`,
+and `src/live_index/git_temporal.rs` — all four inside the `callbacks` closure
+path list — because the torn readers live at the call sites, not in the store.
+The Tier-1 torn readers alone (`health_for_runtime`, `health_compact_for_runtime`,
+`DaemonState::project_health`, the search-tool trust banners) span `tools.rs`
+and `daemon.rs`. So `callbacks` moves along with `writers`, `cache`, `ccr`, and
+`publication_roots`. All five regenerate ONCE, at the end of PR 2, each with
+before/after digests recorded in the evidence document.
+
+Scope resolutions bound with the decision:
+
+1. **T045 is bounded to `src/protocol/` by its own task text**, which resolves
+   the one unresolvable lane name: "persistence" means the protocol-side
+   persistence surfaces — the embedded cache payload rendering and the session
+   read-cache — NOT `src/live_index/persist.rs`, which is index persistence and
+   Slice 4 writer-migration territory.
+2. **T046's named file is wrong and the correction is recorded**: `tasks.md:923`
+   says `src/live_index/view.rs`, which contains zero of the nine `ArcSwap`
+   fields and zero reads of them — it is the Feature-012 base+overlay spike.
+   The work lands in `store.rs` and the reader call sites. The frozen tasks
+   file is NOT edited; this paragraph is the record.
+3. **Five of the nine fields are already consolidated** behind
+   `published_source_set` on the public read surface. The residual defect is
+   HOW MANY TIMES one caller loads the set, so T046 is per-caller
+   single-capture, not a field migration.
+4. **`published_repo_outline` is write-only dead state** — stored on every
+   publish, loaded nowhere. T046 deletes it outright.
+5. **`terminal_dispositions()` ordering hazard**: the only lock-free reader of
+   the raw `live` field, which `swap_and_publish` stores four lines BEFORE
+   `published_source_set` — a caller pairing the two can see new content
+   against the old publication. T046 re-roots it on the captured set.
+6. **The read-MUTATE-read sites are exclusions, not candidates** — the
+   before/after samples enumerated in the recon findings doc stay untouched,
+   listed in the evidence with the reason.
+
 ## Two risks, both now measured rather than assumed
 
 **RISK-A — cache identity under T045. SETTLED, and it is benign.**

--- a/scripts/validate-lifecycle-oracle-traceability.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.cjs
@@ -310,7 +310,7 @@ const FROZEN_DIGESTS = {
   },
   retirement_records: {
     domain: "symforge.lifecycle.v11.retirement.records",
-    hash: "313dceda25ff58697a366b7c8be037a238e70a6c8ab5030f75128844b59c21bf",
+    hash: "d86bd17b3e6ce2cddf86e2755433fe9dc0b5ed91467ad805fc634be1bbe5ce29",
   },
   retirement_edges: {
     domain: "symforge.lifecycle.v11.retirement.edges",

--- a/scripts/validate-lifecycle-oracle-traceability.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.cjs
@@ -310,7 +310,7 @@ const FROZEN_DIGESTS = {
   },
   retirement_records: {
     domain: "symforge.lifecycle.v11.retirement.records",
-    hash: "4c118fabce2e7317934229f63c9f1e3871907a677550ae1294fcddcb1976a6fb",
+    hash: "313dceda25ff58697a366b7c8be037a238e70a6c8ab5030f75128844b59c21bf",
   },
   retirement_edges: {
     domain: "symforge.lifecycle.v11.retirement.edges",

--- a/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
+++ b/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
@@ -1150,7 +1150,7 @@ This machine-verifiable manifest binds the complete Feature 020 corpus, its V11 
       "hash_policy": "raw_bytes",
       "path": "specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md",
       "scope": "feature",
-      "sha256": "f003981fceba6f83abaad88493687b00229ec45f040184f7bf881748469b551c",
+      "sha256": "b351235786073dc02a1684f7209c9456a84b20a9a8198cfcbf2001ab847bfef2",
       "superseded_by": []
     },
     {

--- a/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
+++ b/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
@@ -1150,7 +1150,7 @@ This machine-verifiable manifest binds the complete Feature 020 corpus, its V11 
       "hash_policy": "raw_bytes",
       "path": "specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md",
       "scope": "feature",
-      "sha256": "709ac695457804dd21647f4899f48710e80e90d84da93784e4f5cdb61e9793e9",
+      "sha256": "f003981fceba6f83abaad88493687b00229ec45f040184f7bf881748469b551c",
       "superseded_by": []
     },
     {

--- a/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
+++ b/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
@@ -629,7 +629,7 @@ planned and unexecuted.
       ]
     },
     "writers": {
-      "digest": "bafa517a9142c1ba42b7eea53a42d767643cd3ff094ad97ea930bfa78bdaeee1",
+      "digest": "565e42273f56e3ac467fa09b13bceec9d3e6103695e49cc2f64abf47cfbf3e31",
       "paths": [
         "src/cli/init.rs",
         "src/gitignore_hygiene.rs",

--- a/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
+++ b/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
@@ -590,7 +590,7 @@ planned and unexecuted.
   "kind": "symforge.v10_authority_retirement.v11",
   "preactivation_closure": {
     "cache": {
-      "digest": "4eb220e86cfaf41762f5c920a43157e9f92914cf062fed3102ed05cba5c18a38",
+      "digest": "6fb4cace44005ceb8019730721950c55a904fb1178da83e9782ffe21614fa095",
       "paths": [
         "src/daemon.rs",
         "src/protocol/knowledge_curation.rs",
@@ -600,7 +600,7 @@ planned and unexecuted.
       ]
     },
     "callbacks": {
-      "digest": "48938137b3150288eeac6892ee31b6e7a9d2f3d59262efd26c0f66a7a97e8b22",
+      "digest": "026c548ba79c43b0e48ee1f1c4f87da9fd614d608615a41c059966f7a9fe577b",
       "paths": [
         "src/daemon.rs",
         "src/live_index/git_temporal.rs",
@@ -619,7 +619,7 @@ planned and unexecuted.
       ]
     },
     "publication_roots": {
-      "digest": "e37555add0073b6bafb1e023591d2b1ca623698785ad198f2d9b793ab761e82d",
+      "digest": "b90b8d8862519ac8451ca459288157759298135b5fbb8b9ea326e48755190b54",
       "paths": [
         "src/daemon.rs",
         "src/live_index/store.rs",
@@ -629,7 +629,7 @@ planned and unexecuted.
       ]
     },
     "writers": {
-      "digest": "5137cd7b059a2857b4db4b9c8a1a3c4ded4702422018da948d132709733af7dd",
+      "digest": "bafa517a9142c1ba42b7eea53a42d767643cd3ff094ad97ea930bfa78bdaeee1",
       "paths": [
         "src/cli/init.rs",
         "src/gitignore_hygiene.rs",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1403,7 +1403,11 @@ impl DaemonState {
     pub fn project_health(&self, project_id: &str) -> Option<ProjectHealth> {
         let slot = self.projects.read().get(project_id).cloned()?;
         let project = slot.metadata.read();
-        let published = project.index.published_state();
+        // T046: one capture — the freshness verdict below describes the SAME
+        // publication as the counts it is printed beside, not one from a
+        // separate load 50 lines later.
+        let generation = project.index.published_generation();
+        let published = std::sync::Arc::clone(&generation.health);
         let durability = *project.persistence_health.read();
         let durable_mutation = match durability {
             CapabilityStatus::Available => CapabilityStatus::Available,
@@ -1456,7 +1460,7 @@ impl DaemonState {
             file_count: published.file_count,
             symbol_count: published.symbol_count,
             index_state: published.status_label().to_string(),
-            freshness: project.index.freshness_status().as_ref().clone(),
+            freshness: generation.freshness.as_ref().clone(),
             durability,
             capabilities: ProjectCapabilities {
                 persistent_snapshots: durability,
@@ -4119,7 +4123,11 @@ async fn call_tool_handler(
     // header so the human-readable body stays byte-identical; the adapter
     // parses it into the typed receipt and attaches it to `_meta`.
     let call_evidence_json = {
-        let published = runtime.index.published_state();
+        // T046: one capture. `generation`, `load_source`, the counts, and
+        // `index_state` all come off the SAME published bundle — the atomic
+        // project-generation counter is not consulted, so the evidence cannot
+        // pair a newer generation number with an older publication's counts.
+        let generation = runtime.index.published_generation();
         serde_json::to_string(&crate::protocol::result_status::ProjectEvidence {
             project_id: runtime.project_id.clone(),
             project_name: runtime
@@ -4129,11 +4137,11 @@ async fn call_tool_handler(
                 .unwrap_or("project")
                 .to_string(),
             canonical_root: Some(normalized_path_string(&runtime.canonical_root)),
-            generation: runtime.index.current_project_generation(),
-            index_state: published.status_label().to_string(),
-            load_source: runtime.index.read().load_source().label().to_string(),
-            index_files: published.file_count,
-            index_symbols: published.symbol_count,
+            generation: generation.project_generation,
+            index_state: generation.health.status_label().to_string(),
+            load_source: generation.live.load_source().label().to_string(),
+            index_files: generation.health.file_count,
+            index_symbols: generation.health.symbol_count,
         })
         .ok()
     };

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -1302,8 +1302,8 @@ pub struct PreUpdateSymbol {
 /// index, then atomically publish derived state. A failed mutation is simply discarded —
 /// readers never observe a partially-mutated index.
 ///
-/// `published_state`, `published_repo_outline`, and `git_temporal` also use `ArcSwap`
-/// for contention-free reads (previously `RwLock<Arc<T>>`).
+/// `published_state` and `git_temporal` also use `ArcSwap` for contention-free
+/// reads (previously `RwLock<Arc<T>>`).
 pub struct SharedIndexHandle {
     live: ArcSwap<LiveIndex>,
     published_source_set: ArcSwap<PublishedSourceSet>,
@@ -1326,7 +1326,6 @@ pub struct SharedIndexHandle {
     /// sidecar's per-file baseline cache out of order.
     impact_mutex: tokio::sync::Mutex<()>,
     published_state: ArcSwap<PublishedIndexState>,
-    published_repo_outline: ArcSwap<RepoOutlineView>,
     /// Publish-versioning counter for `PublishedIndexState`; bumped on every publish.
     next_generation: AtomicU64,
     /// Project-identity counter for fencing stale watcher mutations; bumped only on reload.
@@ -1521,7 +1520,6 @@ impl SharedIndexHandle {
             write_mutex: Mutex::new(()),
             impact_mutex: tokio::sync::Mutex::new(()),
             published_state: ArcSwap::new(published_state),
-            published_repo_outline: ArcSwap::new(published_repo_outline),
             next_generation: AtomicU64::new(1),
             project_generation: AtomicU64::new(0),
             last_reset_project_generation: AtomicU64::new(0),
@@ -2066,9 +2064,14 @@ impl SharedIndexHandle {
     pub(crate) fn terminal_dispositions(
         &self,
     ) -> Arc<Vec<(String, crate::domain::FileDisposition)>> {
+        // T046: re-rooted on the published bundle. This was the ONLY lock-free
+        // reader of the raw `live` field, which `swap_and_publish` stores four
+        // lines before `published_source_set` — so a caller pairing this with
+        // any bundle-derived accessor could see new content against the old
+        // publication. Off the bundle, the pair is coherent by construction.
         Arc::new(
-            self.live
-                .load_full()
+            self.published_generation()
+                .live
                 .manifest_entries
                 .iter()
                 .map(|entry| {
@@ -3308,7 +3311,6 @@ impl SharedIndexHandle {
         self.live.store(live);
         after_live_swap();
         self.published_state.store(published_state);
-        self.published_repo_outline.store(published_repo_outline);
         self.published_source_set.store(published_source_set);
     }
 

--- a/src/protocol/claim_provenance.rs
+++ b/src/protocol/claim_provenance.rs
@@ -41,6 +41,14 @@ pub use crate::lifecycle_identity::{
     ProvenanceIdentity, WorktreeScanId,
 };
 
+// T044's explicit authority choice, re-exported the same way and for the same
+// reason as the identities: `read_gate` is a crate-private module, and the
+// Slice 3 oracles are a separate crate that must SEE the seam to pin it. A
+// `pub use` outside `src/embed.rs` adds no public-API census atom.
+pub use crate::protocol::read_gate::{
+    GenerationResolution, observe_disk_beneath, resolve_generation_bytes,
+};
+
 // ── Operations ─────────────────────────────────────────────────────────────
 
 /// The closed operation vocabulary, VERBATIM from the frozen contract:

--- a/src/protocol/edit_tools.rs
+++ b/src/protocol/edit_tools.rs
@@ -723,12 +723,15 @@ impl SymForgeServer {
     /// index is not `Ready` (loading/empty), nothing is appended — the footer is
     /// best-effort and never blocks a successful edit response.
     fn append_impact_footer(&self, output: &mut String, path: &str) {
-        let guard = self.index.read();
+        // T046: one capture — the dependency counts and the co-change rows in
+        // one footer describe the same publication.
+        let generation = self.index.published_generation();
+        let guard = &generation.live;
         if !matches!(guard.index_state(), IndexState::Ready) {
             return;
         }
-        let temporal = self.index.git_temporal();
-        let (deps, cochanges) = format::edit_impact_summary(&guard, &temporal, path);
+        let temporal = &generation.code_signals.temporal;
+        let (deps, cochanges) = format::edit_impact_summary(guard, temporal, path);
         output.push('\n');
         output.push_str(&format::impact_footer(deps, &cochanges));
     }

--- a/src/protocol/read_gate.rs
+++ b/src/protocol/read_gate.rs
@@ -17,12 +17,81 @@
 //! `file_at_ref` reads beside it stayed ungated, disclosing a demoted file's
 //! symbol names and signatures out of git objects. Policy and classification
 //! are shared by both lanes precisely so the next store added cannot repeat it.
+//!
+//! **T044 — the authority CHOICE is explicit.** Serving bytes the generation
+//! PUBLISHED and observing what is on disk RIGHT NOW are different claims with
+//! different scopes, and before this split the choice between them was implicit
+//! in which function a lane reached for: a lane meaning to serve generation
+//! content could take an index miss and silently backfill from disk. The two
+//! lanes are now named — [`resolve_generation_bytes`], which NEVER touches
+//! disk, and [`observe_disk_beneath`], which always does, confined beneath the
+//! workspace root — so a caller states which authority its answer rides on.
 
-use std::path::Path;
+use std::path::{Component, Path};
 
 use crate::domain::{FileDisposition, IndexTargets, LanguageId, MetadataOnlyReason};
 use crate::live_index::LiveIndex;
 use crate::protocol::format;
+
+/// What the generation has to say about one path.
+#[derive(Debug, PartialEq, Eq)]
+pub enum GenerationResolution<'a> {
+    /// The bytes the generation PUBLISHED for this path — index-resident,
+    /// served with zero disk I/O, exactly as `IndexedFile.content` promises.
+    Published(&'a [u8]),
+    /// The generation holds no content for this path. A miss, and ONLY a
+    /// miss: it is never permission to observe the disk. The caller that
+    /// wants current disk bytes says so by calling [`observe_disk_beneath`].
+    NotInGeneration,
+}
+
+/// Resolve the bytes the generation published for `relative_path`.
+///
+/// This function cannot read the disk — it has no path to it. A generation
+/// miss surfaces as [`GenerationResolution::NotInGeneration`] so the
+/// authority choice lands on the caller, in the open.
+pub fn resolve_generation_bytes<'a>(
+    live: &'a LiveIndex,
+    relative_path: &str,
+) -> GenerationResolution<'a> {
+    match live.get_file(relative_path) {
+        Some(file) => GenerationResolution::Published(&file.content),
+        None => GenerationResolution::NotInGeneration,
+    }
+}
+
+/// Deliberately observe `relative_path` on disk RIGHT NOW, confined beneath
+/// `workspace_root`, admitted by the same policy and classification as every
+/// other content read.
+///
+/// Confinement is lexical and refuses BEFORE any read: an absolute path, a
+/// drive or root prefix, or any `..` component is an escape however it is
+/// spelled, and the refusal never carries the escaped content.
+// ponytail: lexical confinement only — a symlink beneath the root that points
+// outside it is governed by the crate's existing never-follow walk policy, not
+// re-checked here; canonicalize-and-compare is the upgrade path if that policy
+// ever changes.
+pub fn observe_disk_beneath(
+    live: &LiveIndex,
+    workspace_root: &Path,
+    relative_path: &str,
+) -> Result<Vec<u8>, String> {
+    let candidate = Path::new(relative_path);
+    let escapes = candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    });
+    if escapes || candidate.is_absolute() {
+        return Err(format!(
+            "{relative_path} [error: path escapes the workspace root; a disk \
+             observation is confined beneath it]"
+        ));
+    }
+    let full_path = workspace_root.join(candidate);
+    admit_disk_read(live, relative_path, &full_path)
+}
 
 /// Working-tree text for `relative_path`, admitted by [`admit_disk_read`].
 ///

--- a/src/protocol/search_format.rs
+++ b/src/protocol/search_format.rs
@@ -1,6 +1,63 @@
+//! The result-envelope formatter and the measured authority axis it rides on.
+
+/// The source-authority axis of a result envelope.
+///
+/// The envelope used to collapse on `source_authority == "current index"` — a
+/// STRING equality, so any caller could assert currency without measuring it,
+/// and one lane did: the context bundle passed the literal whenever it had not
+/// disk-refreshed, collapsing the envelope even while the index was Degraded.
+/// That was the exact defect the repo's reporting invariant names — the thing
+/// that reports is not the thing that knows.
+///
+/// The collapse decision now rides on this type, and the type is honest by
+/// construction: [`SourceAuthority::from_freshness`] is the ONLY constructor
+/// that can produce a collapsible value, and it takes the index's own measured
+/// `FreshnessStatus`. A lying literal is unrepresentable — there is no
+/// constructor that accepts a caller-chosen string and marks it collapsible.
+#[derive(Clone, Copy)]
+pub(crate) struct SourceAuthority {
+    label: &'static str,
+    collapsible: bool,
+}
+
+impl SourceAuthority {
+    /// The measured axis. Collapse is permitted exactly when the index itself
+    /// reports `Current`; `Verifying` and `Degraded` stay loud and say so.
+    pub(crate) fn from_freshness(freshness: &crate::domain::FreshnessStatus) -> Self {
+        match freshness {
+            crate::domain::FreshnessStatus::Current => Self {
+                label: "current index",
+                collapsible: true,
+            },
+            crate::domain::FreshnessStatus::Verifying => Self {
+                label: "index (verifying against disk)",
+                collapsible: false,
+            },
+            crate::domain::FreshnessStatus::Degraded { .. } => Self {
+                label: "index (UNVERIFIED against disk)",
+                collapsible: false,
+            },
+        }
+    }
+
+    /// An authority that never collapses the envelope: disk-refreshed reads,
+    /// composite stores, git-object diffs. The label is display only and
+    /// cannot buy the compact banner, whatever it says.
+    pub(crate) fn never_collapse(label: &'static str) -> Self {
+        Self {
+            label,
+            collapsible: false,
+        }
+    }
+
+    pub(crate) fn label(&self) -> &'static str {
+        self.label
+    }
+}
+
 pub(crate) fn format_search_envelope(
     match_type: &str,
-    source_authority: &str,
+    source_authority: SourceAuthority,
     parse_state: &str,
     completeness: &str,
     scope: &str,
@@ -9,26 +66,24 @@ pub(crate) fn format_search_envelope(
     // "Silence is the happy path": on a fully-trusted result collapse the four
     // invariant status lines (match type / source authority / parse state /
     // completeness) into one compact `Trust:` line, keeping Scope and Evidence
-    // (the differential fields). Any deviation — non-index authority, partial or
-    // degraded parse, or non-full completeness — keeps the full six-line envelope
-    // so degraded/stale/truncated results stay loud.
-    if source_authority == "current index"
-        && parse_state == "parsed"
-        && completeness.starts_with("full")
-    {
+    // (the differential fields). Any deviation — a non-collapsible authority,
+    // partial or degraded parse, or non-full completeness — keeps the full
+    // six-line envelope so degraded/stale/truncated results stay loud.
+    let label = source_authority.label();
+    if source_authority.collapsible && parse_state == "parsed" && completeness.starts_with("full") {
         format!(
-            "Trust: {match_type} | {source_authority} | {parse_state} | {completeness}\nScope: {scope}\nEvidence: {evidence}"
+            "Trust: {match_type} | {label} | {parse_state} | {completeness}\nScope: {scope}\nEvidence: {evidence}"
         )
     } else {
         format!(
-            "Match type: {match_type}\nSource authority: {source_authority}\nParse state: {parse_state}\nCompleteness: {completeness}\nScope: {scope}\nEvidence: {evidence}"
+            "Match type: {match_type}\nSource authority: {label}\nParse state: {parse_state}\nCompleteness: {completeness}\nScope: {scope}\nEvidence: {evidence}"
         )
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_search_envelope;
+    use super::{SourceAuthority, format_search_envelope};
 
     #[test]
     fn test_format_search_envelope() {
@@ -36,7 +91,7 @@ mod tests {
         // compact `Trust:` line, preserving Scope and Evidence.
         let rendered = format_search_envelope(
             "constrained (literal)",
-            "current index",
+            SourceAuthority::from_freshness(&crate::domain::FreshnessStatus::Current),
             "parsed",
             "full for current scope",
             "repo-wide; tests filtered; generated filtered",
@@ -57,7 +112,7 @@ mod tests {
         // so degraded / stale / truncated results stay loud.
         let rendered = format_search_envelope(
             "exact",
-            "disk (refreshed)",
+            SourceAuthority::never_collapse("disk (refreshed)"),
             "partial",
             "truncated by result cap (3 more omitted)",
             "path `src/lib.rs`",
@@ -70,5 +125,37 @@ mod tests {
         assert!(rendered.contains("Completeness: truncated by result cap (3 more omitted)"));
         assert!(rendered.contains("Scope: path `src/lib.rs`"));
         assert!(rendered.contains("Evidence: line anchors `src/lib.rs:7`"));
+    }
+
+    #[test]
+    fn a_measured_degraded_authority_never_collapses_however_clean_the_rest_is() {
+        // The axis that used to be forgeable: parse and completeness are both
+        // pristine, and the ONLY deviation is the measured freshness. The
+        // envelope must stay loud — this is the case the string comparison let
+        // a lane collapse by asserting the literal.
+        for freshness in [
+            crate::domain::FreshnessStatus::Verifying,
+            crate::domain::FreshnessStatus::Degraded {
+                last_valid_content_generation: 1,
+                reason_codes: vec![crate::domain::FreshnessReason::ObservationFailed],
+            },
+        ] {
+            let rendered = format_search_envelope(
+                "exact",
+                SourceAuthority::from_freshness(&freshness),
+                "parsed",
+                "full for current scope",
+                "repo-wide",
+                "line anchors `src/lib.rs:7`",
+            );
+            assert!(
+                rendered.contains("Match type: exact"),
+                "a non-Current measurement keeps the loud envelope: {rendered}"
+            );
+            assert!(
+                !rendered.starts_with("Trust:"),
+                "a non-Current measurement must not buy the compact banner: {rendered}"
+            );
+        }
     }
 }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -6911,6 +6911,11 @@ impl SymForgeServer {
     fn runtime_status_for(
         &self,
         published: &crate::live_index::PublishedIndexState,
+        // T046: the caller says which project-generation it is reporting —
+        // the health pair passes its captured bundle's value so the report
+        // cannot pair a newer counter with an older publication; callers
+        // without a capture pass the atomic EXPLICITLY, named at the site.
+        project_generation: u64,
         mode: format::RuntimeMode,
         project_id: Option<String>,
         session_id: Option<String>,
@@ -6932,7 +6937,7 @@ impl SymForgeServer {
             project_id,
             session_id,
             index_generation: published.generation,
-            project_generation: self.index.current_project_generation(),
+            project_generation,
             reset_project_generation: self.index.current_reset_project_generation(),
             load_source: published.load_source,
         }
@@ -7006,8 +7011,14 @@ impl SymForgeServer {
         // report is served through a daemon session (membership authority
         // applies); local in-process reports carry `None`.
         let session_is_daemon = session_id.is_some();
-        let runtime_status =
-            self.runtime_status_for(&published, mode, project_id, session_id, project_root);
+        let runtime_status = self.runtime_status_for(
+            &published,
+            generation.project_generation,
+            mode,
+            project_id,
+            session_id,
+            project_root,
+        );
         let watcher_guard = self.watcher_info.lock();
         let rejected_stale_mutations = self.index.current_rejected_stale_mutations();
         let mut result = format::health_report_from_published_state_windowed(
@@ -7186,8 +7197,14 @@ impl SymForgeServer {
         let generation = source_set.current_generation();
         let published = Arc::clone(&generation.health);
         let session_is_daemon = session_id.is_some();
-        let runtime_status =
-            self.runtime_status_for(&published, mode, project_id, session_id, project_root);
+        let runtime_status = self.runtime_status_for(
+            &published,
+            generation.project_generation,
+            mode,
+            project_id,
+            session_id,
+            project_root,
+        );
         let watcher_guard = self.watcher_info.lock();
         let rejected_stale_mutations = self.index.current_rejected_stale_mutations();
         let mut result = format::health_report_compact_from_published_state(
@@ -7938,6 +7955,7 @@ impl SymForgeServer {
                     ));
                     let runtime_status = self.runtime_status_for(
                         &published,
+                        self.index.current_project_generation(),
                         self.local_runtime_mode(),
                         None,
                         None,
@@ -11756,8 +11774,14 @@ impl SymForgeServer {
     /// stale or wrong binding is LOUD in every facade response, never silent.
     fn stel_bound_root_line(&self) -> String {
         let published = self.index.published_state();
-        let status =
-            self.runtime_status_for(&published, self.local_runtime_mode(), None, None, None);
+        let status = self.runtime_status_for(
+            &published,
+            self.index.current_project_generation(),
+            self.local_runtime_mode(),
+            None,
+            None,
+            None,
+        );
         format!(
             "project_root: {}",
             status.project_root.as_deref().unwrap_or("(unbound)")

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -2928,7 +2928,10 @@ fn tier2_reference_disclosure(
         // the manifest still records as merely oversized cannot have a textual
         // match disclosed once its bytes turn sensitive. The refusal itself is
         // discarded: only the path reaches the response, via `unswept`.
-        match read_gate::admit_disk_read(live, path, &root.join(path)) {
+        // T045: this is a DISK OBSERVATION by name — the sweep wants what is on
+        // disk right now, confined beneath the root. Manifest paths are
+        // relative and catalogued, so the confine never fires on them.
+        match read_gate::observe_disk_beneath(live, root, path) {
             Ok(bytes) => {
                 bytes_budget = bytes_budget.saturating_sub(bytes.len() as u64);
                 if String::from_utf8_lossy(&bytes).contains(name) {
@@ -8412,10 +8415,14 @@ impl SymForgeServer {
                     })
                     .unwrap_or_default();
 
-                let base_content = repo
-                    .file_at_ref(seed_base_ref, path) // D8/PR2-ungated-git-read
-                    .unwrap_or_default()
-                    .unwrap_or_default();
+                // Gated (D8 closed): the git-object store is a disclosure lane
+                // exactly like the working tree below. A refusal collapses to
+                // "no base content", the same conservative seed as the worktree
+                // arm — withheld beats disclosed for a demoted file's symbols.
+                let base_content =
+                    crate::protocol::read_gate::admit_git_text(&guard, &repo, seed_base_ref, path)
+                        .unwrap_or_default()
+                        .unwrap_or_default();
                 // Gated: a refusal collapses to "no current content", which
                 // seeds conservatively from the index rather than disclosing
                 // the demoted file's current symbol names or signatures.
@@ -8831,10 +8838,15 @@ impl SymForgeServer {
                         // `generation.live` is the same publication that produced
                         // the index miss above — a fresh `self.index.read()` would
                         // be a different snapshot.
-                        let content = match read_gate::admit_disk_read(
+                        // T045: the index MISS above was the generation's answer;
+                        // reading disk anyway is a DISK OBSERVATION, chosen by
+                        // name. `safe_repo_path` keeps the caller-facing message
+                        // split; the store's own lexical confine cannot fire
+                        // after it and is the store's invariant, not a check.
+                        let content = match read_gate::observe_disk_beneath(
                             generation.live.as_ref(),
+                            &root,
                             &input.path,
-                            &canon_path,
                         ) {
                             Ok(content) => content,
                             Err(refusal) => return refusal,
@@ -8966,8 +8978,10 @@ impl SymForgeServer {
         // for the fallback decision, so it gates the CURRENT bytes even when the
         // manifest says `Indexed` (D3: the exemption is about where bytes come
         // from). The gate owns the read; nothing below reopens the path.
+        // T045: a deliberate DISK OBSERVATION by name — validation is about the
+        // bytes on disk right now, never the generation's copy.
         let bytes =
-            match read_gate::admit_disk_read(published.live.as_ref(), &input.path, &canon_path) {
+            match read_gate::observe_disk_beneath(published.live.as_ref(), &root, &input.path) {
                 Ok(bytes) => bytes,
                 Err(refusal) => return refusal,
             };
@@ -31345,18 +31359,10 @@ mod tests {
         ];
         // read_gate owns both fetches; it is the gate, not a bypass of it.
         let gate_owner = ["read_", "gate.rs"].concat();
-        // D8/PR2: detect_impact still reaches git objects directly. It is
-        // production `tools.rs`, so fixing it regenerates the `writers`
-        // retirement-census digest and belongs with that batch. Allowlisted by
-        // an exact SENTINEL on the offending line — not by file and not by
-        // function, so a SECOND ungated read in the same function still fails.
-        // PR 2 deletes the sentinel and the call together.
-        let sentinel = ["D8", "/PR2-ungated-git-read"].concat();
         let protocol = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/protocol");
 
         let mut offenders: Vec<String> = Vec::new();
         let mut scanned = 0usize;
-        let mut allowlisted = 0usize;
         let mut stack = vec![protocol];
         while let Some(dir) = stack.pop() {
             for entry in fs::read_dir(&dir).expect("read protocol dir") {
@@ -31380,10 +31386,6 @@ mod tests {
                     if !needles.iter().any(|needle| line.contains(needle.as_str())) {
                         continue;
                     }
-                    if line.contains(sentinel.as_str()) {
-                        allowlisted += 1;
-                        continue;
-                    }
                     offenders.push(format!(
                         "{}:{}",
                         path.file_name().unwrap_or_default().to_string_lossy(),
@@ -31398,11 +31400,10 @@ mod tests {
             scanned > 20,
             "control: the scan must recurse into protocol subdirectories, only saw {scanned} files"
         );
-        assert_eq!(
-            allowlisted, 1,
-            "exactly one ungated read is allowlisted (D8/PR2 detect_impact); \
-             a changed count means the sentinel was added or removed without updating this guard"
-        );
+        // D8 is closed: detect_impact's base seed now routes through
+        // admit_git_text, so the allowlist that carried it is DELETED rather
+        // than emptied — zero ungated reads and no exceptions machinery left
+        // to quietly grow.
         assert!(
             offenders.is_empty(),
             "these protocol lanes bypass the content gate: {offenders:?}"

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -1237,39 +1237,6 @@ fn parse_state_for_file(file: &IndexedFile) -> &'static str {
     }
 }
 
-fn context_source_authority_label(refreshed: bool) -> &'static str {
-    if refreshed {
-        "disk-refreshed"
-    } else {
-        "current index"
-    }
-}
-
-/// The source-authority axis of a result envelope, MEASURED from the index's own
-/// freshness rather than asserted.
-///
-/// `format_search_envelope` collapses to the compact one-line `Trust:` banner
-/// exactly when authority is `"current index"`, and its own doc says any
-/// deviation must keep the loud six-line form so "degraded/stale/truncated
-/// results stay loud". That contract was unreachable on the code-navigation
-/// lane: every call site passed the literal `"current index"`, so a result could
-/// never be anything but confident — including one served from an index whose
-/// reconciliation against disk had failed or never run.
-///
-/// The rest of the envelope already works this way. The parse-state axis
-/// deliberately degrades (`"metadata-only (not parsed)"`, "instead of the
-/// misleading 'parsed'"), and the knowledge lane already gates its envelope on
-/// `FreshnessStatus`. This applies the same discipline to code navigation, which
-/// is the lane whose anchors an agent actually navigates by — a wrong line
-/// number in the right file is worse than a miss, because it is actionable.
-fn index_source_authority_label(freshness: &crate::domain::FreshnessStatus) -> &'static str {
-    match freshness {
-        crate::domain::FreshnessStatus::Current => "current index",
-        crate::domain::FreshnessStatus::Verifying => "index (verifying against disk)",
-        crate::domain::FreshnessStatus::Degraded { .. } => "index (UNVERIFIED against disk)",
-    }
-}
-
 fn context_bundle_completeness_label(
     view: &crate::live_index::ContextBundleFoundView,
     rendered: &str,
@@ -3313,11 +3280,21 @@ fn what_changed_scope_summary(input: &WhatChangedInput, mode: &WhatChangedMode) 
     parts.join("; ")
 }
 
-fn what_changed_source_authority_label(mode: &WhatChangedMode) -> &'static str {
+fn what_changed_source_authority(
+    mode: &WhatChangedMode,
+    freshness: &crate::domain::FreshnessStatus,
+) -> search_format::SourceAuthority {
     match mode {
-        WhatChangedMode::Timestamp(_) => "current index",
-        WhatChangedMode::Uncommitted => "git working tree",
-        WhatChangedMode::GitRef(_) => "git ref diff",
+        // T045: the Timestamp arm used to assert the literal "current index",
+        // collapsing the envelope regardless of measured freshness — the same
+        // forgeable-axis defect as the context lane, closed the same way.
+        WhatChangedMode::Timestamp(_) => search_format::SourceAuthority::from_freshness(freshness),
+        WhatChangedMode::Uncommitted => {
+            search_format::SourceAuthority::never_collapse("git working tree")
+        }
+        WhatChangedMode::GitRef(_) => {
+            search_format::SourceAuthority::never_collapse("git ref diff")
+        }
     }
 }
 
@@ -3378,7 +3355,7 @@ fn render_diff_symbols_output(
     };
     let envelope = search_format::format_search_envelope(
         "exact (git ref diff)",
-        "git ref diff",
+        search_format::SourceAuthority::never_collapse("git ref diff"),
         "high (tree-sitter AST extraction for supported languages, regex fallback for others)",
         &completeness,
         &scope_parts.join("; "),
@@ -3452,7 +3429,7 @@ fn render_search_text_output(
                     auto_corrected_regex,
                     options.ranked,
                 ),
-                index_source_authority_label(&server.index.freshness_status()),
+                search_format::SourceAuthority::from_freshness(&server.index.freshness_status()),
                 search_parse_state_for_paths(
                     &guard,
                     result.files.iter().map(|file| file.path.as_str()),
@@ -4975,7 +4952,17 @@ impl SymForgeServer {
                     } else {
                         "constrained"
                     },
-                    context_source_authority_label(refreshed),
+                    // T045: the non-refreshed arm used to ASSERT the literal
+                    // "current index", collapsing the envelope even while the
+                    // index was Degraded — the exact forgeable-axis defect the
+                    // measured type closes. Refreshed reads stay loud.
+                    if refreshed {
+                        search_format::SourceAuthority::never_collapse("disk-refreshed")
+                    } else {
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        )
+                    },
                     parse_state,
                     &context_bundle_completeness_label(found.as_ref(), &result),
                     &scope,
@@ -5451,7 +5438,7 @@ impl SymForgeServer {
             let guard = self.index.read();
             Some(search_format::format_search_envelope(
                 search_symbols_match_type_label(&result, is_browse),
-                index_source_authority_label(&self.index.freshness_status()),
+                search_format::SourceAuthority::from_freshness(&self.index.freshness_status()),
                 search_parse_state_for_paths(
                     &guard,
                     result.hits.iter().map(|hit| hit.path.as_str()),
@@ -6137,7 +6124,9 @@ impl SymForgeServer {
                     let guard = self.index.read();
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        index_source_authority_label(&self.index.freshness_status()),
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        ),
                         search_parse_state_for_paths(&guard, std::iter::once(path.as_str())),
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6153,7 +6142,9 @@ impl SymForgeServer {
                     // parse state honestly instead of the misleading "parsed".
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        index_source_authority_label(&self.index.freshness_status()),
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        ),
                         "metadata-only (not parsed)",
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6172,7 +6163,9 @@ impl SymForgeServer {
                     let guard = self.index.read();
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        index_source_authority_label(&self.index.freshness_status()),
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        ),
                         search_parse_state_for_paths(
                             &guard,
                             matches.iter().map(std::string::String::as_str),
@@ -6283,7 +6276,9 @@ impl SymForgeServer {
                             let guard = self.index.read();
                             search_format::format_search_envelope(
                                 "weak heuristic (git-temporal coupling)",
-                                "current index + git temporal",
+                                search_format::SourceAuthority::never_collapse(
+                                    "current index + git temporal",
+                                ),
                                 search_parse_state_for_paths(
                                     &guard,
                                     history
@@ -6336,7 +6331,9 @@ impl SymForgeServer {
                     let guard = self.index.read();
                     search_format::format_search_envelope(
                         "heuristic (git-temporal coupling)",
-                        "current index + git temporal",
+                        search_format::SourceAuthority::never_collapse(
+                            "current index + git temporal",
+                        ),
                         search_parse_state_for_paths(
                             &guard,
                             history.co_changes.iter().map(|entry| entry.path.as_str()),
@@ -6608,11 +6605,17 @@ impl SymForgeServer {
                     // still say "current" unconditionally — worth revisiting
                     // once every lane derives its own prefix.
                     if rank_by_path_cochange {
-                        "current index + optional coupling store"
+                        search_format::SourceAuthority::never_collapse(
+                            "current index + optional coupling store",
+                        )
                     } else if rank_by_frecency {
-                        "current index + optional frecency history"
+                        search_format::SourceAuthority::never_collapse(
+                            "current index + optional frecency history",
+                        )
                     } else {
-                        index_source_authority_label(&self.index.freshness_status())
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        )
                     },
                     search_parse_state_for_paths(&guard, hits.iter().map(|hit| hit.path.as_str())),
                     &search_completeness_label(*overflow_count, hidden_noise_count),
@@ -8028,7 +8031,10 @@ impl SymForgeServer {
                                 let guard = self.index.read();
                                 search_format::format_search_envelope(
                                     "exact (timestamp compare)",
-                                    what_changed_source_authority_label(&mode),
+                                    what_changed_source_authority(
+                                        &mode,
+                                        &self.index.freshness_status(),
+                                    ),
                                     search_parse_state_for_paths(
                                         &guard,
                                         filtered.iter().map(|path| path.as_str()),
@@ -8122,7 +8128,10 @@ impl SymForgeServer {
                                     params.0.include_symbol_diff.unwrap_or(false);
                                 let envelope = search_format::format_search_envelope(
                                     "exact (uncommitted working tree)",
-                                    what_changed_source_authority_label(&mode),
+                                    what_changed_source_authority(
+                                        &mode,
+                                        &self.index.freshness_status(),
+                                    ),
                                     what_changed_parse_state_label(&mode, include_symbol_diff),
                                     &changed_paths_completeness_label(total_paths, filtered.len()),
                                     &what_changed_scope_summary(&params.0, &mode),
@@ -8200,7 +8209,10 @@ impl SymForgeServer {
                                     params.0.include_symbol_diff.unwrap_or(false);
                                 let envelope = search_format::format_search_envelope(
                                     "exact (git ref diff)",
-                                    what_changed_source_authority_label(&mode),
+                                    what_changed_source_authority(
+                                        &mode,
+                                        &self.index.freshness_status(),
+                                    ),
                                     what_changed_parse_state_label(&mode, include_symbol_diff),
                                     &changed_paths_completeness_label(total_paths, filtered.len()),
                                     &what_changed_scope_summary(&params.0, &mode),
@@ -9066,7 +9078,7 @@ impl SymForgeServer {
                 let guard = self.index.read();
                 Some(search_format::format_search_envelope(
                     find_references_match_type_label(input, mode),
-                    index_source_authority_label(&self.index.freshness_status()),
+                    search_format::SourceAuthority::from_freshness(&self.index.freshness_status()),
                     implementations_parse_state_for_paths(&guard, &view),
                     &implementations_completeness_label(&view, &limits),
                     &find_references_scope_summary(input, mode),
@@ -9196,7 +9208,9 @@ impl SymForgeServer {
                     }
                     Some(search_format::format_search_envelope(
                         find_references_match_type_label(input, mode),
-                        index_source_authority_label(&self.index.freshness_status()),
+                        search_format::SourceAuthority::from_freshness(
+                            &self.index.freshness_status(),
+                        ),
                         search_parse_state_for_paths(
                             &guard,
                             view.files.iter().map(|file| file.file_path.as_str()),

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -3407,6 +3407,9 @@ fn apply_path_predicate_filter(
 #[allow(clippy::too_many_arguments)]
 fn render_search_text_output(
     server: &SymForgeServer,
+    // T046: the caller's entry capture — banner and parse-state come off the
+    // SAME publication that produced the rows, not fresh loads taken here.
+    generation: &std::sync::Arc<crate::live_index::store::PublishedGeneration>,
     result: Result<search::TextSearchResult, search::TextSearchError>,
     query: Option<&str>,
     structural: bool,
@@ -3419,7 +3422,7 @@ fn render_search_text_output(
 ) -> String {
     let envelope = match &result {
         Ok(result) if !result.files.is_empty() => {
-            let guard = server.index.read();
+            let guard = Arc::clone(&generation.live);
             Some(search_format::format_search_envelope(
                 &search_text_match_type_label(
                     structural,
@@ -3429,7 +3432,7 @@ fn render_search_text_output(
                     auto_corrected_regex,
                     options.ranked,
                 ),
-                search_format::SourceAuthority::from_freshness(&server.index.freshness_status()),
+                search_format::SourceAuthority::from_freshness(&generation.freshness),
                 search_parse_state_for_paths(
                     &guard,
                     result.files.iter().map(|file| file.path.as_str()),
@@ -5309,8 +5312,12 @@ impl SymForgeServer {
                 est, with_co
             );
         }
+        // T046: captured BEFORE the sidecar await — the co-change footer after
+        // the await uses THIS temporal, not a fresh load that could describe a
+        // publication the impact result never saw.
+        let generation = self.index.published_generation();
         {
-            let guard = self.index.read();
+            let guard = &generation.live;
             loading_guard!(guard);
         }
 
@@ -5332,7 +5339,7 @@ impl SymForgeServer {
 
         // Append co-changes if requested
         if params.0.include_co_changes.unwrap_or(false) {
-            let temporal = self.index.git_temporal();
+            let temporal = Arc::clone(&generation.code_signals.temporal);
             match temporal.state {
                 crate::live_index::git_temporal::GitTemporalState::Ready => {
                     let limit = params.0.co_changes_limit.unwrap_or(10) as usize;
@@ -5388,6 +5395,10 @@ impl SymForgeServer {
     }
 
     pub(crate) async fn search_symbols(&self, params: Parameters<SearchSymbolsInput>) -> String {
+        // T046: one capture of the published generation at entry; rows,
+        // trust banner, parse-state, and temporal data all read off it so a
+        // publication landing mid-render cannot mix generations in one response.
+        let generation = self.index.published_generation();
         let query_str = params.0.query.as_deref().unwrap_or("").trim();
         let is_browse = query_str.is_empty();
         if is_browse && params.0.kind.is_none() && params.0.path_prefix.is_none() {
@@ -5409,7 +5420,7 @@ impl SymForgeServer {
             Err(message) => return message,
         };
         let result = {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             loading_guard!(guard);
             search::search_symbols_with_options(
                 &guard,
@@ -5419,7 +5430,7 @@ impl SymForgeServer {
             )
         };
         let hidden_noise_count = {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             hidden_search_symbols_noise_count(
                 &guard,
                 query_str,
@@ -5435,10 +5446,10 @@ impl SymForgeServer {
         let envelope = if result.hits.is_empty() {
             None
         } else {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             Some(search_format::format_search_envelope(
                 search_symbols_match_type_label(&result, is_browse),
-                search_format::SourceAuthority::from_freshness(&self.index.freshness_status()),
+                search_format::SourceAuthority::from_freshness(&generation.freshness),
                 search_parse_state_for_paths(
                     &guard,
                     result.hits.iter().map(|hit| hit.path.as_str()),
@@ -5466,7 +5477,7 @@ impl SymForgeServer {
             && result.hits.len() < options.result_limit.get() / 2
         {
             let text_fallback = {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 loading_guard!(guard);
                 let mut text_options = search::TextSearchOptions::for_current_code_search();
                 text_options.path_scope = options.path_scope.clone();
@@ -5745,6 +5756,10 @@ impl SymForgeServer {
     }
 
     pub(crate) async fn search_text(&self, params: Parameters<SearchTextInput>) -> String {
+        // T046: one capture of the published generation at entry; rows,
+        // trust banner, parse-state, and temporal data all read off it so a
+        // publication landing mid-render cannot mix generations in one response.
+        let generation = self.index.published_generation();
         if let Some(result) = self.proxy_tool_call("search_text", &params.0).await {
             return result;
         }
@@ -5775,7 +5790,7 @@ impl SymForgeServer {
                 Err(message) => return message,
             };
             let mut result = {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 loading_guard!(guard);
                 let mut result = search::search_structural(&guard, pattern, &options);
                 resolve_text_search_enclosing_symbols(&guard, &mut result);
@@ -5789,6 +5804,7 @@ impl SymForgeServer {
             maybe_compact_text_search_result(&mut result, pattern);
             let output = render_search_text_output(
                 self,
+                &generation,
                 result,
                 Some(pattern),
                 true,
@@ -5841,7 +5857,7 @@ impl SymForgeServer {
         // Extract churn scores from GitTemporalIndex BEFORE acquiring the
         // LiveIndex read lock to avoid lock ordering issues.
         if options.ranked {
-            let git_temporal = self.index.git_temporal();
+            let git_temporal = Arc::clone(&generation.code_signals.temporal);
             if matches!(
                 git_temporal.state,
                 crate::live_index::git_temporal::GitTemporalState::Ready
@@ -5858,7 +5874,7 @@ impl SymForgeServer {
         }
 
         let mut result = {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             loading_guard!(guard);
             let mut r = search::search_text_with_options(
                 &guard,
@@ -5897,7 +5913,7 @@ impl SymForgeServer {
                 && let Some(fixed) = fix_common_double_escapes(query)
             {
                 let mut retry_result = {
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     loading_guard!(guard);
                     let mut r = search::search_text_with_options(
                         &guard,
@@ -5926,6 +5942,7 @@ impl SymForgeServer {
                 {
                     let mut output = render_search_text_output(
                         self,
+                        &generation,
                         retry_result,
                         Some(fixed.as_str()),
                         false,
@@ -5954,6 +5971,7 @@ impl SymForgeServer {
         maybe_compact_text_search_result(&mut result, &compaction_query);
         let output = render_search_text_output(
             self,
+            &generation,
             result,
             params.0.query.as_deref(),
             false,
@@ -6080,6 +6098,10 @@ impl SymForgeServer {
     }
 
     pub(crate) async fn search_files(&self, params: Parameters<SearchFilesInput>) -> String {
+        // T046: one capture of the published generation at entry; rows,
+        // trust banner, parse-state, and temporal data all read off it so a
+        // publication landing mid-render cannot mix generations in one response.
+        let generation = self.index.published_generation();
         if let Some(result) = self.proxy_tool_call("search_files", &params.0).await {
             return result;
         }
@@ -6103,7 +6125,7 @@ impl SymForgeServer {
                 return "search_files with resolve=true requires a non-empty `query`.".to_string();
             }
             let view = {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 loading_guard!(guard);
                 guard.capture_search_files_resolve_view_with_noise(
                     &params.0.query,
@@ -6114,19 +6136,17 @@ impl SymForgeServer {
             let hidden_noise_count = if include_vendor && include_personal_tooling {
                 0
             } else {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 let unfiltered = guard.capture_search_files_resolve_view(&params.0.query);
                 search_files_resolve_candidate_count(&unfiltered)
                     .saturating_sub(search_files_resolve_candidate_count(&view))
             };
             let envelope = match &view {
                 SearchFilesResolveView::Resolved { path } => {
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        search_format::SourceAuthority::from_freshness(
-                            &self.index.freshness_status(),
-                        ),
+                        search_format::SourceAuthority::from_freshness(&generation.freshness),
                         search_parse_state_for_paths(&guard, std::iter::once(path.as_str())),
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6142,9 +6162,7 @@ impl SymForgeServer {
                     // parse state honestly instead of the misleading "parsed".
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        search_format::SourceAuthority::from_freshness(
-                            &self.index.freshness_status(),
-                        ),
+                        search_format::SourceAuthority::from_freshness(&generation.freshness),
                         "metadata-only (not parsed)",
                         &search_completeness_label(0, hidden_noise_count),
                         &search_files_scope_summary(
@@ -6160,12 +6178,10 @@ impl SymForgeServer {
                     overflow_count,
                     ..
                 } => {
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     Some(search_format::format_search_envelope(
                         search_files_resolve_match_type_label(&view),
-                        search_format::SourceAuthority::from_freshness(
-                            &self.index.freshness_status(),
-                        ),
+                        search_format::SourceAuthority::from_freshness(&generation.freshness),
                         search_parse_state_for_paths(
                             &guard,
                             matches.iter().map(std::string::String::as_str),
@@ -6223,7 +6239,7 @@ impl SymForgeServer {
         // Deprecated since v7.x: prefer `rank_by="path+cochange"` with `anchor_path`.
         // Keep this compatibility path behavior unchanged for one release cycle.
         if let Some(ref target_path) = params.0.changed_with {
-            let temporal = self.index.git_temporal();
+            let temporal = Arc::clone(&generation.code_signals.temporal);
             match temporal.state {
                 crate::live_index::git_temporal::GitTemporalState::Ready => {}
                 crate::live_index::git_temporal::GitTemporalState::Unavailable(ref reason) => {
@@ -6273,7 +6289,7 @@ impl SymForgeServer {
                                 hits: weak_hits,
                             });
                         let envelope = {
-                            let guard = self.index.read();
+                            let guard = Arc::clone(&generation.live);
                             search_format::format_search_envelope(
                                 "weak heuristic (git-temporal coupling)",
                                 search_format::SourceAuthority::never_collapse(
@@ -6328,7 +6344,7 @@ impl SymForgeServer {
                     hits,
                 });
                 let envelope = {
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     search_format::format_search_envelope(
                         "heuristic (git-temporal coupling)",
                         search_format::SourceAuthority::never_collapse(
@@ -6383,7 +6399,7 @@ impl SymForgeServer {
             .then(|| self.capture_project_state_dir())
             .flatten();
         let mut view = {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             loading_guard!(guard);
             let cochange_resolution = if rank_by_path_cochange {
                 match params.0.anchor_path.as_deref() {
@@ -6590,7 +6606,7 @@ impl SymForgeServer {
                 overflow_count,
                 ..
             } => {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 let scope = match params.0.current_file.as_deref() {
                     Some(current_file) => {
                         format!("ranked indexed file paths; current file boost `{current_file}`")
@@ -6613,9 +6629,7 @@ impl SymForgeServer {
                             "current index + optional frecency history",
                         )
                     } else {
-                        search_format::SourceAuthority::from_freshness(
-                            &self.index.freshness_status(),
-                        )
+                        search_format::SourceAuthority::from_freshness(&generation.freshness)
                     },
                     search_parse_state_for_paths(&guard, hits.iter().map(|hit| hit.path.as_str())),
                     &search_completeness_label(*overflow_count, hidden_noise_count),
@@ -6981,7 +6995,13 @@ impl SymForgeServer {
         project_root: Option<PathBuf>,
         quarantine_window: format::QuarantineWindow,
     ) -> String {
-        let published = self.index.published_state();
+        // T046: ONE capture of the published set at entry; every axis of this
+        // report — health, live, temporal, source rows — reads off it, so a
+        // publication landing mid-render cannot mix generations inside one
+        // user-visible health report.
+        let source_set = self.index.published_source_set();
+        let generation = source_set.current_generation();
+        let published = Arc::clone(&generation.health);
         // Capture before `session_id` is consumed: a `Some` session id means the
         // report is served through a daemon session (membership authority
         // applies); local in-process reports carry `None`.
@@ -7051,14 +7071,17 @@ impl SymForgeServer {
         // Append git temporal summary.
         result.push('\n');
         result.push_str(&format::git_temporal_health_line(
-            &self.index.git_temporal(),
+            &generation.code_signals.temporal,
         ));
 
         let capabilities = {
             let repo_root = self.capture_repo_root();
             let project_state = self.capture_project_state_dir();
-            let guard = self.index.read();
-            capability_status_report(&guard, repo_root.as_deref(), project_state.as_ref())
+            capability_status_report(
+                &generation.live,
+                repo_root.as_deref(),
+                project_state.as_ref(),
+            )
         };
         result.push('\n');
         result.push_str(&capabilities.full_text());
@@ -7077,8 +7100,7 @@ impl SymForgeServer {
 
         // Feature 020 repository-knowledge health (M-001): manifest, dispositions,
         // source set, bridge, temporal, authority hygiene, plus source-binding/
-        // runtime state. All read from already-published state; nothing recomputed.
-        let source_set = self.index.published_source_set();
+        // runtime state. All read from the entry capture; nothing recomputed.
         let rk_placement = self.capture_state_placement();
         let rk_root = self.capture_repo_root();
         let rk_gitignore = gitignore_hygiene_status(rk_root.as_deref(), rk_placement.as_ref());
@@ -7159,7 +7181,10 @@ impl SymForgeServer {
         session_id: Option<String>,
         project_root: Option<PathBuf>,
     ) -> String {
-        let published = self.index.published_state();
+        // T046: same single-capture shape as health_for_runtime.
+        let source_set = self.index.published_source_set();
+        let generation = source_set.current_generation();
+        let published = Arc::clone(&generation.health);
         let session_is_daemon = session_id.is_some();
         let runtime_status =
             self.runtime_status_for(&published, mode, project_id, session_id, project_root);
@@ -7212,7 +7237,7 @@ impl SymForgeServer {
             }
         }
 
-        let git_temporal = format::git_temporal_health_line(&self.index.git_temporal());
+        let git_temporal = format::git_temporal_health_line(&generation.code_signals.temporal);
         let git_temporal_summary = git_temporal
             .lines()
             .next()
@@ -7226,8 +7251,11 @@ impl SymForgeServer {
         let capabilities = {
             let repo_root = self.capture_repo_root();
             let project_state = self.capture_project_state_dir();
-            let guard = self.index.read();
-            capability_status_report(&guard, repo_root.as_deref(), project_state.as_ref())
+            capability_status_report(
+                &generation.live,
+                repo_root.as_deref(),
+                project_state.as_ref(),
+            )
         };
         result.push('\n');
         result.push_str(&capabilities.compact_text());
@@ -7244,8 +7272,8 @@ impl SymForgeServer {
         result.push('\n');
         result.push_str(&curation_health);
 
-        // Feature 020 repository-knowledge health (M-001), compact form.
-        let source_set = self.index.published_source_set();
+        // Feature 020 repository-knowledge health (M-001), compact form. Reads
+        // from the entry capture.
         let rk_placement = self.capture_state_placement();
         let rk_root = self.capture_repo_root();
         let rk_gitignore = gitignore_hygiene_status(rk_root.as_deref(), rk_placement.as_ref());
@@ -7505,8 +7533,12 @@ impl SymForgeServer {
         &self,
     ) -> Option<crate::protocol::result_status::ProjectEvidence> {
         let root = self.capture_repo_root();
-        let published = self.index.published_state();
-        let load_source = self.index.read().load_source().label().to_string();
+        // T046: one capture; generation, load_source, counts, and index_state
+        // all describe the same publication. The atomic counter is not a
+        // freshness side channel.
+        let generation = self.index.published_generation();
+        let published = Arc::clone(&generation.health);
+        let load_source = generation.live.load_source().label().to_string();
         Some(crate::protocol::result_status::ProjectEvidence {
             project_id: root
                 .as_deref()
@@ -7514,7 +7546,7 @@ impl SymForgeServer {
                 .unwrap_or_else(|| "unbound".to_string()),
             project_name: self.project_name.clone(),
             canonical_root: root.map(|r| r.display().to_string().replace('\\', "/")),
-            generation: self.index.current_project_generation(),
+            generation: generation.project_generation,
             index_state: published.status_label().to_string(),
             load_source,
             index_files: published.file_count,
@@ -8884,11 +8916,10 @@ impl SymForgeServer {
                         return format::enforce_token_budget(with_warning, max_tokens);
                     }
                 }
-                // Suggest similar files from the index
-                let suggestions = {
-                    let guard = self.index.read();
-                    suggest_similar_files(&guard, &input.path)
-                };
+                // Suggest similar files from the SAME publication that produced
+                // the miss above — a fresh read() here could suggest from a
+                // different generation than the one that said not-found (T046).
+                let suggestions = suggest_similar_files(&generation.live, &input.path);
                 format::not_found_file_with_suggestions(&input.path, &suggestions)
             }
         }
@@ -9036,6 +9067,10 @@ impl SymForgeServer {
     }
 
     pub(crate) async fn find_references(&self, params: Parameters<FindReferencesInput>) -> String {
+        // T046: one capture of the published generation at entry; rows,
+        // trust banner, parse-state, and temporal data all read off it so a
+        // publication landing mid-render cannot mix generations in one response.
+        let generation = self.index.published_generation();
         if let Some(result) = self.proxy_tool_call("find_references", &params.0).await {
             return result;
         }
@@ -9050,7 +9085,7 @@ impl SymForgeServer {
         if let Some(path) = input.path.as_deref() {
             let repo_root = self.capture_repo_root();
             let degraded = {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 loading_guard!(guard);
                 admission_tier_degradation_for_path(
                     &guard,
@@ -9068,17 +9103,17 @@ impl SymForgeServer {
 
         if mode == "implementations" {
             let view = {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 loading_guard!(guard);
                 guard.capture_implementations_view(&input.name, input.direction.as_deref())
             };
             let cap = input.limit.unwrap_or(200).min(500);
             let limits = format::OutputLimits::new(cap, cap);
             let envelope = if !view.entries.is_empty() {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 Some(search_format::format_search_envelope(
                     find_references_match_type_label(input, mode),
-                    search_format::SourceAuthority::from_freshness(&self.index.freshness_status()),
+                    search_format::SourceAuthority::from_freshness(&generation.freshness),
                     implementations_parse_state_for_paths(&guard, &view),
                     &implementations_completeness_label(&view, &limits),
                     &find_references_scope_summary(input, mode),
@@ -9089,7 +9124,7 @@ impl SymForgeServer {
             };
             let result = format::implementations_result_view(&view, &input.name, &limits);
             if view.entries.is_empty() {
-                let guard = self.index.read();
+                let guard = Arc::clone(&generation.live);
                 let is_concrete = guard.all_files().any(|(_, file)| {
                     file.symbols.iter().any(|s| {
                         s.name == input.name
@@ -9134,7 +9169,7 @@ impl SymForgeServer {
             format::OutputLimits::new(input.limit.unwrap_or(20), input.max_per_file.unwrap_or(10));
         let collect_qualified_usages = should_collect_qualified_usages(input);
         let (result, indexed_ranges, qualified_usages) = {
-            let guard = self.index.read();
+            let guard = Arc::clone(&generation.live);
             loading_guard!(guard);
             if let Some(path) = input.path.as_deref() {
                 (
@@ -9190,7 +9225,7 @@ impl SymForgeServer {
                 // claiming "full for current scope" over an unscanned file.
                 let tier2_disclosure = {
                     let repo_root = self.capture_repo_root();
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     let candidates = guard.oversized_metadata_only_files();
                     tier2_reference_disclosure(
                         &candidates,
@@ -9200,7 +9235,7 @@ impl SymForgeServer {
                     )
                 };
                 let envelope = if !view.files.is_empty() {
-                    let guard = self.index.read();
+                    let guard = Arc::clone(&generation.live);
                     let mut completeness =
                         find_references_completeness_label(&view, &limits, input.kind.as_deref());
                     if tier2_disclosure.is_some() {
@@ -9208,9 +9243,7 @@ impl SymForgeServer {
                     }
                     Some(search_format::format_search_envelope(
                         find_references_match_type_label(input, mode),
-                        search_format::SourceAuthority::from_freshness(
-                            &self.index.freshness_status(),
-                        ),
+                        search_format::SourceAuthority::from_freshness(&generation.freshness),
                         search_parse_state_for_paths(
                             &guard,
                             view.files.iter().map(|file| file.file_path.as_str()),
@@ -9242,7 +9275,7 @@ impl SymForgeServer {
                     // it is bounded. A reverse symbol-name index would make it
                     // O(1) if this ever shows on a hot path.
                     let def_paths = {
-                        let guard = self.index.read();
+                        let guard = Arc::clone(&generation.live);
                         symbol_candidate_paths(&guard, &input.name)
                     };
                     if def_paths.len() > 1 {
@@ -9273,7 +9306,7 @@ impl SymForgeServer {
                 if view.files.is_empty() {
                     let text_options = search::TextSearchOptions::for_current_code_search();
                     let text_result = {
-                        let guard = self.index.read();
+                        let guard = Arc::clone(&generation.live);
                         search::search_text_with_options(
                             &guard,
                             Some(&input.name),
@@ -10624,9 +10657,11 @@ impl SymForgeServer {
         if let Some(refusal) = self.foreign_project_refusal(params.0.project.as_deref()) {
             return refusal;
         }
-        let guard = self.index.read();
+        // T046: one capture — plan structure and co-change data agree.
+        let generation = self.index.published_generation();
+        let guard = Arc::clone(&generation.live);
         loading_guard!(guard);
-        let temporal = self.index.git_temporal();
+        let temporal = Arc::clone(&generation.code_signals.temporal);
         let output = crate::protocol::edit_plan::plan_edit(&guard, &temporal, &params.0.target);
         self.session_context.record_summary_output(
             "edit_plan",

--- a/tests/read_gate_authority_v11.rs
+++ b/tests/read_gate_authority_v11.rs
@@ -290,6 +290,115 @@ fn a_failed_observation_refuses_without_disturbing_the_current_generation() {
     );
 }
 
+// ── T044: the authority CHOICE is explicit, and generation never reads disk ─
+
+#[test]
+fn generation_resolution_never_reads_unmatched_disk_bytes() {
+    // T042's first clause, on T044's seam. A generation miss is a MISS — it
+    // surfaces to the caller, who must then CHOOSE disk observation by name.
+    // Before the split, the choice was implicit in which function a lane
+    // reached for, which is how a lane meaning to serve published bytes could
+    // silently backfill from disk.
+    use symforge::protocol::format::claim_provenance::{
+        GenerationResolution, observe_disk_beneath, resolve_generation_bytes,
+    };
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("indexed.rs"),
+        "pub fn published_anchor() {}
+",
+    )
+    .expect("write indexed fixture");
+    let shared = symforge::live_index::LiveIndex::load(dir.path()).expect("load index");
+    let live = shared.read();
+
+    // AFTER the load: the indexed file changes on disk, and a new file appears
+    // that the generation never saw. Both are exactly what generation
+    // resolution must not observe.
+    std::fs::write(
+        dir.path().join("indexed.rs"),
+        "pub fn disk_only_anchor_a() {}
+",
+    )
+    .expect("rewrite on disk");
+    std::fs::write(
+        dir.path().join("diskonly.rs"),
+        "pub fn disk_only_anchor_b() {}
+",
+    )
+    .expect("write unindexed fixture");
+
+    // The generation serves the bytes it PUBLISHED, not the current disk.
+    let GenerationResolution::Published(bytes) = resolve_generation_bytes(&live, "indexed.rs")
+    else {
+        panic!("an indexed file resolves from the generation");
+    };
+    let text = std::str::from_utf8(bytes).expect("published bytes are utf8");
+    assert!(
+        text.contains("published_anchor"),
+        "generation resolution serves the published bytes"
+    );
+    assert!(
+        !text.contains("disk_only_anchor_a"),
+        "generation resolution must not observe the disk rewrite"
+    );
+
+    // The miss is a miss — never the disk bytes.
+    assert!(
+        matches!(
+            resolve_generation_bytes(&live, "diskonly.rs"),
+            GenerationResolution::NotInGeneration
+        ),
+        "a generation miss surfaces as a miss, not as disk content"
+    );
+
+    // GREEN-CONTROL: the disk-observation lane EXISTS and serves the current
+    // bytes when chosen by name — the split is a choice, not a wall.
+    let observed = observe_disk_beneath(&live, dir.path(), "diskonly.rs")
+        .expect("a deliberate confined observation is admitted");
+    assert!(
+        std::str::from_utf8(&observed)
+            .expect("observed bytes are utf8")
+            .contains("disk_only_anchor_b"),
+        "disk observation serves what is on disk right now"
+    );
+}
+
+#[test]
+fn a_disk_observation_is_confined_beneath_its_root() {
+    use symforge::protocol::format::claim_provenance::observe_disk_beneath;
+
+    let outside = tempfile::tempdir().expect("outside dir");
+    let canary = ["escape", "-", "canary", "-", "bytes"].concat();
+    std::fs::write(outside.path().join("secret.txt"), &canary).expect("write outside fixture");
+
+    let root = tempfile::TempDir::new_in(outside.path()).expect("nested root");
+    let shared = symforge::live_index::LiveIndex::load(root.path()).expect("load index");
+    let live = shared.read();
+
+    // A traversal component refuses BEFORE any read: the refusal must not
+    // echo the escaped content.
+    let refused = observe_disk_beneath(&live, root.path(), "../secret.txt")
+        .expect_err("a path that escapes the root must refuse");
+    assert!(
+        !refused.contains(canary.as_str()),
+        "the refusal must not carry the escaped bytes"
+    );
+
+    // An absolute path is an escape however it is spelled.
+    let absolute = outside.path().join("secret.txt");
+    let refused = observe_disk_beneath(&live, root.path(), absolute.to_str().expect("utf8 path"))
+        .expect_err("an absolute path must refuse");
+    assert!(!refused.contains(canary.as_str()));
+
+    // GREEN-CONTROL: a plain relative path beneath the root is admitted.
+    std::fs::write(root.path().join("inside.txt"), "inside-bytes").expect("write inside fixture");
+    let observed =
+        observe_disk_beneath(&live, root.path(), "inside.txt").expect("a beneath path is admitted");
+    assert_eq!(observed, b"inside-bytes");
+}
+
 // ── Context acquisition: rebinds refuse rather than composing roots ────────
 
 #[test]


### PR DESCRIPTION
## What this is

Feature 020 V11, Slice 3, PR 2 of 4: tasks T044 + T045 + T046 — named read stores, measured search-envelope authority, and per-caller single capture onto the published generation. Production behavior is intended-neutral except two sanctioned, fail-closed moves named below.

Head is `a12860da`. The full `--all-targets` suite ran green on the parent `0f379271`; the tip is docs-only (evidence table), so that receipt still describes this tree's code.

## What landed

- **T044** — `resolve_generation_bytes` and `observe_disk_beneath`. A lane names which store it is answering from. Disk observations are lexically confined beneath the workspace root before any read.
- **T045 batch 1** — Tier-2 sweep, raw fallback, and `validate_file_syntax` go through `observe_disk_beneath`. `detect_impact`'s base seed goes through `admit_git_text`. D8's sentinel allowlist is deleted; the tripwire is a bare `offenders.is_empty()`.
- **T045 batch 2** — `format_search_envelope` collapses only on a measured `SourceAuthority`. A lying `"current index"` literal is unrepresentable. `ProjectEvidence` / `_meta` stay untyped in this PR (D16; T048/activation).
- **T046** — one `published_generation()` capture at each approved reader: health pair, `project_health`, evidence blocks, search trio plus `search_text`, impact footer / `edit_plan` / `analyze_file_impact` (capture before the sidecar await). `terminal_dispositions` re-rooted onto the bundle. Write-only `published_repo_outline` ArcSwap field deleted. `runtime_status_for` takes caller-supplied project-generation: health passes the captured bundle; the two capture-less callers pass the atomic at the site.

Left alone, recorded: read-MUTATE-read publish paths, watcher reconcile, Tier-3 mutex-held store functions, `what_changed`, and the `scout_plan` / `source_exclusions` / `project_state_dir` ArcSwaps.

## Sanctioned behavior changes

1. A demoted file's `detect_impact` base seed collapses to the conservative fallback instead of disclosing through `file_at_ref` — withheld beats disclosed, same direction as #571.
2. Two envelope lanes that asserted `"current index"` now go loud when freshness is not Current.

Everything else: lib suite 3166/0 with zero test adjustments. The Slice-0 root-split oracle got strictly stronger and stayed green.

## Census — prediction vs measurement

First-commit decision said five categories regenerate. Measurement: **four moved, `ccr` byte-identical**, because CCR was trimmed out of T045 batch 2.

A production edit to `tools.rs` after the first regen moved `writers` again; the crank turned once more. Lesson: the regen is the last production change of the PR.

| category | before | first regen | after re-crank (HEAD) |
|---|---|---|---|
| writers | `5137cd7b…` | `bafa517a…` | `565e4227…bf3e31` |
| callbacks | `48938137…` | `026c548b…` | unchanged from first regen |
| publication_roots | `e37555ad…` | `b90b8d88…` | unchanged from first regen |
| cache | `4eb220e8…` | `6fb4cace…` | unchanged from first regen |
| ccr | `8ad77748…84ad246` | UNCHANGED | UNCHANGED |

`FROZEN_DIGESTS.retirement_records`: `4c118fab…` → `313dceda…` → `d86bd17b…e5ce29`.

## Mutations

M12 (confinement disabled) and M13 (Degraded marked collapsible) caught by named oracles alone. The generation-bytes never-reads-disk guard is structural: the function takes no workspace root.

## Gates

- `cargo test --all-targets` on `0f379271`: clean, ~512s, zero failure signals
- lib 3166/0, embed 1332/0, clippy `-D warnings` clean, fmt clean
- traceability checker OK; refreeze verify-internal passed

Stand-ins `completed_render_authority` and `current_query_lease` are untouched. T047–T052 stay for later PRs. Not Slice 4.

Evidence: `docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md`.

## Test plan

- [ ] CI `rust` job green (`fmt`, clippy `-D warnings`, full suite, `build --release`)
- [ ] CI `embed-build` green (`cargo test --no-default-features --features embed --lib`)
- [ ] Traceability / retirement-closure checker green against the four moved pins plus unchanged `ccr`
- [ ] Spot-check: health report axes describe one publication; search banner and rows share a capture; demoted-file `detect_impact` does not disclose via git objects
