### PR TITLE
fix(session-cache): redeem read-path cache hits through CCR

### DIFF
--- a/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
+++ b/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
@@ -26,7 +26,7 @@ This detached attestation binds the refreeze manifest to the exact baseline, des
   "kind": "symforge-feature-020-refreeze-attestation",
   "manifest": {
     "path": "specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md",
-    "sha256": "581a91ff18651677794f1008f73e9b8f1b137ea1543a6d5a9816c7ff8a8c5f37"
+    "sha256": "8f55622bedc21924badbace78b34263c9fbcb79d7303e2be847c8dada59a7c3d"
   },
   "public_api": {
     "canonical_sha256": "c45f3cd3f77e5690ad1dcd2e5fc7e39e30d52df38fa564d7b663e1c95823a7da",

--- a/scripts/validate-lifecycle-oracle-traceability.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.cjs
@@ -310,7 +310,7 @@ const FROZEN_DIGESTS = {
   },
   retirement_records: {
     domain: "symforge.lifecycle.v11.retirement.records",
-    hash: "3b6870a3923476cbbdad962efdf1b1fb893c5ec3a3e29d5bf936d8fd4c22513d",
+    hash: "7657dd1c96ba2a9a78648ffba3e70c473c1093051c5d2cac0b334e14d30e073f",
   },
   retirement_edges: {
     domain: "symforge.lifecycle.v11.retirement.edges",

--- a/specs/011-ccr-output-compression/contracts/session-cache-hit.md
+++ b/specs/011-ccr-output-compression/contracts/session-cache-hit.md
@@ -18,24 +18,37 @@ mode flags — any param that changes formatted output.
 
 ## Hit behavior
 
-When cache hit and `force_refresh` is false:
+When cache hit and `force_refresh` is false **and** the CCR blob for that
+serve is still retrievable:
 
 1. Do **not** re-execute index query/format for full body.
-2. Return body shaped like STEL cache-hit:
+2. Return a small redeemable hit body:
 
 ```text
 Decision: cache_hit
 Economics: cache_hit (session_repeat_read)
 Session cache: {kind} {target} (prior_tokens={n}, session_age_secs={s})
 
-SymForge did not re-execute a legacy tool for this request.
-Reuse the content already loaded in this session.
+SymForge did not re-execute the read for this request.
+These bytes were served earlier on this MCP connection; that is not proof they are in your context.
+retrieve: symforge_retrieve with hash="{hash}"
+force_refresh=true re-reads the live index and is not the recovery path for missing bytes.
 
 --- cache payload ---
-{StelCacheBody JSON}
+{cache JSON including retrieve_handle}
 ```
 
-3. Record ledger `cache_hit=true` when STEL economics path active.
+3. A caller who does not have those bytes (for example a Cursor subagent
+   sharing the parent's MCP connection) recovers them with existing
+   `symforge_retrieve`, paying once. Do not re-execute the read tool and do
+   not use `force_refresh=true` as byte recovery.
+4. If the fetch record exists but `ccr_store.get(handle)` is `None` (evicted),
+   that is a **miss** — re-serve and re-insert. Never return `cache_hit` for
+   bytes that cannot be handed back.
+5. Record ledger `cache_hit=true` when STEL economics path active.
+
+STEL compact admission does **not** cache-hit these tools: the plan layer has
+no generation identity. The primitive applies the generation-aware key.
 
 ## Miss behavior
 

--- a/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
+++ b/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
@@ -1150,7 +1150,7 @@ This machine-verifiable manifest binds the complete Feature 020 corpus, its V11 
       "hash_policy": "raw_bytes",
       "path": "specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md",
       "scope": "feature",
-      "sha256": "91642250d0400456c4cbe844c7b54d575d80ad56d9c897e5ce6c6611c8e63f74",
+      "sha256": "937e0e85824f146d9ab1d3a77d55ee6ca6ff13a6fc0c6f553e6ba6e710eb9d04",
       "superseded_by": []
     },
     {

--- a/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
+++ b/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
@@ -590,7 +590,7 @@ planned and unexecuted.
   "kind": "symforge.v10_authority_retirement.v11",
   "preactivation_closure": {
     "cache": {
-      "digest": "90ac7e74c17485d9970a9fb8391e0a939997768bab8c08e0597e04458634d456",
+      "digest": "a0add8afe0b4d54b6e06e878abf76ac6c6c670f1d24eb39a212e96b67c7e102b",
       "paths": [
         "src/daemon.rs",
         "src/protocol/knowledge_curation.rs",
@@ -613,13 +613,13 @@ planned and unexecuted.
       ]
     },
     "ccr": {
-      "digest": "8ad77748b8fd9e6eb31853cc9615730fc632a890898321deb915546e384ad246",
+      "digest": "da3d3daf5f490a90f17cdd6f3cf6cb08634a465d6509f9c4f1c854b39b72cb89",
       "paths": [
         "src/protocol/ccr.rs"
       ]
     },
     "publication_roots": {
-      "digest": "9f8bcc30509c88f150828c26e868f740a1eba4690081ebfaf00091e9f36fbb7b",
+      "digest": "8924709a2cb28b77628f08c6d973d15fbf9f5ba79bee5a80c662a7858acca242",
       "paths": [
         "src/daemon.rs",
         "src/live_index/store.rs",
@@ -629,7 +629,7 @@ planned and unexecuted.
       ]
     },
     "writers": {
-      "digest": "780e468ecb7298c74e5f94952e821dac551f2459a983cab85d7b9d9b1b70e04a",
+      "digest": "1b4bd306a1d48195d11e161d1fab7c40371bd91ef8d7f47457f0502f376f9171",
       "paths": [
         "src/cli/init.rs",
         "src/gitignore_hygiene.rs",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9641,7 +9641,7 @@ mod tests {
         first_runtime
             .server
             .session_context
-            .record_file_content_fetch("src/lib.rs", 42, 100);
+            .record_file_content_fetch("src/lib.rs", 42, 100, "deadbeefcafe");
         assert!(
             first_runtime
                 .server

--- a/src/protocol/ccr.rs
+++ b/src/protocol/ccr.rs
@@ -219,6 +219,14 @@ impl CcrStore {
         self.total_bytes = self.total_bytes.saturating_sub(len);
         true
     }
+
+    pub(crate) fn remove_blob(&mut self, handle: &str) -> bool {
+        let Some(blob) = self.blobs.remove(handle) else {
+            return false;
+        };
+        self.total_bytes = self.total_bytes.saturating_sub(blob.formatted_bytes.len());
+        true
+    }
 }
 
 fn mint_handle(tool_name: &str, formatted: &str) -> String {

--- a/src/protocol/format.rs
+++ b/src/protocol/format.rs
@@ -5840,6 +5840,7 @@ pub fn format_session_cache_hit_body(
         "name": meta.name,
         "prior_tokens": meta.prior_tokens,
         "session_age_secs": meta.session_age_secs,
+        "retrieve_handle": meta.retrieve_handle,
     });
     let json = serde_json::to_string_pretty(&cache).expect("cache payload serializes");
     let target = if meta.name.is_empty() {
@@ -5853,11 +5854,13 @@ pub fn format_session_cache_hit_body(
          Session cache: {} {target} (prior_tokens={}, session_age_secs={})\n\
          \n\
          SymForge did not re-execute the read for this request.\n\
-         Reuse the content already loaded in this session, or pass force_refresh=true.\n\
+         These bytes were served earlier on this MCP connection; that is not proof they are in your context.\n\
+         retrieve: symforge_retrieve with hash=\"{}\"\n\
+         force_refresh=true re-reads the live index and is not the recovery path for missing bytes.\n\
          \n\
          --- cache payload ---\n\
          {json}",
-        meta.kind, meta.prior_tokens, meta.session_age_secs,
+        meta.kind, meta.prior_tokens, meta.session_age_secs, meta.retrieve_handle,
     )
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -805,6 +805,12 @@ impl SymForgeServer {
         &self.stel_ledger
     }
 
+    /// Test-only: drop a stored CCR blob so the next matching read must re-serve.
+    #[doc(hidden)]
+    pub fn drop_ccr_blob_for_tests(&self, handle: &str) -> bool {
+        self.ccr_store.lock().remove_blob(handle)
+    }
+
     /// Return the MCP tool definitions advertised by this server.
     ///
     /// This is a read-only view over the generated router metadata so integration
@@ -974,9 +980,10 @@ impl SymForgeServer {
         &self,
         meta: &crate::protocol::session::SessionCacheHitMeta,
         reason: &str,
-    ) -> String {
+    ) -> Option<String> {
+        self.ccr_store.lock().get(&meta.retrieve_handle)?;
         self.session_context.record_cache_hit();
-        format::format_session_cache_hit_body(meta, reason)
+        Some(format::format_session_cache_hit_body(meta, reason))
     }
 
     pub(crate) fn compression_economics(&self) -> crate::protocol::ccr::CcrEconomics {

--- a/src/protocol/session.rs
+++ b/src/protocol/session.rs
@@ -28,6 +28,8 @@ struct FetchKey {
 pub struct SessionFetchRecord {
     pub approx_tokens: u32,
     pub fetched_at: Instant,
+    /// CCR handle for the formatted body last served for this key.
+    pub retrieve_handle: String,
 }
 
 /// Metadata for a session cache-hit response body.
@@ -38,6 +40,7 @@ pub struct SessionCacheHitMeta {
     pub name: String,
     pub prior_tokens: u32,
     pub session_age_secs: u64,
+    pub retrieve_handle: String,
 }
 
 /// Tracks what symbols and files have been served to the LLM this session.
@@ -233,6 +236,7 @@ impl SessionContext {
             name,
             prior_tokens: record.approx_tokens,
             session_age_secs: inner.started_at.elapsed().as_secs(),
+            retrieve_handle: record.retrieve_handle.clone(),
         })
     }
 
@@ -243,6 +247,7 @@ impl SessionContext {
         symbol: &str,
         params_hash: u64,
         tokens: u32,
+        retrieve_handle: &str,
     ) {
         let mut inner = self.inner.lock();
         let key = FetchKey {
@@ -256,6 +261,7 @@ impl SessionContext {
             SessionFetchRecord {
                 approx_tokens: tokens,
                 fetched_at: Instant::now(),
+                retrieve_handle: retrieve_handle.to_string(),
             },
         );
     }
@@ -308,63 +314,73 @@ impl SessionContext {
         self.try_cache_hit(FetchKind::FileContent, path, "", params_hash, force_refresh)
     }
 
-    pub fn record_symbol_fetch(&self, path: &str, name: &str, params_hash: u64, tokens: u32) {
+    pub fn record_symbol_fetch(
+        &self,
+        path: &str,
+        name: &str,
+        params_hash: u64,
+        tokens: u32,
+        retrieve_handle: &str,
+    ) {
         self.record_symbol(path, name, tokens);
-        self.record_detailed_fetch(FetchKind::Symbol, path, name, params_hash, tokens);
+        self.record_detailed_fetch(
+            FetchKind::Symbol,
+            path,
+            name,
+            params_hash,
+            tokens,
+            retrieve_handle,
+        );
     }
 
-    pub fn record_file_context_fetch(&self, path: &str, params_hash: u64, tokens: u32) {
-        self.record_detailed_fetch(FetchKind::FileContext, path, "", params_hash, tokens);
+    pub fn record_file_context_fetch(
+        &self,
+        path: &str,
+        params_hash: u64,
+        tokens: u32,
+        retrieve_handle: &str,
+    ) {
+        self.record_detailed_fetch(
+            FetchKind::FileContext,
+            path,
+            "",
+            params_hash,
+            tokens,
+            retrieve_handle,
+        );
     }
 
-    pub fn record_file_content_fetch(&self, path: &str, params_hash: u64, tokens: u32) {
+    pub fn record_file_content_fetch(
+        &self,
+        path: &str,
+        params_hash: u64,
+        tokens: u32,
+        retrieve_handle: &str,
+    ) {
         self.record_file(path, tokens);
-        self.record_detailed_fetch(FetchKind::FileContent, path, "", params_hash, tokens);
+        self.record_detailed_fetch(
+            FetchKind::FileContent,
+            path,
+            "",
+            params_hash,
+            tokens,
+            retrieve_handle,
+        );
     }
 
     /// STEL compact-step cache lookup using JSON args.
+    ///
+    /// Always `None` for the 011 US1 read surface (`get_symbol`,
+    /// `get_file_context`, `get_file_content`): the plan layer has no
+    /// generation identity. The primitive hashes publication/content generation
+    /// and redeems a CCR blob when the hit is legal.
+    #[allow(clippy::unused_self)]
     pub fn try_cache_hit_from_stel_step(
         &self,
-        tool: &str,
-        args: &serde_json::Value,
+        _tool: &str,
+        _args: &serde_json::Value,
     ) -> Option<SessionCacheHitMeta> {
-        let force_refresh = args
-            .get("force_refresh")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        match tool {
-            "get_symbol" => {
-                let name = args.get("name")?.as_str()?.trim();
-                if name.is_empty() {
-                    return None;
-                }
-                let path = args
-                    .get("path")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .trim();
-                if path.is_empty() {
-                    return None;
-                }
-                let hash = hash_symbol_params_json(args);
-                self.try_symbol_cache_hit(path, name, hash, force_refresh)
-            }
-            "get_file_context" => {
-                let path = args.get("path")?.as_str()?.trim();
-                if path.is_empty() {
-                    return None;
-                }
-                let hash = hash_file_context_params_json(args);
-                self.try_file_context_cache_hit(path, hash, force_refresh)
-            }
-            // `get_file_content` owns a generation-aware cache key that is
-            // computed only after targeted freshness and publication capture.
-            // The plan-only STEL admission layer has neither identity, so it
-            // must execute the primitive instead of reusing a potentially stale
-            // pre-publication fetch.
-            "get_file_content" => None,
-            _ => None,
-        }
+        None
     }
 
     /// Take a snapshot for display.
@@ -461,11 +477,19 @@ pub fn hash_symbol_params(
     kind: Option<&str>,
     symbol_line: Option<u32>,
     max_tokens: Option<u64>,
+    project_generation: u64,
+    source_id: &str,
+    publication_generation: u64,
+    content_generation: u64,
 ) -> u64 {
     hash_value(&serde_json::json!({
         "kind": kind,
         "symbol_line": symbol_line,
         "max_tokens": max_tokens,
+        "project_generation": project_generation,
+        "source_id": source_id,
+        "publication_generation": publication_generation,
+        "content_generation": content_generation,
     }))
 }
 
@@ -659,5 +683,89 @@ mod tests {
         assert!(output.contains("src/main.rs"));
         assert!(output.contains("explore"));
         assert!(output.contains("1695"));
+    }
+
+    #[test]
+    fn hash_symbol_params_binds_generation_identity() {
+        let base = hash_symbol_params(None, None, None, 1, "src-a", 2, 3);
+        assert_ne!(
+            base,
+            hash_symbol_params(None, None, None, 1, "src-a", 2, 4),
+            "content_generation must be part of the cache key"
+        );
+        assert_ne!(
+            base,
+            hash_symbol_params(None, None, None, 1, "src-b", 2, 3),
+            "source_id must be part of the cache key"
+        );
+        assert_ne!(
+            base,
+            hash_symbol_params(None, None, None, 2, "src-a", 2, 3),
+            "project_generation must be part of the cache key"
+        );
+        assert_ne!(
+            base,
+            hash_symbol_params(None, None, None, 1, "src-a", 3, 3),
+            "publication_generation must be part of the cache key"
+        );
+    }
+
+    #[test]
+    fn generation_change_in_hash_is_a_cache_miss() {
+        let ctx = SessionContext::new();
+        let gen1 = hash_symbol_params(None, None, None, 1, "src-a", 1, 1);
+        let gen2 = hash_symbol_params(None, None, None, 1, "src-a", 1, 2);
+        ctx.record_symbol_fetch("src/lib.rs", "foo", gen1, 200, "cafe01234567");
+        assert!(
+            ctx.try_symbol_cache_hit("src/lib.rs", "foo", gen1, false)
+                .is_some()
+        );
+        assert!(
+            ctx.try_symbol_cache_hit("src/lib.rs", "foo", gen2, false)
+                .is_none(),
+            "a later generation identity must not reuse the prior fetch"
+        );
+    }
+
+    #[test]
+    fn stel_admission_does_not_cache_hit_generation_blind_reads() {
+        let ctx = SessionContext::new();
+        ctx.record_symbol_fetch(
+            "src/lib.rs",
+            "foo",
+            hash_symbol_params(None, None, None, 0, "unavailable", 0, 0),
+            200,
+            "cafe01234567",
+        );
+        ctx.record_file_context_fetch("src/lib.rs", 1, 100, "cafe01234567");
+        let symbol_args = serde_json::json!({ "path": "src/lib.rs", "name": "foo" });
+        let file_args = serde_json::json!({ "path": "src/lib.rs" });
+        assert!(
+            ctx.try_cache_hit_from_stel_step("get_symbol", &symbol_args)
+                .is_none()
+        );
+        assert!(
+            ctx.try_cache_hit_from_stel_step("get_file_context", &file_args)
+                .is_none()
+        );
+        assert!(
+            ctx.try_cache_hit_from_stel_step("get_file_content", &file_args)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cache_hit_meta_carries_retrieve_handle() {
+        let ctx = SessionContext::new();
+        ctx.record_symbol_fetch("src/lib.rs", "foo", 7, 200, "deadbeefcafe");
+        let meta = ctx
+            .try_symbol_cache_hit("src/lib.rs", "foo", 7, false)
+            .expect("recorded fetch");
+        assert_eq!(meta.retrieve_handle, "deadbeefcafe");
+        assert!(
+            ctx.try_symbol_cache_hit("src/lib.rs", "foo", 7, true)
+                .is_none(),
+            "force_refresh must bypass cache_hit"
+        );
     }
 }

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -4367,31 +4367,45 @@ impl SymForgeServer {
         }
 
         let force_refresh = params.0.force_refresh == Some(true);
+        // Capture freshness and the immutable publication before consulting the
+        // repeat-read cache. The same request against a later watcher publication
+        // must be a cache miss, and the bytes below must come from this exact
+        // captured generation rather than a second live-index read.
+        let generation = self.index.published_source_set().current_generation();
+        if let Some(message) = loading_guard_message_from_published(&generation.health) {
+            return message;
+        }
+        let source_id = generation
+            .source
+            .as_ref()
+            .map(|source| source.source_id.as_str())
+            .unwrap_or("unavailable");
         let params_hash = crate::protocol::session::hash_symbol_params(
             params.0.kind.as_deref(),
             params.0.symbol_line,
             params.0.max_tokens,
+            generation.project_generation,
+            source_id,
+            generation.publication_generation,
+            generation.content_generation,
         );
         if let Some(meta) = self.session_context.try_symbol_cache_hit(
             &params.0.path,
             &params.0.name,
             params_hash,
             force_refresh,
-        ) {
-            return self.format_read_cache_hit(&meta, "session_repeat_read");
+        ) && let Some(hit) = self.format_read_cache_hit(&meta, "session_repeat_read")
+        {
+            return hit;
         }
 
-        let file = {
-            // The single-project overlay READ was REMOVED: it was redundant (the
-            // shared live index already holds the edit via reindex_after_write) and
-            // carried a narrow staleness shadow risk (overlay-first with no freshness
-            // gate could shadow a base advanced by a watcher event). The base read is
-            // always at-least-as-fresh. See
-            // docs/reviews/overlay-redundancy-decision.md.
-            let guard = self.index.read();
-            loading_guard!(guard);
-            guard.capture_shared_file(&params.0.path)
-        };
+        // The single-project overlay READ was REMOVED: it was redundant (the
+        // shared live index already holds the edit via reindex_after_write) and
+        // carried a narrow staleness shadow risk (overlay-first with no freshness
+        // gate could shadow a base advanced by a watcher event). The base read is
+        // always at-least-as-fresh. See
+        // docs/reviews/overlay-redundancy-decision.md.
+        let file = generation.live.capture_shared_file(&params.0.path);
 
         // Honest Tier-2/Tier-3 response before any miss handling: a path like
         // package-lock.json EXISTS but is admitted metadata-only, so it has no
@@ -4400,15 +4414,11 @@ impl SymForgeServer {
         // the index (Tier-1 files resolve above).
         if file.is_none() {
             let repo_root = self.capture_repo_root();
-            let degraded = {
-                let guard = self.index.read();
-                loading_guard!(guard);
-                admission_tier_file_degradation_for_path(
-                    &guard,
-                    repo_root.as_deref(),
-                    &params.0.path,
-                )
-            };
+            let degraded = admission_tier_file_degradation_for_path(
+                generation.live.as_ref(),
+                repo_root.as_deref(),
+                &params.0.path,
+            );
             if let Some(result) = degraded {
                 return result;
             }
@@ -4468,12 +4478,6 @@ impl SymForgeServer {
                 } else {
                     None
                 };
-                self.session_context.record_symbol_fetch(
-                    &params.0.path,
-                    &params.0.name,
-                    params_hash,
-                    tokens,
-                );
                 // Frecency bump — commitment tool, single-symbol happy path.
                 // Collection policy is resolved inside bump_frecency. See wiki
                 // `[[SymForge Frecency-Weighted File Ranking]]` §"Bump hooks".
@@ -4487,13 +4491,21 @@ impl SymForgeServer {
                         prior.approx_tokens,
                     );
                 }
+                let handle = self
+                    .ccr_store
+                    .lock()
+                    .insert("get_symbol", final_output.clone());
+                self.session_context.record_symbol_fetch(
+                    &params.0.path,
+                    &params.0.name,
+                    params_hash,
+                    tokens,
+                    &handle,
+                );
                 final_output
             }
             None => {
-                let suggestions = {
-                    let guard = self.index.read();
-                    suggest_similar_files(&guard, &params.0.path)
-                };
+                let suggestions = suggest_similar_files(&generation.live, &params.0.path);
                 format::not_found_file_with_suggestions(&params.0.path, &suggestions)
             }
         }
@@ -4712,8 +4724,9 @@ impl SymForgeServer {
             &params.0.path,
             params_hash,
             force_refresh,
-        ) {
-            return self.format_read_cache_hit(&meta, "session_repeat_read");
+        ) && let Some(hit) = self.format_read_cache_hit(&meta, "session_repeat_read")
+        {
+            return hit;
         }
         // Honest Tier-2/Tier-3 response: the path may EXIST on disk but be
         // deliberately admitted as metadata-only (e.g. package-lock.json) or
@@ -4823,8 +4836,16 @@ impl SymForgeServer {
                 context_max_tokens,
             );
             let tokens = (output.len() / 4) as u32;
-            self.session_context
-                .record_file_context_fetch(&params.0.path, params_hash, tokens);
+            let handle = self
+                .ccr_store
+                .lock()
+                .insert("get_file_context", output.clone());
+            self.session_context.record_file_context_fetch(
+                &params.0.path,
+                params_hash,
+                tokens,
+                &handle,
+            );
             self.session_context
                 .record_listed_file(&params.0.path, tokens);
             self.bump_frecency(&[PathBuf::from(&params.0.path)]);
@@ -4881,10 +4902,6 @@ impl SymForgeServer {
                 } else {
                     None
                 };
-                self.session_context
-                    .record_file_context_fetch(&params.0.path, params_hash, tokens);
-                self.session_context
-                    .record_listed_file(&params.0.path, tokens);
                 if let Some(prior) = prior_dedup {
                     output = format::append_dedup_hint_footer(
                         output,
@@ -4893,6 +4910,18 @@ impl SymForgeServer {
                         prior.approx_tokens,
                     );
                 }
+                let handle = self
+                    .ccr_store
+                    .lock()
+                    .insert("get_file_context", output.clone());
+                self.session_context.record_file_context_fetch(
+                    &params.0.path,
+                    params_hash,
+                    tokens,
+                    &handle,
+                );
+                self.session_context
+                    .record_listed_file(&params.0.path, tokens);
                 // Frecency bump — commitment tool. Reached only on the happy
                 // path after a successful outline fetch; collection policy is
                 // resolved inside bump_frecency. See wiki `[[SymForge Frecency-Weighted
@@ -8959,8 +8988,9 @@ impl SymForgeServer {
         if let Some(meta) =
             self.session_context
                 .try_file_content_cache_hit(&input.path, params_hash, force_refresh)
+            && let Some(hit) = self.format_read_cache_hit(&meta, "session_repeat_read")
         {
-            return self.format_read_cache_hit(&meta, "session_repeat_read");
+            return hit;
         }
         let mode_annotation = match (
             &options.content_context.mode_name,
@@ -9005,8 +9035,6 @@ impl SymForgeServer {
                 } else {
                     None
                 };
-                self.session_context
-                    .record_file_content_fetch(&input.path, params_hash, tokens);
                 self.bump_frecency(&[PathBuf::from(&input.path)]);
                 if let Some(prior) = prior_dedup {
                     final_output = format::append_dedup_hint_footer(
@@ -9016,6 +9044,16 @@ impl SymForgeServer {
                         prior.approx_tokens,
                     );
                 }
+                let handle = self
+                    .ccr_store
+                    .lock()
+                    .insert("get_file_content", final_output.clone());
+                self.session_context.record_file_content_fetch(
+                    &input.path,
+                    params_hash,
+                    tokens,
+                    &handle,
+                );
                 final_output
             }
             None => {

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -32205,9 +32205,18 @@ mod tests {
         let cache_step = cache_plan.steps.first().expect("cache plan step");
         assert_eq!(cache_step.tool, "get_file_context");
         let cache_hash = crate::protocol::session::hash_file_context_params_json(&cache_step.args);
-        cache_server
-            .session_context
-            .record_file_context_fetch("src/lib.rs", cache_hash, 64);
+        // Seed a GENUINELY redeemable hit: the CCR blob exists on this
+        // connection, so only the selector guard can stop it being served.
+        let cache_handle = cache_server.ccr_store.lock().insert(
+            "get_file_context",
+            "seeded home-project evidence".to_string(),
+        );
+        cache_server.session_context.record_file_context_fetch(
+            "src/lib.rs",
+            cache_hash,
+            64,
+            &cache_handle,
+        );
         cache_request.project = Some("totally-other-project".to_string());
         let cache_call = SymforgeCallInput {
             request: cache_request,
@@ -32222,8 +32231,10 @@ mod tests {
         let text = tool_result_text(&serialized);
         assert!(
             (text.contains("not available on this connection")
-                || text.contains("cannot be resolved for a local facade-only result"))
-                && !text.contains("Decision: cache_hit"),
+                || text.contains("cannot be resolved for a local facade-only result")
+                || text.contains("cannot be resolved for safe HOME fallback"))
+                && !text.contains("Decision: cache_hit")
+                && !text.contains("seeded home-project evidence"),
             "a foreign cache hit must refuse before returning stored home-project evidence: {text}"
         );
     }

--- a/src/stel/controller.rs
+++ b/src/stel/controller.rs
@@ -795,13 +795,14 @@ mod tests {
     }
 
     #[test]
-    fn session_cache_hit_for_prefetched_symbol() {
+    fn session_prefetch_does_not_stel_cache_hit_get_symbol() {
         let session = SessionContext::new();
         session.record_symbol_fetch(
             "src/lib.rs",
             "cfg_if",
-            crate::protocol::session::hash_symbol_params(None, None, None),
+            crate::protocol::session::hash_symbol_params(None, None, None, 0, "unavailable", 0, 0),
             128,
+            "deadbeefcafe",
         );
         let plan = StelPlan {
             plan_id: "cache".to_string(),
@@ -820,10 +821,12 @@ mod tests {
         };
         let request = StelRequest::default();
         let decision = evaluate_plan_with_session(&request, &plan, Some(&session));
-        assert_eq!(decision.decision, AdmissionDecision::CacheHit);
-        let cache = decision.cache.as_ref().expect("cache body");
-        assert_eq!(cache.kind, "symbol");
-        assert_eq!(cache.prior_tokens, 128);
+        assert_ne!(
+            decision.decision,
+            AdmissionDecision::CacheHit,
+            "plan layer has no generation identity; the primitive must run"
+        );
+        assert!(decision.cache.is_none());
     }
 
     #[test]

--- a/src/stel/executor.rs
+++ b/src/stel/executor.rs
@@ -126,6 +126,7 @@ fn format_cache_hit_body_from(cache: &StelCacheBody, decision_reason: &str) -> S
         name: cache.name.clone(),
         prior_tokens: cache.prior_tokens,
         session_age_secs: cache.session_age_secs,
+        retrieve_handle: String::new(),
     };
     crate::protocol::format::format_session_cache_hit_body(&meta, decision_reason)
 }
@@ -451,7 +452,33 @@ mod tests {
     }
 
     #[test]
-    fn cache_hit_skips_legacy_dispatch() {
+    fn cache_hit_decision_skips_legacy_dispatch() {
+        use crate::stel::types::{StelCacheBody, StelDecision};
+
+        let decision = StelDecision {
+            plan_id: "cache".to_string(),
+            decision: AdmissionDecision::CacheHit,
+            decision_reason: "synthetic cache hit".to_string(),
+            effective_max_tokens: None,
+            degrade_flags: vec![],
+            steps: None,
+            bypass: None,
+            cache: Some(StelCacheBody {
+                kind: "symbol".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "cfg_if".to_string(),
+                prior_tokens: 96,
+                session_age_secs: 0,
+            }),
+        };
+        assert!(should_skip_legacy_dispatch(&decision));
+        let body = format_cache_hit_body(&decision);
+        assert!(body.contains("Decision: cache_hit"));
+        assert!(body.contains("did not re-execute the read"));
+    }
+
+    #[test]
+    fn get_symbol_prefetch_does_not_stel_cache_hit() {
         use crate::protocol::session::SessionContext;
         use crate::stel::controller::evaluate_plan_with_session;
         use crate::stel::types::{IntentBucket, RouteConfidence, StelPlan, StelPlanStep};
@@ -460,8 +487,9 @@ mod tests {
         session.record_symbol_fetch(
             "src/lib.rs",
             "cfg_if",
-            crate::protocol::session::hash_symbol_params(None, None, None),
+            crate::protocol::session::hash_symbol_params(None, None, None, 0, "unavailable", 0, 0),
             96,
+            "deadbeefcafe",
         );
         let plan = StelPlan {
             plan_id: "cache".to_string(),
@@ -480,11 +508,12 @@ mod tests {
         };
         let request = StelRequest::default();
         let decision = evaluate_plan_with_session(&request, &plan, Some(&session));
-        assert_eq!(decision.decision, AdmissionDecision::CacheHit);
-        assert!(should_skip_legacy_dispatch(&decision));
-        let body = format_cache_hit_body(&decision);
-        assert!(body.contains("Decision: cache_hit"));
-        assert!(body.contains("did not re-execute the read"));
+        assert_ne!(
+            decision.decision,
+            AdmissionDecision::CacheHit,
+            "plan layer has no generation identity; the primitive must run"
+        );
+        assert!(!should_skip_legacy_dispatch(&decision));
     }
 
     #[test]

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -802,9 +802,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "78f32c8921a1c1878fc13c29aed8775914d6beb1dfeb878048e5fb9166f67bcb",
+    "5fdf63ca532c587227e6d9fceab1e4b1bcfcbf39e0adaf7fada430ff5c12e45f",
     187,
-    8_980_758,
+    8_987_655,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/session_cache_hit.rs
+++ b/tests/session_cache_hit.rs
@@ -1,4 +1,4 @@
-//! Session cache-hit for full read tools (011 US1).
+//! Session cache-hit for full read tools (011 US1 / #574).
 #![cfg(feature = "server")]
 
 use serde_json::json;
@@ -18,6 +18,12 @@ fn server_for_fixture() -> SymForgeServer {
         Some(root),
         None,
     )
+}
+
+fn ccr_hash(body: &str) -> Option<&str> {
+    body.split("hash=\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
 }
 
 #[tokio::test]
@@ -58,6 +64,96 @@ async fn get_symbol_repeat_returns_cache_hit() {
     assert!(forced.len() > 100);
 }
 
+#[tokio::test]
+async fn get_symbol_cache_hit_is_redeemable_via_retrieve() {
+    let server = server_for_fixture();
+    let params = json!({ "path": "src/main.rs", "name": "main" });
+    let first = server
+        .dispatch_tool_for_tests("get_symbol", params.clone())
+        .await;
+    assert!(!first.contains("Decision: cache_hit"));
+
+    let second = server
+        .dispatch_tool_for_tests("get_symbol", params.clone())
+        .await;
+    assert!(second.contains("Decision: cache_hit"), "{second}");
+    assert!(
+        second.contains("hash=\""),
+        "hit body must use the search_text hash= spelling:\n{second}"
+    );
+    assert!(
+        !second.contains("already loaded in this session"),
+        "hit copy must not claim the caller already has the bytes:\n{second}"
+    );
+    assert!(
+        second.contains("this MCP connection"),
+        "hit copy must name the MCP connection, not the caller:\n{second}"
+    );
+    assert!(
+        second.contains("not the recovery path for missing bytes"),
+        "force_refresh must not be offered as byte recovery:\n{second}"
+    );
+
+    let hash = ccr_hash(&second).expect("retrieve hash in cache_hit body");
+    let retrieved = server
+        .dispatch_tool_for_tests("symforge_retrieve", json!({ "hash": hash }))
+        .await;
+    assert_eq!(
+        retrieved, first,
+        "retrieve must return the first formatted serve, not a re-query"
+    );
+}
+
+#[tokio::test]
+async fn shared_session_cache_hit_is_redeemable_issue_574() {
+    let server = server_for_fixture();
+    let params = json!({ "path": "src/main.rs", "name": "main" });
+    let first = server
+        .dispatch_tool_for_tests("get_symbol", params.clone())
+        .await;
+
+    // Same SymForgeServer / SessionContext — Cursor subagents share the parent's
+    // MCP connection. The second caller never saw `first`.
+    let second = server.dispatch_tool_for_tests("get_symbol", params).await;
+    assert!(
+        second.contains("Decision: cache_hit"),
+        "shared session still cache_hits:\n{second}"
+    );
+    let hash = ccr_hash(&second).expect("retrieve hash");
+    let retrieved = server
+        .dispatch_tool_for_tests("symforge_retrieve", json!({ "hash": hash }))
+        .await;
+    assert_eq!(retrieved, first);
+}
+
+#[tokio::test]
+async fn evicted_ccr_blob_turns_cache_hit_into_miss() {
+    let server = server_for_fixture();
+    let params = json!({ "path": "src/main.rs", "name": "main" });
+    let first = server
+        .dispatch_tool_for_tests("get_symbol", params.clone())
+        .await;
+    let hit = server
+        .dispatch_tool_for_tests("get_symbol", params.clone())
+        .await;
+    let hash = ccr_hash(&hit).expect("retrieve hash");
+    assert!(
+        server.drop_ccr_blob_for_tests(hash),
+        "blob for {hash} must exist before eviction"
+    );
+
+    let third = server.dispatch_tool_for_tests("get_symbol", params).await;
+    assert!(
+        !third.contains("Decision: cache_hit"),
+        "missing CCR blob must be a miss, not a lying hit:\n{third}"
+    );
+    assert!(third.len() > 100, "miss must re-serve a full body");
+    assert_eq!(
+        third, first,
+        "re-serve after eviction should match the original formatted body"
+    );
+}
+
 #[test]
 fn session_detailed_fetch_drives_stel_cache_hit() {
     use symforge::protocol::session::SessionContext;
@@ -70,8 +166,9 @@ fn session_detailed_fetch_drives_stel_cache_hit() {
     session.record_symbol_fetch(
         "src/lib.rs",
         "foo",
-        hash_symbol_params(None, None, None),
+        hash_symbol_params(None, None, None, 0, "unavailable", 0, 0),
         200,
+        "deadbeefcafe",
     );
     let plan = StelPlan {
         plan_id: "t".to_string(),
@@ -89,5 +186,9 @@ fn session_detailed_fetch_drives_stel_cache_hit() {
         suggested_followup: None,
     };
     let decision = evaluate_plan_with_session(&StelRequest::default(), &plan, Some(&session));
-    assert_eq!(decision.decision, AdmissionDecision::CacheHit);
+    assert_ne!(
+        decision.decision,
+        AdmissionDecision::CacheHit,
+        "generation-blind STEL admission must not cache_hit; the primitive owns the key"
+    );
 }

--- a/tests/stel_l2_admission.rs
+++ b/tests/stel_l2_admission.rs
@@ -10,8 +10,8 @@ use symforge::live_index::LiveIndex;
 use symforge::protocol::SymForgeServer;
 use symforge::protocol::session::SessionContext;
 use symforge::stel::{
-    self, AdmissionDecision, IntentBucket, RouteConfidence, StelPlan, StelPlanStep, StelRequest,
-    apply_degrade_to_plan, evaluate_plan, evaluate_plan_with_session,
+    self, AdmissionDecision, IntentBucket, RouteConfidence, StelCacheBody, StelDecision, StelPlan,
+    StelPlanStep, StelRequest, apply_degrade_to_plan, evaluate_plan, evaluate_plan_with_session,
 };
 
 fn repo_root() -> PathBuf {
@@ -125,8 +125,9 @@ fn l2_controller_covers_all_four_admission_states() {
     session.record_symbol_fetch(
         "src/lib.rs",
         "cfg_if",
-        symforge::protocol::session::hash_symbol_params(None, None, None),
+        symforge::protocol::session::hash_symbol_params(None, None, None, 0, "unavailable", 0, 0),
         128,
+        "deadbeefcafe",
     );
     let cache_plan = StelPlan {
         plan_id: "cache".to_string(),
@@ -143,10 +144,13 @@ fn l2_controller_covers_all_four_admission_states() {
         }],
         suggested_followup: None,
     };
-    let cache_hit =
+    let after_prefetch =
         evaluate_plan_with_session(&StelRequest::default(), &cache_plan, Some(&session));
-    assert_eq!(cache_hit.decision, AdmissionDecision::CacheHit);
-    assert!(cache_hit.cache.is_some());
+    assert_ne!(
+        after_prefetch.decision,
+        AdmissionDecision::CacheHit,
+        "plan layer has no generation identity; get_symbol must run the primitive"
+    );
 }
 
 #[test]
@@ -197,16 +201,26 @@ async fn cache_hit_dispatch_skips_legacy_tools_after_session_prefetch() {
 
     let second = dispatch_symforge(&server, request).await;
     assert!(
-        second.contains("decision: cache_hit"),
-        "repeat should cache_hit:\n{second}"
+        second.contains("Decision: cache_hit"),
+        "repeat must hit the generation-aware primitive cache:\n{second}"
     );
-    assert!(second.contains("did not re-execute the read"));
-    assert!(!second.contains("Chosen tool: get_symbol"));
+    assert!(
+        second.contains("hash=\""),
+        "cache_hit must carry a redeemable CCR handle:\n{second}"
+    );
+    assert!(
+        !second.contains("already loaded in this session"),
+        "hit copy must not claim the caller already has the bytes:\n{second}"
+    );
+    assert!(
+        second.contains("decision: serve"),
+        "STEL L2 has no generation identity so it must dispatch the primitive:\n{second}"
+    );
+    assert!(second.contains("Chosen tool: get_symbol"));
 
     let event = server.stel_ledger().lock().last().expect("ledger event");
-    assert_eq!(event.decision, AdmissionDecision::CacheHit);
-    assert!(event.tools_called.is_empty());
-    assert_eq!(event.cache_hit, Some(true));
+    assert_eq!(event.decision, AdmissionDecision::Serve);
+    assert!(!event.tools_called.is_empty());
 }
 
 /// T035 (SC-005, US5 AC-1) end-to-end: the SAME read operation over two real
@@ -335,13 +349,6 @@ fn calibration_summary_counts_degrade_and_cache_hit() {
         surface: "symforge",
     });
 
-    let session = SessionContext::new();
-    session.record_symbol_fetch(
-        "src/lib.rs",
-        "cfg_if",
-        symforge::protocol::session::hash_symbol_params(None, None, None),
-        128,
-    );
     let cache_plan = StelPlan {
         plan_id: "cache".to_string(),
         intent: IntentBucket::Read,
@@ -357,8 +364,22 @@ fn calibration_summary_counts_degrade_and_cache_hit() {
         }],
         suggested_followup: None,
     };
-    let cache_decision =
-        evaluate_plan_with_session(&StelRequest::default(), &cache_plan, Some(&session));
+    let cache_decision = StelDecision {
+        plan_id: cache_plan.plan_id.clone(),
+        decision: AdmissionDecision::CacheHit,
+        decision_reason: "synthetic cache hit for calibration counts".to_string(),
+        effective_max_tokens: None,
+        degrade_flags: vec![],
+        steps: None,
+        bypass: None,
+        cache: Some(StelCacheBody {
+            kind: "symbol".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "cfg_if".to_string(),
+            prior_tokens: 128,
+            session_age_secs: 0,
+        }),
+    };
     let cache_economics = estimate_economics(&cache_plan);
     let (cache_event, _) = capture_ledger(&LedgerCaptureInput {
         plan: &cache_plan,


### PR DESCRIPTION
Fixes #574.

A cache_hit is only legal when the formatted body is still retrievable on this MCP connection: format_read_cache_hit now refuses to mint a voucher unless the CCR store holds the hit's retrieve_handle, so a subagent that never saw the bytes either recovers them via symforge_retrieve or falls through to a fresh full read. Session cache entries record the CCR handle at publish time across the get_symbol, get_file_context, and get_file_content read paths and the STEL facade lanes.

A second commit reconciles the change over the just-landed Slice 3 PR 4 base: the four moved census closures were re-cranked via the designed emitter procedure with the second-order retirement-records, manifest, and attestation pins rebound; the whole-source T051 seal was repinned and confirmed by the Rust seal test; one semantic merge break was repaired where PR 4's facade cross-project test called the pre-widening three-argument record_file_context_fetch; and that facade regression was strengthened while reconciling — it now seeds a genuinely CCR-redeemable cache entry and proves a foreign project selector refuses before any stored home-project evidence is served, accepting the C1-hardened project-routing refusal wording.

Verified locally on the combined tree: full serial all-targets suite exit 0 with the library at 3225 passed, preventive seal suite 8/0 with the oracle-confirmed pin, lifecycle traceability 78/24/13, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn