### PR TITLE
feat(feature-020): Slice 4 pair 5 - dark snapshot migration

### DIFF
--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -130,7 +130,7 @@ GREEN dark.
 
 - [x] T024 [P] [US5] Branch `feature-020-s4-p5-snapshot` from updated `main`; author RED `tests/snapshot_v11_migration.rs` with frozen name `snapshot_seed_requires_complete_current_proof` plus the 020:T057 case list (untrusted V10 seeds, pre-decode capacity, root/digest mismatch, quarantine, rollback, concurrent V10 writers, `.symforge/v11/` namespace isolation, secret-canary bytes never persisted); record observed RED (020:T057)
 - [x] T025 [US5] Implement dark V11 snapshot migration in `src/index_lifecycle/snapshot.rs` (NOT `src/live_index/persist.rs` — the darkness sweep forbids the module token in live files, same ruling as T015/T016; the persist.rs wiring and version bump are cut work) — bounded untrusted-seed restore, complete re-observation, quarantine, atomic V11 replacement, preserved rollback, rebuild fallback, `ProjectStateDir`-only team-artifact persistence, the exact frozen-FR-051 four-state receipt/refusal matrix; the `CURRENT_VERSION` bump and V11 write path stay production-unreachable until T030 activation (020:T065)
-- [x] T026 [US5] Extend darkness seal + census for the persist.rs dark seams; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
+- [x] T026 [US5] Extend darkness seal + census for snapshot.rs (the dark module the T025 correction landed in; persist.rs stays untouched until the cut); refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
 - [x] T027 [US5] Full gate battery via Terminal Commander + traceability validator
 - [ ] T028 [US5] Review (cfg-lens) → PR → green CI → auto-squash-merge
 

--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -113,7 +113,7 @@ GREEN dark.
 - [x] T020 [US4] Implement `src/index_lifecycle/observer.rs` — bounded coalescing accumulator, monotonic invalidation cuts, scope-dirty/gap latches, stable observer handoff, full successor baseline, adapting the live `src/watcher/` event vocabulary without touching its live routing; register in `mod.rs` (020:T061)
 - [x] T021 [US4] Extend darkness seal + census for observer.rs; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
 - [x] T022 [US4] Full gate battery via Terminal Commander + traceability validator
-- [ ] T023 [US4] Review (cfg-lens) → PR → green CI → auto-squash-merge
+- [x] T023 [US4] Review (cfg-lens) → PR → green CI → auto-squash-merge
 
 **Checkpoint**: observer GREEN dark on `main`.
 
@@ -128,10 +128,10 @@ matrix exist dark; the version bump stays unreachable until activation
 **Independent Test**: `cargo test --test snapshot_v11_migration -- --test-threads=1`
 GREEN dark.
 
-- [ ] T024 [P] [US5] Branch `feature-020-s4-p5-snapshot` from updated `main`; author RED `tests/snapshot_v11_migration.rs` with frozen name `snapshot_seed_requires_complete_current_proof` plus the 020:T057 case list (untrusted V10 seeds, pre-decode capacity, root/digest mismatch, quarantine, rollback, concurrent V10 writers, `.symforge/v11/` namespace isolation, secret-canary bytes never persisted); record observed RED (020:T057)
-- [ ] T025 [US5] Implement dark V11 snapshot migration in `src/live_index/persist.rs` — bounded untrusted-seed restore, complete re-observation, quarantine, atomic V11 replacement, preserved rollback, rebuild fallback, `ProjectStateDir`-only team-artifact persistence, the exact frozen-FR-051 four-state receipt/refusal matrix; the `CURRENT_VERSION` bump and V11 write path stay production-unreachable until T030 activation (020:T065)
-- [ ] T026 [US5] Extend darkness seal + census for the persist.rs dark seams; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
-- [ ] T027 [US5] Full gate battery via Terminal Commander + traceability validator
+- [x] T024 [P] [US5] Branch `feature-020-s4-p5-snapshot` from updated `main`; author RED `tests/snapshot_v11_migration.rs` with frozen name `snapshot_seed_requires_complete_current_proof` plus the 020:T057 case list (untrusted V10 seeds, pre-decode capacity, root/digest mismatch, quarantine, rollback, concurrent V10 writers, `.symforge/v11/` namespace isolation, secret-canary bytes never persisted); record observed RED (020:T057)
+- [x] T025 [US5] Implement dark V11 snapshot migration in `src/index_lifecycle/snapshot.rs` (NOT `src/live_index/persist.rs` — the darkness sweep forbids the module token in live files, same ruling as T015/T016; the persist.rs wiring and version bump are cut work) — bounded untrusted-seed restore, complete re-observation, quarantine, atomic V11 replacement, preserved rollback, rebuild fallback, `ProjectStateDir`-only team-artifact persistence, the exact frozen-FR-051 four-state receipt/refusal matrix; the `CURRENT_VERSION` bump and V11 write path stay production-unreachable until T030 activation (020:T065)
+- [x] T026 [US5] Extend darkness seal + census for the persist.rs dark seams; refresh `FULL_SOURCE_PIN_V1` via the Rust oracle
+- [x] T027 [US5] Full gate battery via Terminal Commander + traceability validator
 - [ ] T028 [US5] Review (cfg-lens) → PR → green CI → auto-squash-merge
 
 **Checkpoint**: all five pairs GREEN dark on `main`; the only ignored

--- a/src/index_lifecycle/mod.rs
+++ b/src/index_lifecycle/mod.rs
@@ -45,6 +45,10 @@ pub mod observer;
 // projection seam. Oracle-suite consumption only until activation.
 pub mod query;
 pub mod registry;
+// T065: dark snapshot migration — untrusted seeds, pre-decode capacity,
+// quarantine with preserved rollback, namespace isolation, and the FR-051
+// team-artifact matrix. Oracle-suite consumption only until activation.
+pub mod snapshot;
 pub mod supervisor;
 // T062: dark rolling verification — sealed scope receipts, the fixed
 // 15-minute deadline with its latch-before-acquisition ordering, work

--- a/src/index_lifecycle/snapshot.rs
+++ b/src/index_lifecycle/snapshot.rs
@@ -34,6 +34,8 @@ use std::collections::BTreeMap;
 /// secret-bearing — the canary oracle plants one here).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotSeed {
+    /// Deliberately unread by the store: a seed is untrusted regardless of
+    /// the version it claims.
     pub version: u32,
     pub declared_len: u64,
     pub root_digest: u64,
@@ -60,6 +62,9 @@ pub enum SnapshotRefusal {
     /// The seed declares more payload than the pre-decode capacity allows;
     /// nothing was decoded.
     SeedBeyondCapacity { declared: u64, limit: u64 },
+    /// The seed LIED: its declaration passed, but actual decode consumption
+    /// crossed the limit — aborted mid-decode, nothing promoted.
+    CapacityExceededMidDecode { consumed: u64, limit: u64 },
     /// The binding class refuses team-artifact export BEFORE any mutation.
     BindingRefusesExport(BindingClass),
     /// A companion `.gitattributes` repository-content write requires the
@@ -80,7 +85,9 @@ pub enum RestoreOutcome {
     Quarantined { id: u64 },
 }
 
-/// Quarantine metadata — digests and lengths ONLY, never seed bytes.
+/// Quarantine metadata — digests, counts, and lengths only, never seed
+/// byte CONTENT (`declared_digest` echoes the seed's numeric claim, which
+/// the mismatch explanation requires).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QuarantineMetadata {
     pub id: u64,
@@ -129,7 +136,10 @@ pub struct ExportReceipt {
 
 impl ExportReceipt {
     /// `None` exactly when git visibility is unavailable — shareability is
-    /// never inferred without it.
+    /// never inferred without it. The Some(..) booleans for the other three
+    /// states are a DARK MODELING CHOICE, not frozen semantics: FR-051
+    /// constrains only the None-when-unavailable case, and the oracle
+    /// deliberately pins only that.
     pub fn shareability(&self) -> Option<bool> {
         match self.visibility {
             GitVisibility::AlreadyTracked | GitVisibility::UntrackedVisible => Some(true),
@@ -139,13 +149,28 @@ impl ExportReceipt {
     }
 }
 
-#[derive(Debug)]
 struct QuarantineEntry {
     metadata: QuarantineMetadata,
     /// The untrusted ORIGINAL, preserved byte-intact for one rollback.
     /// Retention is not disclosure: this payload never reaches metadata,
-    /// receipts, diagnostics, or the V11 state.
+    /// receipts, diagnostics, or the V11 state — and the manual Debug below
+    /// redacts it, so no future diagnostics line can leak it by accident.
     rollback_payload: Option<SnapshotSeed>,
+}
+
+impl std::fmt::Debug for QuarantineEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuarantineEntry")
+            .field("metadata", &self.metadata)
+            .field(
+                "rollback_payload",
+                &self
+                    .rollback_payload
+                    .as_ref()
+                    .map(|seed| format!("<retained, {} opaque bytes>", seed.opaque_note.len())),
+            )
+            .finish()
+    }
 }
 
 /// The dark `.symforge/v11/` store model: V10 namespace, V11 current state,
@@ -194,7 +219,18 @@ impl SnapshotStore {
                 limit,
             });
         }
-        let decoded: Vec<(u64, u64)> = seed.entries.iter().map(&mut decode).collect();
+        // The declaration is a fast-path check, never the enforcement: the
+        // bound binds ACTUAL decode consumption (model stride: 16 bytes per
+        // entry), so a seed that lies small aborts mid-decode.
+        let mut decoded: Vec<(u64, u64)> = Vec::new();
+        let mut consumed: u64 = 0;
+        for entry in &seed.entries {
+            consumed += 16;
+            if consumed > limit {
+                return Err(SnapshotRefusal::CapacityExceededMidDecode { consumed, limit });
+            }
+            decoded.push(decode(entry));
+        }
         let computed = seed_digest(&decoded);
         if computed != seed.root_digest {
             let id = self.next_quarantine;

--- a/src/index_lifecycle/snapshot.rs
+++ b/src/index_lifecycle/snapshot.rs
@@ -1,0 +1,305 @@
+//! Feature 020 V11 snapshot migration (Slice 4, T065 — dark).
+//!
+//! Bounded untrusted-seed restore, complete re-observation, quarantine,
+//! preserved rollback, rebuild fallback, `.symforge/v11/` namespace
+//! isolation, and the exact frozen-FR-051 team-artifact receipt/refusal
+//! matrix (frozen tasks.md T065). Every pre-existing V10 byte is an
+//! UNTRUSTED SEED: it may accelerate re-proof, never confer authority, and
+//! nothing promotes to Current without complete current-process proof.
+//!
+//! Dark payload simplifications, in the `runtime.rs` idiom: seeds are
+//! (source, stamp) vectors with an opaque note standing in for arbitrary V10
+//! bytes, namespaces are in-memory models, and decode/proof are injected
+//! closures so oracles can count and refuse. The live
+//! `src/live_index/persist.rs` wiring frozen T065 names — the actual
+//! `CURRENT_VERSION` bump and on-disk V11 write path — is activation work
+//! (T064/T066), because the darkness sweep forbids this module's name in
+//! live files; the companion in-scope `.gitattributes` write through the
+//! mutation-permit path is likewise a sealed negative here and T064's work
+//! there. The authority SEMANTICS — pre-decode capacity, digest quarantine
+//! with rollback-preserved originals, all-or-nothing seed proof, V10/V11
+//! namespace isolation, secret-canary bytes never entering V11 snapshots,
+//! quarantine metadata, receipts, or diagnostics, and the FR-051 four-state
+//! disclosure with no inferred shareability — are exact.
+//!
+//! **Nothing in production calls this module.** Only the Slice 4 oracle
+//! suites and this directory do; activation (T064/T066) is the only planned
+//! production caller.
+
+use std::collections::BTreeMap;
+
+/// One untrusted V10 seed: version, self-declared payload size (checked
+/// BEFORE decode), a digest over the entries, the entries themselves, and
+/// an opaque note standing in for arbitrary V10 bytes (possibly
+/// secret-bearing — the canary oracle plants one here).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotSeed {
+    pub version: u32,
+    pub declared_len: u64,
+    pub root_digest: u64,
+    pub entries: Vec<(u64, u64)>,
+    pub opaque_note: Vec<u8>,
+}
+
+/// The digest the store recomputes over a seed's entries — public so
+/// oracles can build valid and corrupted seeds.
+pub fn seed_digest(entries: &[(u64, u64)]) -> u64 {
+    entries
+        .iter()
+        .fold(0xcbf2_9ce4_8422_2325_u64, |acc, (source, stamp)| {
+            acc.wrapping_mul(0x0100_0000_01b3)
+                .wrapping_add(*source)
+                .wrapping_mul(0x0100_0000_01b3)
+                .wrapping_add(*stamp)
+        })
+}
+
+/// Why a snapshot operation refused outright.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnapshotRefusal {
+    /// The seed declares more payload than the pre-decode capacity allows;
+    /// nothing was decoded.
+    SeedBeyondCapacity { declared: u64, limit: u64 },
+    /// The binding class refuses team-artifact export BEFORE any mutation.
+    BindingRefusesExport(BindingClass),
+    /// A companion `.gitattributes` repository-content write requires the
+    /// `SourceMutationPermit` path — activation (T064) work; this module
+    /// cannot mint one, by design.
+    GitattributesRequiresMutationPermit,
+}
+
+/// How a restore ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RestoreOutcome {
+    /// Every entry was proven by current-process observation; all promoted.
+    Promoted { sources: usize },
+    /// At least one entry lacked proof: NOTHING promoted, rebuild required.
+    SeedRejected { unproven: usize },
+    /// The seed failed integrity: quarantined with its rollback payload
+    /// preserved, rebuild required.
+    Quarantined { id: u64 },
+}
+
+/// Quarantine metadata — digests and lengths ONLY, never seed bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QuarantineMetadata {
+    pub id: u64,
+    pub declared_digest: u64,
+    pub computed_digest: u64,
+    pub entry_count: usize,
+    pub opaque_len: usize,
+}
+
+/// The frozen FR-051 git-visibility states, exactly four.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GitVisibility {
+    AlreadyTracked,
+    UntrackedVisible,
+    IgnoredForceAddRequired,
+    GitVisibilityUnavailable,
+}
+
+impl GitVisibility {
+    pub const ALL: [GitVisibility; 4] = [
+        GitVisibility::AlreadyTracked,
+        GitVisibility::UntrackedVisible,
+        GitVisibility::IgnoredForceAddRequired,
+        GitVisibility::GitVisibilityUnavailable,
+    ];
+}
+
+/// The binding classes FR-051 names; only a normal writable current project
+/// may export.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BindingClass {
+    NormalWritable,
+    ExplicitProtected,
+    ReadOnly,
+    UserLocalOnly,
+    MemoryOnly,
+}
+
+/// The export receipt: disclosing exactly one visibility state, placed in
+/// the project state dir, and NEVER inferring shareability when git
+/// visibility cannot be established.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExportReceipt {
+    pub visibility: GitVisibility,
+}
+
+impl ExportReceipt {
+    /// `None` exactly when git visibility is unavailable — shareability is
+    /// never inferred without it.
+    pub fn shareability(&self) -> Option<bool> {
+        match self.visibility {
+            GitVisibility::AlreadyTracked | GitVisibility::UntrackedVisible => Some(true),
+            GitVisibility::IgnoredForceAddRequired => Some(false),
+            GitVisibility::GitVisibilityUnavailable => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct QuarantineEntry {
+    metadata: QuarantineMetadata,
+    /// The untrusted ORIGINAL, preserved byte-intact for one rollback.
+    /// Retention is not disclosure: this payload never reaches metadata,
+    /// receipts, diagnostics, or the V11 state.
+    rollback_payload: Option<SnapshotSeed>,
+}
+
+/// The dark `.symforge/v11/` store model: V10 namespace, V11 current state,
+/// quarantine, team-artifact persistence, and bounded diagnostics.
+#[derive(Debug, Default)]
+pub struct SnapshotStore {
+    v10: Vec<Vec<u8>>,
+    current: BTreeMap<u64, u64>,
+    quarantine: Vec<QuarantineEntry>,
+    next_quarantine: u64,
+    rebuild_required: bool,
+    team_artifacts: Vec<usize>,
+    diagnostics: Vec<String>,
+}
+
+impl SnapshotStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append raw bytes to the V10 namespace model (a concurrent V10 writer).
+    pub fn v10_write(&mut self, bytes: Vec<u8>) {
+        self.v10.push(bytes);
+    }
+
+    /// The V10 namespace contents, for isolation oracles.
+    pub fn v10_namespace(&self) -> Vec<Vec<u8>> {
+        self.v10.clone()
+    }
+
+    /// Restore from an untrusted seed. `limit` is the PRE-decode capacity:
+    /// a seed declaring more refuses before `decode` runs once. `decode` is
+    /// the per-entry decoder (injected so oracles count invocations);
+    /// `prove` is the current-process re-observation — only a seed whose
+    /// EVERY entry proves promotes anything.
+    pub fn restore(
+        &mut self,
+        seed: SnapshotSeed,
+        limit: u64,
+        mut decode: impl FnMut(&(u64, u64)) -> (u64, u64),
+        prove: impl Fn(u64, u64) -> bool,
+    ) -> Result<RestoreOutcome, SnapshotRefusal> {
+        if seed.declared_len > limit {
+            return Err(SnapshotRefusal::SeedBeyondCapacity {
+                declared: seed.declared_len,
+                limit,
+            });
+        }
+        let decoded: Vec<(u64, u64)> = seed.entries.iter().map(&mut decode).collect();
+        let computed = seed_digest(&decoded);
+        if computed != seed.root_digest {
+            let id = self.next_quarantine;
+            self.next_quarantine += 1;
+            self.diagnostics.push(format!(
+                "seed {id}: digest mismatch, {} entries, opaque {} bytes",
+                decoded.len(),
+                seed.opaque_note.len()
+            ));
+            self.quarantine.push(QuarantineEntry {
+                metadata: QuarantineMetadata {
+                    id,
+                    declared_digest: seed.root_digest,
+                    computed_digest: computed,
+                    entry_count: decoded.len(),
+                    opaque_len: seed.opaque_note.len(),
+                },
+                rollback_payload: Some(seed),
+            });
+            self.rebuild_required = true;
+            return Ok(RestoreOutcome::Quarantined { id });
+        }
+        let unproven = decoded
+            .iter()
+            .filter(|(source, stamp)| !prove(*source, *stamp))
+            .count();
+        if unproven > 0 {
+            self.diagnostics.push(format!(
+                "seed rejected: {unproven} of {} entries lack current-process proof",
+                decoded.len()
+            ));
+            self.rebuild_required = true;
+            return Ok(RestoreOutcome::SeedRejected { unproven });
+        }
+        let sources = decoded.len();
+        self.current = decoded.into_iter().collect();
+        self.diagnostics
+            .push(format!("seed promoted: {sources} sources"));
+        Ok(RestoreOutcome::Promoted { sources })
+    }
+
+    /// The promoted V11 current state.
+    pub fn current(&self) -> BTreeMap<u64, u64> {
+        self.current.clone()
+    }
+
+    /// Whether a rejected/quarantined seed left a rebuild obligation.
+    pub fn rebuild_required(&self) -> bool {
+        self.rebuild_required
+    }
+
+    /// Quarantine metadata rows (digests and lengths only, never bytes).
+    pub fn quarantine_metadata(&self) -> Vec<QuarantineMetadata> {
+        self.quarantine
+            .iter()
+            .map(|entry| entry.metadata.clone())
+            .collect()
+    }
+
+    /// Roll a quarantined seed back out, byte-intact — handed out once.
+    pub fn rollback(&mut self, id: u64) -> Option<SnapshotSeed> {
+        self.quarantine
+            .iter_mut()
+            .find(|entry| entry.metadata.id == id)
+            .and_then(|entry| entry.rollback_payload.take())
+    }
+
+    /// Bounded human-readable diagnostics (never seed bytes).
+    pub fn diagnostics(&self) -> Vec<String> {
+        self.diagnostics.clone()
+    }
+
+    /// Export the opt-in team artifact per frozen FR-051: only a normal
+    /// writable binding may export (everything else refuses BEFORE any
+    /// mutation), and the receipt disclosing the git-visibility state is
+    /// persistence-only — no source mutation authority exists here.
+    pub fn export_team_artifact(
+        &mut self,
+        binding: BindingClass,
+        visibility: GitVisibility,
+        artifact: Vec<u8>,
+    ) -> Result<ExportReceipt, SnapshotRefusal> {
+        if binding != BindingClass::NormalWritable {
+            return Err(SnapshotRefusal::BindingRefusesExport(binding));
+        }
+        self.team_artifacts.push(artifact.len());
+        Ok(ExportReceipt { visibility })
+    }
+
+    /// Team artifacts persisted so far (ProjectStateDir placement is the
+    /// only placement that exists — user-local redirection is
+    /// unrepresentable).
+    pub fn team_artifacts(&self) -> usize {
+        self.team_artifacts.len()
+    }
+
+    /// Sealed negative: a companion `.gitattributes` repository-content
+    /// write through snapshot code. Refused unconditionally — that write
+    /// belongs to the mutation-permit path (T064).
+    pub fn export_with_gitattributes_change(
+        &mut self,
+        binding: BindingClass,
+        visibility: GitVisibility,
+    ) -> SnapshotRefusal {
+        let _ = (binding, visibility);
+        SnapshotRefusal::GitattributesRequiresMutationPermit
+    }
+}

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -802,15 +802,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "b849ddcc81d99161f1a33cbce4ef5f5d71915ef03154933528e15e56639db54d",
+    "c3151e5f30de575f0a5b7cf11653d94c6a88fb34de49faa8ee8f85031f387e46",
     19,
-    287_114,
+    288_823,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "35f0521a2c62d561d5376cda4d833ac031e0ba1a9fd5536f80d34b628b153bef",
+    "e3b00de8b0a9019ac4064ec01f1dd2407a89f5da3a55b500261453d45ca3340b",
     193,
-    9_073_112,
+    9_074_821,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -794,6 +794,7 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
     "index_lifecycle/query.rs",
     "index_lifecycle/registry.rs",
     "index_lifecycle/runtime.rs",
+    "index_lifecycle/snapshot.rs",
     "index_lifecycle/supervisor.rs",
     "index_lifecycle/transition.rs",
     "index_lifecycle/verification.rs",
@@ -801,15 +802,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "b38398b02c47df9a051e47ac935ec73ed178fff475dac1805d4eac7482e6cf84",
-    18,
-    275_376,
+    "b849ddcc81d99161f1a33cbce4ef5f5d71915ef03154933528e15e56639db54d",
+    19,
+    287_114,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "67199d04cb44e0c2bee042735c24bd96204fb2a1c6ff5d7b7ab6a7317c24363a",
-    192,
-    9_061_374,
+    "35f0521a2c62d561d5376cda4d833ac031e0ba1a9fd5536f80d34b628b153bef",
+    193,
+    9_073_112,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/snapshot_v11_migration.rs
+++ b/tests/snapshot_v11_migration.rs
@@ -9,8 +9,8 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 
 use symforge::live_index::index_lifecycle::snapshot::{
-    BindingClass, GitVisibility, RestoreOutcome, SnapshotRefusal, SnapshotSeed, SnapshotStore,
-    seed_digest,
+    BindingClass, ExportReceipt, GitVisibility, QuarantineMetadata, RestoreOutcome,
+    SnapshotRefusal, SnapshotSeed, SnapshotStore, seed_digest,
 };
 
 // ── fixtures ───────────────────────────────────────────────────────────────
@@ -202,15 +202,20 @@ fn the_v11_namespace_is_isolated_and_v10_writers_cannot_reach_current() {
 // ── the secret canary ──────────────────────────────────────────────────────
 
 /// Runtime secret-canary bytes never enter V11 snapshots, quarantine
-/// metadata, receipts, or diagnostics — while the quarantined ORIGINAL is
-/// still preserved intact for rollback, which is exactly the difference
-/// between retention and disclosure.
+/// metadata, receipts, or diagnostics - on the QUARANTINE path and the
+/// PROMOTED path both - while the quarantined ORIGINAL is still preserved
+/// intact for rollback, which is exactly the difference between retention
+/// and disclosure. The typed surfaces are pinned by EXHAUSTIVE
+/// destructuring (pair-5 review): a new byte-carrying field on any of them
+/// breaks this test at compile time instead of slipping past a string scan,
+/// and diagnostics are scanned as string CONTENT, not as a Debug rendering
+/// that would show leaked byte vectors as decimals.
 #[test]
 fn secret_canary_bytes_never_persist_in_v11_surfaces() {
     let mut store = SnapshotStore::new();
     let mut secret_bearing = healthy_seed(2);
     secret_bearing.opaque_note = SECRET_CANARY.to_vec();
-    secret_bearing.root_digest ^= 7; // force the quarantine path too
+    secret_bearing.root_digest ^= 7; // force the quarantine path
     let original = secret_bearing.clone();
 
     let RestoreOutcome::Quarantined { id } = store
@@ -220,26 +225,32 @@ fn secret_canary_bytes_never_persist_in_v11_surfaces() {
         panic!("expected quarantine");
     };
 
-    let metadata_view = format!("{:?}", store.quarantine_metadata());
-    assert!(
-        !contains_canary(&metadata_view),
-        "the canary reached quarantine metadata"
-    );
-    assert!(
-        metadata_view.contains("opaque_len"),
-        "metadata must still describe the opaque payload by size"
-    );
-    let diagnostics_view = store.diagnostics().join("\n");
-    assert!(
-        !contains_canary(&diagnostics_view),
-        "the canary reached diagnostics"
-    );
-    let current_view = format!("{:?}", store.current());
-    assert!(
-        !contains_canary(&current_view),
-        "the canary reached the V11 state"
-    );
+    // Quarantine metadata: every field typed, none byte-carrying — pinned
+    // exhaustively, no `..` allowed.
+    for row in store.quarantine_metadata() {
+        let QuarantineMetadata {
+            id: _,
+            declared_digest: _,
+            computed_digest: _,
+            entry_count,
+            opaque_len,
+        } = row;
+        assert_eq!(entry_count, 2);
+        assert_eq!(
+            opaque_len,
+            SECRET_CANARY.len(),
+            "metadata describes the payload by SIZE"
+        );
+    }
+    // Diagnostics: scanned as string content.
+    for line in store.diagnostics() {
+        assert!(
+            !contains_canary(&line),
+            "the canary reached diagnostics: {line}"
+        );
+    }
 
+    // The receipt: one typed field, pinned exhaustively.
     let receipt = store
         .export_team_artifact(
             BindingClass::NormalWritable,
@@ -247,13 +258,80 @@ fn secret_canary_bytes_never_persist_in_v11_surfaces() {
             b"artifact".to_vec(),
         )
         .expect("a normal writable binding exports");
-    assert!(
-        !contains_canary(&format!("{receipt:?}")),
-        "the canary reached a receipt"
-    );
+    let ExportReceipt { visibility } = receipt;
+    assert_eq!(visibility, GitVisibility::AlreadyTracked);
 
     // Retention is not disclosure: rollback still returns the original.
     assert_eq!(store.rollback(id), Some(original));
+
+    // The PROMOTED path - the first surface the frozen wording names: a
+    // fully proven secret-bearing seed promotes, and the promoted state
+    // (u64 stamps only, pinned by type) plus its diagnostics stay clean.
+    let mut promoted = SnapshotStore::new();
+    let mut proven_secret = healthy_seed(2);
+    proven_secret.opaque_note = SECRET_CANARY.to_vec();
+    promoted
+        .restore(proven_secret, 1_024, identity_decode, |_, _| true)
+        .expect("a proven secret-bearing seed still promotes");
+    let current: std::collections::BTreeMap<u64, u64> = promoted.current();
+    assert_eq!(
+        current.len(),
+        2,
+        "the promoted snapshot carries stamps, never seed bytes"
+    );
+    for line in promoted.diagnostics() {
+        assert!(
+            !contains_canary(&line),
+            "the canary reached promoted-path diagnostics"
+        );
+    }
+}
+
+/// The capacity bound binds the UNTRUSTED input, not its self-declaration
+/// (pair-5 review): a seed that lies small but carries a huge payload
+/// aborts MID-decode with bounded decode invocations - the declared header
+/// is a fast-path check, never the enforcement.
+#[test]
+fn a_lying_declaration_cannot_defeat_the_capacity_bound() {
+    let mut store = SnapshotStore::new();
+    let decodes = Cell::new(0_u32);
+
+    // 200 entries at the model stride of 16 bytes = 3200 actual, declared 16.
+    let entries: Vec<(u64, u64)> = (1..=200).map(|id| (id, id)).collect();
+    let liar = SnapshotSeed {
+        version: 10,
+        declared_len: 16,
+        root_digest: seed_digest(&entries),
+        entries,
+        opaque_note: Vec::new(),
+    };
+    let refusal = store
+        .restore(
+            liar,
+            1_024,
+            |entry| {
+                decodes.set(decodes.get() + 1);
+                *entry
+            },
+            |_, _| true,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            refusal,
+            SnapshotRefusal::CapacityExceededMidDecode { limit: 1_024, .. }
+        ),
+        "a lying seed must abort mid-decode, got {refusal:?}"
+    );
+    assert!(
+        decodes.get() <= 65,
+        "decode must stop within the bound, ran {} times",
+        decodes.get()
+    );
+    assert!(
+        store.current().is_empty(),
+        "an aborted decode promoted something"
+    );
 }
 
 // ── FR-051: the team-artifact matrix ───────────────────────────────────────

--- a/tests/snapshot_v11_migration.rs
+++ b/tests/snapshot_v11_migration.rs
@@ -1,0 +1,336 @@
+//! Feature 020 V11 Slice 4 snapshot-migration oracles (T057).
+//!
+//! RED-first for the pair T057+T065: authored and observed failing against
+//! `todo!()` seams before any machinery existed. Every rejection case asserts
+//! the accepting path in the same test — a store that quarantines everything
+//! satisfies a lone rejection assertion perfectly.
+
+use std::cell::Cell;
+use std::collections::BTreeMap;
+
+use symforge::live_index::index_lifecycle::snapshot::{
+    BindingClass, GitVisibility, RestoreOutcome, SnapshotRefusal, SnapshotSeed, SnapshotStore,
+    seed_digest,
+};
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+/// The runtime secret canary the frozen T057 case list forbids from ever
+/// entering snapshots, quarantine metadata, receipts, or diagnostics.
+const SECRET_CANARY: &[u8] = b"CANARY-9f2c-DO-NOT-PERSIST";
+
+fn healthy_seed(count: u64) -> SnapshotSeed {
+    let entries: Vec<(u64, u64)> = (1..=count).map(|id| (id, 100 + id)).collect();
+    SnapshotSeed {
+        version: 10,
+        declared_len: count * 16,
+        root_digest: seed_digest(&entries),
+        entries,
+        opaque_note: b"ordinary v10 residue".to_vec(),
+    }
+}
+
+fn identity_decode(entry: &(u64, u64)) -> (u64, u64) {
+    *entry
+}
+
+fn contains_canary(haystack: &str) -> bool {
+    haystack.contains(std::str::from_utf8(SECRET_CANARY).unwrap())
+}
+
+// ── the frozen-named oracle ────────────────────────────────────────────────
+
+/// TEST-SNAPSHOT (T057). The name is pinned by
+/// `contracts/lifecycle-oracle-traceability-v11.md` as a `planned_exact`
+/// target; do not rename it without amending that contract.
+///
+/// A seed is a HINT, never authority: only complete current-process proof
+/// promotes anything. One unproven entry rejects the WHOLE seed — nothing
+/// partial, nothing stale, and the rebuild fallback is latched. The
+/// positive control proves an all-proven seed promotes everything.
+#[test]
+fn snapshot_seed_requires_complete_current_proof() {
+    // One unproven entry: nothing promotes.
+    let mut store = SnapshotStore::new();
+    let outcome = store
+        .restore(healthy_seed(3), 1_024, identity_decode, |source, _| {
+            source != 2
+        })
+        .expect("an in-capacity seed is admitted to proof");
+    assert_eq!(outcome, RestoreOutcome::SeedRejected { unproven: 1 });
+    assert!(
+        store.current().is_empty(),
+        "a partially proven seed promoted something"
+    );
+    assert!(
+        store.rebuild_required(),
+        "a rejected seed must latch the rebuild fallback"
+    );
+
+    // Positive control: complete proof promotes all.
+    let mut proven = SnapshotStore::new();
+    let outcome = proven
+        .restore(healthy_seed(3), 1_024, identity_decode, |_, _| true)
+        .expect("an in-capacity seed is admitted to proof");
+    assert_eq!(outcome, RestoreOutcome::Promoted { sources: 3 });
+    assert_eq!(
+        proven.current(),
+        BTreeMap::from([(1, 101), (2, 102), (3, 103)]),
+        "a completely proven seed promotes exactly its entries"
+    );
+    assert!(!proven.rebuild_required());
+}
+
+// ── pre-decode capacity ────────────────────────────────────────────────────
+
+/// The capacity check happens BEFORE decoding: a seed declaring more than
+/// the limit refuses with zero decode calls — untrusted bytes never get to
+/// spend our cycles first.
+#[test]
+fn pre_decode_capacity_refuses_before_any_decode() {
+    let mut store = SnapshotStore::new();
+    let decodes = Cell::new(0_u32);
+
+    let mut oversized = healthy_seed(2);
+    oversized.declared_len = 1_000_000;
+    assert_eq!(
+        store
+            .restore(
+                oversized,
+                1_024,
+                |entry| {
+                    decodes.set(decodes.get() + 1);
+                    *entry
+                },
+                |_, _| true,
+            )
+            .unwrap_err(),
+        SnapshotRefusal::SeedBeyondCapacity {
+            declared: 1_000_000,
+            limit: 1_024,
+        }
+    );
+    assert_eq!(decodes.get(), 0, "an over-capacity seed was decoded anyway");
+
+    // Positive control: within capacity, every entry decodes exactly once.
+    store
+        .restore(
+            healthy_seed(2),
+            1_024,
+            |entry| {
+                decodes.set(decodes.get() + 1);
+                *entry
+            },
+            |_, _| true,
+        )
+        .expect("within capacity");
+    assert_eq!(decodes.get(), 2);
+}
+
+// ── quarantine and rollback ────────────────────────────────────────────────
+
+/// A root-digest mismatch quarantines the seed with its rollback payload
+/// preserved byte-intact, latches the rebuild fallback, and promotes
+/// nothing.
+#[test]
+fn root_digest_mismatch_quarantines_with_rollback_preserved() {
+    let mut store = SnapshotStore::new();
+    let mut corrupt = healthy_seed(3);
+    corrupt.root_digest ^= 0xdead_beef;
+    let original = corrupt.clone();
+
+    let outcome = store
+        .restore(corrupt, 1_024, identity_decode, |_, _| true)
+        .expect("integrity failures quarantine, they do not refuse");
+    let RestoreOutcome::Quarantined { id } = outcome else {
+        panic!("a digest mismatch must quarantine, got {outcome:?}");
+    };
+    assert!(store.current().is_empty());
+    assert!(store.rebuild_required());
+
+    let metadata = store.quarantine_metadata();
+    assert_eq!(metadata.len(), 1);
+    assert_eq!(metadata[0].entry_count, 3);
+    assert_ne!(metadata[0].declared_digest, metadata[0].computed_digest);
+
+    // Rollback: the original seed comes back byte-intact, exactly once.
+    assert_eq!(store.rollback(id), Some(original));
+    assert_eq!(
+        store.rollback(id),
+        None,
+        "a rollback payload is handed out once"
+    );
+}
+
+// ── namespace isolation and concurrent writers ─────────────────────────────
+
+/// The V11 store never touches the V10 namespace: restores and quarantines
+/// leave every V10 byte identical, and a V10 writer landing DURING the V11
+/// era never becomes Current without proof.
+#[test]
+fn the_v11_namespace_is_isolated_and_v10_writers_cannot_reach_current() {
+    let mut store = SnapshotStore::new();
+    store.v10_write(b"legacy snapshot one".to_vec());
+    let before = store.v10_namespace();
+
+    store
+        .restore(healthy_seed(2), 1_024, identity_decode, |_, _| true)
+        .expect("restore succeeds");
+    let mut corrupt = healthy_seed(1);
+    corrupt.root_digest ^= 1;
+    store
+        .restore(corrupt, 1_024, identity_decode, |_, _| true)
+        .expect("quarantine path");
+
+    assert_eq!(
+        store.v10_namespace(),
+        before,
+        "V11 restore or quarantine wrote into the V10 namespace"
+    );
+
+    // A concurrent V10 writer during the V11 era: recorded in ITS namespace,
+    // absent from Current.
+    store.v10_write(b"late v10 writer".to_vec());
+    assert_eq!(store.v10_namespace().len(), 2);
+    assert_eq!(
+        store.current(),
+        BTreeMap::from([(1, 101), (2, 102)]),
+        "an unproven late V10 write leaked into Current"
+    );
+}
+
+// ── the secret canary ──────────────────────────────────────────────────────
+
+/// Runtime secret-canary bytes never enter V11 snapshots, quarantine
+/// metadata, receipts, or diagnostics — while the quarantined ORIGINAL is
+/// still preserved intact for rollback, which is exactly the difference
+/// between retention and disclosure.
+#[test]
+fn secret_canary_bytes_never_persist_in_v11_surfaces() {
+    let mut store = SnapshotStore::new();
+    let mut secret_bearing = healthy_seed(2);
+    secret_bearing.opaque_note = SECRET_CANARY.to_vec();
+    secret_bearing.root_digest ^= 7; // force the quarantine path too
+    let original = secret_bearing.clone();
+
+    let RestoreOutcome::Quarantined { id } = store
+        .restore(secret_bearing, 1_024, identity_decode, |_, _| true)
+        .expect("quarantine path")
+    else {
+        panic!("expected quarantine");
+    };
+
+    let metadata_view = format!("{:?}", store.quarantine_metadata());
+    assert!(
+        !contains_canary(&metadata_view),
+        "the canary reached quarantine metadata"
+    );
+    assert!(
+        metadata_view.contains("opaque_len"),
+        "metadata must still describe the opaque payload by size"
+    );
+    let diagnostics_view = store.diagnostics().join("\n");
+    assert!(
+        !contains_canary(&diagnostics_view),
+        "the canary reached diagnostics"
+    );
+    let current_view = format!("{:?}", store.current());
+    assert!(
+        !contains_canary(&current_view),
+        "the canary reached the V11 state"
+    );
+
+    let receipt = store
+        .export_team_artifact(
+            BindingClass::NormalWritable,
+            GitVisibility::AlreadyTracked,
+            b"artifact".to_vec(),
+        )
+        .expect("a normal writable binding exports");
+    assert!(
+        !contains_canary(&format!("{receipt:?}")),
+        "the canary reached a receipt"
+    );
+
+    // Retention is not disclosure: rollback still returns the original.
+    assert_eq!(store.rollback(id), Some(original));
+}
+
+// ── FR-051: the team-artifact matrix ───────────────────────────────────────
+
+/// The export receipt discloses EXACTLY one of the four frozen git
+/// visibility states, and shareability is never inferred when git
+/// visibility cannot be established.
+#[test]
+fn team_artifact_export_discloses_exactly_one_visibility_state() {
+    let mut store = SnapshotStore::new();
+    for (offset, visibility) in GitVisibility::ALL.into_iter().enumerate() {
+        let receipt = store
+            .export_team_artifact(
+                BindingClass::NormalWritable,
+                visibility,
+                vec![0_u8; offset + 1],
+            )
+            .expect("a normal writable binding exports");
+        assert_eq!(
+            receipt.visibility, visibility,
+            "the receipt must disclose its exact state"
+        );
+        match visibility {
+            GitVisibility::GitVisibilityUnavailable => assert_eq!(
+                receipt.shareability(),
+                None,
+                "shareability must never be inferred without git visibility"
+            ),
+            _ => assert!(receipt.shareability().is_some()),
+        }
+    }
+    assert_eq!(store.team_artifacts(), 4);
+}
+
+/// Explicit-protected, read-only, user-local-only, and memory-only bindings
+/// refuse BEFORE any artifact mutation — and the `.gitattributes` companion
+/// write is a sealed negative: it belongs to the mutation-permit path.
+#[test]
+fn non_writable_bindings_refuse_before_any_mutation() {
+    let mut store = SnapshotStore::new();
+    for binding in [
+        BindingClass::ExplicitProtected,
+        BindingClass::ReadOnly,
+        BindingClass::UserLocalOnly,
+        BindingClass::MemoryOnly,
+    ] {
+        assert_eq!(
+            store
+                .export_team_artifact(binding, GitVisibility::AlreadyTracked, b"a".to_vec())
+                .unwrap_err(),
+            SnapshotRefusal::BindingRefusesExport(binding)
+        );
+    }
+    assert_eq!(
+        store.team_artifacts(),
+        0,
+        "a refused export persisted anyway"
+    );
+
+    // Sealed negative: the companion .gitattributes write is permit-path
+    // work, refused here unconditionally — even for a writable binding.
+    assert_eq!(
+        store.export_with_gitattributes_change(
+            BindingClass::NormalWritable,
+            GitVisibility::IgnoredForceAddRequired,
+        ),
+        SnapshotRefusal::GitattributesRequiresMutationPermit
+    );
+
+    // Positive control: the writable binding still exports the artifact
+    // itself, persistence-only.
+    store
+        .export_team_artifact(
+            BindingClass::NormalWritable,
+            GitVisibility::UntrackedVisible,
+            b"artifact".to_vec(),
+        )
+        .expect("persistence-only export works");
+    assert_eq!(store.team_artifacts(), 1);
+}


### PR DESCRIPTION
Wave 1 pair 5 - the FINAL dark pair - of the Slice 4 campaign (specs/028-preventive-activation-cut; frozen roster 020:T057+T065): untrusted-seed snapshot migration, RED-first.

**RED observed before machinery** (TC job job_01a0148d48e37343a4d1de0a501c176f, exit 101): `0 passed; 7 failed` on todo!() seams. **GREEN**: 7/7 first implementation; 8/8 after the review round.

**Independent review round** (one pass + cfg-lens per spec FR-016): frozen T057 semantics PASS with two MAJORs, FR-051 fidelity PASS (exactly four states structural, None-when-unavailable pinned, refuse-before-mutation proven via post-refusal state, sealed .gitattributes negative correct), T025 dark-module scope correction VERIFIED (persist.rs is itself the pinned snapshot ingress lane - implementing there would trip the seal), cfg-lens CLEAN, retention-vs-disclosure adjudicated HONEST (byte-intact rollback is impossible without retention; the frozen text forbids metadata, not storage). Both MAJORs taken in 9b02284d: the canary oracle gained compile-time teeth (exhaustive destructuring of every typed surface - a new byte-carrying field cannot slip past a string scan) plus a promoted-path case, and the capacity bound now BINDS - a lying declaration aborts mid-decode with bounded invocations (RED observed first: a seed declaring 16 bytes decoded all 200 entries). Suggestions taken: redacting manual Debug on the quarantine entry, shareability booleans recorded as a dark modeling choice, doc-honesty touches, T026 wording aligned.

**Seal**: excluded set +1 (snapshot.rs); both pins refreshed from the Rust oracle after rustfmt (the reviewer independently recomputed the +11,738-byte delta). Seal 8/8; traceability validator OK; frozen specs/020 untouched.

**Gates** (serial via Terminal Commander): fmt clean, clippy -D warnings clean, full serial suite exit 0, embed lib gate 1333/0 zero warnings, release build + verify-tools 7 PASS/0 FAIL, npm 31/31.

**Wave 1 completes with this merge**: all five RED+machinery pairs dark on main; the only ignored lifecycle tests left are T058's four stand-ins, exactly as the campaign plan requires before the Wave 2 activation-cut branch opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn