### PR TITLE
feat(feature-020): Slice 4 pair 4 - dark observer accumulator and handoff

### DIFF
--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -95,7 +95,7 @@ GREEN dark.
 - [x] T015 [US3] Implement `src/index_lifecycle/query.rs` — project/single-source strict leases, exact multi-project selections, separate ranking snapshots, sealed completed-lease render authority, `SourceRefusal` transport mapping, and the committed-vs-attempt health projection seam (all four surfaces modeled INSIDE the dark module — the call-edge sweep forbids the index_lifecycle token in live files, so the `src/live_index/health_view.rs` and `src/protocol/` wiring named by frozen T063 is cut work under T064/T066); register in `mod.rs` (020:T063)
 - [x] T016 [US3] Extend darkness seal + census for query.rs (no health_view/protocol seams — see the T015 scope correction); refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
 - [x] T017 [US3] Full gate battery via Terminal Commander + traceability validator
-- [ ] T018 [US3] Review (cfg-lens) → PR → green CI → auto-squash-merge
+- [x] T018 [US3] Review (cfg-lens) → PR → green CI → auto-squash-merge
 
 **Checkpoint**: query-lease machinery GREEN dark on `main`; US2's oracle exists.
 
@@ -109,10 +109,10 @@ exist dark (020:T054 + T061); the performance gate itself runs at the cut
 **Independent Test**: `cargo test --test observer_handoff_v11 -- --test-threads=1`
 GREEN dark.
 
-- [ ] T019 [P] [US4] Branch `feature-020-s4-p4-observer` from updated `main`; author RED `tests/observer_handoff_v11.rs` with frozen name `stable_token_cut_latches_every_gap` plus the 020:T054 case list (stable-token cuts, gap latching, predecessor drain, post-barrier baseline, ingress unwind retention, exhausted-capacity safety transitions); record observed RED (020:T054)
-- [ ] T020 [US4] Implement `src/index_lifecycle/observer.rs` — bounded coalescing accumulator, monotonic invalidation cuts, scope-dirty/gap latches, stable observer handoff, full successor baseline, adapting the live `src/watcher/` event vocabulary without touching its live routing; register in `mod.rs` (020:T061)
-- [ ] T021 [US4] Extend darkness seal + census for observer.rs; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
-- [ ] T022 [US4] Full gate battery via Terminal Commander + traceability validator
+- [x] T019 [P] [US4] Branch `feature-020-s4-p4-observer` from updated `main`; author RED `tests/observer_handoff_v11.rs` with frozen name `stable_token_cut_latches_every_gap` plus the 020:T054 case list (stable-token cuts, gap latching, predecessor drain, post-barrier baseline, ingress unwind retention, exhausted-capacity safety transitions); record observed RED (020:T054)
+- [x] T020 [US4] Implement `src/index_lifecycle/observer.rs` — bounded coalescing accumulator, monotonic invalidation cuts, scope-dirty/gap latches, stable observer handoff, full successor baseline, adapting the live `src/watcher/` event vocabulary without touching its live routing; register in `mod.rs` (020:T061)
+- [x] T021 [US4] Extend darkness seal + census for observer.rs; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
+- [x] T022 [US4] Full gate battery via Terminal Commander + traceability validator
 - [ ] T023 [US4] Review (cfg-lens) → PR → green CI → auto-squash-merge
 
 **Checkpoint**: observer GREEN dark on `main`.

--- a/src/index_lifecycle/mod.rs
+++ b/src/index_lifecycle/mod.rs
@@ -36,6 +36,10 @@ pub mod embedded;
 pub mod mutation;
 pub mod physical_root;
 pub mod process_runtime;
+// T061: dark observer accumulator — bounded coalescing, monotonic cuts,
+// latch-forces-baseline, drain-before-successor handoff. Oracle-suite
+// consumption only until activation.
+pub mod observer;
 // T063: dark strict query leases — atomic exact-bijection selections,
 // sealed render authority, refusal-not-no-match, and the two-ledger health
 // projection seam. Oracle-suite consumption only until activation.

--- a/src/index_lifecycle/observer.rs
+++ b/src/index_lifecycle/observer.rs
@@ -1,0 +1,219 @@
+//! Feature 020 V11 observer accumulator and handoff (Slice 4, T061 — dark).
+//!
+//! The bounded coalescing accumulator, monotonic invalidation cuts,
+//! scope-dirty/gap latches, stable observer handoff, and the full successor
+//! baseline (frozen tasks.md T061). Every latch cause forces a FULL
+//! baseline cut — a gap, a dirty scope, exhausted capacity, or a handoff
+//! barrier is never a silent drop; the baseline is the retention mechanism.
+//!
+//! Dark payload simplifications, in the `runtime.rs` idiom: observations
+//! are (source, stamp) pairs and stamp derivation is an injected closure so
+//! oracles can drive unwinds; the live `src/watcher/` event vocabulary is
+//! adapted at the cut (T064), not here — the darkness sweep forbids this
+//! module's name in live files. The authority SEMANTICS — strictly
+//! monotonic cut tokens, latch-clears-only-through-baseline, coalescing
+//! with a hard bound, predecessor-drain-before-successor, post-barrier full
+//! baseline, and unwind retention — are exact.
+//!
+//! **Nothing in production calls this module.** Only the Slice 4 oracle
+//! suites and this directory do; activation (T064/T066) is the only planned
+//! production caller.
+
+use std::collections::BTreeMap;
+
+/// One cut's identity: strictly monotonic per accumulator, gap or no gap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CutToken(pub u64);
+
+/// Why a cut was forced to a full baseline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LatchCause {
+    /// The observation stream reported a gap (lost/overflowed events).
+    Gap,
+    /// An observation's payload derivation unwound: the CHANGE is known,
+    /// its content is not — the scope is dirty.
+    ScopeDirty,
+    /// The bounded accumulator refused to grow: the safety transition.
+    CapacityExhausted,
+    /// A completed observer handoff: the successor starts from a barrier.
+    HandoffBarrier,
+}
+
+/// What one cut demands of its consumer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CutKind {
+    /// Apply exactly these invalidations.
+    Incremental,
+    /// Rebuild the whole scope; the latch cause says why.
+    FullBaseline { cause: LatchCause },
+}
+
+/// One monotonic invalidation cut.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservationCut {
+    pub token: CutToken,
+    pub kind: CutKind,
+    pub invalidations: BTreeMap<u64, u64>,
+}
+
+/// The bounded coalescing accumulator (T061). Repeated observations of one
+/// source coalesce to the newest stamp; distinct-source growth beyond the
+/// bound latches `CapacityExhausted` instead of dropping. The FIRST latch
+/// cause wins until a baseline cut clears it.
+#[derive(Debug)]
+pub struct CoalescingAccumulator {
+    bound: usize,
+    pending: BTreeMap<u64, u64>,
+    latch: Option<LatchCause>,
+    next_token: u64,
+}
+
+/// Armed across a payload derivation: if the derivation unwinds, the drop
+/// latches the scope dirty — the observed CHANGE is retained even though
+/// its content never arrived.
+struct UnwindRetention<'a> {
+    latch: &'a mut Option<LatchCause>,
+    armed: bool,
+}
+
+impl Drop for UnwindRetention<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.latch.get_or_insert(LatchCause::ScopeDirty);
+        }
+    }
+}
+
+impl CoalescingAccumulator {
+    /// A fresh accumulator bounded to `bound` distinct pending sources.
+    pub fn new(bound: usize) -> Self {
+        Self {
+            bound,
+            pending: BTreeMap::new(),
+            latch: None,
+            next_token: 1,
+        }
+    }
+
+    /// Observe `source` with a stamp computed by `derive`. If `derive`
+    /// UNWINDS, the observation is retained: the scope latches dirty, so
+    /// the change cannot be lost even though its content is unknown. A
+    /// DISTINCT source beyond the bound latches the safety transition —
+    /// the baseline cut is the retention mechanism, never a drop.
+    pub fn observe(&mut self, source: u64, derive: impl FnOnce() -> u64) {
+        if !self.pending.contains_key(&source) && self.pending.len() >= self.bound {
+            self.latch.get_or_insert(LatchCause::CapacityExhausted);
+            return;
+        }
+        let stamp = {
+            let mut retention = UnwindRetention {
+                latch: &mut self.latch,
+                armed: true,
+            };
+            let stamp = derive();
+            retention.armed = false;
+            drop(retention);
+            stamp
+        };
+        self.pending.insert(source, stamp);
+    }
+
+    /// The observation stream reported a gap: latch it.
+    pub fn report_gap(&mut self) {
+        self.latch.get_or_insert(LatchCause::Gap);
+    }
+
+    /// Pending distinct sources (coalesced).
+    pub fn pending(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Produce the next cut: strictly monotonic token, always. A latched
+    /// accumulator emits a FULL baseline cut (clearing the latch); an
+    /// unlatched one emits the coalesced incremental invalidations. Either
+    /// way the accumulator drains.
+    pub fn cut(&mut self) -> ObservationCut {
+        let token = CutToken(self.next_token);
+        self.next_token += 1;
+        let kind = match self.latch.take() {
+            Some(cause) => CutKind::FullBaseline { cause },
+            None => CutKind::Incremental,
+        };
+        ObservationCut {
+            token,
+            kind,
+            invalidations: std::mem::take(&mut self.pending),
+        }
+    }
+}
+
+/// Why a handoff refused to complete.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HandoffRefusal {
+    /// The predecessor still holds undelivered cuts.
+    PredecessorStillDraining { undelivered: usize },
+    /// No handoff has begun.
+    NoHandoffInProgress,
+}
+
+/// Identity of one observer occupying the slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ObserverId(pub u64);
+
+/// The stable observer slot: one active observer, drain-before-successor
+/// handoff, and a post-barrier full baseline for the successor.
+#[derive(Debug)]
+pub struct ObserverSlot {
+    active: ObserverId,
+    undelivered: Vec<ObservationCut>,
+    handoff_in_progress: bool,
+}
+
+impl ObserverSlot {
+    pub fn new(first: ObserverId) -> Self {
+        Self {
+            active: first,
+            undelivered: Vec::new(),
+            handoff_in_progress: false,
+        }
+    }
+
+    /// The observer currently holding the slot.
+    pub fn active(&self) -> ObserverId {
+        self.active
+    }
+
+    /// Queue a cut the active observer has produced but not yet delivered.
+    pub fn queue_undelivered(&mut self, cut: ObservationCut) {
+        self.undelivered.push(cut);
+    }
+
+    /// Begin handing the slot to a successor: the predecessor drains first.
+    pub fn begin_handoff(&mut self) {
+        self.handoff_in_progress = true;
+    }
+
+    /// Deliver every undelivered predecessor cut, in order.
+    pub fn deliver_pending(&mut self) -> Vec<ObservationCut> {
+        std::mem::take(&mut self.undelivered)
+    }
+
+    /// Complete the handoff. Refuses while the predecessor still holds
+    /// undelivered cuts; on success the successor is active and its FIRST
+    /// obligation is a full post-barrier baseline.
+    pub fn complete_handoff(&mut self, successor: ObserverId) -> Result<CutKind, HandoffRefusal> {
+        if !self.handoff_in_progress {
+            return Err(HandoffRefusal::NoHandoffInProgress);
+        }
+        if !self.undelivered.is_empty() {
+            return Err(HandoffRefusal::PredecessorStillDraining {
+                undelivered: self.undelivered.len(),
+            });
+        }
+        self.active = successor;
+        self.handoff_in_progress = false;
+        Ok(CutKind::FullBaseline {
+            cause: LatchCause::HandoffBarrier,
+        })
+    }
+}

--- a/src/index_lifecycle/observer.rs
+++ b/src/index_lifecycle/observer.rs
@@ -11,9 +11,19 @@
 //! oracles can drive unwinds; the live `src/watcher/` event vocabulary is
 //! adapted at the cut (T064), not here — the darkness sweep forbids this
 //! module's name in live files. The authority SEMANTICS — strictly
-//! monotonic cut tokens, latch-clears-only-through-baseline, coalescing
-//! with a hard bound, predecessor-drain-before-successor, post-barrier full
-//! baseline, and unwind retention — are exact.
+//! monotonic cut tokens, coalescing with a hard bound,
+//! predecessor-drain-before-successor with a bound successor and
+//! producer-fenced queueing, and unwind retention — are exact. Two deltas
+//! are NOT and are recorded cut obligations (T064): the latch clears on cut
+//! EMISSION, not on rescan PROOF (the acceptance oracle's
+//! "remains latched until a complete rescan proof" needs the consumer
+//! acknowledgment seam the live wiring owns — a consumer aborting a rescan
+//! must re-latch via `report_gap`), and the successor's post-barrier
+//! baseline obligation is returned as a value, not yet threaded into any
+//! accumulator's cut stream. The `ObserverSlot`/`ObserverId` pair here is
+//! the accumulator-side MECHANICS complement of
+//! `authority.rs::ObserverPhase`/`ObserverToken` (the per-source
+//! authority-side projection); unifying the two identities is T064 work.
 //!
 //! **Nothing in production calls this module.** Only the Slice 4 oracle
 //! suites and this directory do; activation (T064/T066) is the only planned
@@ -39,12 +49,17 @@ pub enum LatchCause {
     HandoffBarrier,
 }
 
-/// What one cut demands of its consumer.
+/// What one cut demands of its consumer. The invalidations map lives
+/// INSIDE `Incremental`: a baseline cut carrying a partial map is
+/// unrepresentable, so no consumer can mistake an exhausted cut's residue
+/// for a complete invalidation set.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CutKind {
     /// Apply exactly these invalidations.
-    Incremental,
-    /// Rebuild the whole scope; the latch cause says why.
+    Incremental { invalidations: BTreeMap<u64, u64> },
+    /// Rebuild the whole scope; the cause is DIAGNOSTIC only — every cause
+    /// forces the same full baseline, and no consumer may branch on it for
+    /// correctness (the first cause wins until the baseline clears it).
     FullBaseline { cause: LatchCause },
 }
 
@@ -53,7 +68,6 @@ pub enum CutKind {
 pub struct ObservationCut {
     pub token: CutToken,
     pub kind: CutKind,
-    pub invalidations: BTreeMap<u64, u64>,
 }
 
 /// The bounded coalescing accumulator (T061). Repeated observations of one
@@ -135,25 +149,30 @@ impl CoalescingAccumulator {
     pub fn cut(&mut self) -> ObservationCut {
         let token = CutToken(self.next_token);
         self.next_token += 1;
+        let pending = std::mem::take(&mut self.pending);
         let kind = match self.latch.take() {
+            // The baseline SUBSUMES the drained pending set: carrying a
+            // partial map here is unrepresentable by construction.
             Some(cause) => CutKind::FullBaseline { cause },
-            None => CutKind::Incremental,
+            None => CutKind::Incremental {
+                invalidations: pending,
+            },
         };
-        ObservationCut {
-            token,
-            kind,
-            invalidations: std::mem::take(&mut self.pending),
-        }
+        ObservationCut { token, kind }
     }
 }
 
-/// Why a handoff refused to complete.
+/// Why a handoff or queue operation refused.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum HandoffRefusal {
     /// The predecessor still holds undelivered cuts.
     PredecessorStillDraining { undelivered: usize },
     /// No handoff has begun.
     NoHandoffInProgress,
+    /// A handoff is already in progress toward a bound successor.
+    HandoffAlreadyInProgress { bound_successor: ObserverId },
+    /// The producing observer is not the active one.
+    NotTheActiveObserver { producer: ObserverId },
 }
 
 /// Identity of one observer occupying the slot.
@@ -165,8 +184,8 @@ pub struct ObserverId(pub u64);
 #[derive(Debug)]
 pub struct ObserverSlot {
     active: ObserverId,
-    undelivered: Vec<ObservationCut>,
-    handoff_in_progress: bool,
+    undelivered: Vec<(ObserverId, ObservationCut)>,
+    pending_successor: Option<ObserverId>,
 }
 
 impl ObserverSlot {
@@ -174,7 +193,7 @@ impl ObserverSlot {
         Self {
             active: first,
             undelivered: Vec::new(),
-            handoff_in_progress: false,
+            pending_successor: None,
         }
     }
 
@@ -183,35 +202,57 @@ impl ObserverSlot {
         self.active
     }
 
-    /// Queue a cut the active observer has produced but not yet delivered.
-    pub fn queue_undelivered(&mut self, cut: ObservationCut) {
-        self.undelivered.push(cut);
+    /// Queue a cut `producer` has produced but not yet delivered. Only the
+    /// ACTIVE observer may queue: an old observer's late callback can never
+    /// affect the successor's incarnation.
+    pub fn queue_undelivered(
+        &mut self,
+        producer: ObserverId,
+        cut: ObservationCut,
+    ) -> Result<(), HandoffRefusal> {
+        if producer != self.active {
+            return Err(HandoffRefusal::NotTheActiveObserver { producer });
+        }
+        self.undelivered.push((producer, cut));
+        Ok(())
     }
 
-    /// Begin handing the slot to a successor: the predecessor drains first.
-    pub fn begin_handoff(&mut self) {
-        self.handoff_in_progress = true;
+    /// Begin handing the slot to `successor`: the successor is BOUND here
+    /// (completion cannot be redirected), the predecessor drains first, and
+    /// a second begin refuses rather than silently rebinding. A self-handoff
+    /// (successor == active) is a legitimate re-registration that still
+    /// forces the post-barrier baseline.
+    pub fn begin_handoff(&mut self, successor: ObserverId) -> Result<(), HandoffRefusal> {
+        if let Some(bound_successor) = self.pending_successor {
+            return Err(HandoffRefusal::HandoffAlreadyInProgress { bound_successor });
+        }
+        self.pending_successor = Some(successor);
+        Ok(())
     }
 
     /// Deliver every undelivered predecessor cut, in order.
     pub fn deliver_pending(&mut self) -> Vec<ObservationCut> {
         std::mem::take(&mut self.undelivered)
+            .into_iter()
+            .map(|(_, cut)| cut)
+            .collect()
     }
 
-    /// Complete the handoff. Refuses while the predecessor still holds
-    /// undelivered cuts; on success the successor is active and its FIRST
-    /// obligation is a full post-barrier baseline.
-    pub fn complete_handoff(&mut self, successor: ObserverId) -> Result<CutKind, HandoffRefusal> {
-        if !self.handoff_in_progress {
+    /// Complete the handoff toward the successor BOUND at begin. Refuses
+    /// while the predecessor still holds undelivered cuts; on success the
+    /// successor is active and its FIRST obligation is a full post-barrier
+    /// baseline.
+    pub fn complete_handoff(&mut self) -> Result<CutKind, HandoffRefusal> {
+        let Some(successor) = self.pending_successor else {
             return Err(HandoffRefusal::NoHandoffInProgress);
-        }
+        };
         if !self.undelivered.is_empty() {
             return Err(HandoffRefusal::PredecessorStillDraining {
                 undelivered: self.undelivered.len(),
             });
         }
         self.active = successor;
-        self.handoff_in_progress = false;
+        self.pending_successor = None;
         Ok(CutKind::FullBaseline {
             cause: LatchCause::HandoffBarrier,
         })

--- a/tests/observer_handoff_v11.rs
+++ b/tests/observer_handoff_v11.rs
@@ -1,0 +1,218 @@
+//! Feature 020 V11 Slice 4 observer-handoff oracles (T054).
+//!
+//! RED-first for the pair T054+T061: authored and observed failing against
+//! `todo!()` seams before any machinery existed. Every rejection case asserts
+//! the accepting path in the same test — an accumulator that baselines
+//! everything satisfies a lone latch assertion perfectly.
+
+use std::collections::BTreeMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use symforge::live_index::index_lifecycle::observer::{
+    CoalescingAccumulator, CutKind, HandoffRefusal, LatchCause, ObserverId, ObserverSlot,
+};
+
+// ── the frozen-named oracle ────────────────────────────────────────────────
+
+/// TEST-OBSERVER (T054). The name is pinned by
+/// `contracts/lifecycle-oracle-traceability-v11.md` as a `planned_exact`
+/// target; do not rename it without amending that contract.
+///
+/// Cut tokens are STRICTLY monotonic — gap or no gap — and EVERY reported
+/// gap is latched into a full-baseline cut: no gap can slip between cuts as
+/// an incremental. The positive control proves ungapped cuts stay
+/// incremental, so the latch is a decision, not a default.
+#[test]
+fn stable_token_cut_latches_every_gap() {
+    let mut accumulator = CoalescingAccumulator::new(8);
+
+    // Ungapped: incremental, and the token advances.
+    accumulator.observe(1, || 100);
+    let first = accumulator.cut();
+    assert_eq!(first.kind, CutKind::Incremental);
+    assert_eq!(first.invalidations, BTreeMap::from([(1, 100)]));
+
+    // A gap: the very next cut is a FULL baseline, token still advancing.
+    accumulator.observe(2, || 200);
+    accumulator.report_gap();
+    let gapped = accumulator.cut();
+    assert!(
+        gapped.token > first.token,
+        "cut tokens must be strictly monotonic"
+    );
+    assert_eq!(
+        gapped.kind,
+        CutKind::FullBaseline {
+            cause: LatchCause::Gap
+        },
+        "a reported gap must latch into a full baseline"
+    );
+
+    // A second gap latches AGAIN — no gap escapes, ever.
+    accumulator.report_gap();
+    let regapped = accumulator.cut();
+    assert!(regapped.token > gapped.token);
+    assert_eq!(
+        regapped.kind,
+        CutKind::FullBaseline {
+            cause: LatchCause::Gap
+        }
+    );
+
+    // And after the baselines, the stream is incremental again.
+    accumulator.observe(3, || 300);
+    let recovered = accumulator.cut();
+    assert!(recovered.token > regapped.token);
+    assert_eq!(recovered.kind, CutKind::Incremental);
+}
+
+// ── coalescing and the bound ───────────────────────────────────────────────
+
+/// Repeated observations of one source coalesce to the NEWEST stamp, and
+/// growth beyond the bound is a latched safety transition — never a silent
+/// drop.
+#[test]
+fn coalescing_is_bounded_and_exhaustion_latches_not_drops() {
+    let mut accumulator = CoalescingAccumulator::new(2);
+
+    // Coalescing: three observations of one source are ONE invalidation,
+    // carrying the newest stamp.
+    accumulator.observe(1, || 100);
+    accumulator.observe(1, || 101);
+    accumulator.observe(1, || 102);
+    assert_eq!(
+        accumulator.pending(),
+        1,
+        "same-source observations must coalesce"
+    );
+    let cut = accumulator.cut();
+    assert_eq!(cut.invalidations, BTreeMap::from([(1, 102)]));
+
+    // Exhaustion: a third DISTINCT source over a bound of two latches the
+    // safety transition, and the next cut is the retaining full baseline.
+    accumulator.observe(1, || 110);
+    accumulator.observe(2, || 120);
+    accumulator.observe(3, || 130);
+    let exhausted = accumulator.cut();
+    assert_eq!(
+        exhausted.kind,
+        CutKind::FullBaseline {
+            cause: LatchCause::CapacityExhausted
+        },
+        "overflow must latch, and the baseline is the retention mechanism"
+    );
+}
+
+/// Cuts drain the accumulator: what one cut carried, the next must not.
+#[test]
+fn cuts_are_monotonic_and_drain_the_accumulator() {
+    let mut accumulator = CoalescingAccumulator::new(8);
+    accumulator.observe(1, || 100);
+    accumulator.observe(2, || 200);
+
+    let first = accumulator.cut();
+    assert_eq!(first.invalidations.len(), 2);
+    assert_eq!(accumulator.pending(), 0, "a cut must drain the accumulator");
+
+    accumulator.observe(3, || 300);
+    let second = accumulator.cut();
+    assert!(second.token > first.token);
+    assert_eq!(
+        second.invalidations,
+        BTreeMap::from([(3, 300)]),
+        "a cut must never re-carry drained invalidations"
+    );
+}
+
+// ── unwind retention ───────────────────────────────────────────────────────
+
+/// An observation whose payload derivation UNWINDS is retained: the change
+/// is known even though its content is not, so the scope latches dirty and
+/// the next cut is a full baseline. Nothing observed is ever lost to an
+/// unwind.
+#[test]
+fn ingress_unwind_retains_the_observation() {
+    let mut accumulator = CoalescingAccumulator::new(8);
+
+    let unwound = catch_unwind(AssertUnwindSafe(|| {
+        accumulator.observe(7, || panic!("injected derivation unwind"));
+    }));
+    assert!(unwound.is_err(), "the injected unwind must actually unwind");
+
+    let cut = accumulator.cut();
+    assert_eq!(
+        cut.kind,
+        CutKind::FullBaseline {
+            cause: LatchCause::ScopeDirty
+        },
+        "an unwound observation must be retained as a dirty-scope baseline"
+    );
+
+    // Positive control: a healthy derivation stays incremental.
+    accumulator.observe(7, || 700);
+    assert_eq!(accumulator.cut().kind, CutKind::Incremental);
+}
+
+// ── handoff ────────────────────────────────────────────────────────────────
+
+/// The predecessor DRAINS before the successor activates: completion
+/// refuses while undelivered cuts remain, drains deliver in order, and the
+/// successor's first obligation is a full post-barrier baseline.
+#[test]
+fn predecessor_drains_before_the_successor_activates() {
+    let mut slot = ObserverSlot::new(ObserverId(1));
+    assert_eq!(slot.active(), ObserverId(1));
+
+    let mut accumulator = CoalescingAccumulator::new(8);
+    accumulator.observe(1, || 100);
+    let pending_cut = accumulator.cut();
+    let pending_token = pending_cut.token;
+    slot.queue_undelivered(pending_cut);
+
+    slot.begin_handoff();
+    assert_eq!(
+        slot.complete_handoff(ObserverId(2)).unwrap_err(),
+        HandoffRefusal::PredecessorStillDraining { undelivered: 1 },
+        "completion must refuse while the predecessor still holds cuts"
+    );
+    assert_eq!(
+        slot.active(),
+        ObserverId(1),
+        "the predecessor holds the slot until drained"
+    );
+
+    let delivered = slot.deliver_pending();
+    assert_eq!(delivered.len(), 1);
+    assert_eq!(delivered[0].token, pending_token);
+
+    let baseline = slot
+        .complete_handoff(ObserverId(2))
+        .expect("a drained predecessor hands off");
+    assert_eq!(
+        baseline,
+        CutKind::FullBaseline {
+            cause: LatchCause::HandoffBarrier
+        },
+        "the successor's first obligation is the post-barrier baseline"
+    );
+    assert_eq!(slot.active(), ObserverId(2));
+}
+
+/// Completing a handoff that never began refuses — the slot is stable, not
+/// stealable.
+#[test]
+fn the_slot_cannot_be_stolen_without_a_handoff() {
+    let mut slot = ObserverSlot::new(ObserverId(1));
+    assert_eq!(
+        slot.complete_handoff(ObserverId(9)).unwrap_err(),
+        HandoffRefusal::NoHandoffInProgress
+    );
+    assert_eq!(slot.active(), ObserverId(1));
+
+    // Positive control: the legitimate protocol still works.
+    slot.begin_handoff();
+    slot.deliver_pending();
+    slot.complete_handoff(ObserverId(9))
+        .expect("an empty predecessor hands off immediately");
+    assert_eq!(slot.active(), ObserverId(9));
+}

--- a/tests/observer_handoff_v11.rs
+++ b/tests/observer_handoff_v11.rs
@@ -29,8 +29,12 @@ fn stable_token_cut_latches_every_gap() {
     // Ungapped: incremental, and the token advances.
     accumulator.observe(1, || 100);
     let first = accumulator.cut();
-    assert_eq!(first.kind, CutKind::Incremental);
-    assert_eq!(first.invalidations, BTreeMap::from([(1, 100)]));
+    assert_eq!(
+        first.kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(1, 100)])
+        }
+    );
 
     // A gap: the very next cut is a FULL baseline, token still advancing.
     accumulator.observe(2, || 200);
@@ -63,7 +67,12 @@ fn stable_token_cut_latches_every_gap() {
     accumulator.observe(3, || 300);
     let recovered = accumulator.cut();
     assert!(recovered.token > regapped.token);
-    assert_eq!(recovered.kind, CutKind::Incremental);
+    assert_eq!(
+        recovered.kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(3, 300)])
+        }
+    );
 }
 
 // ── coalescing and the bound ───────────────────────────────────────────────
@@ -86,7 +95,12 @@ fn coalescing_is_bounded_and_exhaustion_latches_not_drops() {
         "same-source observations must coalesce"
     );
     let cut = accumulator.cut();
-    assert_eq!(cut.invalidations, BTreeMap::from([(1, 102)]));
+    assert_eq!(
+        cut.kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(1, 102)])
+        }
+    );
 
     // Exhaustion: a third DISTINCT source over a bound of two latches the
     // safety transition, and the next cut is the retaining full baseline.
@@ -111,15 +125,22 @@ fn cuts_are_monotonic_and_drain_the_accumulator() {
     accumulator.observe(2, || 200);
 
     let first = accumulator.cut();
-    assert_eq!(first.invalidations.len(), 2);
+    assert_eq!(
+        first.kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(1, 100), (2, 200)])
+        }
+    );
     assert_eq!(accumulator.pending(), 0, "a cut must drain the accumulator");
 
     accumulator.observe(3, || 300);
     let second = accumulator.cut();
     assert!(second.token > first.token);
     assert_eq!(
-        second.invalidations,
-        BTreeMap::from([(3, 300)]),
+        second.kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(3, 300)])
+        },
         "a cut must never re-carry drained invalidations"
     );
 }
@@ -150,14 +171,20 @@ fn ingress_unwind_retains_the_observation() {
 
     // Positive control: a healthy derivation stays incremental.
     accumulator.observe(7, || 700);
-    assert_eq!(accumulator.cut().kind, CutKind::Incremental);
+    assert_eq!(
+        accumulator.cut().kind,
+        CutKind::Incremental {
+            invalidations: BTreeMap::from([(7, 700)])
+        }
+    );
 }
 
 // ── handoff ────────────────────────────────────────────────────────────────
 
 /// The predecessor DRAINS before the successor activates: completion
-/// refuses while undelivered cuts remain, drains deliver in order, and the
-/// successor's first obligation is a full post-barrier baseline.
+/// refuses while undelivered cuts remain - including cuts queued BETWEEN a
+/// drain and the completion - drains deliver in order, and the successor's
+/// first obligation is a full post-barrier baseline.
 #[test]
 fn predecessor_drains_before_the_successor_activates() {
     let mut slot = ObserverSlot::new(ObserverId(1));
@@ -167,11 +194,13 @@ fn predecessor_drains_before_the_successor_activates() {
     accumulator.observe(1, || 100);
     let pending_cut = accumulator.cut();
     let pending_token = pending_cut.token;
-    slot.queue_undelivered(pending_cut);
+    slot.queue_undelivered(ObserverId(1), pending_cut)
+        .expect("the active observer queues its own cuts");
 
-    slot.begin_handoff();
+    slot.begin_handoff(ObserverId(2))
+        .expect("a fresh handoff begins");
     assert_eq!(
-        slot.complete_handoff(ObserverId(2)).unwrap_err(),
+        slot.complete_handoff().unwrap_err(),
         HandoffRefusal::PredecessorStillDraining { undelivered: 1 },
         "completion must refuse while the predecessor still holds cuts"
     );
@@ -185,8 +214,19 @@ fn predecessor_drains_before_the_successor_activates() {
     assert_eq!(delivered.len(), 1);
     assert_eq!(delivered[0].token, pending_token);
 
+    // A cut queued BETWEEN drain and completion still blocks: the check is
+    // emptiness, never a drained-once flag.
+    accumulator.observe(1, || 101);
+    slot.queue_undelivered(ObserverId(1), accumulator.cut())
+        .expect("the still-active predecessor queues");
+    assert_eq!(
+        slot.complete_handoff().unwrap_err(),
+        HandoffRefusal::PredecessorStillDraining { undelivered: 1 }
+    );
+    slot.deliver_pending();
+
     let baseline = slot
-        .complete_handoff(ObserverId(2))
+        .complete_handoff()
         .expect("a drained predecessor hands off");
     assert_eq!(
         baseline,
@@ -198,21 +238,84 @@ fn predecessor_drains_before_the_successor_activates() {
     assert_eq!(slot.active(), ObserverId(2));
 }
 
-/// Completing a handoff that never began refuses — the slot is stable, not
-/// stealable.
+/// The slot is stable, not stealable: completion without a begun handoff
+/// refuses, the successor is BOUND at begin (a second begin refuses rather
+/// than silently rebinding), and a self-handoff is a legitimate
+/// re-registration that still baselines.
 #[test]
-fn the_slot_cannot_be_stolen_without_a_handoff() {
+fn the_slot_cannot_be_stolen_or_rebound() {
     let mut slot = ObserverSlot::new(ObserverId(1));
     assert_eq!(
-        slot.complete_handoff(ObserverId(9)).unwrap_err(),
+        slot.complete_handoff().unwrap_err(),
         HandoffRefusal::NoHandoffInProgress
     );
     assert_eq!(slot.active(), ObserverId(1));
 
-    // Positive control: the legitimate protocol still works.
-    slot.begin_handoff();
+    slot.begin_handoff(ObserverId(9))
+        .expect("a fresh handoff begins");
+    assert_eq!(
+        slot.begin_handoff(ObserverId(5)).unwrap_err(),
+        HandoffRefusal::HandoffAlreadyInProgress {
+            bound_successor: ObserverId(9)
+        },
+        "an in-progress handoff must not be silently rebound"
+    );
     slot.deliver_pending();
-    slot.complete_handoff(ObserverId(9))
-        .expect("an empty predecessor hands off immediately");
+    slot.complete_handoff()
+        .expect("an empty predecessor hands off to the BOUND successor");
     assert_eq!(slot.active(), ObserverId(9));
+
+    // Self-handoff: a re-registration of the active observer is legitimate
+    // and still forces the post-barrier baseline.
+    slot.begin_handoff(ObserverId(9)).expect("re-registration");
+    let baseline = slot.complete_handoff().expect("self-handoff completes");
+    assert_eq!(
+        baseline,
+        CutKind::FullBaseline {
+            cause: LatchCause::HandoffBarrier
+        }
+    );
+    assert_eq!(slot.active(), ObserverId(9));
+}
+
+/// Cuts carry their producer, and a producer that is not the ACTIVE
+/// observer is refused - an old observer's late callback can never affect
+/// the successor's incarnation.
+#[test]
+fn foreign_producers_cannot_queue_into_the_slot() {
+    let mut slot = ObserverSlot::new(ObserverId(1));
+    let mut accumulator = CoalescingAccumulator::new(8);
+
+    accumulator.observe(4, || 400);
+    assert_eq!(
+        slot.queue_undelivered(ObserverId(3), accumulator.cut())
+            .unwrap_err(),
+        HandoffRefusal::NotTheActiveObserver {
+            producer: ObserverId(3)
+        },
+        "a foreign producer must be refused"
+    );
+    assert!(
+        slot.deliver_pending().is_empty(),
+        "the refused cut must not have landed"
+    );
+
+    // Positive control, then the incarnation fence: after a handoff, the
+    // drained-out predecessor's late cut is refused too.
+    accumulator.observe(4, || 401);
+    slot.queue_undelivered(ObserverId(1), accumulator.cut())
+        .expect("the active observer queues");
+    slot.begin_handoff(ObserverId(2)).expect("handoff begins");
+    slot.deliver_pending();
+    slot.complete_handoff().expect("handoff completes");
+
+    accumulator.observe(4, || 402);
+    assert_eq!(
+        slot.queue_undelivered(ObserverId(1), accumulator.cut())
+            .unwrap_err(),
+        HandoffRefusal::NotTheActiveObserver {
+            producer: ObserverId(1)
+        },
+        "an old observer cannot affect the new incarnation"
+    );
 }

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -801,15 +801,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "d62f9b96b2ece2ac86a89a89da34c04594ab99294a23410aeb766015e5375d33",
+    "b38398b02c47df9a051e47ac935ec73ed178fff475dac1805d4eac7482e6cf84",
     18,
-    272_912,
+    275_376,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "fbe492c5846d0b80829af28f8cc4fcbbd7955f4ffd5ff64755a8ef3bd89427bf",
+    "67199d04cb44e0c2bee042735c24bd96204fb2a1c6ff5d7b7ab6a7317c24363a",
     192,
-    9_058_910,
+    9_061_374,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -787,6 +787,7 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
     "index_lifecycle/embedded.rs",
     "index_lifecycle/mod.rs",
     "index_lifecycle/mutation.rs",
+    "index_lifecycle/observer.rs",
     "index_lifecycle/physical_root.rs",
     "index_lifecycle/process_runtime.rs",
     "index_lifecycle/public_api.rs",
@@ -800,15 +801,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "06f58ed6d212227b8c31347d7d15d06949e77760bf941a088c9a142222773954",
-    17,
-    264_982,
+    "d62f9b96b2ece2ac86a89a89da34c04594ab99294a23410aeb766015e5375d33",
+    18,
+    272_912,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "ac6bf74effaf1e40d486387c9d6b8e01fd786a4228f8ad2e80d55a1474e8cd75",
-    191,
-    9_050_980,
+    "fbe492c5846d0b80829af28f8cc4fcbbd7955f4ffd5ff64755a8ef3bd89427bf",
+    192,
+    9_058_910,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Wave 1 pair 4 of the Slice 4 campaign (specs/028-preventive-activation-cut; frozen roster 020:T054+T061): the dark observer accumulator and stable handoff slot, RED-first.

**RED observed before machinery** (TC job job_01a0143217ed72609a8c998b73a3a957, exit 101): `0 passed; 6 failed` on todo!() seams. **GREEN**: 6/6 first implementation; 7/7 after the review round.

**Independent review round** (one pass + cfg-lens per spec FR-016): all six frozen T054 behaviors pinned with positive controls and adjudicated not-drive-aroundable as worded; the UnwindRetention drop-guard judged sound (armed before derive, panic-free drop, propagation pinned); cfg-lens CLEAN; seal byte-delta independently verified. Three MAJORs found and taken in 3f388d11: (1) baseline cuts shipped a populated-but-incomplete invalidations map - the map now lives INSIDE CutKind::Incremental so the hazard is unrepresentable; (2) the doc's exactness claim was narrowed honestly - clear-on-emission-vs-proof and the untracked HandoffBarrier obligation are now NAMED T064 cut obligations, and the module doc records authority.rs ObserverPhase as the complementary phase projection; (3) the slot gained identity discipline RED-first (two oracles observed failing): successor bound at begin, no silent rebinding, producer-fenced queueing including the drained-predecessor incarnation fence, pinned self-handoff, and the drain check pinned as emptiness-not-flag. Latch cause documented diagnostic-only per the review's masking adjudication.

**Seal**: excluded set +1 (observer.rs); both pins refreshed from the Rust oracle after rustfmt. Seal 8/8; traceability validator OK; frozen specs/020 untouched.

**Gates** (serial via Terminal Commander): fmt clean, clippy -D warnings clean, full serial suite exit 0, embed lib gate 1333/0 zero warnings, release build + verify-tools 7 PASS/0 FAIL, npm 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn