### PR TITLE
chore(test): refresh the gitignore fingerprint for the cursor-plugin negation

### DIFF
--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1251,7 +1251,7 @@ const CARGO_LINES: &[(&str, usize)] = &[
 /// readable basis, not a Gitignore parser. The whole-file fingerprint catches
 /// a later negation or other semantic drift elsewhere in the file.
 const CARGO_CONFIG_SKIP_GITIGNORE_LINES: &[&str] = &["/target", "node_modules/"];
-const GITIGNORE_FINGERPRINT: &str = "4a5801056e073780:1025";
+const GITIGNORE_FINGERPRINT: &str = "b5011af9576da616:1186";
 const PRODUCTION_TARGET_TOPOLOGY: &[(&str, &str)] =
     &[("lib", "src/lib.rs"), ("bin:symforge", "src/main.rs")];
 


### PR DESCRIPTION
**`main` is red and has been since the marketplace-plugin push.** Every Release run now dies in `verify-release-ref` → `Run Rust tests`, and every branch cut from `main` inherits it.

```
thread 'no_gate_builds_doctests' panicked at tests/preventive_runtime_dark_v11.rs:1988:
assertion `left == right` failed: `.gitignore` changed.
  left: "b5011af9576da616:1186"
 right: "4a5801056e073780:1025"
```

The cause is not the README commit — it is `!/.cursor-plugin/`, added to `.gitignore` so the logo could reach GitHub. The dark-seal change detector did exactly its job: the constant's own doc comment says it exists to catch "a later negation or other semantic drift".

**Audit, both parts the assertion demands:**

1. The skips it justifies are `/target` and `node_modules/`. The new rule names neither, so `CARGO_CONFIG_SKIP_GITIGNORE_LINES` still matches the file.
2. It is a *negation*, so `git check-ignore` reports one more directory as NOT ignored. Skips can only decrease; the walk gains coverage of `.cursor-plugin/`. Safe direction.

**Provenance of the new value** — derived twice, independently:

- the Rust oracle's own `left:` actual on run 32382005685;
- a local recomputation of the same FNV-1a over `origin/main`'s `.gitignore` blob.

Hashes agree exactly. The lengths appeared to differ (1186 vs 1180) only because `str::len` counts bytes and the file carries three 3-byte characters — reconciled, not hand-waved.

`chore:` rather than `fix:` deliberately: this is a test-pin refresh with no user-facing behavior, and `fix:` would mint an 11.0.1 for nothing.

One constant changed; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn