### PR TITLE
fix(ccr): route symforge_retrieve through the daemon so handles redeem

### DIFF
--- a/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
+++ b/docs/reviews/FEATURE-020-REFREEZE-ATTESTATION-v11.md
@@ -26,7 +26,7 @@ This detached attestation binds the refreeze manifest to the exact baseline, des
   "kind": "symforge-feature-020-refreeze-attestation",
   "manifest": {
     "path": "specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md",
-    "sha256": "8f55622bedc21924badbace78b34263c9fbcb79d7303e2be847c8dada59a7c3d"
+    "sha256": "80f128ad1ba9f86e84138f5f2cf4038f578d73e9000c5bfab42511cdd20dd2a1"
   },
   "public_api": {
     "canonical_sha256": "c45f3cd3f77e5690ad1dcd2e5fc7e39e30d52df38fa564d7b663e1c95823a7da",

--- a/scripts/validate-lifecycle-oracle-traceability.cjs
+++ b/scripts/validate-lifecycle-oracle-traceability.cjs
@@ -310,7 +310,7 @@ const FROZEN_DIGESTS = {
   },
   retirement_records: {
     domain: "symforge.lifecycle.v11.retirement.records",
-    hash: "7657dd1c96ba2a9a78648ffba3e70c473c1093051c5d2cac0b334e14d30e073f",
+    hash: "9a8de919ec5d3520a1e16d809a703cc7c5eade5c496382a9f813c8ff5570b0d7",
   },
   retirement_edges: {
     domain: "symforge.lifecycle.v11.retirement.edges",

--- a/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
+++ b/specs/020-repository-knowledge-index/REFREEZE-MANIFEST-v11.md
@@ -1150,7 +1150,7 @@ This machine-verifiable manifest binds the complete Feature 020 corpus, its V11 
       "hash_policy": "raw_bytes",
       "path": "specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md",
       "scope": "feature",
-      "sha256": "937e0e85824f146d9ab1d3a77d55ee6ca6ff13a6fc0c6f553e6ba6e710eb9d04",
+      "sha256": "6915c6c7a93698a279b575f3cd5f4f034691d75d1dc5201489260b860a8813ef",
       "superseded_by": []
     },
     {

--- a/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
+++ b/specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md
@@ -590,7 +590,7 @@ planned and unexecuted.
   "kind": "symforge.v10_authority_retirement.v11",
   "preactivation_closure": {
     "cache": {
-      "digest": "a0add8afe0b4d54b6e06e878abf76ac6c6c670f1d24eb39a212e96b67c7e102b",
+      "digest": "95a84a2e2e4ca0165f568898427461a2d9d06f8903df100f6db3dbb0ce393b53",
       "paths": [
         "src/daemon.rs",
         "src/protocol/knowledge_curation.rs",
@@ -600,7 +600,7 @@ planned and unexecuted.
       ]
     },
     "callbacks": {
-      "digest": "5c0f31ac8c807e6cd81520e1e9af70056a6948bf18f36a9784c84471209d29a5",
+      "digest": "0d87a5f96edf5a2d70e222a37e37bc8f69601f2610f24d0e399e96dfa3a055b9",
       "paths": [
         "src/daemon.rs",
         "src/live_index/git_temporal.rs",
@@ -619,7 +619,7 @@ planned and unexecuted.
       ]
     },
     "publication_roots": {
-      "digest": "8924709a2cb28b77628f08c6d973d15fbf9f5ba79bee5a80c662a7858acca242",
+      "digest": "9e1fb439b39f7708acd03a502e4d4fee1789d6acf84e97f4a9929f76c82a85fb",
       "paths": [
         "src/daemon.rs",
         "src/live_index/store.rs",
@@ -629,7 +629,7 @@ planned and unexecuted.
       ]
     },
     "writers": {
-      "digest": "1b4bd306a1d48195d11e161d1fab7c40371bd91ef8d7f47457f0502f376f9171",
+      "digest": "a38a034f20b17b187dd9b36407edb0f27118d097d9dc03c86b6d196a3df966b8",
       "paths": [
         "src/cli/init.rs",
         "src/gitignore_hygiene.rs",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4075,6 +4075,7 @@ pub(crate) fn private_project_routed_tool(tool_name: &str) -> bool {
             | "health_compact"
             | "status"
             | "context_inventory"
+            | "symforge_retrieve"
     )
 }
 
@@ -9675,6 +9676,79 @@ mod tests {
             &first_runtime.token_stats,
             &second_runtime.token_stats,
         ));
+    }
+
+    /// Issue #585: on a daemon connection every producing tool stores its CCR
+    /// blob in the daemon-side session server, so `symforge_retrieve` must be
+    /// daemon-routed and redeem from THAT store. The adapter-side handler used
+    /// to answer from its own empty store, making every advertised handle
+    /// irredeemable.
+    #[tokio::test]
+    async fn symforge_retrieve_redeems_from_the_session_runtime_store() {
+        let project = project_dir("symforge-retrieve-session-store");
+        std::fs::write(
+            project.path().join("src").join("lib.rs"),
+            "pub fn redeemable() {}\n",
+        )
+        .expect("write source");
+        let state = Arc::new(DaemonState::new());
+        let opened = state
+            .open_project_session(OpenProjectRequest {
+                project_root: project.path().display().to_string(),
+                client_name: "retriever".to_string(),
+                pid: None,
+            })
+            .expect("session");
+
+        let stored_body = "── symforge get_symbol ──\npub fn redeemable() {}\n";
+        let handle = {
+            let runtime = state
+                .runtime_for_target(&opened.session_id, None)
+                .expect("session runtime");
+            runtime
+                .server
+                .ccr_store
+                .lock()
+                .insert("get_symbol", stored_body.to_string())
+        };
+
+        // The daemon-private route pin must be accepted for this tool; the
+        // adapter synthesizes it for every selector-less daemon call.
+        let mut pinned = serde_json::json!({
+            "hash": handle,
+            crate::daemon::PRIVATE_PROJECT_ROUTE_PIN: opened.project_id.clone(),
+        });
+        assert_eq!(
+            take_private_project_route_pin("symforge_retrieve", &mut pinned)
+                .expect("the pin is legal for symforge_retrieve"),
+            Some(opened.project_id.clone()),
+        );
+
+        let runtime = state
+            .runtime_for_target(&opened.session_id, None)
+            .expect("session runtime");
+        let body = execute_tool_call(runtime, "symforge_retrieve", pinned)
+            .await
+            .expect("daemon-side retrieve dispatch");
+        assert_eq!(
+            body, stored_body,
+            "the daemon dispatch must round-trip the session store's exact bytes"
+        );
+
+        let runtime = state
+            .runtime_for_target(&opened.session_id, None)
+            .expect("session runtime");
+        let miss = execute_tool_call(
+            runtime,
+            "symforge_retrieve",
+            serde_json::json!({ "hash": "0123456789ab" }),
+        )
+        .await
+        .expect("a miss is a message, not a dispatch error");
+        assert!(
+            miss.contains("stale or expired"),
+            "an unknown handle must keep the honest miss message: {miss}"
+        );
     }
 
     #[test]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -3234,6 +3234,7 @@ mod tests {
             "health_compact",
             "status",
             "context_inventory",
+            "symforge_retrieve",
         ] {
             let body = server
                 .proxy_tool_call(tool_name, &serde_json::json!({}))
@@ -3242,7 +3243,7 @@ mod tests {
             assert!(body.contains(&format!("tool={tool_name}")), "{body}");
         }
         let requests = requests.lock();
-        assert_eq!(requests.len(), 9);
+        assert_eq!(requests.len(), 10);
         for (tool_name, args) in requests.iter().skip(1) {
             assert_eq!(
                 args[crate::daemon::PRIVATE_PROJECT_ROUTE_PIN],

--- a/src/protocol/tools.rs
+++ b/src/protocol/tools.rs
@@ -12270,6 +12270,13 @@ impl SymForgeServer {
         &self,
         params: Parameters<SymforgeRetrieveInput>,
     ) -> String {
+        // On a daemon connection every producing tool stores its CCR blob in
+        // the daemon-side session server, so redemption must reach that same
+        // store. Serving this from the adapter's own (empty) store made every
+        // advertised handle irredeemable (issue #585).
+        if let Some(result) = self.proxy_tool_call("symforge_retrieve", &params.0).await {
+            return result;
+        }
         let hash = params.0.hash.trim().to_lowercase();
         if hash.len() != 12 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
             return "CCR retrieve: invalid hash (expected 12 hex chars)".to_string();

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -802,9 +802,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "5fdf63ca532c587227e6d9fceab1e4b1bcfcbf39e0adaf7fada430ff5c12e45f",
+    "f1921916e8f5e98c1f3320305deae6498bf9c080a17e202cd1588212b1b2b189",
     187,
-    8_987_655,
+    8_991_024,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Fixes #585.

symforge_retrieve was the only read tool without the proxy preamble, so on daemon connections it executed on the local adapter whose CCR store is empty while every producing tool stored blobs in the daemon-side session server. Every session-cache voucher and every CCR compression footer advertised an unredeemable recovery path. The handler now proxies first, and the tool joins the daemon-private route pin table so a concurrent ACTIVE change cannot move redemption onto another project.

Verified locally with the full serial suite green, a new daemon-side regression proving the round trip through the real dispatch plus pin acceptance plus the honest miss message, the adapter-side proxy test extended to all ten selector-less pinned tools, clippy denied-warnings clean, the release build green, and the census, second-order pins, and whole-source seal reconciled with the Rust oracle confirming the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn