### PR TITLE
docs: add a self-contained post-v11 work ledger

### DIFF
--- a/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
+++ b/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
@@ -1,0 +1,366 @@
+# SymForge — Work Ledger (post-v11.0.0)
+
+**Audience**: an agent with nothing but a fresh clone. No MCP servers, no
+agentmemory, no prior session, no chat history. Everything you need to pick up
+work is either in this file or reachable from a path named in it.
+
+**Drafted**: 2026-08-20, at the close of the Feature 020 Slice 4 activation cut
+(shipped as the 11.0.0 breaking release).
+
+**Scope**: this is a ledger of what is *owed*, not a status report. Volatile
+state (SHAs, branches, open PRs, current version) is deliberately absent — see
+§0 for the command that generates it.
+
+---
+
+## 0. Get current state — never trust a hand-written SHA
+
+```
+pwsh scripts/campaign-state.ps1          # human-readable
+pwsh scripts/campaign-state.ps1 -Json    # machine bootstrap
+```
+
+It reads git, `gh`, and `Cargo.toml` on `origin/main` and filters untracked
+files that are byte-identical to `main`. Anything in a doc that contradicts it
+is stale, including anything in this file that looks like a fact about *right
+now*.
+
+Binding rule (repo `CLAUDE.md`): git SHAs, branch/worktree lists, "X is
+uncommitted", open PR numbers, and the current version are **never** typed into
+a document. Cite the command.
+
+---
+
+## 1. Traps that will cost you a day if you skip this section
+
+### 1.1 `specs/020-repository-knowledge-index/` is frozen — its checkboxes are not a ledger
+
+The tree is immutable post-T012, **including checkbox bytes**
+(`specs/020-repository-knowledge-index/tasks.md:858-865`). The `- [ ]` / `- [x]`
+marks are a snapshot from the moment of freeze. They do not track progress and
+must never be edited.
+
+Proof that reading them as progress is wrong: every Gate H and Gate I row is
+unchecked, yet `src/knowledge/`, `src/protocol/knowledge_search.rs`,
+`knowledge_review.rs`, `knowledge_curation.rs`, `knowledge_model.rs` and the
+registered `search_knowledge` tool are all live in the shipped binary.
+
+**Live progress lives in**, in descending authority:
+
+| What | Where |
+|---|---|
+| As-executed record of the Slice 4 cut, with every deviation | `specs/028-preventive-activation-cut/activation-cut-execution-map.md` |
+| Slice 4 evidence + adversarial review rounds + "what green does not prove" | `docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md` |
+| Slice 3 / Slice 2 evidence | `docs/reviews/FEATURE-020-SLICE3-EVIDENCE-v11.md`, `…SLICE2-EVIDENCE-v11.md` |
+| Machine-checked acceptance roster (the only self-verifying one) | `scripts/slice0-oracle-artifact.cjs` |
+| Requirement↔oracle↔retirement traceability | `node scripts/validate-lifecycle-oracle-traceability.cjs` |
+| Migration boundary and its open scopes | `docs/migrations/v11-index-lifecycle.md` |
+| Project rules, gates, merge mechanics | `CLAUDE.md`, `AGENTS.md`, `.specify/memory/constitution.md` |
+
+### 1.2 Lib unit-test paths carry an `internals::` prefix
+
+The V11 cut mounts the server modules under `src/internals.rs` via `#[path]`.
+Every `cargo test --lib … -- --exact` filter written before the cut silently
+selects **nothing** and exits 0 having run nothing. Correct form:
+
+```
+cargo test --lib internals::daemon::tests::<name> -- --exact --ignored
+```
+
+This broke `scripts/slice0-oracle-artifact.cjs` in post-merge CI. Assume it
+broke other pre-cut filters that nobody has run yet.
+
+### 1.3 The default-feature gates cannot catch a feature-gated `cfg` mistake
+
+Before pushing anything that adds a `#[cfg(test)]` helper, run exactly:
+
+```
+cargo test --no-default-features --features embed --lib -- --test-threads=1
+```
+
+A `#[cfg(test)]` item whose only consumer sits behind `feature = "server"` is an
+unused import in that cell, and `-D warnings` fails the build — while every
+default-feature gate passes. When the consumer is server-only, gate the helper
+`#[cfg(all(test, feature = "server"))]`.
+
+### 1.4 Long builds must not run through a 10-minute-capped tool
+
+A cold `cargo test --all-targets` here takes ~25 minutes. Killing it mid-write
+corrupts `target/` and produces errors that look like code defects and are not
+(`E0786 found invalid metadata files`, rustc ICEs, `E0463 can't find crate`).
+Run long cargo through a daemon that owns the process, and never interleave
+feature sets in one target dir — run `--all-targets` and
+`--no-default-features --features embed` one at a time.
+
+Recovery, cheapest first: delete `target/debug/incremental` → `cargo clean -p
+symforge` → full `cargo clean`.
+
+### 1.5 The reporting invariant is binding, and it is what this project sells
+
+> A component may not report success for an operation whose completion it did
+> not observe.
+
+Not "attempted", not "the code path was called" — observed. When you add any
+status line, banner, envelope, or success return, answer in the PR: *what did
+this observe, and what does it emit when the observation fails?* Six defects
+fixed on 2026-08-06 were this one defect wearing different clothes, and all six
+shipped green.
+
+### 1.6 Merge mechanics
+
+Squash by default, always with an explicit body:
+
+```
+gh pr merge <N> --squash --delete-branch \
+  --subject "<conventional PR title> (#<N>)" \
+  --body "<one short paragraph, no parentheses, no colon-bearing prose lines>"
+```
+
+The default squash body concatenates inner commit messages; any line shaped like
+`word: text` impersonates a conventional header and one parse error makes the
+entire commit invisible to release-please — no version bump, no changelog, no
+error raised. Release PRs themselves stay `--merge`.
+
+---
+
+## 2. The ledger
+
+Four tracks are live. Everything else in `specs/` is dormant (§3).
+
+### Track A — eleven Slice 0 acceptance controls are still RED, and every owning slice has already shipped
+
+This is the largest and most material item. Feature 020 Slice 0's product was
+positive controls observed failing *before* the machinery existed. Eleven still
+fail. Each names an owning slice in its `#[ignore]` prose; **all of those slices
+have landed**. So these are eleven frozen-tree acceptance behaviors that are
+owed and currently unowned by any remaining slice.
+
+**Roster file (authoritative, fail-closed)**: `scripts/slice0-oracle-artifact.cjs`
+— `RED_CASES` (11) and `RESOLVED_CASES` (1).
+**Test bodies**: `tests/project_index_lifecycle_slice0.rs` (10) and
+`src/daemon.rs` lib tests (1).
+**Run it**: `node scripts/slice0-oracle-artifact.cjs` → writes
+`target/ci/lifecycle-v11/slice-0-oracle-contract.json`. CI's `rust` job runs it.
+
+| Control | Named owner (already shipped) | Defect / seam |
+|---|---|---|
+| `capacity_refused_open_creates_no_slot_and_no_watcher` | Slice 2 (T030–T040) | 2.1 — admission refusal is not a typed outcome |
+| `configured_capacity_bounds_the_process_not_each_load` | Slice 2 (T030–T040) | 2.5 — capacity is not a process-wide reservation |
+| `internals::daemon::tests::concurrent_first_open_performs_exactly_one_cold_load` | Slice 2 (T030–T040) | 2.4 — project admission is not single-flight |
+| `same_path_root_replacement_is_not_silently_adopted` | Slice 1 (T022–T029) | physical root identity not canonical/fenced |
+| `empty_placeholder_publication_refuses_watcher_mutation` | Slice 4 (spec 028) | 2.2/2.3 — watcher seam |
+| `failed_reload_retains_the_recovery_observer` | Slice 4 (spec 028) | 2.10 — observer handoff destructive at daemon seam |
+| `observer_replacement_gap_is_latched_as_non_current` | Slice 4 (spec 028) | handoff does not latch the gap |
+| `old_observer_delivery_after_promotion_is_not_current` | Slice 4 (spec 028) | no stable observer token fencing delivery |
+| `watcher_mutation_during_candidate_build_is_not_discarded` | Slice 4 (spec 028) | 2.7/2.9 — precondition window unreachable at this seam |
+| `whole_project_publication_preserves_latest_siblings` | Slice 4 (spec 028) | FR-008/FR-009/SC-005 — precondition window unreachable |
+| `snapshot_seed_is_not_queryable_before_verification` | Slice 4 (spec 028) | 2.11 — `SnapshotStore` per-entry verify-state wiring absent |
+
+Two sub-shapes, and they need different work:
+
+- **"Still red at the seam"** (watcher/daemon) — the behavior is genuinely
+  absent. Ordinary RED-first fix work.
+- **"Precondition window unreachable"** (`watcher_mutation_during_candidate_build…`,
+  `whole_project_publication_preserves_latest_siblings`) — the control cannot
+  *reach* the state it asserts on at this seam. Fixing production code will not
+  turn these green on its own; the control needs a seam where the window is
+  observable, or an explicit adjudication recorded in the evidence doc. Do not
+  quietly weaken the assertion.
+
+The four Slice-1/Slice-2 rows still carry **stale prose** predicting a slice that
+already landed ("remove this attribute in Slice 2 …"). Whoever picks these up
+must rewrite those `#[ignore]` reasons to name the real carried owner, exactly as
+the seven Slice-4 rows were rewritten on 2026-08-20 — a prediction that has been
+falsified is not allowed to stand in the tree.
+
+**The roster's fail-closed contract, so you do not fight it:**
+
+- A `RED_CASES` control that *starts passing* is a **CI error**, not a success.
+  Either the defect was fixed without its slice removing the `#[ignore]`, or the
+  control went vacuous. Both need a human.
+- To land a fix, move the control into `RESOLVED_CASES` with `slice`, `tasks`,
+  `defect`, and `fix` fields, delete its `#[ignore]`, and let it run in the
+  default suite. Never delete a control — that deletes the regression guard and
+  the evidence of the RED→GREEN transition.
+- A resolved suite must **not** pass `--ignored` (with the attribute gone it
+  would select nothing and exit 0 having run nothing).
+
+The one already-resolved row is the pattern to copy:
+`internals::watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b`
+(Slice 1, T028, defect 2.8).
+
+### Track B — six recorded design residuals from the Slice 4 cut
+
+Adjudicated open with named owners across three adversarial review rounds, all
+assessed sub-P2. Full text in
+`docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md` §5 and §7a–7c, and
+in the C-group records of
+`specs/028-preventive-activation-cut/activation-cut-execution-map.md`.
+
+| # | Residual | Where it lives |
+|---|---|---|
+| B1 | Retarget-in-place admission identity — a root physically replaced at the same path keeps its admission identity | `src/index_lifecycle/` admission + transitions (C4b/C5 records) |
+| B2 | `project_source_authority` remains a per-root static convergence lookup after the flip | `src/index_lifecycle/authority.rs` |
+| B3 | Serve access-mode threading — the serve path surfaces no `RootBinding` and presents `NormalProject` | serve loader path |
+| B4 | `SnapshotStore` per-entry verify-state wiring into the live restore path | `src/live_index/persist.rs`; scope stated in `docs/migrations/v11-index-lifecycle.md` §4 |
+| B5 | Supersede multi-party heal residual — a multi-party interleave following a crash-orphan can still strip a live marker (bounded to a microsecond window by a double-checked re-read; no name-based marker scheme closes it fully) | stale-marker heal path, comment states the bound in code |
+| B6 | Kilo init classification | `src/cli/init.rs` |
+
+Also recorded, and cheap: the `OBSERVED-REFRESH-GATE-v1.md` sub-millisecond
+lanes quantize 1→2 ms against a ratio gate below the measurement quantum. The
+honest bound is recorded; **microsecond receipts** are the named follow-up
+(`docs/reviews/OBSERVED-REFRESH-GATE-v1.md`).
+
+### Track C — Slice 5: mechanical removal (T074–T077) — not started
+
+Roster: `specs/020-repository-knowledge-index/tasks.md` Phase 7 (lines 958–966).
+Goal, verbatim: *"Delete only code already proven unreachable in Slice 4; do not
+change runtime authority, public behavior, writer reachability, or activation
+mode."*
+
+| Task | Deliverable | Artifact status |
+|---|---|---|
+| T074 | Capture pre-cleanup public API / authority-reachability / behavior / activation baseline | `docs/reviews/FEATURE-020-SLICE5-BASELINE-v11.md` — **does not exist** |
+| T075 | Remove unreachable placeholder storage, bootstrap/circuit-breaker lifecycle fields, legacy mode branches, secondary publication roots, obsolete tests, compatibility comments | `src/` |
+| T076 | Remove dead V10 embed implementation — **only after** the allowlist negative suite proves it unnameable | `src/embed.rs` |
+| T077 | Re-run the T074 baseline, prove Slice 5 changed nothing, complete the post-slice adversarial review | `docs/reviews/FEATURE-020-SLICE5-EVIDENCE-v11.md` — **does not exist** |
+
+This is the next sequential slice and it is unblocked. It is also the *safest*
+remaining track: a pure-deletion slice whose acceptance criterion is "the
+baseline is bit-identical afterward".
+
+### Track D — Phase 8: release and adversarial closure (T078–T090) — not started
+
+Roster: `specs/020-repository-knowledge-index/tasks.md` Phase 8 (lines 968–985).
+
+**Read this first**: 11.0.0 already shipped to npm, crates.io, and GitHub
+Releases at the Slice 4 cut, because Slice 4 *is* the V11 breaking lifecycle/embed
+boundary. The Phase 8 formal closure gate did **not** run. The version is out;
+the gate is still owed. Nothing in Phase 8 blocks users — it is the evidence
+obligation the feature carries, and it is the largest single body of unbuilt work
+in the repo.
+
+Central artifact for all of T078–T090:
+`docs/reviews/FEATURE-020-V11-RELEASE-GATE.md` — **does not exist**.
+
+Never-materialized code artifacts:
+
+| Path | Owed by | Status |
+|---|---|---|
+| `tests/model/` — four separate pure proptest command models | T080 | **missing** |
+| `formal/v11/` — four TLA+ specs (process ownership, registry identity, source promotion/invalidation, capacity admission) | T080 | **missing** |
+| `src/index_lifecycle/loom_tests.rs` — shared production transition kernel through its `cfg(loom)` adapter | T080 | **missing** |
+| `benches/observed_refresh_gate_v1.rs` | T068 | exists |
+| `tests/delta_full_rebuild_equivalence_v11.rs` | T071 | exists |
+| `docs/migrations/v11-index-lifecycle.md` | T073 | exists (B4 scope still open) |
+
+Task shape, condensed — each records exact commands and results into the release-gate doc:
+
+- **T078** fmt + clippy, warnings denied.
+- **T079** focused lifecycle/capacity/watcher/snapshot/provenance/embed/migration/activation suites.
+- **T080** the proptest models + TLA+ specs + loom adapter above, with assumptions, bounds, fairness, traceability recorded.
+- **T081** serial all-target suite, release build, canonical full/compact tool + resource + prompt fixtures, and the **SC-006 token comparator with ≥50 % median reduction as a hard gate**.
+- **T082** cold-start race, same-stamp/suppressed-notification, rolling-deadline, observer-handoff, root-replacement campaigns — *with working positive controls*.
+- **T083** measured concurrent-project memory coverage (retired query-pinned generations, retained-plus-candidate overlap, snapshot scratch, accumulators).
+- **T084** the full provenance/refusal matrix through text, structured, HTTP, cache, CCR, persistence, retrieval — including `OperationContractV1` Cartesian negatives, exact-bijection `SelectedAggregate` cases, cache-confusion negatives, equal-shape nonexistent-vs-unauthorized `InvalidSelection`, `KnowledgeVoiceFilter`-not-consistency proofs, `RankingSnapshot` identity/order algebra, post-lease-only `OutputCoverage::Truncated` round trips, and secret-canary + policy-mismatch campaigns that **report only rule IDs and `file:line`, never values**.
+- **T085** same-process activation and restart campaigns seeded with apparently-valid V10 cache records, CCR handles, snapshots, and live legacy writers.
+- **T086** generated V11 public-API allowlist, all-cfg graph cover, dependent-crate fixtures, unknown-configuration rejection.
+- **T087** secret-safety scan — rule IDs and `file:line` only.
+- **T088** freeze the exact release commit/tree and all gate digests, obtain an **independent** adversarial review, resolve every accepted P0/P1/P2.
+- **T089** re-run `execution/refreeze_v11.py` with the trusted external approval record, prove the approved refreeze is still the immutable ancestor of the release tree, assemble `target/ci/lifecycle-v11/release-evidence.json`.
+- **T090** run exactly:
+  ```
+  node scripts/validate-lifecycle-oracle-traceability.cjs \
+    --require-materialized \
+    --evidence target/ci/lifecycle-v11/release-evidence.json
+  ```
+  Clear-to-land only when every planned Rust case and benchmark is materialized,
+  every requirement row plus T078–T089 is green, and every receipt binds that
+  same tree.
+
+Note the dependency: **T090 is why Track A matters to Track D**. `--require-materialized`
+will not pass while planned cases are unmaterialized, and the slice-0 roster is
+part of what it checks.
+
+### Track E — bookkeeping leftovers (minutes, not days)
+
+| Item | Where |
+|---|---|
+| `specs/028-preventive-activation-cut/tasks.md` T040/T041 still `- [ ]` although the cut merged, released, and the worktree was cleaned | `specs/028-preventive-activation-cut/tasks.md:167-168` |
+| `docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md` status line still reads *"EXECUTED through T039, awaiting the T040 operator gate"* — stale; the gate was given and it shipped | that file, "Execution status" block |
+| Trailing "merge the PR" checkboxes in already-closed specs: 002 T053, 018 T027, 025 T252 | those `tasks.md` files |
+
+Track E is safe for any agent to do first as a warm-up; it changes no code.
+
+---
+
+## 3. Dormant — do not start these without asking
+
+These carry unchecked tasks but no live campaign. Last touched (by any commit
+under that directory):
+
+| Spec | Last touched | Note |
+|---|---|---|
+| `specs/011-ccr-output-compression` | 2026-08-17 | touched only by an unrelated session-cache fix; 0 of 41 tasks ever checked |
+| `specs/027-answer-identity-disclosure` | 2026-08-07 | docs-only landing |
+| `specs/021-admission-coverage-honesty` | 2026-08-06 | 0 of 75 checked |
+| `specs/026-serve-snapshot-restore` | 2026-08-04 | delivered via PR, checkboxes never closed |
+| `specs/016-perl-parser-hardening` | 2026-07-06 | 0 of 60 checked |
+| `specs/015-cbm-capability-ports` | 2026-07-06 | 43 of 149 checked |
+| `specs/013-stel-predictor-calibration` | 2026-06-22 | 0 of 53 checked |
+| `specs/003`, `004`, `005`, `008`, `009`, `010` | ≤ 2026-06-18 | v8-era, superseded |
+
+`specs/024-optimization-backlog` has no `tasks.md`; it is a backlog document, not
+a live roster.
+
+---
+
+## 4. Verification gates — the exact commands
+
+Run all of these before claiming anything is done. Backend changes need every
+row; `npm/`-only changes need the last row alone; mixed changes need both.
+
+```
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets -- --test-threads=1
+cargo test --no-default-features --features embed --lib -- --test-threads=1
+cargo build --release
+node scripts/slice0-oracle-artifact.cjs
+node scripts/validate-lifecycle-oracle-traceability.cjs
+cd npm && npm test
+```
+
+CI runs a superset (version sync, conventional-commit title check, release
+build + `verify-tools.cjs --bin target/release/symforge`, darwin/musl/embed
+cells). `--test-threads=1` is a correctness gate, not a performance choice — do
+not remove it. `cargo clippy --all-targets` is deliberately run **without** a
+preceding `cargo check`; clippy is a strict superset and running both compiles
+the graph twice for one answer.
+
+Do **not** re-add the four-key `Swatinem/rust-cache` configuration. It was tried
+and measured slower on four jobs; the measurement and the likely cause (four
+distinct shared-keys against a 10 GB repo-wide cap) are recorded in `CLAUDE.md`.
+
+**Clean up after yourself.** `target/` lands beside the checkout and has reached
+180 GB on this repo. Run `cargo clean` when you finish a heavy local session.
+
+---
+
+## 5. Suggested order for a fresh agent
+
+1. **Track E** (minutes) — clears stale prose so the next reader is not misled.
+2. **Track C** (Slice 5) — sequential next slice, pure deletion, baseline-pinned,
+   lowest risk of introducing a defect.
+3. **Track A** — the real acceptance debt. Start with the four rows whose named
+   owner already shipped (they have the clearest defect statements), and rewrite
+   the stale `#[ignore]` prose as you go.
+4. **Track B** — small, adjudicated, well-localized; good filler between the
+   larger tracks.
+5. **Track D** — the largest. T080's models/TLA+/loom are green-field and can be
+   built in parallel with anything above; T088–T090 must run last, on one frozen
+   tree, and T090 depends on Track A being materialized.
+
+Whatever you pick: RED first, observe the failure, then the minimal green, then
+the focused verification. An acceptance spec is not reported executed until its
+production seam exists.


### PR DESCRIPTION
Adds `docs/reviews/FEATURE-020-POST-V11-LEDGER.md` — what Feature 020 still owes now that the Slice 4 activation cut has shipped as 11.0.0, written for an agent with a fresh clone and nothing else: no session history, no memory store, no MCP.

Four live tracks:

- **A** — eleven Slice 0 acceptance controls still RED. Every one names an owning slice that has already landed, so they are owed and unowned. Four still carry stale prose predicting Slice 1/2.
- **B** — six adjudicated design residuals from the cut, with file locations.
- **C** — Slice 5 mechanical removal, unstarted, unblocked, lowest risk.
- **D** — Phase 8 release closure, unstarted. 11.0.0 shipped at the cut because Slice 4 is the V11 boundary; the formal gate never ran. `tests/model/`, `formal/v11/`, `loom_tests.rs`, and the release-gate doc do not exist.

Plus the traps that cost real time: frozen-tree checkbox bytes are not a progress ledger, the `internals::` test-path remount, the embed cfg cell, and the long-build target corruption.

Volatile state is deliberately absent per repo doc hygiene — the ledger cites `scripts/campaign-state.ps1` instead of naming SHAs, branches, or versions.

Docs only; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn