### PR TITLE
feat(feature-020): Slice 4 pair 1 - dark supervisor and candidate pipeline

### DIFF
--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -31,7 +31,7 @@ current `main` after the previous pair merges (seal/census files serialize).
 
 **Purpose**: land the execution-spec docs so every pair PR can reference them
 
-- [ ] T001 Commit `specs/028-preventive-activation-cut/*` + the CLAUDE.md plan-pointer update on `feature-020-slice-4-candidates`, open a docs-only PR to `main`, and on green CI squash-merge with explicit `--subject "docs(feature-020): Slice 4 execution spec (speckit 028) (#N)" --body "..."` per the repo squash rules
+- [x] T001 Commit `specs/028-preventive-activation-cut/*` + the CLAUDE.md plan-pointer update on `feature-020-slice-4-candidates`, open a docs-only PR to `main`, and on green CI squash-merge with explicit `--subject "docs(feature-020): Slice 4 execution spec (speckit 028) (#N)" --body "..."` per the repo squash rules
 
 ---
 
@@ -52,11 +52,11 @@ as dark machinery (020:T053 + T059 + T060)
 **Independent Test**: `cargo test --test index_candidate_lifecycle_v11 -- --test-threads=1`
 GREEN; darkness seal proves the new modules unreachable from production.
 
-- [ ] T002 [US1] Branch `feature-020-s4-p1-candidate` from `main`; author RED `tests/index_candidate_lifecycle_v11.rs` with frozen names `closed_candidate_promotion_matrix` and `opaque_non_utf8_path_identity_is_lossless` plus the full 020:T053 case list (isolated build, publish-before-prune, retry supersession, all seven matrix outcomes, metadata-terminal exclusions, certificate-cannot-authorize-partial, failed/panicked discard); run only this file and record the observed RED output in the PR description (020:T053)
-- [ ] T003 [US1] Implement `src/index_lifecycle/supervisor.rs` — loader ownership, cancellation, attempt accounting, classified failure, retry triggers moved from the existing loader seams (020:T059)
-- [ ] T004 [US1] Implement `src/index_lifecycle/candidate.rs` — capacity-reserved isolated full/delta candidates, complete artifact certificates, one runtime-store commit point, `CatalogPath` native/opaque identity end-to-end, delta exact-validation of only the changed source token, no-allocation whole-root patch, same-source drift retry/abort, epochs-never-authorize; register both modules in `src/index_lifecycle/mod.rs` (020:T060)
-- [ ] T005 [US1] Extend `tests/preventive_runtime_dark_v11.rs` (constructor unreachability + census) to cover supervisor+candidate; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle only; reconcile the contract chain if census categories shift (quickstart step 3)
-- [ ] T006 [US1] Run the full gate battery serially via Terminal Commander (fmt, clippy -D warnings, all-targets serial suite, `--no-default-features --features embed --lib`, release build, verify-tools, npm) plus `node scripts/validate-lifecycle-oracle-traceability.cjs`; `cargo clean` if `target/` grew heavy
+- [x] T002 [US1] Branch `feature-020-s4-p1-candidate` from `main`; author RED `tests/index_candidate_lifecycle_v11.rs` with frozen names `closed_candidate_promotion_matrix` and `opaque_non_utf8_path_identity_is_lossless` plus the full 020:T053 case list (isolated build, publish-before-prune, retry supersession, all seven matrix outcomes, metadata-terminal exclusions, certificate-cannot-authorize-partial, failed/panicked discard); run only this file and record the observed RED output in the PR description (020:T053)
+- [x] T003 [US1] Implement `src/index_lifecycle/supervisor.rs` — loader ownership, cancellation, attempt accounting, classified failure, retry triggers moved from the existing loader seams (020:T059)
+- [x] T004 [US1] Implement `src/index_lifecycle/candidate.rs` — capacity-reserved isolated full/delta candidates, complete artifact certificates, one runtime-store commit point, `CatalogPath` native/opaque identity end-to-end, delta exact-validation of only the changed source token, no-allocation whole-root patch, same-source drift retry/abort, epochs-never-authorize; register both modules in `src/index_lifecycle/mod.rs` (020:T060)
+- [x] T005 [US1] Extend `tests/preventive_runtime_dark_v11.rs` (constructor unreachability + census) to cover supervisor+candidate; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle only; reconcile the contract chain if census categories shift (quickstart step 3)
+- [x] T006 [US1] Run the full gate battery serially via Terminal Commander (fmt, clippy -D warnings, all-targets serial suite, `--no-default-features --features embed --lib`, release build, verify-tools, npm) plus `node scripts/validate-lifecycle-oracle-traceability.cjs`; `cargo clean` if `target/` grew heavy
 - [ ] T007 [US1] One independent code review including the mandatory cfg-lens sweep; open PR; on green CI auto-squash-merge with explicit subject/body (spec FR-015/FR-016)
 
 **Checkpoint**: candidate pipeline GREEN dark on `main`; the Wave 1 workflow

--- a/src/index_lifecycle/candidate.rs
+++ b/src/index_lifecycle/candidate.rs
@@ -132,6 +132,11 @@ pub struct CandidateManifest {
 /// Per-source promoted artifacts (dark payloads).
 #[derive(Debug)]
 pub struct SourceArtifacts {
+    /// Content stamp. Metadata-only sources carry `SourceContentToken(0)` —
+    /// a dark payload simplification, not a contract: the real token shape
+    /// lands with the sealed artifact machinery at the cut, and a delta over
+    /// a metadata-only sibling must pass `Some(SourceContentToken(0))` until
+    /// then.
     pub token: SourceContentToken,
     pub manifest: CandidateManifest,
     pub artifacts: BTreeMap<ArtifactKind, u64>,
@@ -174,13 +179,20 @@ impl ProjectArtifactRoot {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PromotionRefusal {
     /// A closed-matrix cause observed during build.
+    ///
+    /// Incompleteness of the required artifact set has no variant here on
+    /// purpose: the dark build constructs all four kinds unconditionally, so
+    /// an "incomplete" refusal would be an error nothing can emit — the
+    /// reporting invariant's shape in miniature. The real refusal arrives
+    /// with the sealed `RequiredArtifactSet` compiler at the cut (T067).
     Failure(ClassifiedFailure),
-    /// The sealed required artifact set is not completely certified.
-    IncompleteRequiredArtifacts { missing: Vec<ArtifactKind> },
     /// A capability certificate was offered in place of completeness.
     CapabilityCannotAuthorize,
     /// A retry trigger superseded the owning attempt.
     Superseded,
+    /// The owning attempt already terminal-ended; one attempt commits at
+    /// most once.
+    AttemptAlreadyTerminal,
     /// The delta's changed source token no longer matches the live root.
     SameSourceDrift {
         expected: Option<SourceContentToken>,
@@ -362,6 +374,9 @@ impl IsolatedCandidate {
         let mut supervisor = self.supervisor.lock().expect("supervisor lock");
         if supervisor.is_superseded(self.attempt) {
             return Err(PromotionRefusal::Superseded);
+        }
+        if supervisor.is_terminal(self.attempt) {
+            return Err(PromotionRefusal::AttemptAlreadyTerminal);
         }
         match self.outcome {
             BuildOutcome::Classified(cause) => {

--- a/src/index_lifecycle/candidate.rs
+++ b/src/index_lifecycle/candidate.rs
@@ -1,0 +1,415 @@
+//! Feature 020 V11 isolated candidate pipeline (Slice 4, T060 — dark).
+//!
+//! Capacity-reserved isolated full and delta candidates with complete artifact
+//! certificates and ONE runtime-store commit point. `CatalogPath`
+//! native/opaque identity is preserved through candidate, manifest, and
+//! promotion without lossy reconstruction; a prepared source delta
+//! exact-validates only its changed source token and no-allocation patches the
+//! LATEST whole project root so unrelated newer membership/source siblings
+//! survive; same-source drift retries or aborts; numeric epochs never
+//! authorize publication (frozen tasks.md T060).
+//!
+//! Dark payload simplifications, in the `runtime.rs` idiom: artifact digests
+//! are stamps, not real derivations; the sealed `RequiredArtifactSet` compiler
+//! is a fixed closed set. The authority SEMANTICS — isolation, the single
+//! commit point, completeness, supersession, drift, sibling survival — are
+//! exact; the payloads are recorded Slice 4/release obligations.
+//!
+//! **Nothing in production calls this module.** Only the Slice 4 oracle
+//! suites and this directory do; activation (T064/T066) is the only planned
+//! production caller.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use crate::domain::index::CatalogPath;
+use crate::domain::index::MetadataOnlyReason;
+
+use super::capacity::CapacityPermit;
+use super::capacity::CapacityRefusal;
+use super::capacity::OwnerIdentity;
+use super::capacity::ProcessCapacityPool;
+use super::supervisor::AttemptId;
+use super::supervisor::ClassifiedFailure;
+use super::supervisor::LoadAttempt;
+use super::supervisor::SupervisorState;
+
+/// Identity of one source within its project's artifact root.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceId(pub u64);
+
+/// Content stamp for one source at observation time — the "changed source
+/// token" a delta exact-validates against. A token compares by value; it
+/// carries no authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SourceContentToken(pub u64);
+
+/// The closed required artifact set (dark stand-in for the sealed
+/// `RequiredArtifactSet` compiler: only the set's IDENTITY crosses the seam;
+/// callers cannot choose a subset or construct completeness).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ArtifactKind {
+    Catalog,
+    Symbols,
+    References,
+    Outline,
+}
+
+impl ArtifactKind {
+    pub const REQUIRED: [ArtifactKind; 4] = [
+        ArtifactKind::Catalog,
+        ArtifactKind::Symbols,
+        ArtifactKind::References,
+        ArtifactKind::Outline,
+    ];
+}
+
+/// A capability claim. Deliberately inert at the promotion gate: capability
+/// certificates cannot authorize partial promotion, and this type exists so
+/// the oracle can prove that refusal against a real value.
+#[derive(Clone, Copy, Debug)]
+pub struct CapabilityCertificate {
+    _private: (),
+}
+
+impl CapabilityCertificate {
+    pub fn for_test() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// What one source looked like when the candidate observed it.
+#[derive(Clone, Debug)]
+pub enum SourceObservation {
+    /// Textual content admitted for derivation.
+    Content {
+        path: CatalogPath,
+        token: SourceContentToken,
+        bytes: u64,
+    },
+    /// Catalog-only admission: present in the manifest, excluded from every
+    /// content derivation, never content-probed.
+    MetadataOnly {
+        path: CatalogPath,
+        reason: MetadataOnlyReason,
+    },
+    /// The observation itself failed with a classified cause.
+    Failed(ClassifiedFailure),
+}
+
+/// One source's input to a candidate build.
+#[derive(Clone, Debug)]
+pub struct CandidateSource {
+    pub id: SourceId,
+    pub observation: SourceObservation,
+}
+
+/// Disposition of one manifest entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntryDisposition {
+    Indexed { content_stamp: u64 },
+    MetadataOnly { reason: MetadataOnlyReason },
+}
+
+/// One promoted manifest row. The `path` is the EXACT `CatalogPath` the
+/// observation carried — never reconstructed, never lossily respelled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifestEntry {
+    pub path: CatalogPath,
+    pub disposition: EntryDisposition,
+}
+
+/// The candidate's manifest: total over its observed sources.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CandidateManifest {
+    pub entries: Vec<ManifestEntry>,
+}
+
+/// Per-source promoted artifacts (dark payloads).
+#[derive(Debug)]
+pub struct SourceArtifacts {
+    pub token: SourceContentToken,
+    pub manifest: CandidateManifest,
+    pub artifacts: BTreeMap<ArtifactKind, u64>,
+}
+
+/// One published whole-project artifact snapshot. A delta patch replaces
+/// exactly one source's `Arc`; every sibling's `Arc` survives identical.
+#[derive(Debug, Default)]
+pub struct ProjectArtifacts {
+    pub sources: HashMap<SourceId, Arc<SourceArtifacts>>,
+}
+
+/// The LATEST whole project artifact root — the one runtime store the single
+/// commit point publishes into.
+#[derive(Debug, Default)]
+pub struct ProjectArtifactRoot {
+    pub(crate) inner: Mutex<Arc<ProjectArtifacts>>,
+}
+
+impl ProjectArtifactRoot {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// The current publication. Holders keep reading their snapshot after any
+    /// later commit: publish happens before prune.
+    pub fn load(&self) -> Arc<ProjectArtifacts> {
+        Arc::clone(&self.inner.lock().expect("artifact root lock"))
+    }
+
+    /// Sealed negative: a bare numeric epoch is never publication authority.
+    /// Nothing is published, unconditionally.
+    pub fn publish_claiming_epoch_only(&self, epoch: u64) -> PromotionRefusal {
+        let _ = epoch;
+        PromotionRefusal::EpochIsNotAuthority
+    }
+}
+
+/// Why a candidate refused to promote.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PromotionRefusal {
+    /// A closed-matrix cause observed during build.
+    Failure(ClassifiedFailure),
+    /// The sealed required artifact set is not completely certified.
+    IncompleteRequiredArtifacts { missing: Vec<ArtifactKind> },
+    /// A capability certificate was offered in place of completeness.
+    CapabilityCannotAuthorize,
+    /// A retry trigger superseded the owning attempt.
+    Superseded,
+    /// The delta's changed source token no longer matches the live root.
+    SameSourceDrift {
+        expected: Option<SourceContentToken>,
+        found: Option<SourceContentToken>,
+    },
+    /// A bare numeric epoch was presented as publication authority.
+    EpochIsNotAuthority,
+    /// The build panicked; the candidate was discarded whole.
+    Panicked,
+}
+
+#[derive(Debug)]
+struct DeltaSpec {
+    changed: SourceId,
+    expected: Option<SourceContentToken>,
+}
+
+#[derive(Debug)]
+enum BuildOutcome {
+    Ready {
+        built: HashMap<SourceId, Arc<SourceArtifacts>>,
+        delta: Option<DeltaSpec>,
+    },
+    Classified(ClassifiedFailure),
+    Panicked,
+}
+
+/// A capacity-reserved isolated candidate: nothing it does is observable in
+/// the project root until `commit`, its single runtime-store commit point.
+/// The capacity permit is held for the candidate's whole life; dropping the
+/// candidate (any terminal path) refunds the charge.
+#[derive(Debug)]
+pub struct IsolatedCandidate {
+    outcome: BuildOutcome,
+    attempt: AttemptId,
+    supervisor: Arc<Mutex<SupervisorState>>,
+    _permit: CapacityPermit,
+}
+
+fn reserved_bytes(sources: &[CandidateSource]) -> u64 {
+    sources
+        .iter()
+        .map(|source| match &source.observation {
+            SourceObservation::Content { bytes, .. } => *bytes,
+            _ => 0,
+        })
+        .sum::<u64>()
+        .max(1)
+}
+
+/// Build every source's artifacts in ISOLATION. A `Failed` observation
+/// classifies the whole candidate; a panicking derivation discards it whole.
+fn build_sources(
+    sources: &[CandidateSource],
+    derive: &mut dyn FnMut(&CandidateSource) -> u64,
+) -> BuildOutcome {
+    let mut built = HashMap::new();
+    for source in sources {
+        match &source.observation {
+            SourceObservation::Failed(cause) => return BuildOutcome::Classified(*cause),
+            SourceObservation::Content { path, token, .. } => {
+                let stamp = match catch_unwind(AssertUnwindSafe(|| derive(source))) {
+                    Ok(stamp) => stamp,
+                    Err(_) => return BuildOutcome::Panicked,
+                };
+                let mut artifacts = BTreeMap::new();
+                for (offset, kind) in ArtifactKind::REQUIRED.into_iter().enumerate() {
+                    artifacts.insert(kind, stamp.wrapping_add(offset as u64));
+                }
+                built.insert(
+                    source.id,
+                    Arc::new(SourceArtifacts {
+                        token: *token,
+                        manifest: CandidateManifest {
+                            entries: vec![ManifestEntry {
+                                path: path.clone(),
+                                disposition: EntryDisposition::Indexed {
+                                    content_stamp: stamp,
+                                },
+                            }],
+                        },
+                        artifacts,
+                    }),
+                );
+            }
+            SourceObservation::MetadataOnly { path, reason } => {
+                built.insert(
+                    source.id,
+                    Arc::new(SourceArtifacts {
+                        token: SourceContentToken(0),
+                        manifest: CandidateManifest {
+                            entries: vec![ManifestEntry {
+                                path: path.clone(),
+                                disposition: EntryDisposition::MetadataOnly {
+                                    reason: reason.clone(),
+                                },
+                            }],
+                        },
+                        artifacts: BTreeMap::new(),
+                    }),
+                );
+            }
+        }
+    }
+    BuildOutcome::Ready { built, delta: None }
+}
+
+impl IsolatedCandidate {
+    /// Prepare a FULL candidate over `sources`, deriving content artifacts
+    /// through `derive` (injected so oracles can observe probe counts and
+    /// inject panics). Capacity is reserved before any work.
+    pub fn prepare_full(
+        pool: &Arc<ProcessCapacityPool>,
+        owner: OwnerIdentity,
+        attempt: &LoadAttempt,
+        sources: Vec<CandidateSource>,
+        mut derive: impl FnMut(&CandidateSource) -> u64,
+    ) -> Result<Self, CapacityRefusal> {
+        let permit = pool.redeem(pool.reserve(owner, reserved_bytes(&sources))?)?;
+        let outcome = build_sources(&sources, &mut derive);
+        Ok(Self {
+            outcome,
+            attempt: attempt.id,
+            supervisor: Arc::clone(&attempt.state),
+            _permit: permit,
+        })
+    }
+
+    /// Prepare a DELTA candidate for exactly one changed source, valid only
+    /// against `expected` — the changed source token it exact-validates
+    /// (`None` expects the source to be new membership).
+    pub fn prepare_delta(
+        pool: &Arc<ProcessCapacityPool>,
+        owner: OwnerIdentity,
+        attempt: &LoadAttempt,
+        changed: CandidateSource,
+        expected: Option<SourceContentToken>,
+        mut derive: impl FnMut(&CandidateSource) -> u64,
+    ) -> Result<Self, CapacityRefusal> {
+        let changed_id = changed.id;
+        let sources = vec![changed];
+        let permit = pool.redeem(pool.reserve(owner, reserved_bytes(&sources))?)?;
+        let outcome = match build_sources(&sources, &mut derive) {
+            BuildOutcome::Ready { built, .. } => BuildOutcome::Ready {
+                built,
+                delta: Some(DeltaSpec {
+                    changed: changed_id,
+                    expected,
+                }),
+            },
+            terminal => terminal,
+        };
+        Ok(Self {
+            outcome,
+            attempt: attempt.id,
+            supervisor: Arc::clone(&attempt.state),
+            _permit: permit,
+        })
+    }
+
+    /// Whether the build reached a terminal classified failure.
+    pub fn classified_failure(&self) -> Option<ClassifiedFailure> {
+        match &self.outcome {
+            BuildOutcome::Classified(cause) => Some(*cause),
+            _ => None,
+        }
+    }
+
+    /// The ONE runtime-store commit point. A full candidate replaces the
+    /// root; a delta candidate exact-validates its changed source token and
+    /// patches the LATEST root — cloning only the `Arc` table, never sibling
+    /// contents, so unrelated and newer siblings survive with their `Arc`s
+    /// intact. The swap publishes BEFORE the prior generation is pruned:
+    /// holders of the old `Arc` keep reading it.
+    pub fn commit(
+        self,
+        root: &ProjectArtifactRoot,
+    ) -> Result<Arc<ProjectArtifacts>, PromotionRefusal> {
+        let mut supervisor = self.supervisor.lock().expect("supervisor lock");
+        if supervisor.is_superseded(self.attempt) {
+            return Err(PromotionRefusal::Superseded);
+        }
+        match self.outcome {
+            BuildOutcome::Classified(cause) => {
+                supervisor.record_discard(self.attempt, cause);
+                Err(PromotionRefusal::Failure(cause))
+            }
+            BuildOutcome::Panicked => {
+                supervisor.record_panic(self.attempt);
+                Err(PromotionRefusal::Panicked)
+            }
+            BuildOutcome::Ready { built, delta } => {
+                let mut inner = root.inner.lock().expect("artifact root lock");
+                let next = match delta {
+                    None => Arc::new(ProjectArtifacts { sources: built }),
+                    Some(spec) => {
+                        let found = inner.sources.get(&spec.changed).map(|arts| arts.token);
+                        if found != spec.expected {
+                            return Err(PromotionRefusal::SameSourceDrift {
+                                expected: spec.expected,
+                                found,
+                            });
+                        }
+                        let changed = built
+                            .get(&spec.changed)
+                            .expect("a delta candidate builds its changed source");
+                        let mut sources = inner.sources.clone();
+                        sources.insert(spec.changed, Arc::clone(changed));
+                        Arc::new(ProjectArtifacts { sources })
+                    }
+                };
+                *inner = Arc::clone(&next);
+                drop(inner);
+                supervisor.record_commit(self.attempt);
+                Ok(next)
+            }
+        }
+    }
+
+    /// Sealed negative: promotion of a partially-certified candidate on the
+    /// strength of a capability certificate. Refused unconditionally —
+    /// completeness comes from the sealed required set, never from a caller's
+    /// capability.
+    pub fn promote_partial_with_capability(
+        self,
+        root: &ProjectArtifactRoot,
+        certificate: CapabilityCertificate,
+    ) -> PromotionRefusal {
+        let _ = (root, certificate);
+        PromotionRefusal::CapabilityCannotAuthorize
+    }
+}

--- a/src/index_lifecycle/mod.rs
+++ b/src/index_lifecycle/mod.rs
@@ -27,12 +27,17 @@
 
 pub mod adapters;
 pub mod authority;
+// T059/T060: the dark per-source supervisor and isolated candidate pipeline.
+// In-directory and oracle-suite consumption only; T064/T066 activation is the
+// only planned production caller.
+pub mod candidate;
 pub mod capacity;
 pub mod embedded;
 pub mod mutation;
 pub mod physical_root;
 pub mod process_runtime;
 pub mod registry;
+pub mod supervisor;
 // T047: the dark V11 runtime. In-directory consumption only; the dark factory
 // is the single door and Slice 4's activation cut is the only planned caller.
 pub mod runtime;

--- a/src/index_lifecycle/supervisor.rs
+++ b/src/index_lifecycle/supervisor.rs
@@ -65,22 +65,32 @@ pub enum AttemptDisposition {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AttemptId(pub(crate) u64);
 
-/// One bounded-diagnostics row. Deliberately carries no manifest digest,
-/// certificate, or query authority.
+/// One diagnostics row (the ledger keeps the newest [`MAX_ATTEMPT_RECORDS`]).
+/// Deliberately carries no manifest digest, certificate, or query authority.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AttemptRecord {
     pub id: AttemptId,
     pub disposition: AttemptDisposition,
 }
 
-/// Shared interior. Locked for every transition so the two ledgers can never
-/// disagree about what happened.
+/// The diagnostics ledger keeps at most this many newest terminal rows. The
+/// frozen data model requires bounded diagnostics; the attempt-id SETS below
+/// are compact but unbounded, and bounding them is a recorded activation
+/// obligation (they guard replay of still-live candidate tokens, so they
+/// cannot be pruned before the cut defines candidate lifetime).
+const MAX_ATTEMPT_RECORDS: usize = 64;
+
+/// Shared interior. Locked for every transition, and every terminal row goes
+/// through [`SupervisorState::terminal_row`], so one attempt can terminal-end
+/// exactly once: replaying an attempt's token can never make the committed
+/// ledger and the diagnostics ledger disagree.
 #[derive(Debug, Default)]
 pub(crate) struct SupervisorState {
     next_attempt: u64,
     /// Non-terminal attempts, in mint order (last = most recent).
     live: Vec<AttemptId>,
     superseded: BTreeSet<AttemptId>,
+    terminal: BTreeSet<AttemptId>,
     records: Vec<AttemptRecord>,
     committed: u64,
 }
@@ -93,37 +103,41 @@ impl SupervisorState {
         id
     }
 
-    fn retire(&mut self, id: AttemptId) {
+    /// Terminal-end `id` with `disposition` — exactly once. Returns whether
+    /// this call was the one that ended it; a second terminal event for the
+    /// same attempt records nothing.
+    fn terminal_row(&mut self, id: AttemptId, disposition: AttemptDisposition) -> bool {
+        if !self.terminal.insert(id) {
+            return false;
+        }
         self.live.retain(|live| *live != id);
+        self.records.push(AttemptRecord { id, disposition });
+        if self.records.len() > MAX_ATTEMPT_RECORDS {
+            self.records.remove(0);
+        }
+        true
     }
 
     pub(crate) fn is_superseded(&self, id: AttemptId) -> bool {
         self.superseded.contains(&id)
     }
 
+    pub(crate) fn is_terminal(&self, id: AttemptId) -> bool {
+        self.terminal.contains(&id)
+    }
+
     pub(crate) fn record_commit(&mut self, id: AttemptId) {
-        self.retire(id);
-        self.records.push(AttemptRecord {
-            id,
-            disposition: AttemptDisposition::Committed,
-        });
-        self.committed += 1;
+        if self.terminal_row(id, AttemptDisposition::Committed) {
+            self.committed += 1;
+        }
     }
 
     pub(crate) fn record_discard(&mut self, id: AttemptId, cause: ClassifiedFailure) {
-        self.retire(id);
-        self.records.push(AttemptRecord {
-            id,
-            disposition: AttemptDisposition::Discarded(cause),
-        });
+        self.terminal_row(id, AttemptDisposition::Discarded(cause));
     }
 
     pub(crate) fn record_panic(&mut self, id: AttemptId) {
-        self.retire(id);
-        self.records.push(AttemptRecord {
-            id,
-            disposition: AttemptDisposition::Panicked,
-        });
+        self.terminal_row(id, AttemptDisposition::Panicked);
     }
 }
 
@@ -161,7 +175,8 @@ impl SourceSupervisor {
     /// Record a classified failure for the source's newest live attempt and
     /// mint its superseding successor — the retry trigger. Every OTHER live
     /// attempt is superseded too: the source is being re-observed, so every
-    /// in-flight build is stale.
+    /// in-flight build is stale. With no live attempt the cause has no row to
+    /// land on and rides the successor's future terminal row instead.
     pub fn retry_trigger(&self, cause: ClassifiedFailure) -> LoadAttempt {
         let mut state = self.state.lock().expect("supervisor lock");
         if let Some(newest) = state.live.last().copied() {
@@ -170,10 +185,7 @@ impl SourceSupervisor {
         }
         for stale in std::mem::take(&mut state.live) {
             state.superseded.insert(stale);
-            state.records.push(AttemptRecord {
-                id: stale,
-                disposition: AttemptDisposition::Superseded,
-            });
+            state.terminal_row(stale, AttemptDisposition::Superseded);
         }
         let id = state.mint();
         drop(state);
@@ -214,13 +226,12 @@ impl LoadAttempt {
             .is_superseded(self.id)
     }
 
-    /// Cancel this attempt: recorded in diagnostics, never committed.
+    /// Cancel this attempt: recorded in diagnostics, never committed. A
+    /// cancel after the attempt already terminal-ended records nothing.
     pub fn cancel(self) {
-        let mut state = self.state.lock().expect("supervisor lock");
-        state.retire(self.id);
-        state.records.push(AttemptRecord {
-            id: self.id,
-            disposition: AttemptDisposition::Cancelled,
-        });
+        self.state
+            .lock()
+            .expect("supervisor lock")
+            .terminal_row(self.id, AttemptDisposition::Cancelled);
     }
 }

--- a/src/index_lifecycle/supervisor.rs
+++ b/src/index_lifecycle/supervisor.rs
@@ -1,0 +1,226 @@
+//! Feature 020 V11 per-source supervisor (Slice 4, T059 — dark).
+//!
+//! The supervisor owns LOADING for exactly one source: attempt ownership,
+//! cancellation, attempt accounting, classified failure, and retry triggers.
+//! Attempt history is DIAGNOSTIC data. It is structurally separate from
+//! committed dispositions and deliberately cannot carry a manifest digest, a
+//! completeness certificate, or query authority (`data-model.md:794-800` in
+//! the frozen 020 tree): the two ledgers this type exposes are the seam the
+//! T056 health split (`committed_generation_and_attempt_health_are_separate`)
+//! will later project.
+//!
+//! **Nothing in production calls this module.** The darkness property is about
+//! call edges: the only callers are `candidate.rs` (same directory) and the
+//! Slice 4 oracle suites under `tests/`. Activation (T066/T064) is the only
+//! planned production caller.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// Closed classification of a failed load/build attempt — exactly the causes
+/// the closed promotion matrix refuses on (frozen tasks.md T053: `Unreadable`,
+/// `UnstableDuringRead`, `AbortedCircuitBreaker`, `ParseStatus::Failed`,
+/// unknown ordering, truncated required derivations, `PartialParse`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClassifiedFailure {
+    Unreadable,
+    UnstableDuringRead,
+    AbortedCircuitBreaker,
+    ParseFailed,
+    UnknownOrdering,
+    TruncatedRequiredDerivation,
+    PartialParse,
+}
+
+impl ClassifiedFailure {
+    /// Every member of the closed matrix, for exhaustive oracle sweeps.
+    pub const ALL: [ClassifiedFailure; 7] = [
+        ClassifiedFailure::Unreadable,
+        ClassifiedFailure::UnstableDuringRead,
+        ClassifiedFailure::AbortedCircuitBreaker,
+        ClassifiedFailure::ParseFailed,
+        ClassifiedFailure::UnknownOrdering,
+        ClassifiedFailure::TruncatedRequiredDerivation,
+        ClassifiedFailure::PartialParse,
+    ];
+}
+
+/// Terminal disposition of one attempt in the diagnostics ledger.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttemptDisposition {
+    /// The attempt's candidate reached the single commit point and published.
+    Committed,
+    /// Discarded with a classified cause; nothing published.
+    Discarded(ClassifiedFailure),
+    /// Cancelled by its owner before any terminal outcome.
+    Cancelled,
+    /// A retry trigger minted a successor; this attempt can never commit.
+    Superseded,
+    /// The build panicked; the candidate was discarded whole.
+    Panicked,
+}
+
+/// Identity of one attempt within its supervisor's sequence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AttemptId(pub(crate) u64);
+
+/// One bounded-diagnostics row. Deliberately carries no manifest digest,
+/// certificate, or query authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AttemptRecord {
+    pub id: AttemptId,
+    pub disposition: AttemptDisposition,
+}
+
+/// Shared interior. Locked for every transition so the two ledgers can never
+/// disagree about what happened.
+#[derive(Debug, Default)]
+pub(crate) struct SupervisorState {
+    next_attempt: u64,
+    /// Non-terminal attempts, in mint order (last = most recent).
+    live: Vec<AttemptId>,
+    superseded: BTreeSet<AttemptId>,
+    records: Vec<AttemptRecord>,
+    committed: u64,
+}
+
+impl SupervisorState {
+    fn mint(&mut self) -> AttemptId {
+        let id = AttemptId(self.next_attempt);
+        self.next_attempt += 1;
+        self.live.push(id);
+        id
+    }
+
+    fn retire(&mut self, id: AttemptId) {
+        self.live.retain(|live| *live != id);
+    }
+
+    pub(crate) fn is_superseded(&self, id: AttemptId) -> bool {
+        self.superseded.contains(&id)
+    }
+
+    pub(crate) fn record_commit(&mut self, id: AttemptId) {
+        self.retire(id);
+        self.records.push(AttemptRecord {
+            id,
+            disposition: AttemptDisposition::Committed,
+        });
+        self.committed += 1;
+    }
+
+    pub(crate) fn record_discard(&mut self, id: AttemptId, cause: ClassifiedFailure) {
+        self.retire(id);
+        self.records.push(AttemptRecord {
+            id,
+            disposition: AttemptDisposition::Discarded(cause),
+        });
+    }
+
+    pub(crate) fn record_panic(&mut self, id: AttemptId) {
+        self.retire(id);
+        self.records.push(AttemptRecord {
+            id,
+            disposition: AttemptDisposition::Panicked,
+        });
+    }
+}
+
+/// Per-source supervisor: loader ownership, cancellation, attempt accounting,
+/// classified failure, retry triggers (T059).
+#[derive(Debug)]
+pub struct SourceSupervisor {
+    pub(crate) state: Arc<Mutex<SupervisorState>>,
+}
+
+/// Ownership token for one in-flight attempt. Only a non-superseded attempt
+/// can commit; a retry trigger supersedes every live predecessor.
+#[derive(Debug)]
+pub struct LoadAttempt {
+    pub(crate) id: AttemptId,
+    pub(crate) state: Arc<Mutex<SupervisorState>>,
+}
+
+impl SourceSupervisor {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SupervisorState::default())),
+        }
+    }
+
+    /// Begin a fresh attempt, taking loader ownership for it.
+    pub fn begin_attempt(&self) -> LoadAttempt {
+        let id = self.state.lock().expect("supervisor lock").mint();
+        LoadAttempt {
+            id,
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Record a classified failure for the source's newest live attempt and
+    /// mint its superseding successor — the retry trigger. Every OTHER live
+    /// attempt is superseded too: the source is being re-observed, so every
+    /// in-flight build is stale.
+    pub fn retry_trigger(&self, cause: ClassifiedFailure) -> LoadAttempt {
+        let mut state = self.state.lock().expect("supervisor lock");
+        if let Some(newest) = state.live.last().copied() {
+            state.superseded.insert(newest);
+            state.record_discard(newest, cause);
+        }
+        for stale in std::mem::take(&mut state.live) {
+            state.superseded.insert(stale);
+            state.records.push(AttemptRecord {
+                id: stale,
+                disposition: AttemptDisposition::Superseded,
+            });
+        }
+        let id = state.mint();
+        drop(state);
+        LoadAttempt {
+            id,
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// The bounded diagnostics ledger: every terminal attempt, in order.
+    pub fn attempt_records(&self) -> Vec<AttemptRecord> {
+        self.state.lock().expect("supervisor lock").records.clone()
+    }
+
+    /// The committed ledger: count of attempts whose candidate actually
+    /// published. Separate from diagnostics by construction.
+    pub fn committed_generations(&self) -> u64 {
+        self.state.lock().expect("supervisor lock").committed
+    }
+}
+
+impl Default for SourceSupervisor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoadAttempt {
+    pub fn id(&self) -> AttemptId {
+        self.id
+    }
+
+    /// Whether a retry trigger has superseded this attempt.
+    pub fn is_superseded(&self) -> bool {
+        self.state
+            .lock()
+            .expect("supervisor lock")
+            .is_superseded(self.id)
+    }
+
+    /// Cancel this attempt: recorded in diagnostics, never committed.
+    pub fn cancel(self) {
+        let mut state = self.state.lock().expect("supervisor lock");
+        state.retire(self.id);
+        state.records.push(AttemptRecord {
+            id: self.id,
+            disposition: AttemptDisposition::Cancelled,
+        });
+    }
+}

--- a/tests/index_candidate_lifecycle_v11.rs
+++ b/tests/index_candidate_lifecycle_v11.rs
@@ -381,6 +381,61 @@ fn publish_before_prune_keeps_prior_snapshots_readable() {
 
 // ── supervisor: supersession, cancellation, accounting ─────────────────────
 
+/// One attempt terminal-ends exactly once (pair-1 review, MAJOR finding).
+/// Two candidates prepared under one attempt cannot both commit, and a
+/// cancel after a commit adds no row: replaying one attempt's token can
+/// never make the committed ledger and the diagnostics ledger disagree.
+#[test]
+fn an_attempt_terminal_ends_exactly_once() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let attempt = supervisor.begin_attempt();
+    let attempt_id = attempt.id();
+    let first = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![content_source(1, "a.rs", 1)],
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+    let second = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![content_source(1, "a.rs", 2)],
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+
+    let published = first.commit(&root).expect("the first commit wins");
+    let refusal = second
+        .commit(&root)
+        .expect_err("one attempt must not commit twice");
+    assert_eq!(refusal, PromotionRefusal::AttemptAlreadyTerminal);
+    assert!(
+        Arc::ptr_eq(&root.load(), &published),
+        "a replayed attempt republished the root"
+    );
+
+    attempt.cancel();
+    let records = supervisor.attempt_records();
+    let rows: Vec<_> = records
+        .iter()
+        .filter(|record| record.id == attempt_id)
+        .collect();
+    assert_eq!(
+        rows.len(),
+        1,
+        "one attempt produced more than one terminal row: {records:?}"
+    );
+    assert_eq!(rows[0].disposition, AttemptDisposition::Committed);
+    assert_eq!(supervisor.committed_generations(), 1);
+}
+
 /// A retry trigger supersedes the older attempt: its candidate can never
 /// commit, the failure is accounted with its cause, and the successor commits.
 #[test]
@@ -477,8 +532,12 @@ fn cancellation_is_accounted_and_never_committed() {
 // ── metadata-terminal exclusions ───────────────────────────────────────────
 
 /// Every metadata-terminal reason stays cataloged and stays EXCLUDED from
-/// content derivation — the exclusion set is complete over the closed reason
-/// list, and a content sibling in the same candidate still derives.
+/// content derivation — and a content sibling in the same candidate still
+/// derives. The reason list below is the frozen data model's ten members,
+/// hand-typed because `MetadataOnlyReason` is `#[non_exhaustive]`: an
+/// integration test cannot write an exhaustive match against it, so a variant
+/// added later is NOT caught here. The in-crate exhaustiveness pin is a
+/// recorded cut obligation (T064 metadata handling goes live there).
 #[test]
 fn metadata_terminal_exclusions_remain_complete() {
     let reasons: Vec<MetadataOnlyReason> = vec![

--- a/tests/index_candidate_lifecycle_v11.rs
+++ b/tests/index_candidate_lifecycle_v11.rs
@@ -1,0 +1,834 @@
+//! Feature 020 V11 Slice 4 candidate-pipeline oracles (T053).
+//!
+//! RED-first for the pair T053+T059+T060: these tests were authored and
+//! observed failing against `todo!()` seams before any machinery existed.
+//! Every rejection case asserts the accepting path in the same test — a
+//! pipeline that refuses everything satisfies a lone negative perfectly.
+
+use std::ffi::OsString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use symforge::domain::index::{CatalogPath, MetadataOnlyReason};
+use symforge::live_index::index_lifecycle::candidate::{
+    CandidateSource, CapabilityCertificate, EntryDisposition, IsolatedCandidate,
+    ProjectArtifactRoot, ProjectArtifacts, PromotionRefusal, SourceContentToken, SourceId,
+    SourceObservation,
+};
+use symforge::live_index::index_lifecycle::capacity::ProcessCapacityPool;
+use symforge::live_index::index_lifecycle::supervisor::{
+    AttemptDisposition, ClassifiedFailure, SourceSupervisor,
+};
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+fn utf8_path(rel: &str) -> CatalogPath {
+    CatalogPath {
+        public_id: format!("pid-utf8-{rel}"),
+        normalized_utf8: Some(rel.to_string()),
+    }
+}
+
+fn content_source(id: u64, rel: &str, token: u64) -> CandidateSource {
+    CandidateSource {
+        id: SourceId(id),
+        observation: SourceObservation::Content {
+            path: utf8_path(rel),
+            token: SourceContentToken(token),
+            bytes: 64,
+        },
+    }
+}
+
+fn failed_source(id: u64, cause: ClassifiedFailure) -> CandidateSource {
+    CandidateSource {
+        id: SourceId(id),
+        observation: SourceObservation::Failed(cause),
+    }
+}
+
+/// Two native identities that COLLIDE under lossy display conversion, the
+/// same shape the frozen pattern base
+/// (`discovery::tests::metadata_first_scout::non_utf8_path_is_opaque_catalog_only_without_lossy_collision`)
+/// proves at the scout seam.
+fn colliding_native_pair() -> (OsString, OsString) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStringExt;
+        let mut first: Vec<u16> = "src/we".encode_utf16().collect();
+        let mut second = first.clone();
+        first.push(0xD800);
+        second.push(0xD801);
+        let tail: Vec<u16> = "ird.rs".encode_utf16().collect();
+        first.extend(&tail);
+        second.extend(&tail);
+        (OsString::from_wide(&first), OsString::from_wide(&second))
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        let mut first = b"src/we".to_vec();
+        let mut second = first.clone();
+        first.push(0xFF);
+        second.push(0xFE);
+        first.extend_from_slice(b"ird.rs");
+        second.extend_from_slice(b"ird.rs");
+        (OsString::from_vec(first), OsString::from_vec(second))
+    }
+}
+
+/// A stable public identity per native spelling, distinct whenever the native
+/// encoding units differ — the property the scout's minting guarantees and
+/// the pipeline must PRESERVE, which is what this suite proves.
+fn public_id_for(native: &std::ffi::OsStr) -> String {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        let units: Vec<u16> = native.encode_wide().collect();
+        format!("pid-native-{units:x?}")
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        format!("pid-native-{:x?}", native.as_bytes())
+    }
+}
+
+fn opaque_source(id: u64, native: &std::ffi::OsStr) -> CandidateSource {
+    CandidateSource {
+        id: SourceId(id),
+        observation: SourceObservation::MetadataOnly {
+            path: CatalogPath {
+                public_id: public_id_for(native),
+                normalized_utf8: None,
+            },
+            reason: MetadataOnlyReason::UnsupportedPathEncoding,
+        },
+    }
+}
+
+fn stamp_derive(source: &CandidateSource) -> u64 {
+    match &source.observation {
+        SourceObservation::Content { token, .. } => token.0.wrapping_mul(31),
+        other => panic!("derive called for a non-content observation: {other:?}"),
+    }
+}
+
+/// Commit a healthy full candidate over `sources`; panics on any refusal.
+fn commit_full(
+    pool: &Arc<ProcessCapacityPool>,
+    owner: symforge::live_index::index_lifecycle::capacity::OwnerIdentity,
+    supervisor: &SourceSupervisor,
+    root: &ProjectArtifactRoot,
+    sources: Vec<CandidateSource>,
+) -> Arc<ProjectArtifacts> {
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(pool, owner, &attempt, sources, stamp_derive)
+        .expect("capacity headroom exists");
+    candidate.commit(root).expect("healthy candidate promotes")
+}
+
+// ── the closed promotion matrix ────────────────────────────────────────────
+
+/// TEST-CANDIDATE (T053). The name is pinned by
+/// `contracts/lifecycle-oracle-traceability-v11.md` as a `planned_exact`
+/// target; do not rename it without amending that contract.
+///
+/// The matrix is CLOSED: `Unreadable`, `UnstableDuringRead`,
+/// `AbortedCircuitBreaker`, `ParseFailed` (`ParseStatus::Failed`),
+/// `UnknownOrdering`, `TruncatedRequiredDerivation`, and `PartialParse` each
+/// block promotion — only their own candidate's, never a sibling's — and a
+/// blocked candidate leaves no trace: the root is untouched, the capacity
+/// charge is refunded, and the discard is accounted with its exact cause.
+#[test]
+fn closed_candidate_promotion_matrix() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+
+    for cause in ClassifiedFailure::ALL {
+        let supervisor = SourceSupervisor::new();
+        let root = ProjectArtifactRoot::empty();
+        let baseline = commit_full(
+            &pool,
+            owner,
+            &supervisor,
+            &root,
+            vec![content_source(1, "a.rs", 10)],
+        );
+
+        let attempt = supervisor.begin_attempt();
+        let candidate = IsolatedCandidate::prepare_full(
+            &pool,
+            owner,
+            &attempt,
+            vec![content_source(1, "a.rs", 11), failed_source(2, cause)],
+            stamp_derive,
+        )
+        .expect("capacity headroom exists");
+        assert_eq!(
+            candidate.classified_failure(),
+            Some(cause),
+            "the build must classify its terminal cause"
+        );
+
+        let refusal = candidate
+            .commit(&root)
+            .expect_err("a classified candidate must not promote");
+        assert_eq!(refusal, PromotionRefusal::Failure(cause));
+        assert!(
+            Arc::ptr_eq(&root.load(), &baseline),
+            "a refused candidate mutated the published root ({cause:?})"
+        );
+        assert_eq!(
+            pool.charged(owner),
+            0,
+            "a refused candidate leaked its capacity charge ({cause:?})"
+        );
+        assert!(
+            supervisor
+                .attempt_records()
+                .iter()
+                .any(|record| record.disposition == AttemptDisposition::Discarded(cause)),
+            "the discard was not accounted with its cause ({cause:?})"
+        );
+        assert_eq!(
+            supervisor.committed_generations(),
+            1,
+            "only the baseline committed"
+        );
+    }
+}
+
+/// TEST-OPAQUE-PATH (T053). The name is pinned by
+/// `contracts/lifecycle-oracle-traceability-v11.md` as a `planned_exact`
+/// target; do not rename it without amending that contract.
+///
+/// Two native identities whose lossy displays COLLIDE must survive candidate,
+/// manifest, and promotion as DISTINCT stable identities: catalog-only, zero
+/// content probes, and no lossy spelling persisted anywhere in the promoted
+/// manifest. The scout half of the chain is the frozen pattern base in
+/// `src/discovery/mod.rs`; this oracle owns the pipeline half.
+#[test]
+fn opaque_non_utf8_path_identity_is_lossless() {
+    let (first, second) = colliding_native_pair();
+    assert_eq!(
+        first.to_string_lossy(),
+        second.to_string_lossy(),
+        "fixture must prove two native identities collide under lossy conversion"
+    );
+    assert_ne!(
+        first, second,
+        "the native identities themselves are distinct"
+    );
+    let lossy = first.to_string_lossy().into_owned();
+
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let opaque_a = opaque_source(1, &first);
+    let opaque_b = opaque_source(2, &second);
+    let expected_a = match &opaque_a.observation {
+        SourceObservation::MetadataOnly { path, .. } => path.clone(),
+        _ => unreachable!(),
+    };
+    let expected_b = match &opaque_b.observation {
+        SourceObservation::MetadataOnly { path, .. } => path.clone(),
+        _ => unreachable!(),
+    };
+    assert_ne!(expected_a.public_id, expected_b.public_id);
+
+    let probes = AtomicUsize::new(0);
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![opaque_a, opaque_b, content_source(3, "normal.rs", 7)],
+        |source| {
+            probes.fetch_add(1, Ordering::SeqCst);
+            stamp_derive(source)
+        },
+    )
+    .expect("capacity headroom exists");
+    let published = candidate
+        .commit(&root)
+        .expect("opaque paths must remain catalogable");
+
+    assert_eq!(
+        probes.load(Ordering::SeqCst),
+        1,
+        "a catalog-only entry was content-probed"
+    );
+
+    for (id, expected) in [(SourceId(1), &expected_a), (SourceId(2), &expected_b)] {
+        let artifacts = published
+            .sources
+            .get(&id)
+            .unwrap_or_else(|| panic!("opaque source {id:?} missing from the promoted root"));
+        let entry = artifacts
+            .manifest
+            .entries
+            .iter()
+            .find(|entry| entry.path == *expected)
+            .unwrap_or_else(|| panic!("opaque source {id:?} lost its exact identity"));
+        assert_eq!(
+            entry.disposition,
+            EntryDisposition::MetadataOnly {
+                reason: MetadataOnlyReason::UnsupportedPathEncoding
+            }
+        );
+        assert!(
+            entry.path.normalized_utf8.is_none(),
+            "an opaque path grew a UTF-8 spelling"
+        );
+        assert_ne!(
+            entry.path.public_id, lossy,
+            "the promoted manifest persisted the lossy spelling as an identity"
+        );
+    }
+
+    let promoted_a = &published.sources[&SourceId(1)].manifest;
+    let promoted_b = &published.sources[&SourceId(2)].manifest;
+    assert_ne!(
+        promoted_a.entries[0].path.public_id, promoted_b.entries[0].path.public_id,
+        "two colliding native identities merged during promotion"
+    );
+}
+
+// ── isolation and publish-before-prune ─────────────────────────────────────
+
+/// A building candidate is invisible: the published root is byte-identical
+/// until the single commit point, including WHILE derivation runs.
+#[test]
+fn isolated_build_leaves_the_published_root_untouched() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+    let baseline = commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![content_source(1, "a.rs", 2), content_source(2, "b.rs", 1)],
+        |source| {
+            assert!(
+                Arc::ptr_eq(&root.load(), &baseline),
+                "the published root changed while a candidate was still building"
+            );
+            stamp_derive(source)
+        },
+    )
+    .expect("capacity headroom exists");
+
+    assert!(
+        Arc::ptr_eq(&root.load(), &baseline),
+        "a prepared, uncommitted candidate is already observable"
+    );
+
+    let published = candidate.commit(&root).expect("healthy candidate promotes");
+    assert!(Arc::ptr_eq(&root.load(), &published));
+    assert!(!Arc::ptr_eq(&published, &baseline));
+}
+
+/// Publication precedes pruning: a holder of the prior snapshot keeps reading
+/// exactly what it captured, while new loads see the successor.
+#[test]
+fn publish_before_prune_keeps_prior_snapshots_readable() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let prior = commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+    let successor = commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 2), content_source(2, "b.rs", 1)],
+    );
+
+    assert!(Arc::ptr_eq(&root.load(), &successor));
+    assert_eq!(
+        prior.sources.len(),
+        1,
+        "the prior snapshot was pruned in place"
+    );
+    assert_eq!(
+        prior.sources[&SourceId(1)].token,
+        SourceContentToken(1),
+        "the prior snapshot's content changed under its holder"
+    );
+    assert_eq!(successor.sources[&SourceId(1)].token, SourceContentToken(2));
+}
+
+// ── supervisor: supersession, cancellation, accounting ─────────────────────
+
+/// A retry trigger supersedes the older attempt: its candidate can never
+/// commit, the failure is accounted with its cause, and the successor commits.
+#[test]
+fn retry_supersession_blocks_the_older_attempt() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let stale = supervisor.begin_attempt();
+    let stale_candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &stale,
+        vec![content_source(1, "a.rs", 1)],
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+
+    let fresh = supervisor.retry_trigger(ClassifiedFailure::UnstableDuringRead);
+    assert!(
+        stale.is_superseded(),
+        "the retry trigger must supersede the live attempt"
+    );
+    assert!(!fresh.is_superseded());
+
+    let refusal = stale_candidate
+        .commit(&root)
+        .expect_err("a superseded attempt's candidate must not commit");
+    assert_eq!(refusal, PromotionRefusal::Superseded);
+    assert_eq!(
+        root.load().sources.len(),
+        0,
+        "a superseded candidate published anyway"
+    );
+
+    let fresh_candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &fresh,
+        vec![content_source(1, "a.rs", 2)],
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+    fresh_candidate
+        .commit(&root)
+        .expect("the successor attempt commits");
+
+    let records = supervisor.attempt_records();
+    assert!(
+        records.iter().any(|record| record.disposition
+            == AttemptDisposition::Discarded(ClassifiedFailure::UnstableDuringRead)),
+        "the retried failure lost its classified cause: {records:?}"
+    );
+    assert_eq!(supervisor.committed_generations(), 1);
+}
+
+/// Cancellation lands in the diagnostics ledger and never in the committed
+/// ledger — the two are separate by construction.
+#[test]
+fn cancellation_is_accounted_and_never_committed() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    supervisor.begin_attempt().cancel();
+    assert_eq!(supervisor.committed_generations(), 0);
+    assert!(
+        supervisor
+            .attempt_records()
+            .iter()
+            .any(|record| record.disposition == AttemptDisposition::Cancelled),
+        "the cancellation was not accounted"
+    );
+
+    commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+    assert_eq!(supervisor.committed_generations(), 1);
+    let records = supervisor.attempt_records();
+    assert!(
+        records
+            .iter()
+            .any(|record| record.disposition == AttemptDisposition::Committed),
+        "the commit was not accounted: {records:?}"
+    );
+}
+
+// ── metadata-terminal exclusions ───────────────────────────────────────────
+
+/// Every metadata-terminal reason stays cataloged and stays EXCLUDED from
+/// content derivation — the exclusion set is complete over the closed reason
+/// list, and a content sibling in the same candidate still derives.
+#[test]
+fn metadata_terminal_exclusions_remain_complete() {
+    let reasons: Vec<MetadataOnlyReason> = vec![
+        MetadataOnlyReason::Lockfile,
+        MetadataOnlyReason::Binary,
+        MetadataOnlyReason::OversizedData,
+        MetadataOnlyReason::GeneratedOrVendor,
+        MetadataOnlyReason::SensitivePath {
+            rule_id: "RULE-PATH".into(),
+        },
+        MetadataOnlyReason::SensitiveContent {
+            rule_ids: vec!["RULE-CONTENT".into()],
+            finding_count: 1,
+        },
+        MetadataOnlyReason::LfsPointer {
+            declared_oid: None,
+            declared_size: None,
+        },
+        MetadataOnlyReason::UnsupportedPathEncoding,
+        MetadataOnlyReason::PathMetadataTooLarge,
+        MetadataOnlyReason::UnsupportedTextEncoding,
+    ];
+
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let mut sources = Vec::new();
+    for (offset, reason) in reasons.iter().enumerate() {
+        let id = offset as u64 + 10;
+        sources.push(CandidateSource {
+            id: SourceId(id),
+            observation: SourceObservation::MetadataOnly {
+                path: utf8_path(&format!("meta-{id}.bin")),
+                reason: reason.clone(),
+            },
+        });
+    }
+    sources.push(content_source(1, "content.rs", 5));
+
+    let probes = AtomicUsize::new(0);
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(&pool, owner, &attempt, sources, |source| {
+        probes.fetch_add(1, Ordering::SeqCst);
+        stamp_derive(source)
+    })
+    .expect("capacity headroom exists");
+    let published = candidate
+        .commit(&root)
+        .expect("metadata-terminal entries must not block");
+
+    assert_eq!(
+        probes.load(Ordering::SeqCst),
+        1,
+        "a metadata-terminal entry was content-probed"
+    );
+    for (offset, reason) in reasons.iter().enumerate() {
+        let id = SourceId(offset as u64 + 10);
+        let artifacts = published
+            .sources
+            .get(&id)
+            .unwrap_or_else(|| panic!("metadata-terminal source {id:?} fell out of the catalog"));
+        assert_eq!(
+            artifacts.manifest.entries[0].disposition,
+            EntryDisposition::MetadataOnly {
+                reason: reason.clone()
+            },
+            "the exclusion reason was not preserved for {id:?}"
+        );
+        assert!(
+            artifacts.artifacts.is_empty(),
+            "a metadata-terminal source grew content artifacts ({reason:?})"
+        );
+    }
+    assert!(
+        !published.sources[&SourceId(1)].artifacts.is_empty(),
+        "the content sibling must still derive"
+    );
+}
+
+// ── completeness and capability ────────────────────────────────────────────
+
+/// A capability certificate is not completeness: offering one in place of a
+/// complete required artifact set refuses, publishes nothing — and the same
+/// candidate content promotes through the honest commit path.
+#[test]
+fn capability_certificates_cannot_authorize_partial_promotion() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![content_source(1, "a.rs", 1)],
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+
+    let refusal =
+        candidate.promote_partial_with_capability(&root, CapabilityCertificate::for_test());
+    assert_eq!(refusal, PromotionRefusal::CapabilityCannotAuthorize);
+    assert_eq!(
+        root.load().sources.len(),
+        0,
+        "a capability claim published state"
+    );
+
+    // Positive control: the identical content promotes through commit().
+    commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+    assert_eq!(root.load().sources.len(), 1);
+}
+
+/// A panicking derivation discards the candidate WHOLE: nothing publishes,
+/// the capacity charge is refunded, and the panic is accounted.
+#[test]
+fn failed_and_panicked_candidates_are_discarded() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+    let baseline = commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+
+    let attempt = supervisor.begin_attempt();
+    let candidate = IsolatedCandidate::prepare_full(
+        &pool,
+        owner,
+        &attempt,
+        vec![content_source(1, "a.rs", 2), content_source(2, "b.rs", 1)],
+        |source| match &source.observation {
+            SourceObservation::Content { token, .. } if token.0 == 1 => {
+                panic!("injected derivation panic")
+            }
+            _ => stamp_derive(source),
+        },
+    )
+    .expect("capacity headroom exists");
+
+    let refusal = candidate
+        .commit(&root)
+        .expect_err("a panicked candidate must not promote");
+    assert_eq!(refusal, PromotionRefusal::Panicked);
+    assert!(
+        Arc::ptr_eq(&root.load(), &baseline),
+        "a panicked candidate published state"
+    );
+    assert_eq!(
+        pool.charged(owner),
+        0,
+        "a panicked candidate leaked its capacity charge"
+    );
+    assert!(
+        supervisor
+            .attempt_records()
+            .iter()
+            .any(|record| record.disposition == AttemptDisposition::Panicked),
+        "the panic was not accounted"
+    );
+    assert_eq!(
+        supervisor.committed_generations(),
+        1,
+        "only the baseline committed"
+    );
+}
+
+// ── deltas ─────────────────────────────────────────────────────────────────
+
+/// A prepared delta exact-validates ONLY its changed source token and patches
+/// the LATEST whole project root: membership and siblings that arrived after
+/// it was prepared survive with their `Arc`s intact.
+#[test]
+fn delta_exact_validates_only_its_changed_token_and_spares_siblings() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![
+            content_source(1, "x.rs", 1),
+            content_source(2, "y.rs", 1),
+            content_source(3, "z.rs", 1),
+        ],
+    );
+
+    // Prepare the delta for Y against the CURRENT root...
+    let delta_attempt = supervisor.begin_attempt();
+    let delta = IsolatedCandidate::prepare_delta(
+        &pool,
+        owner,
+        &delta_attempt,
+        content_source(2, "y.rs", 2),
+        Some(SourceContentToken(1)),
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+
+    // ...then let NEWER membership land first: W arrives via its own delta.
+    let w_attempt = supervisor.begin_attempt();
+    let w_delta = IsolatedCandidate::prepare_delta(
+        &pool,
+        owner,
+        &w_attempt,
+        content_source(4, "w.rs", 1),
+        None,
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+    let with_w = w_delta
+        .commit(&root)
+        .expect("adding a new source is a valid delta");
+    let x_before = Arc::clone(&with_w.sources[&SourceId(1)]);
+    let z_before = Arc::clone(&with_w.sources[&SourceId(3)]);
+    let w_before = Arc::clone(&with_w.sources[&SourceId(4)]);
+
+    // The Y delta still commits: only Y's token is validated, and it patches
+    // the latest root, not the one it was prepared against.
+    let patched = delta
+        .commit(&root)
+        .expect("the delta's own token still matches");
+    assert_eq!(patched.sources[&SourceId(2)].token, SourceContentToken(2));
+    assert_eq!(
+        patched.sources.len(),
+        4,
+        "newer membership was lost by the patch"
+    );
+    assert!(
+        Arc::ptr_eq(&patched.sources[&SourceId(1)], &x_before),
+        "an unrelated sibling was reallocated"
+    );
+    assert!(
+        Arc::ptr_eq(&patched.sources[&SourceId(3)], &z_before),
+        "an unrelated sibling was reallocated"
+    );
+    assert!(
+        Arc::ptr_eq(&patched.sources[&SourceId(4)], &w_before),
+        "a newer sibling was reallocated"
+    );
+}
+
+/// Same-source drift refuses the stale delta — and a delta re-prepared
+/// against the drifted token commits, which is the retry the contract names.
+#[test]
+fn same_source_drift_retries_or_aborts() {
+    let pool = ProcessCapacityPool::new();
+    let owner = pool.root(1_000_000);
+    let supervisor = SourceSupervisor::new();
+    let root = ProjectArtifactRoot::empty();
+
+    commit_full(
+        &pool,
+        owner,
+        &supervisor,
+        &root,
+        vec![content_source(1, "a.rs", 1)],
+    );
+
+    let stale_attempt = supervisor.begin_attempt();
+    let stale_delta = IsolatedCandidate::prepare_delta(
+        &pool,
+        owner,
+        &stale_attempt,
+        content_source(1, "a.rs", 9),
+        Some(SourceContentToken(1)),
+        stamp_derive,
+    )
+    .expect("capacity headroom exists");
+
+    // The source drifts to token 5 before the stale delta commits.
+    let drift_attempt = supervisor.begin_attempt();
+    IsolatedCandidate::prepare_delta(
+        &pool,
+        owner,
+        &drift_attempt,
+        content_source(1, "a.rs", 5),
+        Some(SourceContentToken(1)),
+        stamp_derive,
+    )
+    .expect("capacity headroom exists")
+    .commit(&root)
+    .expect("the drifting update itself is valid");
+
+    let refusal = stale_delta
+        .commit(&root)
+        .expect_err("a drifted delta must not commit");
+    assert_eq!(
+        refusal,
+        PromotionRefusal::SameSourceDrift {
+            expected: Some(SourceContentToken(1)),
+            found: Some(SourceContentToken(5)),
+        }
+    );
+    assert_eq!(
+        root.load().sources[&SourceId(1)].token,
+        SourceContentToken(5)
+    );
+
+    // The retry: re-prepared against the drifted token, it commits.
+    let retry_attempt = supervisor.begin_attempt();
+    IsolatedCandidate::prepare_delta(
+        &pool,
+        owner,
+        &retry_attempt,
+        content_source(1, "a.rs", 9),
+        Some(SourceContentToken(5)),
+        stamp_derive,
+    )
+    .expect("capacity headroom exists")
+    .commit(&root)
+    .expect("the re-prepared delta commits");
+    assert_eq!(
+        root.load().sources[&SourceId(1)].token,
+        SourceContentToken(9)
+    );
+}
+
+// ── epochs ─────────────────────────────────────────────────────────────────
+
+/// A numeric epoch is bookkeeping, never authority: presenting one without a
+/// candidate refuses and publishes nothing.
+#[test]
+fn numeric_epochs_never_authorize_publication() {
+    let root = ProjectArtifactRoot::empty();
+    let before = root.load();
+    assert_eq!(
+        root.publish_claiming_epoch_only(u64::MAX),
+        PromotionRefusal::EpochIsNotAuthority
+    );
+    assert!(
+        Arc::ptr_eq(&root.load(), &before),
+        "an epoch claim mutated the published root"
+    );
+}

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -798,15 +798,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "4f3b5e9e93d6d3027c2e498adfa100b31dcd13467f6f9c9ce0cd86ef6cd83c2e",
+    "33f3885974de102a02ef57995e7262fa9914ea9f202c32beda4f74447c636d24",
     15,
-    228_198,
+    230_046,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "2c6aff5f372da919c278d5090ffeba4076fba5917ae5e2c45906cbe114b955e5",
+    "1318b2b6efde06506d503205cfa126f02e7376b47639a3eec7c2473476d17a8d",
     189,
-    9_014_196,
+    9_016_044,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -782,6 +782,7 @@ fn source_splicing_is_allowlisted() {
 const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
     "index_lifecycle/adapters.rs",
     "index_lifecycle/authority.rs",
+    "index_lifecycle/candidate.rs",
     "index_lifecycle/capacity.rs",
     "index_lifecycle/embedded.rs",
     "index_lifecycle/mod.rs",
@@ -791,20 +792,21 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
     "index_lifecycle/public_api.rs",
     "index_lifecycle/registry.rs",
     "index_lifecycle/runtime.rs",
+    "index_lifecycle/supervisor.rs",
     "index_lifecycle/transition.rs",
     "server_api.rs",
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "09b51bdbe46837b860a7144387a643b5de4fbd2428fce4bc9ff651036aa6ebca",
-    13,
-    205_026,
+    "4f3b5e9e93d6d3027c2e498adfa100b31dcd13467f6f9c9ce0cd86ef6cd83c2e",
+    15,
+    228_198,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "f1921916e8f5e98c1f3320305deae6498bf9c080a17e202cd1588212b1b2b189",
-    187,
-    8_991_024,
+    "2c6aff5f372da919c278d5090ffeba4076fba5917ae5e2c45906cbe114b955e5",
+    189,
+    9_014_196,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Wave 1 pair 1 of the Slice 4 campaign (specs/028-preventive-activation-cut; frozen roster 020:T053+T059+T060): the dark per-source supervisor and isolated candidate pipeline, RED-first.

**RED observed before machinery** (TC job job_01a011e3d35670d0bff327720eff3c78, 2026-08-17T22:44:15Z, exit 101): `test result: FAILED. 0 passed; 12 failed` - all twelve oracles failed on todo!() seams. **GREEN**: 12/12, then 13/13 after the review round.

**Independent review round** (one pass + mandatory cfg-lens sweep per spec FR-016): cfg-lens CLEAN (unix fixture arms analyzed - Linux CI is still their first executor), frozen contracts CLEAN, darkness CLEAN, repo idiom CLEAN. One MAJOR found and fixed RED-first in 2561c751: an attempt could terminal-end twice (double-commit / commit-then-cancel), corrupting the committed-vs-attempt ledger split. New oracle `an_attempt_terminal_ends_exactly_once` observed RED (TC job job_01a0121049347fc1b0d0c0226a361423), then the guarded terminal_row door turned it GREEN. Adjudicated minors: diagnostics ledger actually bounded (newest 64 rows); unconstructible IncompleteRequiredArtifacts variant dropped (an error nothing can emit is the reporting invariant's shape in miniature); metadata-token sentinel and the non-exhaustive-enum test limitation documented rather than claimed away. Deferred with rationale: Option-token API reshape (introduces absent-vs-metadata ambiguity; real token shape lands at the cut), O(sources) Arc-table clone per delta commit (semantics exact and oracle-pinned; flagged for activation perf review), drift-abort accounting oracle (rides pair follow-ups).

**Seal and census**: EXCLUDED_RUNTIME_SOURCE_PATHS +2; both pins refreshed from the Rust oracle's printed actuals after rustfmt (reviewer independently recomputed both fingerprints byte-for-byte). Seal suite 8/8; traceability validator OK with zero contract edits; the frozen specs/020 tree is untouched.

**Gates** (serial via Terminal Commander): fmt clean, clippy --all-targets -D warnings clean, full serial suite exit 0, embed lib gate 1333/0 with zero warnings, release build + verify-tools 7 PASS/0 FAIL, npm 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn