### PR TITLE
feat(feature-020): Slice 4 pair 2 - dark rolling verification

### DIFF
--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -57,7 +57,7 @@ GREEN; darkness seal proves the new modules unreachable from production.
 - [x] T004 [US1] Implement `src/index_lifecycle/candidate.rs` — capacity-reserved isolated full/delta candidates, complete artifact certificates, one runtime-store commit point, `CatalogPath` native/opaque identity end-to-end, delta exact-validation of only the changed source token, no-allocation whole-root patch, same-source drift retry/abort, epochs-never-authorize; register both modules in `src/index_lifecycle/mod.rs` (020:T060)
 - [x] T005 [US1] Extend `tests/preventive_runtime_dark_v11.rs` (constructor unreachability + census) to cover supervisor+candidate; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle only; reconcile the contract chain if census categories shift (quickstart step 3)
 - [x] T006 [US1] Run the full gate battery serially via Terminal Commander (fmt, clippy -D warnings, all-targets serial suite, `--no-default-features --features embed --lib`, release build, verify-tools, npm) plus `node scripts/validate-lifecycle-oracle-traceability.cjs`; `cargo clean` if `target/` grew heavy
-- [ ] T007 [US1] One independent code review including the mandatory cfg-lens sweep; open PR; on green CI auto-squash-merge with explicit subject/body (spec FR-015/FR-016)
+- [x] T007 [US1] One independent code review including the mandatory cfg-lens sweep; open PR; on green CI auto-squash-merge with explicit subject/body (spec FR-015/FR-016)
 
 **Checkpoint**: candidate pipeline GREEN dark on `main`; the Wave 1 workflow
 (RED → GREEN → seal → gates → review → merge) is proven end to end.

--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -72,10 +72,10 @@ deadline machine and sealed receipts exist dark (020:T055 + T062)
 **Independent Test**: `cargo test --test rolling_verification_v11 -- --test-threads=1`
 GREEN dark.
 
-- [ ] T008 [P] [US2] Branch `feature-020-s4-p2-verification` from updated `main`; author RED `tests/rolling_verification_v11.rs` with frozen name `rolling_passes_are_fair_resumable_and_fenced` plus the full 020:T055 case list (scope discovery, entry obligations, same-stamp rewrites, exact deadline boundary with `VerificationOverdueLatched`, no-extension-by-partial-work, overdue acquisition refusal, fenced proof refresh, sealed `VerificationScopeReceipt`, `VerificationWorkBound` ≤ 712 s, `VerificationFeasibilityReceipt` lost-reservation → non-Current, policy-mismatch re-scout); record observed RED (020:T055)
-- [ ] T009 [US2] Implement `src/index_lifecycle/verification.rs` from nothing — racy-clean entry obligations, scope-discovery deadlines, resumable rolling passes, immutable proof refresh, the exact frozen-FR-049 monotonic overdue predicate; register in `mod.rs` (020:T062)
-- [ ] T010 [US2] Extend darkness seal + census for verification.rs; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
-- [ ] T011 [US2] Full gate battery via Terminal Commander + traceability validator
+- [x] T008 [P] [US2] Branch `feature-020-s4-p2-verification` from updated `main`; author RED `tests/rolling_verification_v11.rs` with frozen name `rolling_passes_are_fair_resumable_and_fenced` plus the full 020:T055 case list (scope discovery, entry obligations, same-stamp rewrites, exact deadline boundary with `VerificationOverdueLatched`, no-extension-by-partial-work, overdue acquisition refusal, fenced proof refresh, sealed `VerificationScopeReceipt`, `VerificationWorkBound` ≤ 712 s, `VerificationFeasibilityReceipt` lost-reservation → non-Current, policy-mismatch re-scout); record observed RED (020:T055)
+- [x] T009 [US2] Implement `src/index_lifecycle/verification.rs` from nothing — racy-clean entry obligations, scope-discovery deadlines, resumable rolling passes, immutable proof refresh, the exact frozen-FR-049 monotonic overdue predicate; register in `mod.rs` (020:T062)
+- [x] T010 [US2] Extend darkness seal + census for verification.rs; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
+- [x] T011 [US2] Full gate battery via Terminal Commander + traceability validator
 - [ ] T012 [US2] Review (cfg-lens) → PR → green CI → auto-squash-merge
 
 **Checkpoint**: verification machine GREEN dark on `main`.

--- a/src/index_lifecycle/mod.rs
+++ b/src/index_lifecycle/mod.rs
@@ -38,6 +38,10 @@ pub mod physical_root;
 pub mod process_runtime;
 pub mod registry;
 pub mod supervisor;
+// T062: dark rolling verification — sealed scope receipts, the fixed
+// 15-minute deadline with its latch-before-acquisition ordering, work
+// bounds, and feasibility. Oracle-suite consumption only until activation.
+pub mod verification;
 // T047: the dark V11 runtime. In-directory consumption only; the dark factory
 // is the single door and Slice 4's activation cut is the only planned caller.
 pub mod runtime;

--- a/src/index_lifecycle/verification.rs
+++ b/src/index_lifecycle/verification.rs
@@ -14,7 +14,10 @@
 //! `MonotonicInstant` parameter so oracles drive the deadline exactly. The
 //! authority SEMANTICS — sealed scope, exact-identity advancement, the
 //! at/after latch ordering, feasibility-loss → non-Current, policy-mismatch →
-//! re-scout — are exact; payloads are recorded cut obligations.
+//! re-scout — are exact; payloads are recorded cut obligations. Deliberately
+//! deferred with them: `MAX_SUCCESSOR_VERIFICATION_START` (180 s) and the
+//! `successor_start_deadline` scheduling arithmetic, which sit outside
+//! T055's case list and land with the live scheduler at the cut.
 //!
 //! **Nothing in production calls this module.** Only the Slice 4 oracle
 //! suites and this directory do; activation (T064/T066) is the only planned
@@ -83,6 +86,10 @@ pub enum VerificationRefusal {
     WorkBeyondCaps,
     /// The pass's policy version does not match the sealed receipt's.
     PolicyMismatch,
+    /// The feasibility receipt was reserved for a DIFFERENT scope receipt —
+    /// feasibility is bound, never bearer (frozen data model:
+    /// `VerificationWorkBound.scope_receipt`).
+    FeasibilityNotForThisScope,
     /// The verifier is non-Current; only an authoritative re-scout returns.
     NonCurrent(NonCurrentCause),
     /// An entry drifted to a DIFFERENT stamp during the pass (a same-stamp
@@ -138,13 +145,16 @@ impl VerificationScopeReceipt {
 /// disagree with the operands it was derived from.
 #[derive(Debug)]
 pub struct VerificationWorkBound {
+    scope_receipt: VerificationScopeReceiptId,
     bound: Duration,
 }
 
 impl VerificationWorkBound {
-    /// Compute the bound for a scope's declared work, refusing work beyond
-    /// the frozen admission caps.
+    /// Compute the bound for ONE sealed scope's declared work, refusing work
+    /// beyond the frozen admission caps. The bound carries the receipt it
+    /// was computed for: feasibility is bound to a scope, never bearer.
     pub fn for_scope(
+        receipt: &VerificationScopeReceipt,
         verification_bytes: u64,
         verification_entries: u64,
     ) -> Result<Self, VerificationRefusal> {
@@ -156,6 +166,7 @@ impl VerificationWorkBound {
         let seconds = verification_bytes.div_ceil(RESERVED_VERIFICATION_BYTES_PER_SECOND)
             + verification_entries.div_ceil(RESERVED_VERIFICATION_ENTRIES_PER_SECOND);
         Ok(Self {
+            scope_receipt: receipt.id,
             bound: Duration::from_secs(seconds),
         })
     }
@@ -170,12 +181,16 @@ impl VerificationWorkBound {
 /// extending the deadline.
 #[derive(Debug)]
 pub struct VerificationFeasibilityReceipt {
-    _work: VerificationWorkBound,
+    work: VerificationWorkBound,
 }
 
 impl VerificationFeasibilityReceipt {
     pub fn reserve(work: VerificationWorkBound) -> Self {
-        Self { _work: work }
+        Self { work }
+    }
+
+    fn scope_receipt(&self) -> VerificationScopeReceiptId {
+        self.work.scope_receipt
     }
 }
 
@@ -287,42 +302,51 @@ pub struct RollingVerifier {
 }
 
 impl RollingVerifier {
-    /// Promote to Current at `now`. Requires a feasibility reservation —
-    /// affordability is admission, not advice, and the type makes a
-    /// reservation-free promotion unrepresentable.
+    /// Promote to Current at `now`. Requires a feasibility reservation whose
+    /// work bound was computed for THIS receipt — affordability is admission,
+    /// not advice, and a foreign reservation refuses.
     pub fn promote(
         receipt: VerificationScopeReceipt,
         feasibility: VerificationFeasibilityReceipt,
         now: MonotonicInstant,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, VerificationRefusal> {
+        if feasibility.scope_receipt() != receipt.id {
+            return Err(VerificationRefusal::FeasibilityNotForThisScope);
+        }
+        Ok(Self {
             receipt,
             _feasibility: feasibility,
             verified_at: now,
             non_current: None,
             scope_dirty: false,
-        }
+        })
     }
 
     /// Begin a rolling pass over the sealed scope under `policy`. A policy
-    /// mismatch refuses AND forces non-Current: only an authoritative
-    /// re-scout may mint a new Current after that.
+    /// mismatch refuses AND forces non-Current (without relabeling an
+    /// already-latched cause): only an authoritative re-scout may mint a new
+    /// Current after that. An OVERDUE-latched verifier may still begin a
+    /// pass — frozen FR-049's latch is cleared by exactly a fresh complete
+    /// verification, so the path to one must stay open; the other
+    /// non-Current causes refuse (no capacity, or an invalidated scope).
     pub fn begin_pass(
         &mut self,
         policy: PolicyVersion,
     ) -> Result<RollingPass, VerificationRefusal> {
         if policy != self.receipt.policy {
-            self.non_current = Some(NonCurrentCause::PolicyMismatch);
+            if self.non_current.is_none() {
+                self.non_current = Some(NonCurrentCause::PolicyMismatch);
+            }
             return Err(VerificationRefusal::PolicyMismatch);
         }
-        if let Some(cause) = self.non_current {
-            return Err(VerificationRefusal::NonCurrent(cause));
+        match self.non_current {
+            None | Some(NonCurrentCause::OverdueLatched) => Ok(RollingPass {
+                receipt: self.receipt.id,
+                scope: self.receipt.entries.clone(),
+                verified: BTreeMap::new(),
+            }),
+            Some(cause) => Err(VerificationRefusal::NonCurrent(cause)),
         }
-        Ok(RollingPass {
-            receipt: self.receipt.id,
-            scope: self.receipt.entries.clone(),
-            verified: BTreeMap::new(),
-        })
     }
 
     /// Whether the source is Current at `now`: never while a non-Current
@@ -351,8 +375,9 @@ impl RollingVerifier {
 
     /// Advance the deadline with a complete record at `now`. Anything less
     /// than the exact sealed whole scope was already refused at `complete`;
-    /// here a stale receipt binding fences, a dirty scope refuses, and a
-    /// latched verifier stays latched.
+    /// here a stale receipt binding fences and a dirty scope refuses. A
+    /// fresh complete record CLEARS an overdue latch — frozen FR-049's
+    /// exact clear clause — while the other non-Current causes refuse.
     pub fn advance(
         &mut self,
         record: VerificationRecord,
@@ -364,19 +389,34 @@ impl RollingVerifier {
         if self.scope_dirty {
             return Err(VerificationRefusal::ScopeDirty);
         }
-        if let Some(cause) = self.non_current {
-            return Err(VerificationRefusal::NonCurrent(cause));
+        match self.non_current {
+            None | Some(NonCurrentCause::OverdueLatched) => {
+                self.non_current = None;
+                self.verified_at = now;
+                Ok(())
+            }
+            Some(cause) => Err(VerificationRefusal::NonCurrent(cause)),
         }
-        self.verified_at = now;
-        Ok(())
     }
 
     /// Refresh the proof scope: seals a NEW receipt (new identity) and
     /// fences every pass still bound to the old one. The old receipt is
-    /// never mutated; the fresh receipt starts racy-clean.
-    pub fn refresh_scope(&mut self, receipt: VerificationScopeReceipt) {
+    /// never mutated; the fresh receipt starts racy-clean. A receipt sealed
+    /// under a DIFFERENT policy refuses — a policy change may not smuggle
+    /// past the mandated re-scout.
+    pub fn refresh_scope(
+        &mut self,
+        receipt: VerificationScopeReceipt,
+    ) -> Result<(), VerificationRefusal> {
+        if receipt.policy != self.receipt.policy {
+            if self.non_current.is_none() {
+                self.non_current = Some(NonCurrentCause::PolicyMismatch);
+            }
+            return Err(VerificationRefusal::PolicyMismatch);
+        }
         self.receipt = receipt;
         self.scope_dirty = false;
+        Ok(())
     }
 
     /// Record that an entry was rewritten during verification with `stamp`.
@@ -400,18 +440,24 @@ impl RollingVerifier {
         self.non_current
     }
 
-    /// The only path back to Current from non-Current: an authoritative
-    /// re-scout sealing a fresh receipt with fresh feasibility.
+    /// The authoritative re-scout: a fresh receipt with fresh feasibility
+    /// bound to it. The only path back to Current from a lost reservation or
+    /// a policy mismatch (the overdue latch alternatively clears through a
+    /// fresh complete verification, per frozen FR-049).
     pub fn re_scout(
         &mut self,
         receipt: VerificationScopeReceipt,
         feasibility: VerificationFeasibilityReceipt,
         now: MonotonicInstant,
-    ) {
+    ) -> Result<(), VerificationRefusal> {
+        if feasibility.scope_receipt() != receipt.id {
+            return Err(VerificationRefusal::FeasibilityNotForThisScope);
+        }
         self.receipt = receipt;
         self._feasibility = feasibility;
         self.verified_at = now;
         self.non_current = None;
         self.scope_dirty = false;
+        Ok(())
     }
 }

--- a/src/index_lifecycle/verification.rs
+++ b/src/index_lifecycle/verification.rs
@@ -1,0 +1,417 @@
+//! Feature 020 V11 rolling verification (Slice 4, T062 — dark).
+//!
+//! Racy-clean entry obligations, scope-discovery deadlines, resumable rolling
+//! verification, immutable proof refresh, and the exact frozen-FR-049
+//! monotonic overdue predicate: only a complete exact-identity whole-scope
+//! `VerificationRecord` bound to its sealed `VerificationScopeReceipt`
+//! advances the fixed 15-minute deadline; promotion requires a
+//! `VerificationFeasibilityReceipt` whose `VerificationWorkBound` is
+//! affordable at the reserved service floors; deadline expiry atomically
+//! latches non-Current before any strict lease (frozen tasks.md T062).
+//!
+//! Dark payload simplifications, in the `runtime.rs` idiom: scope entries are
+//! id→stamp pairs, not real catalog derivations, and the clock is an explicit
+//! `MonotonicInstant` parameter so oracles drive the deadline exactly. The
+//! authority SEMANTICS — sealed scope, exact-identity advancement, the
+//! at/after latch ordering, feasibility-loss → non-Current, policy-mismatch →
+//! re-scout — are exact; payloads are recorded cut obligations.
+//!
+//! **Nothing in production calls this module.** Only the Slice 4 oracle
+//! suites and this directory do; activation (T064/T066) is the only planned
+//! production caller.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+/// Frozen defaults (`specs/020-repository-knowledge-index/data-model.md`):
+/// the bound computed at the reserved floors caps at 512 + 200 = 712 seconds,
+/// so `DEFAULT_MAX_COMPLETE_VERIFICATION_PASS` is a ceiling the defaults
+/// never reach.
+pub const DEFAULT_MAX_VERIFICATION_BYTES: u64 = 17_179_869_184;
+pub const DEFAULT_MAX_VERIFICATION_ENTRIES: u64 = 200_000;
+pub const DEFAULT_MAX_COMPLETE_VERIFICATION_PASS: Duration = Duration::from_secs(720);
+pub const RESERVED_VERIFICATION_BYTES_PER_SECOND: u64 = 33_554_432;
+pub const RESERVED_VERIFICATION_ENTRIES_PER_SECOND: u64 = 1_000;
+/// The fixed 15-minute deadline (frozen FR-049).
+pub const MAX_CURRENT_UNVERIFIED_AGE: Duration = Duration::from_secs(900);
+
+/// An explicit monotonic instant in milliseconds. Oracles drive it; nothing
+/// here reads an ambient clock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MonotonicInstant(pub u64);
+
+impl MonotonicInstant {
+    pub fn plus(self, delta: Duration) -> Self {
+        Self(self.0 + u64::try_from(delta.as_millis()).expect("delta fits in u64 millis"))
+    }
+}
+
+fn age_millis() -> u64 {
+    u64::try_from(MAX_CURRENT_UNVERIFIED_AGE.as_millis()).expect("age fits in u64 millis")
+}
+
+/// Scope/policy version an observation was discovered under.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PolicyVersion(pub u64);
+
+/// Identity of one verification scope receipt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VerificationScopeReceiptId(pub(crate) u64);
+
+static NEXT_RECEIPT: AtomicU64 = AtomicU64::new(1);
+
+/// Why verification refused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VerificationRefusal {
+    /// The deadline latched: at/after the fixed age, non-Current is latched
+    /// BEFORE any strict acquisition can be served.
+    OverdueLatched,
+    /// The record's entry set is not the exact sealed scope.
+    NotWholeScope {
+        missing: usize,
+        extra: usize,
+        mismatched: usize,
+    },
+    /// The record or pass is bound to a receipt this verifier no longer
+    /// serves (immutable proof refresh fenced it out).
+    ProofFenced,
+    /// The scope's declared work exceeds the admission caps.
+    WorkBeyondCaps,
+    /// The pass's policy version does not match the sealed receipt's.
+    PolicyMismatch,
+    /// The verifier is non-Current; only an authoritative re-scout returns.
+    NonCurrent(NonCurrentCause),
+    /// An entry drifted to a DIFFERENT stamp during the pass (a same-stamp
+    /// rewrite stays racy-clean; a changed stamp dirties the scope).
+    ScopeDirty,
+}
+
+/// Why a verifier is non-Current.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NonCurrentCause {
+    OverdueLatched,
+    ReservationLost,
+    PolicyMismatch,
+}
+
+/// Sealed enumeration of everything one complete whole-declared-scope pass
+/// must check. Sealed at construction and never widened or narrowed in
+/// place: a scope change produces a NEW receipt with a NEW identity.
+#[derive(Debug)]
+pub struct VerificationScopeReceipt {
+    id: VerificationScopeReceiptId,
+    policy: PolicyVersion,
+    entries: BTreeMap<u64, u64>,
+}
+
+impl VerificationScopeReceipt {
+    /// Seal a receipt over discovered scope entries (id → stamp) under one
+    /// policy version.
+    pub fn seal(policy: PolicyVersion, entries: BTreeMap<u64, u64>) -> Self {
+        Self {
+            id: VerificationScopeReceiptId(NEXT_RECEIPT.fetch_add(1, Ordering::Relaxed)),
+            policy,
+            entries,
+        }
+    }
+
+    pub fn receipt_id(&self) -> VerificationScopeReceiptId {
+        self.id
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Cost of the pass the receipt describes. The private constructor computes
+/// `bound` from the operands at the reserved service floors; `bound` is never
+/// separately settable, so the value the admission gate trusts cannot
+/// disagree with the operands it was derived from.
+#[derive(Debug)]
+pub struct VerificationWorkBound {
+    bound: Duration,
+}
+
+impl VerificationWorkBound {
+    /// Compute the bound for a scope's declared work, refusing work beyond
+    /// the frozen admission caps.
+    pub fn for_scope(
+        verification_bytes: u64,
+        verification_entries: u64,
+    ) -> Result<Self, VerificationRefusal> {
+        if verification_bytes > DEFAULT_MAX_VERIFICATION_BYTES
+            || verification_entries > DEFAULT_MAX_VERIFICATION_ENTRIES
+        {
+            return Err(VerificationRefusal::WorkBeyondCaps);
+        }
+        let seconds = verification_bytes.div_ceil(RESERVED_VERIFICATION_BYTES_PER_SECOND)
+            + verification_entries.div_ceil(RESERVED_VERIFICATION_ENTRIES_PER_SECOND);
+        Ok(Self {
+            bound: Duration::from_secs(seconds),
+        })
+    }
+
+    pub fn bound(&self) -> Duration {
+        self.bound
+    }
+}
+
+/// Capacity actually reserved for the pass. Promotion to `Current` requires
+/// one; losing the reservation makes the source non-Current rather than
+/// extending the deadline.
+#[derive(Debug)]
+pub struct VerificationFeasibilityReceipt {
+    _work: VerificationWorkBound,
+}
+
+impl VerificationFeasibilityReceipt {
+    pub fn reserve(work: VerificationWorkBound) -> Self {
+        Self { _work: work }
+    }
+}
+
+/// A complete exact-identity whole-scope verification result, bound to the
+/// sealed receipt that scoped it.
+#[derive(Debug)]
+pub struct VerificationRecord {
+    receipt: VerificationScopeReceiptId,
+}
+
+/// One resumable rolling pass over a sealed receipt's scope. Partial
+/// progress lives HERE, never in the verifier: nothing short of `complete`
+/// can touch a deadline.
+#[derive(Debug)]
+pub struct RollingPass {
+    receipt: VerificationScopeReceiptId,
+    scope: BTreeMap<u64, u64>,
+    verified: BTreeMap<u64, u64>,
+}
+
+impl RollingPass {
+    /// Verify a chunk of entry ids (id → observed stamp). Partial progress
+    /// accumulates in the pass and NEVER advances any deadline.
+    pub fn verify_chunk(
+        &mut self,
+        observed: BTreeMap<u64, u64>,
+    ) -> Result<(), VerificationRefusal> {
+        self.verified.extend(observed);
+        Ok(())
+    }
+
+    /// The entry ids still owed.
+    pub fn remaining(&self) -> BTreeSet<u64> {
+        self.scope
+            .keys()
+            .filter(|id| !self.verified.contains_key(id))
+            .copied()
+            .collect()
+    }
+
+    /// Complete the pass into a record — only when the accumulated set is
+    /// EXACTLY the sealed scope: nothing missing, nothing extra, every stamp
+    /// identical.
+    pub fn complete(self) -> Result<VerificationRecord, VerificationRefusal> {
+        let missing = self
+            .scope
+            .keys()
+            .filter(|id| !self.verified.contains_key(id))
+            .count();
+        let extra = self
+            .verified
+            .keys()
+            .filter(|id| !self.scope.contains_key(id))
+            .count();
+        let mismatched = self
+            .scope
+            .iter()
+            .filter(|(id, stamp)| self.verified.get(id).is_some_and(|seen| seen != *stamp))
+            .count();
+        if missing + extra + mismatched > 0 {
+            return Err(VerificationRefusal::NotWholeScope {
+                missing,
+                extra,
+                mismatched,
+            });
+        }
+        Ok(VerificationRecord {
+            receipt: self.receipt,
+        })
+    }
+}
+
+/// Fair scheduler over concurrently rolling passes: strict rotation, so
+/// every registered pass makes progress and none starves.
+#[derive(Debug, Default)]
+pub struct PassScheduler {
+    queue: VecDeque<u64>,
+}
+
+impl PassScheduler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a pass identity for scheduling.
+    pub fn register(&mut self, pass_id: u64) {
+        self.queue.push_back(pass_id);
+    }
+
+    /// The next pass to grant a verification slot to; the grantee rotates to
+    /// the back of the queue.
+    pub fn next_grant(&mut self) -> Option<u64> {
+        let granted = self.queue.pop_front()?;
+        self.queue.push_back(granted);
+        Some(granted)
+    }
+}
+
+/// The per-source verification machine: owns the sealed receipt, the fixed
+/// deadline, the overdue latch, and the only paths between Current and
+/// non-Current.
+#[derive(Debug)]
+pub struct RollingVerifier {
+    receipt: VerificationScopeReceipt,
+    _feasibility: VerificationFeasibilityReceipt,
+    verified_at: MonotonicInstant,
+    non_current: Option<NonCurrentCause>,
+    scope_dirty: bool,
+}
+
+impl RollingVerifier {
+    /// Promote to Current at `now`. Requires a feasibility reservation —
+    /// affordability is admission, not advice, and the type makes a
+    /// reservation-free promotion unrepresentable.
+    pub fn promote(
+        receipt: VerificationScopeReceipt,
+        feasibility: VerificationFeasibilityReceipt,
+        now: MonotonicInstant,
+    ) -> Self {
+        Self {
+            receipt,
+            _feasibility: feasibility,
+            verified_at: now,
+            non_current: None,
+            scope_dirty: false,
+        }
+    }
+
+    /// Begin a rolling pass over the sealed scope under `policy`. A policy
+    /// mismatch refuses AND forces non-Current: only an authoritative
+    /// re-scout may mint a new Current after that.
+    pub fn begin_pass(
+        &mut self,
+        policy: PolicyVersion,
+    ) -> Result<RollingPass, VerificationRefusal> {
+        if policy != self.receipt.policy {
+            self.non_current = Some(NonCurrentCause::PolicyMismatch);
+            return Err(VerificationRefusal::PolicyMismatch);
+        }
+        if let Some(cause) = self.non_current {
+            return Err(VerificationRefusal::NonCurrent(cause));
+        }
+        Ok(RollingPass {
+            receipt: self.receipt.id,
+            scope: self.receipt.entries.clone(),
+            verified: BTreeMap::new(),
+        })
+    }
+
+    /// Whether the source is Current at `now`: never while a non-Current
+    /// cause is latched, and only STRICTLY before the fixed deadline — AT
+    /// the deadline is overdue.
+    pub fn is_current(&self, now: MonotonicInstant) -> bool {
+        self.non_current.is_none() && now.0 < self.verified_at.0 + age_millis()
+    }
+
+    /// Acquire a strict lease at `now`. At/after the deadline this LATCHES
+    /// non-Current first and then refuses — the latch is observable even
+    /// though the acquisition never was.
+    pub fn acquire_strict(&mut self, now: MonotonicInstant) -> Result<(), VerificationRefusal> {
+        match self.non_current {
+            Some(NonCurrentCause::OverdueLatched) => Err(VerificationRefusal::OverdueLatched),
+            Some(cause) => Err(VerificationRefusal::NonCurrent(cause)),
+            None => {
+                if now.0 >= self.verified_at.0 + age_millis() {
+                    self.non_current = Some(NonCurrentCause::OverdueLatched);
+                    return Err(VerificationRefusal::OverdueLatched);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Advance the deadline with a complete record at `now`. Anything less
+    /// than the exact sealed whole scope was already refused at `complete`;
+    /// here a stale receipt binding fences, a dirty scope refuses, and a
+    /// latched verifier stays latched.
+    pub fn advance(
+        &mut self,
+        record: VerificationRecord,
+        now: MonotonicInstant,
+    ) -> Result<(), VerificationRefusal> {
+        if record.receipt != self.receipt.id {
+            return Err(VerificationRefusal::ProofFenced);
+        }
+        if self.scope_dirty {
+            return Err(VerificationRefusal::ScopeDirty);
+        }
+        if let Some(cause) = self.non_current {
+            return Err(VerificationRefusal::NonCurrent(cause));
+        }
+        self.verified_at = now;
+        Ok(())
+    }
+
+    /// Refresh the proof scope: seals a NEW receipt (new identity) and
+    /// fences every pass still bound to the old one. The old receipt is
+    /// never mutated; the fresh receipt starts racy-clean.
+    pub fn refresh_scope(&mut self, receipt: VerificationScopeReceipt) {
+        self.receipt = receipt;
+        self.scope_dirty = false;
+    }
+
+    /// Record that an entry was rewritten during verification with `stamp`.
+    /// A SAME-stamp rewrite stays racy-clean; a different stamp — or a
+    /// rewrite outside the sealed scope — dirties it.
+    pub fn observe_rewrite(&mut self, entry: u64, stamp: u64) {
+        match self.receipt.entries.get(&entry) {
+            Some(sealed) if *sealed == stamp => {}
+            _ => self.scope_dirty = true,
+        }
+    }
+
+    /// The reservation backing feasibility was lost: the source becomes
+    /// non-Current — the deadline is NOT extended and the cause says why.
+    pub fn reservation_lost(&mut self) {
+        self.non_current = Some(NonCurrentCause::ReservationLost);
+    }
+
+    /// The cause if non-Current.
+    pub fn non_current_cause(&self) -> Option<NonCurrentCause> {
+        self.non_current
+    }
+
+    /// The only path back to Current from non-Current: an authoritative
+    /// re-scout sealing a fresh receipt with fresh feasibility.
+    pub fn re_scout(
+        &mut self,
+        receipt: VerificationScopeReceipt,
+        feasibility: VerificationFeasibilityReceipt,
+        now: MonotonicInstant,
+    ) {
+        self.receipt = receipt;
+        self._feasibility = feasibility;
+        self.verified_at = now;
+        self.non_current = None;
+        self.scope_dirty = false;
+    }
+}

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -794,19 +794,20 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
     "index_lifecycle/runtime.rs",
     "index_lifecycle/supervisor.rs",
     "index_lifecycle/transition.rs",
+    "index_lifecycle/verification.rs",
     "server_api.rs",
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "33f3885974de102a02ef57995e7262fa9914ea9f202c32beda4f74447c636d24",
-    15,
-    230_046,
+    "9007fe075febb73febe63d7e41a22ef0c7854934fbf4328df3a3134d29e92d30",
+    16,
+    245_287,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "1318b2b6efde06506d503205cfa126f02e7376b47639a3eec7c2473476d17a8d",
-    189,
-    9_016_044,
+    "8ec86ad48123bced40304dee579cd87005b9728670a7ee2c8466d7f52f21b10a",
+    190,
+    9_031_285,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -799,15 +799,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "9007fe075febb73febe63d7e41a22ef0c7854934fbf4328df3a3134d29e92d30",
+    "9c3ef0fc73fd319c04856a112815220c4d9b7221f40a9074e700c828cdf58005",
     16,
-    245_287,
+    247_728,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "8ec86ad48123bced40304dee579cd87005b9728670a7ee2c8466d7f52f21b10a",
+    "dec13efff5826653e12ab199bf41469be0f4c7025a870b0b7721c43591e7191d",
     190,
-    9_031_285,
+    9_033_726,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/rolling_verification_v11.rs
+++ b/tests/rolling_verification_v11.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use symforge::live_index::index_lifecycle::verification::{
     DEFAULT_MAX_COMPLETE_VERIFICATION_PASS, DEFAULT_MAX_VERIFICATION_BYTES,
     DEFAULT_MAX_VERIFICATION_ENTRIES, MAX_CURRENT_UNVERIFIED_AGE, MonotonicInstant,
-    NonCurrentCause, PassScheduler, PolicyVersion, RollingVerifier, VerificationFeasibilityReceipt,
+    NonCurrentCause, PassScheduler, PolicyVersion, RESERVED_VERIFICATION_BYTES_PER_SECOND,
+    RESERVED_VERIFICATION_ENTRIES_PER_SECOND, RollingVerifier, VerificationFeasibilityReceipt,
     VerificationRefusal, VerificationScopeReceipt, VerificationWorkBound,
 };
 
@@ -28,14 +29,16 @@ fn sealed(count: u64) -> VerificationScopeReceipt {
     VerificationScopeReceipt::seal(POLICY, scope_entries(count))
 }
 
-fn feasibility() -> VerificationFeasibilityReceipt {
+fn feasibility_for(receipt: &VerificationScopeReceipt) -> VerificationFeasibilityReceipt {
     VerificationFeasibilityReceipt::reserve(
-        VerificationWorkBound::for_scope(1_024, 4).expect("tiny scope is affordable"),
+        VerificationWorkBound::for_scope(receipt, 1_024, 4).expect("tiny scope is affordable"),
     )
 }
 
 fn promoted(count: u64) -> RollingVerifier {
-    RollingVerifier::promote(sealed(count), feasibility(), T0)
+    let receipt = sealed(count);
+    let feasibility = feasibility_for(&receipt);
+    RollingVerifier::promote(receipt, feasibility, T0).expect("feasibility is bound to this scope")
 }
 
 fn just_before_deadline() -> MonotonicInstant {
@@ -102,7 +105,9 @@ fn rolling_passes_are_fair_resumable_and_fenced() {
         pass.verify_chunk(scope_entries(2)).expect("chunk verifies");
         pass
     };
-    fenced.refresh_scope(VerificationScopeReceipt::seal(POLICY, scope_entries(2)));
+    fenced
+        .refresh_scope(VerificationScopeReceipt::seal(POLICY, scope_entries(2)))
+        .expect("a same-policy refresh is legitimate");
     let stale_record = stale_pass
         .complete()
         .expect("the stale pass still completes locally");
@@ -260,6 +265,63 @@ fn the_deadline_boundary_is_exact_and_latches_before_acquisition() {
     assert!(verifier.acquire_strict(just_before_deadline()).is_err());
 }
 
+/// Frozen FR-049's latch-clear clause, exactly: "Only a fresh complete
+/// exact-bound verification and publication may clear the latch." A latched
+/// OVERDUE verifier can still verify — begin a pass, complete the whole
+/// scope, and advance — and that fresh complete record clears the latch;
+/// strict leases resume. The other non-Current causes stay re-scout-only:
+/// a lost reservation has no capacity to verify with, and a policy mismatch
+/// invalidates the scope itself (pair-2 review, MAJOR finding).
+#[test]
+fn a_fresh_complete_verification_clears_the_overdue_latch() {
+    let mut verifier = promoted(2);
+    assert_eq!(
+        verifier.acquire_strict(at_deadline()).unwrap_err(),
+        VerificationRefusal::OverdueLatched
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::OverdueLatched)
+    );
+
+    // A mismatched-policy probe against the latched verifier refuses WITHOUT
+    // relabeling the latch: the recorded cause stays honest.
+    assert_eq!(
+        verifier.begin_pass(PolicyVersion(9)).unwrap_err(),
+        VerificationRefusal::PolicyMismatch
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::OverdueLatched),
+        "an unrelated later probe must not relabel the latch"
+    );
+
+    // The latched verifier may still VERIFY (never lease): the FR's named
+    // clear-path must be representable.
+    let mut pass = verifier
+        .begin_pass(POLICY)
+        .expect("an overdue-latched verifier must still be verifiable");
+    pass.verify_chunk(scope_entries(2)).expect("chunks verify");
+    let record = pass.complete().expect("whole scope");
+    let cleared_at = at_deadline().plus(Duration::from_secs(60));
+    verifier
+        .advance(record, cleared_at)
+        .expect("a fresh complete verification clears the overdue latch");
+    assert_eq!(verifier.non_current_cause(), None);
+    verifier
+        .acquire_strict(MonotonicInstant(cleared_at.0 + 1))
+        .expect("strict leases resume after the latch clears");
+
+    // Negative control: a lost reservation is NOT clearable by verification.
+    let mut lost = promoted(2);
+    lost.reservation_lost();
+    assert_eq!(
+        lost.begin_pass(POLICY).unwrap_err(),
+        VerificationRefusal::NonCurrent(NonCurrentCause::ReservationLost),
+        "only the overdue latch is verification-clearable"
+    );
+}
+
 /// Partial, cancelled, and resumed work never extends the deadline: only a
 /// complete exact-identity whole-scope record does.
 #[test]
@@ -304,12 +366,31 @@ fn partial_cancelled_or_resumed_work_never_extends_the_deadline() {
 
 // ── work bounds and feasibility ────────────────────────────────────────────
 
+/// The frozen constants are pinned by VALUE, not only by the source seal: a
+/// changed deadline or cap must fail an oracle, not just a hash refresh
+/// (pair-2 review). Values verbatim from the frozen data model.
+#[test]
+fn the_frozen_constants_are_pinned_by_value() {
+    assert_eq!(MAX_CURRENT_UNVERIFIED_AGE, Duration::from_secs(900));
+    assert_eq!(
+        DEFAULT_MAX_COMPLETE_VERIFICATION_PASS,
+        Duration::from_secs(720)
+    );
+    assert_eq!(DEFAULT_MAX_VERIFICATION_BYTES, 17_179_869_184);
+    assert_eq!(DEFAULT_MAX_VERIFICATION_ENTRIES, 200_000);
+    assert_eq!(RESERVED_VERIFICATION_BYTES_PER_SECOND, 33_554_432);
+    assert_eq!(RESERVED_VERIFICATION_ENTRIES_PER_SECOND, 1_000);
+}
+
 /// The computed bound is the ceiling arithmetic at the reserved floors, the
-/// caps make 712 s the reachable maximum (strictly under the 720 s default),
-/// and work beyond the caps refuses at admission.
+/// caps make 712 s the reachable maximum (STRICTLY under the 720 s default —
+/// "a ceiling the defaults never reach"), work beyond the caps refuses at
+/// admission, and feasibility is bound to its scope — a reservation for one
+/// receipt cannot promote another.
 #[test]
 fn the_work_bound_never_exceeds_the_reachable_default() {
-    let tiny = VerificationWorkBound::for_scope(1, 1).expect("affordable");
+    let receipt = sealed(1);
+    let tiny = VerificationWorkBound::for_scope(&receipt, 1, 1).expect("affordable");
     assert_eq!(
         tiny.bound(),
         Duration::from_secs(2),
@@ -317,20 +398,31 @@ fn the_work_bound_never_exceeds_the_reachable_default() {
     );
 
     let max = VerificationWorkBound::for_scope(
+        &receipt,
         DEFAULT_MAX_VERIFICATION_BYTES,
         DEFAULT_MAX_VERIFICATION_ENTRIES,
     )
     .expect("the caps themselves are affordable");
     assert_eq!(max.bound(), Duration::from_secs(712));
-    assert!(max.bound() <= DEFAULT_MAX_COMPLETE_VERIFICATION_PASS);
+    assert!(max.bound() < DEFAULT_MAX_COMPLETE_VERIFICATION_PASS);
 
     assert_eq!(
-        VerificationWorkBound::for_scope(DEFAULT_MAX_VERIFICATION_BYTES + 1, 1).unwrap_err(),
+        VerificationWorkBound::for_scope(&receipt, DEFAULT_MAX_VERIFICATION_BYTES + 1, 1)
+            .unwrap_err(),
         VerificationRefusal::WorkBeyondCaps
     );
     assert_eq!(
-        VerificationWorkBound::for_scope(1, DEFAULT_MAX_VERIFICATION_ENTRIES + 1).unwrap_err(),
+        VerificationWorkBound::for_scope(&receipt, 1, DEFAULT_MAX_VERIFICATION_ENTRIES + 1)
+            .unwrap_err(),
         VerificationRefusal::WorkBeyondCaps
+    );
+
+    // Feasibility is bound, never bearer: a foreign reservation refuses.
+    let this_scope = sealed(2);
+    let other_scope = sealed(2);
+    assert_eq!(
+        RollingVerifier::promote(this_scope, feasibility_for(&other_scope), T0).unwrap_err(),
+        VerificationRefusal::FeasibilityNotForThisScope
     );
 }
 
@@ -357,9 +449,14 @@ fn a_lost_reservation_forces_non_current_not_an_extension() {
         VerificationRefusal::NonCurrent(NonCurrentCause::ReservationLost)
     );
 
-    // The only way back: an authoritative re-scout with fresh feasibility.
+    // The only way back: an authoritative re-scout with fresh feasibility
+    // bound to the fresh receipt.
     let rescouted_at = MonotonicInstant(T0.0 + 10_000);
-    verifier.re_scout(sealed(2), feasibility(), rescouted_at);
+    let fresh = sealed(2);
+    let fresh_feasibility = feasibility_for(&fresh);
+    verifier
+        .re_scout(fresh, fresh_feasibility, rescouted_at)
+        .expect("re-scout accepts its own scope's feasibility");
     assert_eq!(verifier.non_current_cause(), None);
     verifier
         .acquire_strict(MonotonicInstant(rescouted_at.0 + 1))
@@ -386,13 +483,29 @@ fn policy_mismatch_forces_rescout_before_new_current() {
         VerificationRefusal::NonCurrent(NonCurrentCause::PolicyMismatch)
     );
 
+    // A cross-policy refresh may not smuggle past the mandated re-scout:
+    // it refuses without relabeling the latched cause.
+    assert_eq!(
+        verifier
+            .refresh_scope(VerificationScopeReceipt::seal(
+                PolicyVersion(8),
+                scope_entries(2)
+            ))
+            .unwrap_err(),
+        VerificationRefusal::PolicyMismatch
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::PolicyMismatch)
+    );
+
     // Re-scout under the new policy is the only path to a new Current.
     let rescouted_at = MonotonicInstant(T0.0 + 5_000);
-    verifier.re_scout(
-        VerificationScopeReceipt::seal(PolicyVersion(8), scope_entries(2)),
-        feasibility(),
-        rescouted_at,
-    );
+    let repolicied = VerificationScopeReceipt::seal(PolicyVersion(8), scope_entries(2));
+    let repolicied_feasibility = feasibility_for(&repolicied);
+    verifier
+        .re_scout(repolicied, repolicied_feasibility, rescouted_at)
+        .expect("re-scout accepts its own scope's feasibility");
     let mut pass = verifier
         .begin_pass(PolicyVersion(8))
         .expect("the re-scouted policy matches");

--- a/tests/rolling_verification_v11.rs
+++ b/tests/rolling_verification_v11.rs
@@ -1,0 +1,404 @@
+//! Feature 020 V11 Slice 4 rolling-verification oracles (T055).
+//!
+//! RED-first for the pair T055+T062: authored and observed failing against
+//! `todo!()` seams before any machinery existed. Every rejection case asserts
+//! the accepting path in the same test — a verifier that refuses everything
+//! satisfies a lone negative perfectly.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use symforge::live_index::index_lifecycle::verification::{
+    DEFAULT_MAX_COMPLETE_VERIFICATION_PASS, DEFAULT_MAX_VERIFICATION_BYTES,
+    DEFAULT_MAX_VERIFICATION_ENTRIES, MAX_CURRENT_UNVERIFIED_AGE, MonotonicInstant,
+    NonCurrentCause, PassScheduler, PolicyVersion, RollingVerifier, VerificationFeasibilityReceipt,
+    VerificationRefusal, VerificationScopeReceipt, VerificationWorkBound,
+};
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+const POLICY: PolicyVersion = PolicyVersion(7);
+const T0: MonotonicInstant = MonotonicInstant(1_000_000);
+
+fn scope_entries(count: u64) -> BTreeMap<u64, u64> {
+    (0..count).map(|id| (id, 100 + id)).collect()
+}
+
+fn sealed(count: u64) -> VerificationScopeReceipt {
+    VerificationScopeReceipt::seal(POLICY, scope_entries(count))
+}
+
+fn feasibility() -> VerificationFeasibilityReceipt {
+    VerificationFeasibilityReceipt::reserve(
+        VerificationWorkBound::for_scope(1_024, 4).expect("tiny scope is affordable"),
+    )
+}
+
+fn promoted(count: u64) -> RollingVerifier {
+    RollingVerifier::promote(sealed(count), feasibility(), T0)
+}
+
+fn just_before_deadline() -> MonotonicInstant {
+    MonotonicInstant(T0.0 + u64::try_from(MAX_CURRENT_UNVERIFIED_AGE.as_millis()).unwrap() - 1)
+}
+
+fn at_deadline() -> MonotonicInstant {
+    T0.plus(MAX_CURRENT_UNVERIFIED_AGE)
+}
+
+// ── the frozen-named oracle ────────────────────────────────────────────────
+
+/// TEST-ROLLING-VERIFICATION (T055). The name is pinned by
+/// `contracts/lifecycle-oracle-traceability-v11.md` as a `planned_exact`
+/// target; do not rename it without amending that contract.
+///
+/// FAIR: concurrently rolling passes each make progress — the scheduler
+/// rotates, none starves. RESUMABLE: a pass interrupted mid-scope continues
+/// from its cursor and completes without re-verifying finished entries.
+/// FENCED: a proof refresh seals a NEW receipt and a record bound to the old
+/// one can never advance the deadline — the old proof is immutable, not
+/// updated in place.
+#[test]
+fn rolling_passes_are_fair_resumable_and_fenced() {
+    // Fair rotation over registered passes.
+    let mut scheduler = PassScheduler::new();
+    scheduler.register(1);
+    scheduler.register(2);
+    let grants: Vec<u64> = (0..4)
+        .map(|_| scheduler.next_grant().expect("passes queued"))
+        .collect();
+    assert_eq!(
+        grants,
+        vec![1, 2, 1, 2],
+        "the scheduler must rotate, not starve"
+    );
+
+    // Resumable: verify in two chunks with an interruption between them.
+    let mut verifier = promoted(4);
+    let mut pass = verifier.begin_pass(POLICY).expect("policy matches");
+    pass.verify_chunk(scope_entries(4).into_iter().take(2).collect())
+        .expect("first chunk verifies");
+    assert_eq!(
+        pass.remaining().len(),
+        2,
+        "the cursor must reflect finished work"
+    );
+    pass.verify_chunk(scope_entries(4).into_iter().skip(2).collect())
+        .expect("the resumed chunk verifies");
+    let record = pass.complete().expect("the whole scope was verified");
+    let advanced_at = MonotonicInstant(T0.0 + 60_000);
+    verifier
+        .advance(record, advanced_at)
+        .expect("a complete record advances");
+    assert!(
+        verifier.is_current(at_deadline()),
+        "the advanced deadline must move with the record"
+    );
+
+    // Fenced: a refresh seals a NEW receipt; the stale pass's record refuses.
+    let mut fenced = promoted(2);
+    let stale_pass = {
+        let mut pass = fenced.begin_pass(POLICY).expect("policy matches");
+        pass.verify_chunk(scope_entries(2)).expect("chunk verifies");
+        pass
+    };
+    fenced.refresh_scope(VerificationScopeReceipt::seal(POLICY, scope_entries(2)));
+    let stale_record = stale_pass
+        .complete()
+        .expect("the stale pass still completes locally");
+    assert_eq!(
+        fenced
+            .advance(stale_record, MonotonicInstant(T0.0 + 1_000))
+            .unwrap_err(),
+        VerificationRefusal::ProofFenced,
+        "a record bound to a refreshed-away receipt must not advance"
+    );
+    // Positive control: a pass against the NEW receipt advances.
+    let mut fresh_pass = fenced.begin_pass(POLICY).expect("policy matches");
+    fresh_pass
+        .verify_chunk(scope_entries(2))
+        .expect("chunk verifies");
+    let fresh_record = fresh_pass.complete().expect("whole scope");
+    fenced
+        .advance(fresh_record, MonotonicInstant(T0.0 + 2_000))
+        .expect("the fresh receipt's record advances");
+}
+
+// ── sealed scope ───────────────────────────────────────────────────────────
+
+/// The receipt is sealed at discovery: a pass over a SUBSET refuses with the
+/// exact shortfall, extra entries refuse, mismatched stamps refuse — and the
+/// exact whole scope completes.
+#[test]
+fn scope_discovery_seals_the_receipt_and_no_pass_may_narrow_it() {
+    let mut verifier = promoted(3);
+
+    // Subset: silent narrowing refused with the counts.
+    let mut narrow = verifier.begin_pass(POLICY).expect("policy matches");
+    narrow
+        .verify_chunk(scope_entries(3).into_iter().take(2).collect())
+        .expect("chunks verify");
+    match narrow.complete().unwrap_err() {
+        VerificationRefusal::NotWholeScope {
+            missing,
+            extra,
+            mismatched,
+        } => {
+            assert_eq!((missing, extra, mismatched), (1, 0, 0));
+        }
+        other => panic!("a narrowed pass must refuse as NotWholeScope, got {other:?}"),
+    }
+
+    // Extra entries: a pass may not widen either.
+    let mut wide = verifier.begin_pass(POLICY).expect("policy matches");
+    let mut extra_entries = scope_entries(3);
+    extra_entries.insert(99, 999);
+    wide.verify_chunk(extra_entries).expect("chunks verify");
+    match wide.complete().unwrap_err() {
+        VerificationRefusal::NotWholeScope {
+            missing,
+            extra,
+            mismatched,
+        } => {
+            assert_eq!((missing, extra, mismatched), (0, 1, 0));
+        }
+        other => panic!("a widened pass must refuse as NotWholeScope, got {other:?}"),
+    }
+
+    // Mismatched stamp: verifying different bytes is not verifying the scope.
+    let mut skewed = verifier.begin_pass(POLICY).expect("policy matches");
+    let mut skewed_entries = scope_entries(3);
+    skewed_entries.insert(1, 555);
+    skewed.verify_chunk(skewed_entries).expect("chunks verify");
+    match skewed.complete().unwrap_err() {
+        VerificationRefusal::NotWholeScope {
+            missing,
+            extra,
+            mismatched,
+        } => {
+            assert_eq!((missing, extra, mismatched), (0, 0, 1));
+        }
+        other => panic!("a stamp-skewed pass must refuse as NotWholeScope, got {other:?}"),
+    }
+
+    // Positive control: the exact whole scope completes and advances.
+    let mut exact = verifier.begin_pass(POLICY).expect("policy matches");
+    exact.verify_chunk(scope_entries(3)).expect("chunks verify");
+    let record = exact.complete().expect("exact whole scope");
+    verifier
+        .advance(record, MonotonicInstant(T0.0 + 1_000))
+        .expect("the exact record advances");
+}
+
+/// A same-stamp rewrite during a pass stays racy-clean; a different stamp
+/// dirties the scope and the pass's record cannot advance.
+#[test]
+fn same_stamp_rewrites_stay_racy_clean() {
+    // Racy-clean: rewritten with the SAME stamp mid-pass.
+    let mut clean = promoted(2);
+    let mut pass = clean.begin_pass(POLICY).expect("policy matches");
+    pass.verify_chunk(scope_entries(2)).expect("chunks verify");
+    clean.observe_rewrite(0, 100);
+    let record = pass.complete().expect("whole scope");
+    clean
+        .advance(record, MonotonicInstant(T0.0 + 1_000))
+        .expect("a same-stamp rewrite must not dirty the scope");
+
+    // Dirty: rewritten with a DIFFERENT stamp mid-pass.
+    let mut dirty = promoted(2);
+    let mut pass = dirty.begin_pass(POLICY).expect("policy matches");
+    pass.verify_chunk(scope_entries(2)).expect("chunks verify");
+    dirty.observe_rewrite(0, 4_242);
+    let record = pass.complete().expect("whole scope");
+    let before = dirty.is_current(just_before_deadline());
+    assert_eq!(
+        dirty
+            .advance(record, MonotonicInstant(T0.0 + 1_000))
+            .unwrap_err(),
+        VerificationRefusal::ScopeDirty,
+        "a changed-stamp rewrite must dirty the scope"
+    );
+    assert_eq!(
+        dirty.is_current(just_before_deadline()),
+        before,
+        "a refused advance must not move the deadline either way"
+    );
+}
+
+// ── the exact deadline ─────────────────────────────────────────────────────
+
+/// Frozen FR-049's boundary, exactly: strictly-before the fixed 15-minute
+/// age remains eligible; AT the deadline the verifier latches
+/// `VerificationOverdueLatched` BEFORE any strict acquisition is served.
+#[test]
+fn the_deadline_boundary_is_exact_and_latches_before_acquisition() {
+    let mut verifier = promoted(2);
+
+    // Just-before: eligible, acquirable, no latch.
+    assert!(verifier.is_current(just_before_deadline()));
+    verifier
+        .acquire_strict(just_before_deadline())
+        .expect("just-before the deadline remains eligible");
+    assert_eq!(verifier.non_current_cause(), None);
+
+    // AT the deadline: the latch lands first, then the refusal.
+    assert!(
+        !verifier.is_current(at_deadline()),
+        "AT the deadline is overdue, not eligible"
+    );
+    assert_eq!(
+        verifier.acquire_strict(at_deadline()).unwrap_err(),
+        VerificationRefusal::OverdueLatched
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::OverdueLatched),
+        "the latch must be observable after the refusal"
+    );
+
+    // Latched is sticky: even an earlier instant no longer acquires.
+    assert!(verifier.acquire_strict(just_before_deadline()).is_err());
+}
+
+/// Partial, cancelled, and resumed work never extends the deadline: only a
+/// complete exact-identity whole-scope record does.
+#[test]
+fn partial_cancelled_or_resumed_work_never_extends_the_deadline() {
+    let mut verifier = promoted(4);
+
+    // Partial progress, then a cancelled pass, then a resumed partial pass.
+    let mut abandoned = verifier.begin_pass(POLICY).expect("policy matches");
+    abandoned
+        .verify_chunk(scope_entries(4).into_iter().take(2).collect())
+        .expect("chunks verify");
+    drop(abandoned); // cancelled
+
+    let mut resumed = verifier.begin_pass(POLICY).expect("policy matches");
+    resumed
+        .verify_chunk(scope_entries(4).into_iter().take(3).collect())
+        .expect("chunks verify");
+    assert_eq!(resumed.remaining().len(), 1, "still partial by design");
+
+    // None of that moved the deadline: AT the original deadline it latches.
+    assert!(!verifier.is_current(at_deadline()));
+    assert_eq!(
+        verifier.acquire_strict(at_deadline()).unwrap_err(),
+        VerificationRefusal::OverdueLatched
+    );
+
+    // Positive control on a fresh verifier: a COMPLETE record extends.
+    let mut extended = promoted(4);
+    let mut pass = extended.begin_pass(POLICY).expect("policy matches");
+    pass.verify_chunk(scope_entries(4)).expect("chunks verify");
+    let record = pass.complete().expect("whole scope");
+    let advanced_at = MonotonicInstant(T0.0 + 120_000);
+    extended
+        .advance(record, advanced_at)
+        .expect("complete record advances");
+    assert!(
+        extended.is_current(at_deadline()),
+        "the deadline must now anchor at the record"
+    );
+    assert!(!extended.is_current(advanced_at.plus(MAX_CURRENT_UNVERIFIED_AGE)));
+}
+
+// ── work bounds and feasibility ────────────────────────────────────────────
+
+/// The computed bound is the ceiling arithmetic at the reserved floors, the
+/// caps make 712 s the reachable maximum (strictly under the 720 s default),
+/// and work beyond the caps refuses at admission.
+#[test]
+fn the_work_bound_never_exceeds_the_reachable_default() {
+    let tiny = VerificationWorkBound::for_scope(1, 1).expect("affordable");
+    assert_eq!(
+        tiny.bound(),
+        Duration::from_secs(2),
+        "ceil(1/floor) is one second per axis"
+    );
+
+    let max = VerificationWorkBound::for_scope(
+        DEFAULT_MAX_VERIFICATION_BYTES,
+        DEFAULT_MAX_VERIFICATION_ENTRIES,
+    )
+    .expect("the caps themselves are affordable");
+    assert_eq!(max.bound(), Duration::from_secs(712));
+    assert!(max.bound() <= DEFAULT_MAX_COMPLETE_VERIFICATION_PASS);
+
+    assert_eq!(
+        VerificationWorkBound::for_scope(DEFAULT_MAX_VERIFICATION_BYTES + 1, 1).unwrap_err(),
+        VerificationRefusal::WorkBeyondCaps
+    );
+    assert_eq!(
+        VerificationWorkBound::for_scope(1, DEFAULT_MAX_VERIFICATION_ENTRIES + 1).unwrap_err(),
+        VerificationRefusal::WorkBeyondCaps
+    );
+}
+
+/// Losing the feasibility reservation forces non-Current — it never extends
+/// the deadline, and only an authoritative re-scout returns to Current.
+#[test]
+fn a_lost_reservation_forces_non_current_not_an_extension() {
+    let mut verifier = promoted(2);
+    assert!(verifier.is_current(MonotonicInstant(T0.0 + 1)));
+
+    verifier.reservation_lost();
+    assert!(
+        !verifier.is_current(MonotonicInstant(T0.0 + 2)),
+        "losing the reservation is non-Current NOW"
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::ReservationLost)
+    );
+    assert_eq!(
+        verifier
+            .acquire_strict(MonotonicInstant(T0.0 + 3))
+            .unwrap_err(),
+        VerificationRefusal::NonCurrent(NonCurrentCause::ReservationLost)
+    );
+
+    // The only way back: an authoritative re-scout with fresh feasibility.
+    let rescouted_at = MonotonicInstant(T0.0 + 10_000);
+    verifier.re_scout(sealed(2), feasibility(), rescouted_at);
+    assert_eq!(verifier.non_current_cause(), None);
+    verifier
+        .acquire_strict(MonotonicInstant(rescouted_at.0 + 1))
+        .expect("re-scout restores Current");
+}
+
+/// A policy-version mismatch refuses the pass AND forces non-Current: no new
+/// Current promotion happens before an authoritative re-scout.
+#[test]
+fn policy_mismatch_forces_rescout_before_new_current() {
+    let mut verifier = promoted(2);
+    assert_eq!(
+        verifier.begin_pass(PolicyVersion(8)).unwrap_err(),
+        VerificationRefusal::PolicyMismatch
+    );
+    assert_eq!(
+        verifier.non_current_cause(),
+        Some(NonCurrentCause::PolicyMismatch)
+    );
+    assert_eq!(
+        verifier
+            .acquire_strict(MonotonicInstant(T0.0 + 1))
+            .unwrap_err(),
+        VerificationRefusal::NonCurrent(NonCurrentCause::PolicyMismatch)
+    );
+
+    // Re-scout under the new policy is the only path to a new Current.
+    let rescouted_at = MonotonicInstant(T0.0 + 5_000);
+    verifier.re_scout(
+        VerificationScopeReceipt::seal(PolicyVersion(8), scope_entries(2)),
+        feasibility(),
+        rescouted_at,
+    );
+    let mut pass = verifier
+        .begin_pass(PolicyVersion(8))
+        .expect("the re-scouted policy matches");
+    pass.verify_chunk(scope_entries(2)).expect("chunks verify");
+    let record = pass.complete().expect("whole scope");
+    verifier
+        .advance(record, MonotonicInstant(rescouted_at.0 + 1_000))
+        .expect("the re-scouted scope promotes and advances");
+}


### PR DESCRIPTION
Wave 1 pair 2 of the Slice 4 campaign (specs/028-preventive-activation-cut; frozen roster 020:T055+T062): dark rolling verification built from nothing, RED-first.

**RED observed before machinery** (TC job job_01a0124d62227730b8dd4b3c7b9dc3ed, exit 101): `test result: FAILED. 0 passed; 8 failed` on todo!() seams. **GREEN**: 8/8 first implementation, 10/10 after the review round.

**Independent review round** (one pass + cfg-lens per spec FR-016): frozen constants CLEAN (values and 712-arithmetic verified against the frozen data model), adversarial forgery CLEAN (VerificationRecord is private-constructed, non-Clone, consumed by value - replay is unrepresentable; the reviewer independently verified both seal byte deltas to the byte), cfg-lens CLEAN (zero cfg in the diff), seal CLEAN. One MAJOR found and fixed RED-first in f9dd5ef4: the overdue latch was re-scout-only, STRICTER than frozen FR-049, whose clear clause names exactly one path - a fresh complete exact-bound verification. New oracle a_fresh_complete_verification_clears_the_overdue_latch observed RED, then the machine opened that path (verify-never-lease while latched; ReservationLost/PolicyMismatch stay re-scout-only with a negative control). Adjudicated minors all taken: feasibility now bound to its scope receipt (the bearer-token hole the old fixture itself exploited refuses with FeasibilityNotForThisScope), cross-policy refresh_scope refuses, mismatch probes no longer relabel a latched cause, and the six frozen constants are pinned by VALUE with 712 asserted strictly under 720. Noted deferral recorded in the module doc: MAX_SUCCESSOR_VERIFICATION_START and successor scheduling land with the live scheduler at the cut.

**Seal**: excluded set +1 (verification.rs); both pins refreshed from the Rust oracle after rustfmt. Seal 8/8; traceability validator OK; frozen specs/020 untouched.

**Gates** (serial via Terminal Commander): fmt clean, clippy -D warnings clean, full serial suite exit 0, embed lib gate 1333/0 zero warnings, release build + verify-tools 7 PASS/0 FAIL, npm 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn