### PR TITLE
fix(release): teardown tolerates a fixture path that is already gone

### DIFF
--- a/execution/test_refreeze_v11.py
+++ b/execution/test_refreeze_v11.py
@@ -526,8 +526,17 @@ class RefreezeV11Tests(unittest.TestCase):
             path: str,
             _error: object,
         ) -> None:
-            os.chmod(path, stat.S_IWRITE)
-            function(path)
+            # Windows read-only git objects need a chmod before the unlink can
+            # retry. A path that is ALREADY GONE is rmtree's goal state, not a
+            # failure: the Linux release runner hit a teardown race where a
+            # `.git/objects/*` entry vanished mid-walk and the chmod of the
+            # missing path turned cleanup into the ERROR that blocked
+            # prepare-release before release-please ever ran.
+            try:
+                os.chmod(path, stat.S_IWRITE)
+                function(path)
+            except FileNotFoundError:
+                return
 
         for path in reversed(created):
             if path.exists():


### PR DESCRIPTION
## What failed

`prepare-release` on `main` at `1f8dcffb` — run [31750123956](https://github.com/special-place-ai-heaven/symforge/actions/runs/31750123956) — died in the refreeze suite's **teardown**, not in any assertion: `shutil.rmtree` hit a `.git/objects/5f` entry that had already vanished mid-walk, the `onexc` handler `chmod`ed the missing path, and the resulting `FileNotFoundError` became the ERROR that stopped the job **before release-please ran**. The #573 version bump is currently owed and unprocessed because of it.

## The fix

One `except FileNotFoundError: return` inside the existing handler. Its job is the Windows case — chmod a read-only git object, retry the unlink. A path that is already gone is `rmtree`'s goal state, so the handler now treats it as success and keeps every other failure loud. No helper extraction, no behavior change for real errors.

## Proof

The exact CI invocation, locally: `python -m unittest discover -s execution -p 'test_*.py'` → exit 0, internal refreeze verification passed within it.

## Sequencing

Intended to merge **before** #575's squash, so the release run that squash triggers already carries the fix. After this merges: `gh run rerun 31750123956` to process the owed #573 bump — no hand-dispatched tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
