### PR TITLE
docs: close the Slice 4 campaign record and Track E bookkeeping

### DIFF
--- a/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
+++ b/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
@@ -284,13 +284,17 @@ part of what it checks.
 
 ### Track E — bookkeeping leftovers (minutes, not days)
 
-| Item | Where |
-|---|---|
-| `specs/028-preventive-activation-cut/tasks.md` T040/T041 still `- [ ]` although the cut merged, released, and the worktree was cleaned | `specs/028-preventive-activation-cut/tasks.md:167-168` |
-| `docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md` status line still reads *"EXECUTED through T039, awaiting the T040 operator gate"* — stale; the gate was given and it shipped | that file, "Execution status" block |
-| Trailing "merge the PR" checkboxes in already-closed specs: 002 T053, 018 T027, 025 T252 | those `tasks.md` files |
+**Done 2026-08-20** — `specs/028-preventive-activation-cut/tasks.md` T040/T041 are
+marked complete (SC-008 re-verified first: `git diff` over the frozen tree is empty
+from the approved ancestor through the merge and through `main` today), and the
+`FEATURE-020-SLICE4-CAMPAIGN-v11.md` status line now reads CLOSED with the carried
+work named.
 
-Track E is safe for any agent to do first as a warm-up; it changes no code.
+**Deliberately left open**, and this is a decision rather than an oversight:
+
+| Item | Where | Why untouched |
+|---|---|---|
+| Trailing "merge the PR" / "run the full gate" checkboxes: 002 T053, 018 T027, 025 T252 | those `tasks.md` files | Ticking them asserts a verification nobody living observed. Those specs are dormant (§3) and their work landed through PRs months ago, but "the gate was run and was green" is a claim about an event, and the reporting invariant (§1.5) does not get suspended for checkboxes. Anyone who can reconstruct the evidence should tick them and cite it; nobody should tick them to tidy the file. |
 
 ---
 

--- a/docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md
+++ b/docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md
@@ -8,8 +8,26 @@ from a three-lens recon of `specs/020-repository-knowledge-index/tasks.md`
 `src/index_lifecycle/`. This document is campaign planning under
 `docs/reviews/`; the spec tree is frozen and is never edited.
 
-> **Execution status (as_of 2026-08-20)**: EXECUTED through T039, awaiting
-> the T040 operator gate. The as-executed record (with every deviation
+> **Execution status (as_of 2026-08-20)**: CLOSED. The T040 operator gate
+> was given, the cut squash-merged as PR #601, and the release-please cycle
+> carried it to **11.0.0** on npm, crates.io, and GitHub Releases. SC-008
+> holds: `git diff` over `specs/020-repository-knowledge-index/` is empty
+> from the approved ancestor through the merge and through `main` today —
+> the frozen tree was never touched. Two post-merge CI fixes were required,
+> both to tools written before the cut: the traceability self-test needed
+> preactivation fixtures built from the approved ancestor's own bytes, and
+> `scripts/slice0-oracle-artifact.cjs` needed `internals::`-prefixed lib
+> test paths (the cut mounts the server modules under `src/internals.rs`,
+> so every pre-cut `--exact` filter silently selected nothing).
+>
+> **Carried, not discharged**: the seven Slice 0 positive controls whose
+> `#[ignore]` prose predicted resolution "in Slice 4" were each run
+> un-ignored against the cut and remain red at the daemon/watcher seams.
+> That prediction is falsified, not satisfied. They stay on the slice-0
+> oracle roster as post-cut work; the standing ledger of what Feature 020
+> still owes is `docs/reviews/FEATURE-020-POST-V11-LEDGER.md`.
+>
+> The as-executed record (with every deviation
 > from this plan) lives in
 > `specs/028-preventive-activation-cut/activation-cut-execution-map.md`;
 > the evidence and review record is

--- a/specs/028-preventive-activation-cut/tasks.md
+++ b/specs/028-preventive-activation-cut/tasks.md
@@ -164,8 +164,8 @@ live acceptance for all five user stories verified via quickstart spot-checks.
 
 - [x] T038 Complete the post-slice multi-round adversarial code review (fresh reviewer rounds + refuters, mandatory cfg-lens, explicit verdicts on each T037 residual family) and close `docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md` with zero unresolved P0/P1/P2 (020:T072, evidence half)
 - [x] T039 [P] Write the breaking lifecycle/embed migration boundary, removed exports, replacement APIs, and rollback constraints in `docs/migrations/v11-index-lifecycle.md` (020:T073)
-- [ ] T040 Verify `git diff --stat <merge-base> HEAD -- specs/020-repository-knowledge-index/` is empty (spec SC-008); present the cut PR to the operator and **wait for explicit approval** before merging (spec FR-015); after approval, squash-merge with explicit subject/body and watch the release-please cycle per repo rules
-- [ ] T041 [P] Save durable findings to agentmemory with the `[symforge]` prefix; run `cargo clean` in the worktree; update `docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md` status line via a follow-up docs commit if the campaign deviated from plan
+- [x] T040 Verify `git diff --stat <merge-base> HEAD -- specs/020-repository-knowledge-index/` is empty (spec SC-008); present the cut PR to the operator and **wait for explicit approval** before merging (spec FR-015); after approval, squash-merge with explicit subject/body and watch the release-please cycle per repo rules
+- [x] T041 [P] Save durable findings to agentmemory with the `[symforge]` prefix; run `cargo clean` in the worktree; update `docs/reviews/FEATURE-020-SLICE4-CAMPAIGN-v11.md` status line via a follow-up docs commit if the campaign deviated from plan
 
 ---
 


### PR DESCRIPTION
Track E from the post-v11 ledger — the bookkeeping that was left stale when the cut shipped.

- `specs/028-preventive-activation-cut/tasks.md` T040/T041 marked complete.
- The campaign doc's status line said *"EXECUTED through T039, awaiting the T040 operator gate"* — it had outlived the gate, the merge, and the 11.0.0 release. Now reads CLOSED.

**SC-008 was re-verified before ticking, not assumed**: `git diff` over `specs/020-repository-knowledge-index/` is empty from the approved ancestor through the cut's merge and through `main` today. The frozen tree was never touched.

The new status block also records what the cut did **not** discharge — the seven Slice 0 controls whose `#[ignore]` prose predicted resolution "in Slice 4" and which remain red — so the record cannot be misread as a clean close.

**On the trailing checkboxes in specs 002, 018, 025**: left unticked on purpose, and the ledger now says why. Ticking them asserts a gate run that nobody observed. Those specs are dormant and their work landed through PRs months ago, but the reporting invariant does not get suspended for checkboxes. Anyone who can reconstruct the evidence should tick them and cite it.

Docs and one spec checkbox pair; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn