### PR TITLE
chore(test): retry refreeze fixture teardown through the ENOTEMPTY race

### DIFF
--- a/execution/test_refreeze_v11.py
+++ b/execution/test_refreeze_v11.py
@@ -8,6 +8,7 @@ import shutil
 import stat
 import subprocess
 import tempfile
+import time
 import unittest
 import uuid
 from copy import deepcopy
@@ -539,8 +540,26 @@ class RefreezeV11Tests(unittest.TestCase):
                 return
 
         for path in reversed(created):
-            if path.exists():
-                shutil.rmtree(path, onexc=remove_readonly)
+            if not path.exists():
+                continue
+            # The sibling race the handler above cannot see. A `git` process
+            # can still be finishing a write under `.git/objects` while the
+            # walk is inside it, so the rmdir of a directory the walk had just
+            # emptied raises ENOTEMPTY. chmod-and-retry cannot help — nothing
+            # is read-only and the path is not gone — so the handler re-raises
+            # and a passing test is reported as an ERROR. That is what cost
+            # prepare-release a full cycle on 2026-08-20, on a tree whose same
+            # 274 tests had reported OK in verify-release-ref 38 minutes
+            # earlier. Retry the whole walk: the writer finishes in
+            # milliseconds and the next pass finds the directory empty.
+            for attempt in range(5):
+                try:
+                    shutil.rmtree(path, onexc=remove_readonly)
+                    break
+                except OSError:
+                    if attempt == 4:
+                        raise
+                    time.sleep(0.2)
 
     def assert_internal_error(
         self,


### PR DESCRIPTION
`cleanup_fixture_directories` already handles one half of a known teardown race — a `.git/objects/*` entry that **vanishes** mid-walk, whose `chmod` then raises `FileNotFoundError`. Its comment says so, and names `prepare-release` as what that one blocked.

This is the sibling half: a `git` process still **finishing a write** while the walk is inside that directory, so the `rmdir` of a directory the walk had just emptied raises

```
OSError: [Errno 39] Directory not empty: .../.git/objects
```

Nothing is read-only and the path is not gone, so chmod-and-retry cannot help. The handler re-raises, and unittest reports a **passing** test as an `ERROR`.

**It is not hypothetical.** Release run `32389192427` lost `prepare-release` to exactly this — on a tree whose same 274 tests reported `OK` in `verify-release-ref` **38 minutes earlier, in the same run, from the same command**:

| Job, same run, same commit, same command | Result |
|---|---|
| `verify-release-ref` → Run version sync tests | `Ran 274 tests` → **OK** |
| `prepare-release` → Run version sync tests | `Ran 274 tests` → **FAILED (errors=1)** |

`prepare-release` is the job before release-please, so the entire release cycle stalled on a directory that was going to be empty a millisecond later.

**The change:** retry the whole `rmtree` walk up to five times, 200 ms apart. The writer finishes in milliseconds; the next pass finds the directory empty. The fifth failure still raises, so a genuinely undeletable tree is not swallowed.

**On verification, honestly:** a race cannot be proven fixed by a green run — this run would have been green before too. What *is* verified: `python -m unittest discover -s execution -p 'test_*.py'` exits 0, and the refreeze module's own 164 tests pass locally on Windows. And the retry cannot make prior behavior worse, because the old code is exactly the first iteration of the new loop.

`chore:` not `fix:` — test-harness only, no user-facing behavior, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn