### PR TITLE
docs(029): specify Slice 5, disposition the Slice 0 controls, and record four reviews

### DIFF
--- a/docs/reviews/APPENDIX-track-a-suspicions-2026-08-21.md
+++ b/docs/reviews/APPENDIX-track-a-suspicions-2026-08-21.md
@@ -1,0 +1,93 @@
+# SEALED APPENDIX — Track A suspicions
+
+> **Do not read this before your independent pass is written to disk.**
+>
+> This file exists because the requester has opinions, and opinions in a review
+> brief become the reviewer's findings. Everything below is unverified belief.
+> None of it has been independently checked. Some of it is probably wrong —
+> that is the point of you having written Parts 1–4 first.
+>
+> If your Parts 1–4 are not yet on disk, close this file.
+
+---
+
+## S1 — Every owning slice has already shipped
+
+Each control's `#[ignore]` names the slice expected to resolve it. All of those
+slices have landed:
+
+| Controls | Named owner | Owner status |
+|---|---|---|
+| `same_path_root_replacement_is_not_silently_adopted` | Slice 1 (T022–T029) | shipped |
+| `capacity_refused_open_creates_no_slot_and_no_watcher`, `configured_capacity_bounds_the_process_not_each_load`, `concurrent_first_open_performs_exactly_one_cold_load` | Slice 2 (T030–T040) | shipped |
+| the remaining seven | Slice 4 (spec 028) | shipped as 11.0.0 |
+
+So no unshipped slice owns any of them. Suspicion: this is why nobody has
+looked — each was somebody's future problem, and the future arrived without a
+handoff.
+
+## S2 — Four of them still carry prose predicting a slice that already landed
+
+The four Slice-1/Slice-2 rows still read "remove this attribute in Slice 2
+(T030–T040) when …". Those slices shipped months ago. The seven Slice-4 rows
+were rewritten on 2026-08-20 to say "observed still red … after the Slice 4
+activation cut", but the older four were not.
+
+Suspicion: a stale prediction left standing in a test attribute is itself a
+defect, independent of whether the control is right. It tells the next reader
+the item is somebody else's job.
+
+## S3 — Two of them may not be fixable by production code at all
+
+`watcher_mutation_during_candidate_build_is_not_discarded` and
+`whole_project_publication_preserves_latest_siblings` were rewritten to say
+"observed still red (precondition window unreachable)". If the control cannot
+reach the state it asserts on, then no amount of correct production code turns
+it green.
+
+Suspicion: these two are a different category from the other nine, and treating
+them as ordinary failures is a category error. They may need a different seam,
+an explicit adjudication, or deletion — but not a fix.
+
+This is the specific pair a second opinion was reserved for.
+
+## S4 — "Still red at the daemon seam" may be doing a lot of work
+
+Five controls were rewritten to say they remain red "at the daemon/watcher
+seams they drive". That phrasing was written by the same process that ran them
+un-ignored and observed the failure — it records *that* they failed, not *why*.
+
+Suspicion: nobody has distinguished "the behaviour is genuinely absent" from
+"the control's setup no longer constructs the situation it was written for". A
+control written against a V10 daemon may be assembling a world the V11 cut no
+longer has.
+
+## S5 — The roster's fail-closed rule may be load-bearing in an unintended way
+
+`scripts/slice0-oracle-artifact.cjs` treats a RED control that starts passing
+as an **error**. That is deliberate and defensible. But it also means: if the
+V11 cut accidentally made one of these pass for the wrong reason, CI would go
+red and the cheapest fix would look like reclassifying it to `RESOLVED_CASES`.
+
+Suspicion: worth checking whether any control is currently passing-but-listed,
+or whether the roster has drifted from the test file in either direction.
+
+## S6 — The controls might be better evidence than the code
+
+The unexamined assumption in the whole framing is that failing controls are
+debt. The opposite reading is available: eleven controls that survived four
+slices of pressure without being quietly deleted are the most honest artifact
+in the repository, and the correct response is to fix the code.
+
+Suspicion: I lean toward this reading and am aware that I lean toward it, which
+is exactly why it is in a sealed appendix rather than in the brief.
+
+## What I deliberately did not tell you in the brief
+
+- Which controls I think are wrong.
+- That I suspect S3's pair is unfixable.
+- That I consider S2's stale prose a defect in its own right.
+- Any ranking of the eleven by severity or difficulty.
+
+If your independent pass reached different conclusions from these, your pass is
+the more valuable document. Say so plainly in Part 5.

--- a/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
+++ b/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
@@ -142,36 +142,64 @@ owed and currently unowned by any remaining slice.
 **Run it**: `node scripts/slice0-oracle-artifact.cjs` → writes
 `target/ci/lifecycle-v11/slice-0-oracle-contract.json`. CI's `rust` job runs it.
 
-| Control | Named owner (already shipped) | Defect / seam |
-|---|---|---|
-| `capacity_refused_open_creates_no_slot_and_no_watcher` | Slice 2 (T030–T040) | 2.1 — admission refusal is not a typed outcome |
-| `configured_capacity_bounds_the_process_not_each_load` | Slice 2 (T030–T040) | 2.5 — capacity is not a process-wide reservation |
-| `internals::daemon::tests::concurrent_first_open_performs_exactly_one_cold_load` | Slice 2 (T030–T040) | 2.4 — project admission is not single-flight |
-| `same_path_root_replacement_is_not_silently_adopted` | Slice 1 (T022–T029) | physical root identity not canonical/fenced |
-| `empty_placeholder_publication_refuses_watcher_mutation` | Slice 4 (spec 028) | 2.2/2.3 — watcher seam |
-| `failed_reload_retains_the_recovery_observer` | Slice 4 (spec 028) | 2.10 — observer handoff destructive at daemon seam |
-| `observer_replacement_gap_is_latched_as_non_current` | Slice 4 (spec 028) | handoff does not latch the gap |
-| `old_observer_delivery_after_promotion_is_not_current` | Slice 4 (spec 028) | no stable observer token fencing delivery |
-| `watcher_mutation_during_candidate_build_is_not_discarded` | Slice 4 (spec 028) | 2.7/2.9 — precondition window unreachable at this seam |
-| `whole_project_publication_preserves_latest_siblings` | Slice 4 (spec 028) | FR-008/FR-009/SC-005 — precondition window unreachable |
-| `snapshot_seed_is_not_queryable_before_verification` | Slice 4 (spec 028) | 2.11 — `SnapshotStore` per-entry verify-state wiring absent |
+**DISPOSITIONED 2026-08-21** by two independent read-only passes (LINUS,
+HOLMES) on shipped `main`, reconciled with no `cargo` battery and no patches.
+This is a **disposition table, not an implementation queue.**
 
-Two sub-shapes, and they need different work:
+The eleven split into two kinds, and the distinction decides who is wrong:
 
-- **"Still red at the seam"** (watcher/daemon) — the behavior is genuinely
-  absent. Ordinary RED-first fix work.
-- **"Precondition window unreachable"** (`watcher_mutation_during_candidate_build…`,
-  `whole_project_publication_preserves_latest_siblings`) — the control cannot
-  *reach* the state it asserts on at this seam. Fixing production code will not
-  turn these green on its own; the control needs a seam where the window is
-  observable, or an explicit adjudication recorded in the evidence doc. Do not
-  quietly weaken the assertion.
+### Control-stale (3) — retarget the test body; do NOT change production to win
 
-The four Slice-1/Slice-2 rows still carry **stale prose** predicting a slice that
-already landed ("remove this attribute in Slice 2 …"). Whoever picks these up
-must rewrite those `#[ignore]` reasons to name the real carried owner, exactly as
-the seven Slice-4 rows were rewritten on 2026-08-20 — a prediction that has been
-falsified is not allowed to stand in the tree.
+The property is still worth having, but the body asserts a *retired encoding*.
+Rewriting production to satisfy the old assertion would move the code away from
+the frozen oracle, not toward it.
+
+| Control | Why the body is stale |
+|---|---|
+| `capacity_refused_open_creates_no_slot_and_no_watcher` | V11 answers a refused open with `Ok` + typed `SourceRefusal` + a non-ready slot, not `Err` + zero slots. FR-004 strict acquisition is the lease. Unmeasured residual: `activate` still starts a watcher (`daemon.rs:3398-3403`) |
+| `whole_project_publication_preserves_latest_siblings` | Frozen oracle is pause A / publish B / rebase / tokens / one store. The body races V10 `LiveIndex::reload` against 1500 files in 150 ms |
+| `configured_capacity_bounds_the_process_not_each_load` | FR-004 makes capacity a per-candidate catalog; SC-025 owns `ProcessCapacityPool`; `SYMFORGE_MAX_INDEX_FILES` is per discovery pass. Forcing it process-wide fights FR-004 and still misses SC-025 |
+
+### Code-wrong (8) — keep ignored and fail-closed; do not un-ignore for green
+
+| Control | Live miss |
+|---|---|
+| `empty_placeholder_publication_refuses_watcher_mutation` | `add_file` (`store.rs:2820-2831`) has no EmptyBootstrap gate; the default-suite check at `store.rs:6402-6412` is a paper-over |
+| `failed_reload_retains_the_recovery_observer` | aborts the watcher then `?`; no replacement on `Err` |
+| `observer_replacement_gap_is_latched_as_non_current` | `recompute_freshness_locked` drops the historical gap → `Current` |
+| `old_observer_delivery_after_promotion_is_not_current` | same rederive; no token fence |
+| `snapshot_seed_is_not_queryable_before_verification` | persist hydrates files immediately; `get_file` has no Pending gate; `is_ready()` is status-only |
+| `same_path_root_replacement_is_not_silently_adopted` | path-keyed map; publishes `Current` |
+| `concurrent_first_open_performs_exactly_one_cold_load` | load happens outside the lock then `or_insert`; `admit_project` does not skip bootstrap |
+| `watcher_mutation_during_candidate_build_is_not_discarded` | `store.rs:2403-2436` still reaches `swap_and_publish`; `IsolatedCandidate` appears **zero** times in `store.rs` |
+
+### The "precondition window unreachable" claim was false
+
+Two controls carried `#[ignore]` text asserting their precondition window was
+unreachable. On `watcher_mutation_during_candidate_build_is_not_discarded` that
+is **false on the shipped tree** — the window is reachable; the seam simply
+never routes through the candidate pipeline. The other, 
+`whole_project_publication_preserves_latest_siblings`, is control-stale rather
+than unreachable. Both strings were corrected in the tree on 2026-08-21.
+
+That claim originated from a process that ran the controls un-ignored, observed
+failure, and wrote down *that* they failed — then described *why* without
+having established it. It stood unchallenged for a day and would have
+misdirected whoever picked this up next.
+
+### Owed, not done
+
+`src/daemon.rs`'s `#[ignore]` string still predicts "remove this attribute in
+Slice 2", a slice that shipped. The correction is written and was reverted
+unapplied: `daemon.rs` is inside `FULL_SOURCE_PIN_V1`'s file set, so editing it
+moves a seal that only the Rust oracle may recompute, which needs a full gate
+run. Do it in a change that can afford one.
+
+### Track A residuals from the reviewers
+
+- No `cargo test` battery was run against the ignored roster in these passes.
+- `src/server_api` was not fetched; MCP `is_ready` vs `get_file` is unaudited.
+- Do not reopen PR #603 to discharge any of this.
 
 **The roster's fail-closed contract, so you do not fight it:**
 

--- a/docs/reviews/GROVE-TEAM-REPORT-track-a-and-029-2026-08-21.md
+++ b/docs/reviews/GROVE-TEAM-REPORT-track-a-and-029-2026-08-21.md
@@ -1,0 +1,102 @@
+# Grove team report — for the Feature 020 / 029 agent
+
+From: GROVE (campaign runner) with LINUS, HOLMES, JEZ, LARRY, JUNIO, FRED
+To: the agent holding the 029 spec/plan and the Slice 5 brief
+Date: 2026-08-21 (Europe/Ljubljana)
+Repo: `special-place-ai-heaven/symforge`
+
+This is one file. It is compiled from specialists' Output blocks, not a second review. Grove did not write the Rust, the review, or the git.
+
+## SHAs
+
+| Ref | SHA | What |
+|---|---|---|
+| `main` (v11 shipped) | `2f27cb681687b1b2948dc67838a449ae7ea69247` | Track A read this |
+| `feature-029-mechanical-removal` | `cd6b18adf26f` | Nine 029 amendments; §5 read this |
+| Prior brief (not restaffed) | `8e3edc23ed2d` | Slice 5 review-request; Grok+Composer already covered 029 |
+
+## What this team will not do
+
+- We will not spend compute making leftover Slice 0 oracles green so a draft PR looks busy.
+- We will not run a third 029 spec/plan pass under the same framing as Grok and Composer.
+- We will not patch, un-ignore, merge, or reopen **PR #603**.
+- We will not treat default-suite green as Slice 0 success.
+
+## PR #603 (leftover, retired)
+
+Draft `fix(lifecycle): discharge Feature 020 Slice 0 daemon/watcher controls` opened hours after v11.0.0 (`#601` + `#602`). It was 2 commits ahead of `main` (`f568838`, `a12ce7c`) to un-ignore Slice 0 controls. CI went red (rust, then `live_index_integration::test_persist_round_trip`). Rob stopped leftover-test work. JUNIO Lane A: closed #603 without merge; deleted `cursor/feature-020-slice0-green-fb1a` (last SHA `a12ce7c56f96`, recovery: recreate ref). Main untouched.
+
+## Track A — eleven still-RED Slice 0 controls
+
+Independent read-only passes on `main` @ `2f27cb68`. LINUS file: `/workspace/REVIEW-FINDINGS-linus-feature-020-slice-0-reconcile-2026-08-21.md`. HOLMES tables in chat. Reconciled. No `cargo test` battery. No patches.
+
+Keep `#[ignore]` + fail-closed Slice 0 oracle roster. Do not treat green default `cargo test` as Slice 0 success.
+
+### Stale tests (move the body; do not SWITCH production to win the encoding)
+
+| Control | Agreed | Why |
+|---|---|---|
+| `capacity_refused_open_creates_no_slot_and_no_watcher` | **control-stale** | V11 is `Ok` + typed `SourceRefusal` / non-ready slot, not `Err` + 0 slots. FR-004 strict acquisition is the lease. Residual: `activate` still starts a watcher (`daemon.rs:3398–3403`) — unmeasured by this body. |
+| `whole_project_publication_preserves_latest_siblings` | **control-stale** | Frozen oracle is pause A / publish B / rebase / tokens / one store. Body is V10 `LiveIndex::reload` vs 1500 files / 150ms. Switching reload to win the race is not the oracle. |
+| `configured_capacity_bounds_the_process_not_each_load` | **control-stale** | FR-004 is per-candidate catalog. SC-025 is `ProcessCapacityPool`. `SYMFORGE_MAX_INDEX_FILES` is per discovery pass. Making it process-wide fights FR-004 and still misses SC-025. |
+
+### Code-wrong (keep the control; do not un-ignore as fake green)
+
+| Control | Agreed | Live miss (file:line from the reviewers) |
+|---|---|---|
+| `empty_placeholder_publication_refuses_watcher_mutation` | **code-wrong** | `spec.md:14–20` Loading holds none. `add_file` `store.rs:2820–2831` has no EmptyBootstrap gate. Default-suite `store.rs:6402–6412` is a paper-over. |
+| `failed_reload_retains_the_recovery_observer` | **code-wrong** | abort watcher then `?`; no replacement on Err |
+| `observer_replacement_gap_is_latched_as_non_current` | **code-wrong** | `recompute_freshness_locked` drops historical gap → Current |
+| `old_observer_delivery_after_promotion_is_not_current` | **code-wrong** | same rederive; no token fence |
+| `snapshot_seed_is_not_queryable_before_verification` | **code-wrong** | persist hydrates files immediately; `get_file` has no Pending gate; `is_ready()` is status-only |
+| `same_path_root_replacement_is_not_silently_adopted` | **code-wrong** | path-keyed map; publish Current |
+| `concurrent_first_open_performs_exactly_one_cold_load` | **code-wrong** | load outside lock then `or_insert`; `admit_project` does not skip bootstrap |
+| `watcher_mutation_during_candidate_build_is_not_discarded` | **code-wrong** | `store.rs:2403–2436` still `swap_and_publish`; `IsolatedCandidate` not on this path. Ignore-text “window unreachable” is false on this SHA. Do not un-ignore until a deterministic pause exists. Official TEST-CANDIDATE does not retire this seam. |
+
+Already RESOLVED, not classified: `internals::watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b`.
+
+### Track A residuals
+
+- No `cargo test` on the ignored roster in these passes.
+- `src/server_api` not fetched; MCP `is_ready` vs `get_file` unaudited.
+- LARRY was not given a punch list. Do not reopen 603 to discharge these.
+
+## §5 — two questions, uncontaminated, on `cd6b18ad`
+
+LINUS file: `/workspace/REVIEW-FINDINGS-linus-feature-029-two-questions-2026-08-21.md`. HOLMES independent (did not read findings). Did not re-review the rest of 029. No prior Grok/Composer endorsement used.
+
+### 1. Bracket-as-P1
+
+**Team: the control is discipline; making the bracket the slice is over-engineering.**
+
+- LINUS: **split.** Keep C-1 / US1 Independent Test (must name the field that moved) as a **gate**. Demote “primary deliverable is not the removal but the neutrality bracket” (`plan.md:20–24`) and “standalone value / any future removal” (`spec.md:32–42`). Put roster disposition back as the slice. Do not ship a bracketing platform so the slice has a product when it deletes nothing.
+- HOLMES: **over-engineering.** SWITCH the priority: bracket is a gate, not the slice. Frozen job is delete-only-proven-unreachable. C-2 already owns public-surface neutrality. Markdown baseline + void→armed diagram is not a product. “Any future removal” is YAGNI. **Keep C-1 and US1 scenario 3 as the canary — do not NIT the canary away.** Demote US1 to admission-for-removal; if anything is evidenced-unreachable, US2 is P1.
+
+They agree on the change: demote US1 from P1 product to admission instrument. Keep the canary.
+
+### 2. C-7 empty removal is a pass
+
+**Team: discipline. Stay.**
+
+- LINUS: C-7 requires C-1 armed ∧ C-6 every prediction discharged with command+output ∧ evidence says nothing removed (`neutrality-bracket-v1.md:149–159`). Honest disposition, not a line count (`spec.md:231–235`). Would not change C-7. `plan.md:45` is looser wording, not the defect.
+- HOLMES: governing constraint forbids unevidenced deletion; failing the slice for an empty recon would force the invented removal C-7 exists to block. Residual: pass still needs C-6 verbatim transcripts. Empty ≠ skip disposition. **Do not combine with bracket-as-P1 to close Slice 5 on markdown alone.**
+
+They agree: empty is a pass only as full roster disposition, not as “zero lines.”
+
+## What we recommend you do next
+
+1. Treat Track A as a **disposition table**, not an implementation queue. Retarget the three stale bodies. Keep the eight code-wrong controls ignored-fail-closed until a real seam owner exists. Do not invent a 603-class PR.
+2. On 029 @ `cd6b18ad`: demote bracket-as-P1 per both reviewers; keep C-1 canary; leave C-7; do not close the slice on the diagram.
+3. If you want code, name **one** seam and Grove will @ LARRY for that seam only. Default: no.
+
+## Board at report time
+
+| Job | Owner | Status |
+|---|---|---|
+| 603 leftover CI / discharge | JEZ / LARRY / FRED | cancelled; PR closed, branch deleted |
+| Track A Slice 0 RED controls | LINUS + HOLMES | done-with-evidence (agreed table) |
+| §5 bracket-as-P1 + C-7 | LINUS + HOLMES | done-with-evidence (agreed substance) |
+| Implementation of Track A seams | LARRY | not dispatched |
+| Push / merge | JUNIO | Lane B unless Rob says |
+
+Blocked on human: none for this report.

--- a/docs/reviews/REVIEW-FINDINGS-composer-feature-020-slice-5-spec-plan-2026-08-21.md
+++ b/docs/reviews/REVIEW-FINDINGS-composer-feature-020-slice-5-spec-plan-2026-08-21.md
@@ -1,0 +1,88 @@
+# Review findings — Feature 020 Slice 5 spec+plan (Composer)
+
+**Model**: Composer  
+**Date**: 2026-08-21  
+**Scope**: `specs/029-mechanical-removal/{spec,plan,research,data-model,quickstart,contracts/*}` vs frozen Phase 7 roster and checker source
+
+---
+
+### MAJOR — R1 is true for the gate but overstates automatic coverage of the manifest atom list
+
+- **Where**: `specs/029-mechanical-removal/research.md:30-33`, `scripts/validate-lifecycle-oracle-traceability.cjs:2032-2034,2063`
+- **Claim**: `directPublicAtoms` drops every manifest atom with more than three `::` segments before building the postactivation set, so the lifecycle equality check covers 34 type/module-level atoms today, not all 64 `introduced_v11_atoms` rows (30 associated-method paths are manifest-only for this gate).
+- **Why it matters**: Removing a public associated item (e.g. `symforge::embed::Claim::value`) leaves `symforge::embed::Claim` in the derived set, so `ordinaryRetirementLifecycle` can stay green while real public behaviour shrinks. R1’s “cannot remove a public atom at all” is process-true via `RemovalCandidate.visibility = public` but not checker-true for method-level API.
+- **Recommended fix**: Narrow R1/plan/C-2 prose to “the checker freezes the 3-segment lifecycle atom set (currently 34 atoms)”; add `python execution/refreeze_v11.py verify-internal --target-ref HEAD` (or the consumer compile-fail suite) to research R6 / quickstart Step 6 for **every** removal landing, not only the T076 embed path.
+
+---
+
+### MINOR — Baseline requires `lifecycle_phase` but no runbook command emits it
+
+- **Where**: `specs/029-mechanical-removal/data-model.md:22,37`, `specs/029-mechanical-removal/quickstart.md:16-27`, `scripts/validate-lifecycle-oracle-traceability.cjs:3609`
+- **Claim**: Step 1 runs the traceability checker, which prints only `OK (…)` and never names `preactivation` or `postactivation`, yet `NeutralityBaseline.lifecycle_phase` is mandatory and must be “recorded as observed”.
+- **Why it matters**: Two executors can both paste “postactivation” with only a green checker as justification; one may have inferred it. That violates FR-001/FR-013 provenance for the field that bounds the whole slice.
+- **Recommended fix**: Add an explicit sub-second probe to quickstart Step 1 (document the `ordinaryRetirementLifecycle` helper or a 10-line node one-liner) and require its stdout in `commands.lifecycle_phase`.
+
+---
+
+### MINOR — Pin arithmetic prose overstates EXCLUDED pin movement
+
+- **Where**: `specs/029-mechanical-removal/research.md:51-52,65-66`, `specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md:96-98`, `tests/preventive_runtime_dark_v11.rs:958-979,1054-1080`
+- **Claim**: `EXCLUDED_RUNTIME_SOURCE_PIN_V1` fingerprints only the 20 paths in `EXCLUDED_RUNTIME_SOURCE_PATHS` (`index_lifecycle/**` + `server_api.rs`), not all of `src/`.
+- **Why it matters**: A T075 deletion in e.g. `src/daemon.rs` must move `FULL_SOURCE_PIN_V1` but should leave the excluded pin unchanged. C-5’s “counts stay flat across a non-empty removal is a defect” is only true when the removal intersects that pin’s file set; flat excluded counts after a deletion elsewhere are correct.
+- **Recommended fix**: Replace research R2’s “move on any `src/` deletion” with “move when the deletion intersects the pin’s file set”; in quickstart Step 6, say excluded pin differs only when an excluded-path file changed.
+
+---
+
+### NIT — Open observation #1 is already cheaply closed on current `main`
+
+- **Where**: `specs/029-mechanical-removal/research.md:191-193`, `specs/029-mechanical-removal/quickstart.md:16-27`
+- **Claim**: Deferring lifecycle-phase observation to execution is correct (Principle I), but the tree is **`postactivation` today** (`actual=34`, `pre=83`, `post=34`; checker `OK`).
+- **Why it matters**: None for correctness; it confirms the slice’s bounding case (no public atom removal) applies now, not only after a future cut.
+- **Recommended fix**: Optional one-line note in research Open observations: “on a postactivation tree at spec authoring time, R1’s no-public-removal bound is already live.”
+
+---
+
+## §5 adjudication (explicit)
+
+**5.1 Bracket before removal (P1)** — **Discipline, not over-engineering.** T074/T077 already require a baseline re-run; FR-003 adds only the RED-first control the frozen roster implied but did not spell out. Given Slice 4’s “confidently wrong banner” history and Principle II, certifying a negative instrument without a positive control would repeat a known failure class. Cost is one deliberate edit discarded before deletion.
+
+**5.2 C-7 empty removal pass** — **Honest scoping, not a blank check.** C-6 plus `DischargedExpectation.evidence` (command + output, not prose) has teeth if the evidence doc is filled per data-model. The failure mode is social (inventing a deletion), and C-7 names the legitimate outcome so FR-011 is not “satisfied” by scope creep. Weak only if the executor treats discharge as a one-liner — that would violate FR-013, not C-7 itself.
+
+---
+
+## Negatives
+
+Checked and found sound:
+
+- **R1 core logic**: `deriveLifecyclePublicAtoms` is source-derived (`derivePublicApiAtoms(sourceMap)` at line 2038, then regex scan for non-embed introduced modules at 2044–2049). Manifest alone does not drive `actual`.
+- **Phase on this tree**: `postactivation` with identical 34-atom `actual` and `post` sets (command probe using checker logic; matches `node scripts/validate-lifecycle-oracle-traceability.cjs` → `OK`).
+- **Manifest counts**: python block → 12 categories, 3 kept ids, 4 kept atoms, 64 introduced rows (unchanged from brief).
+- **LegacyOpen/LegacyClosing**: `src/index_lifecycle/activation.rs:57-64` — live bootstrap states; plan/spec assumption excluding them from T075’s naive “legacy mode branches” wording is correct.
+- **R3 census asymmetry**: `source_anchor_policy` at checker line 209 matches research (V10 anchors on refreeze ancestor; V11 seams need same-tree receipts). `validatePostactivationRetirement` enforces seam resolution post-cut.
+- **Frozen roster coverage**: T074→FR-001/002/003; T075→FR-004–010 + US2; T076→FR-011 + US3; T077→FR-002/012/013 + SC-001–010. No orphaned Phase 7 task.
+- **Success criteria measurability**: SC-003–SC-007 are zero-count checks with explicit numerators; SC-008 is the enumerated R6 gate list; SC-009 maps to C-6 discharge records.
+- **Constitution Check**: No false PASS spotted. Weakest entries (IV, VI) still hold — full gate set unchanged, T077 mandates adversarial review + cfg sweep.
+- **Deliberate §7 choices**: Contract-id quoting, R4 unresolved embed, omitted Complexity Tracking, non-indivisible slice — all consistent with constitution and Slice 4 evidence style.
+- **refreeze co-gate exists**: `python execution/refreeze_v11.py verify-internal --target-ref HEAD` passes on this tree (~6s); suitable as a supplemental public-surface gate if added to R6 as recommended above.
+
+No BLOCKER findings.
+
+---
+
+## Verdict
+
+1. **Is the load-bearing claim in §4 true?** **Yes, with the MAJOR incompleteness above.** On this checkout the tree is `postactivation`; equality is against a 34-atom 3-segment set (`kept ∪ introduced` after `directPublicAtoms`), not the full 64-row manifest list. Non-public removal cannot change that set; removing a surviving 3-segment public atom would fail the checker; removing associated methods could slip past the checker but is blocked by enumeration rules and should be caught by refreeze if wired into R6.
+
+   Deciding commands:
+   ```
+   node scripts/validate-lifecycle-oracle-traceability.cjs
+   → lifecycle oracle traceability v11: OK (78 requirements, 24 acceptance oracles, 13 retirement categories)
+
+   python -c "…" (brief §4 block)
+   → categories: 12; kept atoms: 4; introduced: 64
+
+   lifecycle phase probe (checker logic replicated)
+   → phase: postactivation; actual/pre/post counts: 34/83/34
+   ```
+
+2. **Implement as written, amended, or rejected?** **Amended, then implement.** No rejection warranted: scope inversion (bracket first, deletion maybe empty) matches Phase 7 and postactivation reality. Land the three prose fixes (R1 narrowing + refreeze in R6, lifecycle_phase probe in quickstart, pin-set wording) before execution; none require frozen-tree edits.

--- a/docs/reviews/REVIEW-FINDINGS-grok-4-6-feature-020-slice-5-spec-plan-2026-08-21.md
+++ b/docs/reviews/REVIEW-FINDINGS-grok-4-6-feature-020-slice-5-spec-plan-2026-08-21.md
@@ -1,0 +1,116 @@
+# Review findings — Feature 020 V11 Slice 5 spec+plan (pre-implementation)
+
+**Reviewer:** grok-4-6
+**Date:** 2026-08-21
+**Scope:** `specs/029-mechanical-removal/{spec,plan,research,data-model,quickstart,contracts/neutrality-bracket-v1}.md` against the frozen roster and the current tree. No implementation exists. No `cargo` run.
+
+---
+
+### BLOCKER
+
+None.
+
+---
+
+### MAJOR — R1 is true on this tree and incomplete as the definition of “public behaviour”
+
+- **Where**: `specs/029-mechanical-removal/research.md:9-38`; `contracts/neutrality-bracket-v1.md:30-47` (C-2); `scripts/validate-lifecycle-oracle-traceability.cjs:1998-2070`; `specs/020-repository-knowledge-index/contracts/public-api-v11.json` `introduced_v11_atoms`; `tests/fixtures/public-api-v11-consumer/compile-fail/cases.json`; `execution/refreeze_v11.py:2634-2639`
+- **Claim**: The traceability checker’s postactivation set is kept ∪ introduced, depth ≤ 3. On this tree `actual` equals that set (34 atoms), so no *lifecycle* atom is removable. That set is not the public surface. 34 of 64 `introduced_v11_atoms` are depth-4 methods; `deriveLifecyclePublicAtoms` never sees them (`embed` is excluded from the 2044–2049 regex; `directPublicAtoms` drops `split("::").length > 3`). `refreeze_v11.py` still requires the full 64-atom introduced set, and the consumer compile-fail/dependent-positive fixtures pin names the lifecycle checker does not.
+- **Why it matters**: C-2 would stay green after deleting `Claim::value` (or any other depth-4 method). That is a public-behaviour change the frozen consumer surface would catch and the Slice 5 contract would not. The 2044–2049 regex also has no `cfg(test)` filter; it scans only `server_api`, so a test-only `pub fn` there would move the lifecycle set without being API.
+- **Recommended fix**: State C-2 as one conjunct of public-behaviour neutrality, not the definition. Name the other owners: the 64-atom introduced set, the consumer fixtures, and `verify-internal`. Keep lifecycle-atom immutability. Do not treat a green `ordinaryRetirementLifecycle` as “public behaviour unchanged.”
+
+### MAJOR — Open observation 1 is already answered; the Observe step cannot record it
+
+- **Where**: `research.md:189-193`; `plan.md:128`; `quickstart.md:16-27`; `data-model.md:22,37`; `spec.md:161-163` (FR-007)
+- **Claim**: The phase is `postactivation`. `node scripts/validate-lifecycle-oracle-traceability.cjs` prints `OK (78 requirements, 24 acceptance oracles, 13 retirement categories)` and does not print the phase, yet Step 1 tells the executor to “record which frozen set the tree currently matches” from that output. FR-007 still allows either frozen set; C-2 already requires postactivation.
+- **Why it matters**: R1’s “cannot remove a public atom” is only true in postactivation. Deferring that at plan time was Principle I. Leaving it deferred after it is a one-second derivation, and pointing the observe step at a command that cannot fill `lifecycle_phase`, is an unobserved field. FR-007’s either-set wording is now the wrong rule for this tree.
+- **Recommended fix**: Record `postactivation` in research (observation 1 closed, with the derivation). Change quickstart Step 1 to a command that *emits* the phase (the checker’s `ordinaryRetirementLifecycle` result, or the independent derivation). Tighten FR-007 / SC-004 to “the observed postactivation set.”
+
+### MAJOR — C-5’s audit property is false for T076 and for any in-file deletion
+
+- **Where**: `contracts/neutrality-bracket-v1.md:87-98`; `research.md:49-67`; `tests/preventive_runtime_dark_v11.rs:960-1110`
+- **Claim**: C-5 requires both whole-source pins’ file and byte counts to move downward by the removed amount, and treats a flat count across a non-empty removal as a defect. `EXCLUDED_RUNTIME_SOURCE_PIN_V1` is the 20-file set `index_lifecycle/**` + `server_api.rs`. `src/embed.rs` is outside that set. `FULL_SOURCE_PIN_V1` covers all of `src/`. Deleting bytes inside a file does not change file count.
+- **Why it matters**: T076’s target is `src/embed.rs`. A real embed deletion moves FULL bytes down, leaves FULL file count flat, and leaves EXCLUDED entirely flat. C-5 as written refuses the correct refresh. An executor who then “fixes” EXCLUDED is corrupting a pin that did not move.
+- **Recommended fix**: Per pin: counts must not *rise*. File count may stay flat when no file was deleted. A pin whose path set does not contain the removed bytes must stay identical. Direction is checked only on pins that actually covered the deletion.
+
+### MAJOR — US1’s Independent Test is the vacuous check Principle II forbids
+
+- **Where**: `spec.md:41-45` vs `:56-59`, `:154-155` (FR-003), `:198-199` (SC-002); `research.md:125-144`; `.specify/memory/constitution.md:36-41`
+- **Claim**: US1’s Independent Test is: capture, change nothing, re-run, confirm identity. A comparison that never moves would pass that test whether or not it can detect a change. Scenario 3, FR-003, SC-002, and C-1 already require the positive control.
+- **Why it matters**: Spec-kit Independent Tests are what an executor uses to close a story alone. Closing US1 on the null re-run skips the only thing that makes the bracket a bracket. That is the `format_search_envelope` shape the research cites.
+- **Recommended fix**: Replace the Independent Test with the control: a named field must move, then the control edit is discarded. Keep the null re-run as scenario 2, not as the story’s standalone proof.
+
+---
+
+### MINOR — C-6’s schema has teeth; nothing machine-checks the evidence field
+
+- **Where**: `contracts/neutrality-bracket-v1.md:102-111`; `data-model.md:102-118`
+- **Claim**: A `DischargedExpectation` requires `observed`, a command-backed `evidence` citation, and `discharge ∈ {already-removed, never-existed}`, and forbids substitution. No checker reads that document.
+- **Why it matters**: C-7’s empty pass is honest only if those records are real observations. A one-line “already gone” with no failing-capable command would still parse as a filled-in record. FR-012 (the T077 review) is the only backstop.
+- **Recommended fix**: In the evidence doc template, require the discharging command and its output verbatim, one record per T075/T076 predicted class. That is enough; do not add a new gate.
+
+### MINOR — Principle V is claimed PASS for a prose state machine
+
+- **Where**: `plan.md:59`; `data-model.md:63-71`
+- **Claim**: `NeutralityComparison` has “no edge from `void` to `armed`.” That edge is a markdown diagram. Anyone can write an evidence doc that skips it.
+- **Why it matters**: Principle V’s force is types that cannot spell the illegal state. Applied to artifacts this is a checklist, and C-1’s “refuses void” is still a human gate. The PASS is not false; it is the weakest of the six.
+- **Recommended fix**: Either keep the PASS and say “document convention, enforced by T077 review,” or drop V to “PASS with that limit.” Do not pretend the diagram makes `void → armed` unrepresentable.
+
+### MINOR — Quickstart does not name commands for two baseline fields
+
+- **Where**: `quickstart.md:29-48`; `data-model.md:25-29,33-34`
+- **Claim**: `activation_result` and `writer_reachability_verdict` are required baseline fields, each needing a command. Step 2 lists cargo/node gates and then says “also record” those results, with no command.
+- **Why it matters**: Data-model rule: a field without a command is not a captured field. T074 will invent the commands under time pressure.
+- **Recommended fix**: Name them (the activation-cut writer-reachability case and the activation-mode observation already cited in `plan.md`’s test list).
+
+---
+
+### NIT
+
+None that survive the bar. `plan.md` listing `tasks.md` before `/speckit-tasks` is expected, not a defect.
+
+---
+
+## Adjudications (§5)
+
+### 5.1 Bracket as P1 — discipline, not over-engineering
+
+T074/T077 already mandate a baseline and a re-run. The only added cost is C-1’s one deliberate control, discarded before removal. That is Principle II applied to a negative instrument, and it is cheap. Making the instrument P1 is correct because an empty T075 still needs a working bracket (spec Edge Cases, C-7). What *is* over-engineering is not the P1 call; it is US1’s Independent Test describing the vacuous half (MAJOR above). Fix that test. Keep P1.
+
+### 5.2 C-7 empty removal as a pass — honest scoping, not a pre-authorized excuse
+
+Slice 4 may already have deleted most of T075/T076. Naming the empty outcome a pass is how you stop someone inventing a deletion. C-6 is not a formality on paper: closed `discharge` enum, evidence must be an observation, substitution forbidden. It is a formality in enforcement (MINOR above). That is not a reason to drop C-7. An executor who writes “already gone” with no command fails FR-011/FR-013 and should fail T077, not C-7.
+
+---
+
+## Negatives
+
+- **R1’s three-state check, as far as it goes.** `ordinaryRetirementLifecycle` (cjs:2054-2070) compares source-derived `actual` to preactivation (all migration atoms, depth ≤ 3) and postactivation (kept ∪ introduced, depth ≤ 3). Anything else is `RETIREMENT_LIFECYCLE_PHASE_INVALID`. Python against the manifest: 12 categories, kept `v10-00-crate-root` / `v10-02-embed-module` / `v10-03-engine-info`, 4 kept atoms, 64 introduced. Independent derivation: `actual` length 34, equals postactivation, not preactivation (83). Checker: `lifecycle oracle traceability v11: OK (78 requirements, 24 acceptance oracles, 13 retirement categories)`. `derivePublicApiAtoms` is source-derived (`lib.rs` `pub mod` + `embed.rs` pub items/`pub use`). The 2044–2049 regex currently scans only `server_api` and adds exactly `ServerBootstrapError`, `ServerExit`, `run` — no extras today (`actualOnly` empty).
+- **Phase is postactivation**, so R1’s operational conclusion holds: no depth-≤3 lifecycle atom is removable. Plan is not mis-scoped.
+- **`LegacyOpen` / `LegacyClosing` are live.** `src/index_lifecycle/activation.rs:7-64` — monotonic `LegacyOpen -> LegacyClosing -> PreventiveV1Open`, process boot path. Excluding them from T075 is correct. Acting on the roster’s “legacy mode branches” wording would delete startup. C-4’s example is the right one.
+- **R3 asymmetry is real on this tree.** Ordinary postactivation skips current-tree V10 `src/` member resolution (`validateRetirement` cjs:2687-2691) and instead runs `validatePostactivationRetirement`, which fails if a retired API atom is reachable or a frozen seam lacks a same-tree receipt (`EXPECTED_PRODUCTION_SEAMS`, cjs:160-168, 2073-2088). Materialized/release evidence resolves V10 anchors on `gitRustSourceMap(approved_refreeze_commit)` (cjs:2892-2894). Deleting retired V10 code cannot break the ordinary census; deleting a V11 seam can. FR-005 is the right tripwire.
+- **Pin owners match R2.** `FULL_SOURCE_PIN_V1` = all `src/` (196 files, 9_300_142 bytes). `EXCLUDED_RUNTIME_SOURCE_PIN_V1` = 20 listed relative paths (cjs-equivalent list in the test). Refresh is `source_set_fingerprint` over LF-normalized bytes. Counts in research.md match the test constants. The subset relationship is why C-5 as written is wrong (MAJOR), not why the pins are the wrong seals.
+- **T074–T077 are covered.** T074 → FR-001, US1, SC-001. T075 → FR-004/005/006/008/009, US2, C-4/C-6. T076 → FR-011, US3, R4. T077 → FR-002/003/012/013, SC-008/010. No roster task is orphaned. T075’s named classes are predictions to perform or discharge, not extra FRs.
+- **SC-003–SC-007 are measurable** once the artifacts exist: evidence citations on candidates, checker equality, `git diff` over `specs/020-…`, seam set vs `EXPECTED_PRODUCTION_SEAMS`, tests deleted only with their subject. None is a “zero X” nobody can check.
+- **R4 unresolved embed is correct.** `src/embed.rs` is 163 lines of the kept identity plus `pub use` of V11 atoms plus a `#[cfg(test)]` contract module. Predicting “no dead V10 left” from line count would be Principle I. Leave it to the allowlist suite.
+- **Known deliberate items (§7) not re-reported:** contract identifiers in the spec; Complexity Tracking omitted; slice not indivisible.
+- **No live `internals::` `--exact` footgun** in the 029 docs. Quickstart’s suite filter is `--lib --bins --tests`, not a pre-cut exact name.
+- **Constitution I, II, III, IV, VI** as argued in `plan.md` match the artifacts, with I’s observe-step hole called out above. II is carried by C-1, not by US1’s Independent Test.
+
+---
+
+## Verdict
+
+1. **Is the load-bearing claim in §4 true?** **Yes**, on this tree, for the lifecycle atom set the checker actually compares.
+
+   Command output that decided it:
+
+   ```
+   python (manifest): categories: 12; kept ids: ['v10-00-crate-root', 'v10-02-embed-module', 'v10-03-engine-info']; kept atoms: 4; introduced: 64
+   node scripts/validate-lifecycle-oracle-traceability.cjs: lifecycle oracle traceability v11: OK (78 requirements, 24 acceptance oracles, 13 retirement categories)
+   independent derivation of ordinaryRetirementLifecycle: phase=postactivation; actual=34; preactivation=83; postactivation=34; scannedModules=['server_api']; introduced depth {2:1, 3:29, 4:34}; actualOnly=[]; postOnly=[]
+   ```
+
+   Incomplete in the sense of the MAJOR: 34 depth-4 introduced methods and the consumer/refreeze gates also constrain public behaviour and are outside C-2.
+
+2. **Should this spec+plan be implemented as written, amended, or rejected?** **Amended.** Do not implement as written. Do not reject. Close observation 1 (`postactivation`), split C-2 from the rest of the public surface, fix C-5’s pin arithmetic, and replace US1’s Independent Test with the control. The two design decisions (bracket as P1, C-7 empty pass) stand.

--- a/docs/reviews/REVIEW-REQUEST-feature-020-slice-5-spec-plan-2026-08-21.md
+++ b/docs/reviews/REVIEW-REQUEST-feature-020-slice-5-spec-plan-2026-08-21.md
@@ -1,0 +1,311 @@
+# Review request — Feature 020 V11, Slice 5 (mechanical removal): SPEC AND PLAN, pre-implementation
+
+## Instructions to the reviewing model
+
+**This is a READ-ONLY review. Write no code. Change no file except your own
+findings file. Do not run `cargo build`, `cargo test`, or anything that takes
+minutes — every verification you need is a `grep`, a `sed -n`, or a sub-second
+node/python invocation, and the exact commands are given below.**
+
+**Keep verbosity low. Do not explain the codebase back to me. Produce one file
+and nothing else.**
+
+Write your findings to:
+
+```
+docs/reviews/REVIEW-FINDINGS-<your-model-name>-feature-020-slice-5-spec-plan-2026-08-21.md
+```
+
+Use your own model name in the filename (e.g. `gpt-5-2`, `grok-4-6`, `kimi-k3`,
+`composer`) so several independent reviews can sit side by side and be diffed.
+
+Every finding uses exactly this shape:
+
+```
+### <BLOCKER|MAJOR|MINOR|NIT> — <one-line title>
+- **Where**: path:line
+- **Claim**: one sentence, falsifiable.
+- **Why it matters**: one or two sentences.
+- **Recommended fix**: concrete, minimal.
+```
+
+End the file with a `## Negatives` section listing, explicitly, the things you
+checked and found sound. A silent omission is indistinguishable from not having
+looked, which is why this section is mandatory.
+
+If you find nothing at a severity, say so. Do not pad.
+
+Additionally, end with a `## Verdict` section answering exactly two questions:
+
+1. **Is the load-bearing claim in §4 true?** (yes / no / cannot determine, plus
+   the command output that decided it.)
+2. **Should this spec+plan be implemented as written, amended, or rejected?**
+
+---
+
+## 1. What you are reviewing, and what you are NOT
+
+You are reviewing **two documents describing work that has not started**:
+
+- `specs/029-mechanical-removal/spec.md`
+- `specs/029-mechanical-removal/plan.md`
+
+plus their Phase 0/1 supporting artifacts (listed in §3).
+
+You are **not** reviewing an implementation. No code has been removed. No
+baseline has been captured. The value of this review is catching a mis-scoped
+or wrongly-reasoned plan **before** anyone spends a day executing it.
+
+The most useful thing you can do is try to **falsify the central claim in §4**.
+If that claim is wrong, the plan is mis-scoped and most of the rest of the
+review is moot — say so early and loudly.
+
+---
+
+## 2. Context you need (the campaign, in six sentences)
+
+SymForge is a Rust MCP server. Feature 020 ("repository knowledge index") is a
+long campaign delivered in slices against a **frozen, immutable spec tree** at
+`specs/020-repository-knowledge-index/`, which must never be edited — including
+its checkbox bytes.
+
+Slice 4 was the "activation cut": it switched the preventive index lifecycle on
+everywhere in one indivisible change, and shipped as the breaking **11.0.0**
+release. **Slice 5 is the follow-up: delete only the code Slice 4 proved
+unreachable, and change nothing observable.** Its frozen goal text is:
+
+> "Delete only code already proven unreachable in Slice 4; do not change
+> runtime authority, public behavior, writer reachability, or activation mode."
+> — `specs/020-repository-knowledge-index/tasks.md:960-961`
+
+The project's governing rules live in `.specify/memory/constitution.md`
+(v1.0.0, six principles) and `CLAUDE.md`. Two you should hold the documents to
+hardest:
+
+- **Principle I, the reporting invariant**: a component may not report success
+  for an operation whose completion it did not observe. This applies to
+  documents too — a spec that asserts an unobserved fact is the same defect.
+- **Principle II, RED-first evidence**: every negative test must carry its
+  accepting positive control in the same test, because "a system that refuses
+  everything satisfies a lone negative perfectly."
+
+---
+
+## 3. Read these, in this order
+
+| # | Path | Why |
+|---|---|---|
+| 1 | `specs/029-mechanical-removal/spec.md` | The spec under review |
+| 2 | `specs/029-mechanical-removal/plan.md` | The plan under review |
+| 3 | `specs/029-mechanical-removal/research.md` | Phase 0. **R1 carries the load-bearing claim** |
+| 4 | `specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md` | The evidence contract, C-1…C-7 |
+| 5 | `specs/029-mechanical-removal/data-model.md` | Artifact shapes and state transitions |
+| 6 | `specs/029-mechanical-removal/quickstart.md` | The run guide |
+| 7 | `.specify/memory/constitution.md` | The six principles the plan claims to satisfy |
+| 8 | `specs/020-repository-knowledge-index/tasks.md` lines **958–966** | Phase 7, the frozen roster (T074–T077). **Read-only — never edit this tree** |
+| 9 | `docs/reviews/FEATURE-020-POST-V11-LEDGER.md` | What Feature 020 still owes overall; Slice 5 is "Track C" |
+| 10 | `docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md` §5, §6 | What Slice 4 did **not** discharge, and its six recorded residuals |
+
+Supporting source you may need to check claims against:
+
+- `scripts/validate-lifecycle-oracle-traceability.cjs` — `ordinaryRetirementLifecycle` (~line 2054)
+- `specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md`
+- `specs/020-repository-knowledge-index/contracts/public-api-v11.json`
+- `src/index_lifecycle/activation.rs` lines 1–110
+- `src/embed.rs` (163 lines total)
+- `tests/preventive_runtime_dark_v11.rs` lines 981–992 (the two source pins)
+
+---
+
+## 4. The load-bearing claim — attack this first
+
+The plan's entire scope rests on **research.md R1**, which claims:
+
+> The traceability checker defines "public behaviour unchanged" as equality
+> against a frozen **postactivation** atom set. That set is defined as
+> *kept ∪ introduced*. Therefore every public atom that survived the cut is
+> already required by contract to exist, and **Slice 5 cannot remove a public
+> atom at all** — its removal surface is strictly non-public code.
+
+If this is true, the slice is tightly bounded and the plan is right to invert
+its priorities. If it is false — if public atoms *can* legitimately leave the
+set, or if the tree is currently in the `preactivation` phase rather than
+`postactivation`, or if `deriveLifecyclePublicAtoms` does not mean what R1
+assumes — then the plan is mis-scoped and should be rejected or heavily
+amended.
+
+Verify it yourself. These are all sub-second:
+
+```bash
+# The three-state check the claim rests on
+sed -n '2054,2072p' scripts/validate-lifecycle-oracle-traceability.cjs
+
+# What "kept" and "introduced" actually resolve to
+python -c "
+import json
+d=json.load(open('specs/020-repository-knowledge-index/contracts/public-api-v11.json'))
+m=d.get('migration_v10',{}); cats=m.get('categories',[])
+kept=[c for c in cats if c.get('decision')=='keep']
+print('categories:',len(cats))
+print('kept ids:',[c['id'] for c in kept])
+print('kept atoms:',sum(len(c.get('atoms',[])) for c in kept))
+print('introduced:',len(m.get('introduced_v11_atoms',[])))
+"
+
+# Where the atoms are derived from — source map, or manifest?
+sed -n '2037,2052p' scripts/validate-lifecycle-oracle-traceability.cjs
+
+# Does the checker pass today, and what does it report?
+node scripts/validate-lifecycle-oracle-traceability.cjs
+```
+
+Expected output of the python block at time of writing: 12 categories, 3 kept
+(`v10-00-crate-root`, `v10-02-embed-module`, `v10-03-engine-info`) contributing
+4 atoms, plus 64 introduced. If your numbers differ, the tree has moved and you
+should say so — that alone would be a finding.
+
+**Specific things to try to break:**
+
+- Does `deriveLifecyclePublicAtoms` derive from *source* or from the *manifest*?
+  R1's conclusion only follows if it derives from source. My own reading says
+  line 2038 calls `derivePublicApiAtoms(sourceMap)`, and lines 2044–2049 then
+  scan module source for additional `pub` items — i.e. source-derived, so R1's
+  premise holds. **Check this independently; do not take my word for it.**
+- Note lines 2044–2049 add atoms by *regex over source* for introduced modules,
+  excluding `embed`. Does that regex path create a way for a non-public-API
+  edit to move the set, or for a genuinely removable item to look public? This
+  is the most likely place R1 is subtly wrong.
+- Is the tree currently `preactivation` or `postactivation`? The plan admits it
+  does **not** know and defers this to an executed observation
+  (research.md "Open observations", item 1). Is deferring it correct, or is it
+  cheaply knowable now and therefore a gap the plan should have closed?
+- Does any other gate constrain the public surface in a way R1 missed
+  (`execution/refreeze_v11.py`, the `tests/fixtures/public-api-v11-consumer/`
+  compile-fail cases)? R1 may be *right but incomplete*, which is a MAJOR, not
+  a BLOCKER.
+
+---
+
+## 5. Two design decisions I want explicitly adjudicated
+
+Both are deliberate. Both may be wrong. **Say so plainly if they are** — I
+would rather hear it now than after implementation. Do not soften a real
+objection into a NIT, and do not manufacture an objection to seem rigorous: if
+a decision is sound, put it in `## Negatives` and say why.
+
+### 5.1 The bracket, not the removal, is the P1 deliverable
+
+The spec makes the **neutrality bracket** (User Story 1) the P1 slice, ahead of
+any actual deletion (US2). The argument: a bracket is a negative instrument —
+it reports "nothing changed" whether or not it works — so it must be shown
+detecting a deliberate control change *before* it may certify the absence of
+one (spec FR-003, SC-002, contract C-1).
+
+**Adjudicate**: Is making the measurement instrument the primary deliverable of
+a *removal* slice correct discipline, or is it over-engineering that inflates a
+mechanical cleanup into a methodology exercise? Consider that the frozen roster
+(T074/T077) already mandates a baseline and a re-run — does the added control
+requirement earn its cost, or is it ceremony bolted onto an existing gate?
+
+### 5.2 C-7 declares an empty removal a passing outcome
+
+Contract clause C-7 states that removing **nothing** is conforming, provided
+the bracket is armed and every roster prediction is discharged with evidence.
+The stated rationale is that a slice which finds nothing to delete feels like a
+failure, and the cheapest way to make it feel successful is to delete something
+unevidenced.
+
+**Adjudicate**: Is this honest scoping, or is it a pre-authorized excuse to do
+nothing and still claim the slice closed? Specifically — does C-6 (a predicted
+removal that does not happen must leave a `DischargedExpectation` with
+evidence) actually have teeth, or is it a formality that a lazy executor could
+satisfy with a one-line "already gone" and no observation?
+
+---
+
+## 6. Other properties worth attacking
+
+- **The `LegacyOpen` finding.** The plan asserts that T075's "remove legacy mode
+  branches" must NOT mean `ActivationMode::LegacyOpen`/`LegacyClosing`, because
+  those are the live bootstrap states of the machine the cut installed. Verify
+  against `src/index_lifecycle/activation.rs:1-110`. If the plan is wrong here,
+  it is a BLOCKER in the opposite direction — the slice would be excluding a
+  legitimate target.
+- **The census claim.** research.md R3 asserts that deleting retired V10 code
+  cannot break the retirement census, because preactivation anchors resolve
+  against the approved refreeze *ancestor* tree. Check
+  `scripts/validate-lifecycle-oracle-traceability.cjs` around line 209
+  (`source_anchor_policy`) and the retirement contract. Is the asymmetry with
+  V11 seams (R3 consequence 2) real?
+- **Pin arithmetic.** Contract C-5 requires the two whole-source pins' file and
+  byte counts to move *downward* by the removed amount. Is that actually true
+  of how those pins are computed — e.g. does `EXCLUDED_RUNTIME_SOURCE_PIN_V1`
+  cover a disjoint file set such that a removal could move one pin and not the
+  other, or move one in an unexpected direction?
+- **Unfalsifiable success criteria.** Several criteria are "zero X" (SC-003
+  through SC-007). Is each actually *measurable*, or is any of them a claim
+  nobody can check after the fact?
+- **Gaps.** Is anything in the frozen T074–T077 roster **not** covered by the
+  spec's requirements? Map each frozen task to the FRs claiming to cover it and
+  report anything orphaned.
+- **The Constitution Check.** `plan.md` claims PASS on all six principles. Pick
+  the two you find least convincing and argue them.
+
+---
+
+## 7. Known and deliberate — challenge these only if you disagree
+
+Listed so you do not spend effort re-reporting them as discoveries. Each is a
+conscious decision with a stated reason; challenging one is welcome, restating
+it as a finding is not.
+
+- The spec quotes contract identifiers and file paths despite the spec template
+  saying "written for non-technical stakeholders". Reason: Constitution III
+  requires exact quoting; paraphrasing a contract identifier into friendlier
+  wording makes it wrong. The qualification is written in
+  `specs/029-mechanical-removal/checklists/requirements.md` Notes.
+- `research.md` R4 deliberately leaves "is there dead V10 embed code left?"
+  **unresolved**, rather than predicting it from `src/embed.rs` being 163
+  lines. Reason: Principle I — predicting it would be a success claim for an
+  unobserved operation.
+- Complexity Tracking is omitted from `plan.md` rather than included empty,
+  because the Constitution Check found no violations.
+- The slice is explicitly **not** indivisible (unlike Slice 4); candidates may
+  land in separate changes.
+
+---
+
+## 8. Repository facts you will need
+
+- Do **not** trust any SHA, branch name, version, or PR number written in any
+  document. Generate current state with:
+  ```
+  pwsh scripts/campaign-state.ps1
+  ```
+- `main` is branch-protected: PRs required, no direct pushes. You are not
+  merging anything; this is read-only.
+- The frozen tree `specs/020-repository-knowledge-index/` must be byte-identical
+  when you finish. If you open a file there, open it read-only.
+- Lib unit-test paths carry an `internals::` prefix since the V11 cut mounted
+  the server modules under `src/internals.rs`. Any pre-cut `cargo test --lib
+  … -- --exact` filter you find in a document silently selects nothing — that
+  is a real bug class, and worth reporting if you find a live instance.
+
+---
+
+## 9. What a good review looks like here
+
+The best possible outcome of this review is **one of**:
+
+- "R1 is false, here is the command output that shows it, the plan is
+  mis-scoped" — highest value, saves a day of misdirected work;
+- "R1 is true but incomplete: gate X also constrains the surface" — high value;
+- "R1 is true, the plan is sound, and here are the two places the reasoning is
+  thinner than it reads" — normal good outcome;
+- "R1 is true and I could not break anything; here is what I checked" — a
+  legitimate result, provided `## Negatives` is specific enough that I can tell
+  you actually looked.
+
+The worst outcome is a review that agrees pleasantly without having run a
+single verification command. If you did not check something, do not list it
+under Negatives.

--- a/docs/reviews/REVIEW-REQUEST-track-a-slice0-red-controls-2026-08-21.md
+++ b/docs/reviews/REVIEW-REQUEST-track-a-slice0-red-controls-2026-08-21.md
@@ -1,0 +1,156 @@
+# Review request — Track A: the eleven still-RED Feature 020 Slice 0 controls
+
+## What this is
+
+Eleven acceptance controls in this repository are failing. They were written
+deliberately failing, as a record of behaviour the system did not yet have.
+Every slice that was supposed to make them pass has since shipped. They are
+still failing.
+
+Nobody has independently examined whether the controls are still asking for the
+right thing.
+
+**Your job**: for each of the eleven, return a verdict on one question.
+
+> Is the control right and the code wrong — or has the code moved such that the
+> control is now the wrong test?
+
+Those are not the only two answers. If a third is true for some control, say so
+and name it.
+
+## Rules of engagement
+
+- **Read-only.** Change no file except your own findings file.
+- **Do not build.** No `cargo build`, `cargo test`, `cargo clippy`. A cold build
+  here takes ~25–40 minutes and killing one mid-write corrupts `target/`.
+  Everything you need is reading source, plus `grep`/`sed`.
+- **Do not un-ignore anything, do not patch anything, do not open a PR.**
+- `specs/020-repository-knowledge-index/` is a frozen tree. Read it; never
+  write to it.
+- This work is unrelated to PR #603 (closed, unmerged). Do not use it as input.
+
+## Where things are
+
+Branch: `feature-029-mechanical-removal` (or `main` — the eleven controls are
+identical on both).
+
+**The roster — authoritative, and it fails closed:**
+
+`scripts/slice0-oracle-artifact.cjs` — `RED_CASES` (11) and `RESOLVED_CASES`
+(1). Read the header comment; it explains why a control that *starts* passing
+is an error rather than a success, and how a fixed control is meant to be
+reclassified rather than deleted.
+
+> **Read this file; do not run it.** It spawns `cargo test` once per case. It
+> is the roster's authority as *source*, not as a command you should execute
+> here — running it is a build, and builds are out of scope for this review.
+
+**The control bodies:**
+
+| # | Control | Location |
+|---|---|---|
+| 1 | `capacity_refused_open_creates_no_slot_and_no_watcher` | `tests/project_index_lifecycle_slice0.rs:109` |
+| 2 | `empty_placeholder_publication_refuses_watcher_mutation` | `tests/project_index_lifecycle_slice0.rs:156` |
+| 3 | `failed_reload_retains_the_recovery_observer` | `tests/project_index_lifecycle_slice0.rs:263` |
+| 4 | `observer_replacement_gap_is_latched_as_non_current` | `tests/project_index_lifecycle_slice0.rs:375` |
+| 5 | `old_observer_delivery_after_promotion_is_not_current` | `tests/project_index_lifecycle_slice0.rs:483` |
+| 6 | `watcher_mutation_during_candidate_build_is_not_discarded` | `tests/project_index_lifecycle_slice0.rs:576` |
+| 7 | `whole_project_publication_preserves_latest_siblings` | `tests/project_index_lifecycle_slice0.rs:674` |
+| 8 | `snapshot_seed_is_not_queryable_before_verification` | `tests/project_index_lifecycle_slice0.rs:777` |
+| 9 | `configured_capacity_bounds_the_process_not_each_load` | `tests/project_index_lifecycle_slice0.rs:858` |
+| 10 | `same_path_root_replacement_is_not_silently_adopted` | `tests/project_index_lifecycle_slice0.rs:922` |
+| 11 | `concurrent_first_open_performs_exactly_one_cold_load` | `src/daemon.rs:10054` |
+
+Line numbers are the `#[ignore]` attribute; the function follows it. Each
+`#[ignore]` string states which defect the control was written against and
+which slice was expected to resolve it.
+
+**The seams they drive:**
+
+- `src/daemon.rs` — project admission, cold load, session lifecycle
+- `src/watcher/mod.rs` — observation, reconciliation, publication fencing
+- `src/index_lifecycle/` — `registry.rs`, `capacity.rs`, `observer.rs`,
+  `verification.rs`, `supervisor.rs`, `candidate.rs`, `activation.rs`,
+  `physical_root.rs`, `authority.rs`
+- `src/live_index/persist.rs` — snapshot restore
+
+**Background, if you want it:**
+
+- `docs/reviews/FEATURE-020-POST-V11-LEDGER.md` — what the whole feature still
+  owes; this is its "Track A"
+- `docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md` §5 and §6 —
+  what the most recent slice did and did not discharge
+- `specs/020-repository-knowledge-index/tasks.md` — the frozen roster
+- `.specify/memory/constitution.md` — the six rules this codebase is held to
+- `CLAUDE.md` — repository rules and known traps
+
+**One trap that will waste your time if you hit it blind**: the V11 cut mounts
+the server modules under `src/internals.rs` via `#[path]`. Lib unit-test paths
+therefore carry an `internals::` prefix, and any pre-cut
+`cargo test --lib … -- --exact` filter silently selects *nothing* and exits 0
+having run nothing. You are not running tests, but you will see such filters in
+documents and scripts.
+
+## What to produce
+
+Write to:
+
+```
+docs/reviews/REVIEW-FINDINGS-<your-name>-track-a-slice0-2026-08-21.md
+```
+
+### Part 1 — a verdict per control (all eleven, none skipped)
+
+```
+### <N>. <control name> — <CONTROL-RIGHT | CONTROL-WRONG | OTHER>
+- **What it asserts**: one or two sentences, in your own words.
+- **What the code does**: where you looked, and what you found there.
+- **Verdict**: which of the above, and why.
+- **Confidence**: high / medium / low, and what would raise it.
+```
+
+If you cannot reach a verdict on a control from reading alone, say
+`INSUFFICIENT` and name exactly what you would need. That is a legitimate
+answer and more useful than a guess dressed as a finding.
+
+### Part 2 — open questions
+
+Answer these in your own words. They are deliberately not leading.
+
+1. What is the strongest argument that these eleven should be **deleted**
+   rather than fixed?
+2. What is the strongest argument they should be fixed **exactly as written**?
+3. Do any of the eleven contradict each other, or assert something a later
+   design decision deliberately reversed?
+4. Are any of them testing the same underlying property twice?
+5. If you had to fix only three, which three, and why those?
+6. What did this brief fail to ask about?
+
+### Part 3 — Outside the questions asked (MANDATORY)
+
+Anything you noticed that none of the above covers — in the controls, the
+roster script, the seams, the surrounding documents, the process. If you found
+nothing, write "nothing" and say what you looked at. This section is not
+optional and is not a place for padding; it exists because the questions above
+were written by someone with assumptions, and the things worth knowing are
+usually outside them.
+
+### Part 4 — Negatives
+
+What you checked and found sound. Be specific enough that a reader can tell you
+actually looked. A silent omission is indistinguishable from not having looked.
+
+## Only after Parts 1–4 are written
+
+Open [`APPENDIX-track-a-suspicions-2026-08-21.md`](APPENDIX-track-a-suspicions-2026-08-21.md)
+(same directory). It contains what the requester already suspects.
+
+Read it only once your own pass is on disk. Then append:
+
+### Part 5 — Delta
+
+- Which appendix suspicions your independent pass had already reached.
+- Which you now think are wrong.
+- Which changed a verdict above, and to what.
+
+**Do not read the appendix first.** Its entire value is that you did not.

--- a/scripts/lifecycle-phase-probe.cjs
+++ b/scripts/lifecycle-phase-probe.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+"use strict";
+
+// Emit the V11 retirement lifecycle phase.
+//
+// `validate-lifecycle-oracle-traceability.cjs` decides the phase internally and
+// prints only a green summary, so there is no command that ANSWERS "which
+// frozen set does this tree match?". Feature 020 Slice 5 needs that answer as a
+// recorded baseline field, and a field whose value cannot be produced by a
+// command is not an observation — it is a claim someone typed. This probe
+// exists to make it an observation.
+//
+// It deliberately REPLICATES the checker's derivation rather than importing it
+// (the checker is a script, not a module). That duplication is the cost of the
+// answer, and it is bounded: if the two ever disagree, the checker is the
+// authority and this probe is the bug. The `--verify` flag exists to catch that
+// drift — it asserts the derived phase is one the checker would accept at all.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const read = (relative) => {
+  try {
+    return fs.readFileSync(path.join(root, relative), "utf8");
+  } catch {
+    return "";
+  }
+};
+
+// Mirrors `derivePublicApiAtoms` in the checker.
+function derivePublicApiAtoms() {
+  const atoms = new Set(["symforge"]);
+  const lib = read("src/lib.rs");
+  for (const match of lib.matchAll(/^\s*pub\s+mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/gmu)) {
+    atoms.add(`symforge::${match[1]}`);
+  }
+  const embed = read("src/embed.rs");
+  for (const match of embed.matchAll(
+    /^\s*pub\s+(?:async\s+)?(?:fn|struct|enum|type|trait|const|static)\s+([A-Za-z_][A-Za-z0-9_]*)/gmu,
+  )) {
+    atoms.add(`symforge::embed::${match[1]}`);
+  }
+  for (const match of embed.matchAll(/\bpub\s+use\s+crate::([\s\S]*?);/gu)) {
+    const expression = match[1].trim();
+    const open = expression.indexOf("{");
+    const close = expression.lastIndexOf("}");
+    const leaves =
+      open === -1 || close < open
+        ? [expression.split("::").at(-1)]
+        : expression.slice(open + 1, close).split(",");
+    for (const leaf of leaves) {
+      const alias = /\bas\s+([A-Za-z_][A-Za-z0-9_]*)\s*$/u.exec(leaf);
+      const identifiers = [...leaf.matchAll(/[A-Za-z_][A-Za-z0-9_]*/gu)].map((item) => item[0]);
+      const name = alias ? alias[1] : identifiers.at(-1);
+      if (name && name !== "self") atoms.add(`symforge::embed::${name}`);
+    }
+  }
+  return atoms;
+}
+
+// The 3-segment filter that makes this probe worth having: 34 of the manifest's
+// 64 introduced atoms are 4-segment associated methods the lifecycle set never
+// contains, so a green checker does not mean the public surface is intact.
+const directPublicAtoms = (atoms) =>
+  [...new Set(atoms.filter((atom) => typeof atom === "string" && atom.split("::").length <= 3))].sort();
+
+function main() {
+  const manifest = JSON.parse(read("specs/020-repository-knowledge-index/contracts/public-api-v11.json"));
+  const migration = manifest.migration_v10 || {};
+  const categories = Array.isArray(migration.categories) ? migration.categories : [];
+  const introduced = Array.isArray(migration.introduced_v11_atoms) ? migration.introduced_v11_atoms : [];
+
+  const derived = derivePublicApiAtoms();
+  const scanned = new Set(
+    introduced
+      .filter((atom) => atom.split("::").length >= 2)
+      .map((atom) => atom.split("::")[1])
+      .filter((module) => module !== "embed"),
+  );
+  for (const module of scanned) {
+    if (!derived.has(`symforge::${module}`)) continue;
+    const source = read(`src/${module}.rs`) || read(`src/${module}/mod.rs`);
+    for (const match of source.matchAll(
+      /^\s*pub\s+(?:async\s+)?(?:fn|struct|enum|type|trait|const|static)\s+([A-Za-z_][A-Za-z0-9_]*)/gmu,
+    )) {
+      derived.add(`symforge::${module}::${match[1]}`);
+    }
+  }
+
+  const actual = [...derived].sort();
+  const preactivation = directPublicAtoms(categories.flatMap((c) => c.atoms || []));
+  const kept = categories.filter((c) => c.decision === "keep").flatMap((c) => c.atoms || []);
+  const postactivation = directPublicAtoms([...kept, ...introduced]);
+
+  const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+  const phase = same(actual, preactivation)
+    ? "preactivation"
+    : same(actual, postactivation)
+      ? "postactivation"
+      : "INVALID";
+
+  const deep = introduced.filter((atom) => atom.split("::").length > 3).length;
+
+  process.stdout.write(
+    `PHASE: ${phase}\n` +
+      `actual: ${actual.length}  pre: ${preactivation.length}  post: ${postactivation.length}\n` +
+      `scannedModules: [${[...scanned].join(", ")}]\n` +
+      `actualOnly: [${actual.filter((a) => !postactivation.includes(a)).join(", ")}]\n` +
+      `postOnly: [${postactivation.filter((a) => !actual.includes(a)).join(", ")}]\n` +
+      `introduced atoms invisible to this set (>3 segments): ${deep} of ${introduced.length}` +
+      ` — covered by execution/refreeze_v11.py, not by the lifecycle checker\n`,
+  );
+
+  if (phase === "INVALID") {
+    process.stderr.write(
+      "phase is neither frozen set; the traceability checker would fail with " +
+        "RETIREMENT_LIFECYCLE_PHASE_INVALID\n",
+    );
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/specs/029-mechanical-removal/checklists/requirements.md
+++ b/specs/029-mechanical-removal/checklists/requirements.md
@@ -1,0 +1,56 @@
+# Specification Quality Checklist: Feature 020 Slice 5 — Mechanical Removal
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Two items deserve their qualification stated rather than a bare tick, because
+ticking them silently would be the same defect this project's reporting
+invariant exists to prevent.
+
+- **"Written for non-technical stakeholders"** passes against this repository's
+  actual audience, which is the maintainer and the agents executing the
+  campaign, and matches the convention of every prior Feature 020 execution
+  spec. The spec's prose explains *why* each rule exists rather than assuming
+  campaign context, so a reader outside the campaign can follow the reasoning —
+  but it does name contract-level concepts (public API atom set, production
+  seams, whole-source seals) because Constitution Principle III requires
+  contract identifiers to be quoted exactly rather than paraphrased into
+  something friendlier and wrong.
+
+- **"No implementation details"** and **"technology-agnostic success
+  criteria"** pass in the sense that matters: no success criterion names a
+  language, framework, library, or command. The criteria are stated as counts
+  and equalities (zero differing fields, zero atoms outside both sets, zero
+  frozen bytes changed) that can be evaluated without knowing how the tree is
+  built. File paths appear only where the frozen tree makes a path part of the
+  contract itself.
+
+No item is deferred and no requirement is left unverifiable.

--- a/specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md
+++ b/specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md
@@ -27,24 +27,34 @@ whose control was not run before the removal.
 
 ---
 
-## C-2 — The public atom set does not move
+## C-2 — The public surface does not move, and THREE owners enforce that
 
-**Requires**: the derived public atom set after removal equals the frozen
-**postactivation** set exactly (kept ∪ introduced).
+**Requires**: all three of the following after every removal —
 
-**Refuses**: any removal that changes the set, in either direction.
+| # | Requirement | Owner |
+|---|---|---|
+| C-2a | The derived 3-segment lifecycle atom set still equals the frozen postactivation set (34 atoms on this tree) | `scripts/validate-lifecycle-oracle-traceability.cjs`, `ordinaryRetirementLifecycle` |
+| C-2b | The full 64-atom `introduced_v11_atoms` set still resolves | `python execution/refreeze_v11.py verify-internal --target-ref HEAD` |
+| C-2c | The consumer fixtures still compile as expected | `tests/fixtures/public-api-v11-consumer/` compile-fail + dependent-positive |
 
-**Emits on refusal**:
+**Refuses**: any removal that changes any of the three, in either direction.
+
+**Emits on refusal (C-2a)**:
 `RETIREMENT_LIFECYCLE_PHASE_INVALID: public API is neither frozen preactivation (N) nor postactivation (M); actual=K`
 
-**Owner**: `scripts/validate-lifecycle-oracle-traceability.cjs`,
-`ordinaryRetirementLifecycle`.
-
-> This is not a rule Slice 5 invents; it is a gate that already exists and
-> already fails closed. It is written here because its consequence is
-> counter-intuitive for a slice named "mechanical removal": **no public atom is
-> removable**, since every surviving one is required by the postactivation
-> definition. The removal surface is non-public code only.
+> **Amended 2026-08-21** after independent review. The original clause named
+> C-2a alone and called it the definition of public-behaviour neutrality. It is
+> not. `directPublicAtoms` filters to `split("::").length <= 3`, and 34 of the
+> 64 introduced atoms are 4-segment associated methods — all under `embed`,
+> which is also excluded from the regex scan. **Deleting
+> `symforge::embed::Claim::value` would have left C-2a green** while real
+> public API shrank. C-2b is the owner that catches it, and it runs in about
+> six seconds, so it belongs on *every* removal landing rather than only the
+> T076 embed path.
+>
+> The practical rule is unchanged and still counter-intuitive for a slice named
+> "mechanical removal": **no public atom is removable.** What changed is which
+> gate you must run to know that.
 
 ---
 
@@ -93,22 +103,46 @@ actuals transcribed into the pins.
 
 **Emits on refusal**: the pin name and both values.
 
-**Audit property**: file and byte counts must move **downward** by the amount
-removed. A refresh whose counts rise, or stay flat across a non-empty removal,
-is a defect and not a formality.
+**Audit property, per pin** — evaluated against *that pin's own file set*:
+
+| Situation | Required outcome |
+|---|---|
+| Deletion intersects the pin's file set | Byte count moves **down**. File count moves down **only if a whole file was deleted**; flat is correct for an in-file deletion. |
+| Deletion does **not** intersect the pin's file set | The pin is **byte-identical**. Refreshing it at all is the defect. |
+| Any pin | Counts must never **rise**. |
+
+> **Amended 2026-08-21** after independent review. The original required both
+> pins' counts to move downward and called a flat count across a non-empty
+> removal a defect. That is false twice over. `EXCLUDED_RUNTIME_SOURCE_PIN_V1`
+> covers only 19 `index_lifecycle/*.rs` plus `server_api.rs` — T076's target
+> `src/embed.rs` is outside it — and deleting *within* a file never changes a
+> file count. The original clause would have refused the correct refresh for
+> the one removal the roster explicitly predicts, and an executor obeying it
+> would have "fixed" a pin that legitimately never moved. A seal corrupted to
+> satisfy a contract clause is worse than the drift the seal exists to catch.
 
 ---
 
 ## C-6 — A predicted removal that does not happen leaves a record
 
 **Requires**: a `DischargedExpectation` for each roster-predicted removal not
-performed, carrying the observation that discharged it.
+performed, carrying **the discharging command and its output verbatim** — not a
+prose summary of what the command showed.
 
 **Refuses**: silent omission; substituting an adjacent deletion to make the
-slice look productive.
+slice look productive; a discharge whose evidence is an assertion rather than a
+transcript.
 
 **Emits on refusal**: the predicted item and the phrase
 `prediction neither performed nor discharged`.
+
+> **Amended 2026-08-21** after independent review flagged that nothing
+> machine-checks this document, so "already gone" with no command would still
+> parse as a filled-in record. Requiring the command and its verbatim output
+> is the cheapest thing with teeth: a reviewer can re-run the transcript. No
+> new gate is added — T077's review remains the enforcer, and a slice that
+> needed a new gate to police its own honesty would have a worse problem than
+> this clause solves.
 
 ---
 

--- a/specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md
+++ b/specs/029-mechanical-removal/contracts/neutrality-bracket-v1.md
@@ -1,0 +1,125 @@
+# Contract — Neutrality Bracket v1
+
+The interface Slice 5 exposes is not an API. It is an **evidence contract**:
+what a removal must present before it is believed. This document is that
+contract, stated so a reviewer can reject a non-conforming removal without
+re-litigating the reasoning.
+
+Derived from `specs/020-repository-knowledge-index/tasks.md` Phase 7
+(T074–T077), which is frozen and is not edited by this slice.
+
+---
+
+## C-1 — A removal is authorized only by an armed bracket
+
+**Requires**: a `NeutralityComparison` whose `control_result` is
+`detected(<field>)`.
+
+**Refuses**: any removal presented with a comparison that is `void`, absent, or
+whose control was not run before the removal.
+
+**Emits on refusal**: the name of the missing or void artifact.
+
+> A neutrality bracket reports "nothing changed". So does a broken one. The
+> control is the only thing that distinguishes them, and it must precede the
+> removal it authorizes — a control run afterwards has already been influenced
+> by the change it was meant to be independent of.
+
+---
+
+## C-2 — The public atom set does not move
+
+**Requires**: the derived public atom set after removal equals the frozen
+**postactivation** set exactly (kept ∪ introduced).
+
+**Refuses**: any removal that changes the set, in either direction.
+
+**Emits on refusal**:
+`RETIREMENT_LIFECYCLE_PHASE_INVALID: public API is neither frozen preactivation (N) nor postactivation (M); actual=K`
+
+**Owner**: `scripts/validate-lifecycle-oracle-traceability.cjs`,
+`ordinaryRetirementLifecycle`.
+
+> This is not a rule Slice 5 invents; it is a gate that already exists and
+> already fails closed. It is written here because its consequence is
+> counter-intuitive for a slice named "mechanical removal": **no public atom is
+> removable**, since every surviving one is required by the postactivation
+> definition. The removal surface is non-public code only.
+
+---
+
+## C-3 — Frozen V11 production seams are not removable
+
+**Requires**: every frozen V11 production seam retains a same-tree source
+receipt.
+
+**Refuses**: removal of any such seam.
+
+**Emits on refusal**: the seam's identifier and the receipt that would be
+orphaned.
+
+> Retired V10 members are safe to delete because their anchors resolve on the
+> approved refreeze ancestor, which the current tree cannot change. V11 seams
+> are the mirror image: their receipts must bind *this* tree, so deleting one
+> destroys the evidence rather than merely the code.
+
+---
+
+## C-4 — Unreachability is cited, never argued
+
+**Requires**: each removed item cites an executed Slice 4 reachability case or
+a retirement-inventory disposition.
+
+**Refuses**: "unused", "legacy-looking name", "no callers found by search",
+"the task list says to remove it".
+
+**Emits on refusal**: the candidate identifier and the phrase
+`no admissible unreachability evidence`.
+
+> The last of those refusals is the subtle one. The frozen roster naming an
+> item is what puts it on the candidate list; it is not what proves the item is
+> dead. Slice 5's own goal text illustrates why: it says to remove "legacy mode
+> branches", and the machine's `LegacyOpen`/`LegacyClosing` states match that
+> description while being the live bootstrap path on every process start.
+
+---
+
+## C-5 — Seals are refreshed by their oracle, after formatting
+
+**Requires**: `cargo fmt --check` green, then the owning Rust oracle's observed
+actuals transcribed into the pins.
+
+**Refuses**: any hand-computed digest; any pin refresh preceding `fmt`.
+
+**Emits on refusal**: the pin name and both values.
+
+**Audit property**: file and byte counts must move **downward** by the amount
+removed. A refresh whose counts rise, or stay flat across a non-empty removal,
+is a defect and not a formality.
+
+---
+
+## C-6 — A predicted removal that does not happen leaves a record
+
+**Requires**: a `DischargedExpectation` for each roster-predicted removal not
+performed, carrying the observation that discharged it.
+
+**Refuses**: silent omission; substituting an adjacent deletion to make the
+slice look productive.
+
+**Emits on refusal**: the predicted item and the phrase
+`prediction neither performed nor discharged`.
+
+---
+
+## C-7 — The slice may remove nothing
+
+**Requires**: nothing. An empty removal is a conforming outcome provided C-1
+produced an armed bracket, C-6 discharged every prediction, and the evidence
+document states plainly that no code was removed.
+
+> Recorded as a contract clause rather than a footnote because the pressure
+> runs the other way. A slice that finds nothing to delete feels like a failed
+> slice, and the cheapest way to make it feel successful is to delete something
+> that was not evidenced. C-7 exists to make "nothing was removable" a passing
+> result with a name, so nobody has to invent a removal to close it.

--- a/specs/029-mechanical-removal/data-model.md
+++ b/specs/029-mechanical-removal/data-model.md
@@ -1,0 +1,134 @@
+# Phase 1 Data Model — Feature 020 Slice 5 (Mechanical Removal)
+
+This slice adds no runtime types. Its entities are the artifacts that make a
+removal auditable. They are modelled here so the tasks phase has exact field
+names to produce and the evidence document has exact fields to compare.
+
+The design rule throughout is Constitution Principle V: prefer states that
+cannot be spelled wrongly over states that are checked after the fact. Applied
+to documents rather than Rust, that means **every field carries the command
+that produced it**, so a field cannot be present without provenance.
+
+---
+
+## NeutralityBaseline
+
+The recorded pre-removal state. Captured once as T074, re-captured unchanged as
+T077, and compared field by field.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `captured_at_ref` | git ref | The tree the capture describes. Recorded, never hand-typed into prose elsewhere. |
+| `lifecycle_phase` | `preactivation` \| `postactivation` | Which frozen set the derived public atom set matched (research R1). |
+| `public_atom_count` | integer | Size of the derived public atom set. |
+| `public_atom_digest` | digest | Order-independent digest of that set, so a swap of two atoms is not mistaken for no change. |
+| `activation_result` | text | The observed terminal activation mode and the lane-registration outcome. |
+| `writer_reachability_verdict` | pass \| fail + case name | The executed ingress-authority case and its result. |
+| `gate_outcomes` | list of (gate, result, duration) | Every gate from research R6. |
+| `source_pins` | list of (pin name, digest, file count, byte count) | The two whole-source pins (research R2). |
+| `commands` | map field → command | The exact command that produced each field above. **Required for every field**; a field without one is not a captured field, it is a claim. |
+
+**Validation rules**
+
+- Every field in the record has an entry in `commands`. A record failing this
+  is invalid and cannot serve as a baseline.
+- `public_atom_digest` is order-independent; `public_atom_count` alone is
+  insufficient because a same-size substitution would be invisible.
+- `lifecycle_phase` is recorded as observed, never as expected.
+
+---
+
+## NeutralityComparison
+
+The diff of two `NeutralityBaseline` records, plus the evidence that the diff
+can detect a real change.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `before` / `after` | baseline refs | The two records compared. |
+| `differing_fields` | list of field names | Empty for a neutral removal. Named, not counted, when non-empty. |
+| `control_result` | detected(field) \| **not-detected** | Outcome of the deliberate control edit (research R5). |
+| `control_description` | text | What the control changed, so a reader can judge whether it was a real change. |
+
+**Validation rules**
+
+- A comparison whose `control_result` is `not-detected` is **void**. It may not
+  be cited as evidence of anything, and no removal may proceed on it.
+- `differing_fields` names fields; a comparison reporting only a count is
+  incomplete.
+- The control edit is discarded before any removal lands; it never appears in
+  a shipped diff.
+
+**State transitions**
+
+```
+captured(before) → control-run → { void | armed }
+armed → removal applied → captured(after) → compared → { neutral | differences named }
+```
+
+`armed` is the only state from which a removal may proceed. There is no edge
+from `void` to `armed` except by fixing the comparison and re-running the
+control — a bracket that failed its control is not repaired by re-reading it.
+
+---
+
+## RemovalCandidate
+
+One named item considered for deletion.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `item` | qualified path | Exact identifier, quoted as the contract spells it (Principle III). |
+| `visibility` | public \| non-public | Public candidates are refused outright (research R1). |
+| `unreachability_evidence` | citation | The executed Slice 4 reachability case or inventory disposition. Task wording and "looks unused" are not admissible. |
+| `is_frozen_v11_seam` | bool | `true` refuses the candidate (research R3, spec FR-005). |
+| `dependent_tests` | list | Tests whose only subject is this item; they go in the same change. |
+| `disposition` | removed \| retained | Outcome. |
+| `retained_reason` | text | Required when `retained`. |
+
+**Validation rules**
+
+- `visibility = public` ⇒ `disposition = retained`. Not a warning — the
+  postactivation set requires every surviving public atom to exist.
+- `is_frozen_v11_seam = true` ⇒ `disposition = retained`.
+- `unreachability_evidence` empty ⇒ `disposition = retained`. The absence of
+  evidence is itself the reason, and it is recorded rather than resolved by
+  looking harder for a justification.
+- A test may be listed in `dependent_tests` only if the candidate is its sole
+  subject.
+
+---
+
+## DischargedExpectation
+
+A removal the frozen roster predicts, which the tree turns out not to need.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `predicted` | text | The roster's own words for what should be removed. |
+| `observed` | text | What the tree actually contains. |
+| `evidence` | citation | The command and output establishing `observed`. |
+| `discharge` | already-removed \| never-existed | Which of the two it was. |
+
+**Validation rules**
+
+- A `DischargedExpectation` is not satisfied by removing something adjacent.
+  Spec FR-011 exists because that substitution is the tempting move when a
+  slice looks empty.
+- `evidence` must be an observation, not an inference from file size or name.
+
+---
+
+## Relationships
+
+```
+NeutralityBaseline ──(before)──┐
+                               ├──> NeutralityComparison ──gates──> RemovalCandidate*
+NeutralityBaseline ──(after)───┘
+
+RemovalCandidate.disposition = retained ──when roster-predicted──> DischargedExpectation
+```
+
+Read as one sentence: **a comparison that has survived its own control is the
+only thing that authorizes a candidate to become a removal, and any predicted
+removal that does not happen must leave a discharge record behind.**

--- a/specs/029-mechanical-removal/plan.md
+++ b/specs/029-mechanical-removal/plan.md
@@ -56,14 +56,25 @@ Assessed against Constitution v1.0.0 (ratified 2026-08-18).
 | **II. RED-First Evidence** | PASS | The bracket is a negative instrument, so it carries its positive control: a deliberate change the comparison must catch, run *before* any removal (research R5, contract C-1). A bracket failing its control is `void` and authorizes nothing. |
 | **III. Frozen Contracts Win** | PASS | `specs/020-…` is input only; SC-005 requires zero bytes changed there. Contract identifiers are quoted exactly. Where the roster's prose and the tree disagree — "legacy mode branches" versus the live `LegacyOpen`/`LegacyClosing` bootstrap states — the plan records the divergence as a stated assumption instead of editing the frozen text. |
 | **IV. Verification Gates** | PASS | Research R6 fixes the full gate set unchanged, one cargo invocation at a time, long runs through Terminal Commander. The slice adds no gate and relaxes none. |
-| **V. Unrepresentable Over Checked** | PASS | Applied to artifacts: `NeutralityComparison` has no edge from `void` to `armed`, so an unproven bracket cannot authorize a removal by oversight. Pin refresh is oracle-only, after `fmt`, with counts that must move downward — an auditable direction, not just a new digest. |
+| **V. Unrepresentable Over Checked** | **PASS, with a stated limit — the weakest of the six** | Pin refresh is genuinely oracle-only and after `fmt`, with a per-pin audit direction. But the `void → armed` prohibition on `NeutralityComparison` is a **document convention drawn in a markdown state diagram, not a type**. Nothing makes the illegal transition unspellable; an executor can write an evidence document that skips it, and C-1 is a human gate. Enforcement is T077's review. Recorded as a limit rather than claimed as full compliance. |
 | **VI. Independent Review Before Merge** | PASS | T077 carries an independent adversarial review including the mandatory cfg-lens sweep; findings fixed RED-first or adjudicated with rationale, never dropped. |
 
-**Post-Phase-1 re-check**: PASS, unchanged. The Phase 1 artifacts strengthened
-two of these rather than straining them — C-2 made Principle III's boundary
-mechanical (a checker error string, not a judgement call), and C-7 made
-Principle I's honesty requirement explicit for the awkward case where the
-honest answer is "nothing was removable".
+**Post-Phase-1 re-check**: PASS, with Principle V carrying the limit above.
+
+**Post-review re-check (2026-08-21)**: PASS. Two independent reviews
+(`REVIEW-FINDINGS-grok-4-6-…`, `REVIEW-FINDINGS-composer-…`) returned no
+BLOCKER and a verdict of *amend, then implement*. Four MAJORs were confirmed
+against source and amended: C-2 narrowed from "the definition of public
+behaviour" to one of three owners; C-5's pin arithmetic corrected per-pin;
+research observation 1 closed as `postactivation`; and US1's Independent Test
+replaced, because as written it closed the story on the null re-run — the
+vacuous negative Principle II exists to forbid, in the document that invokes
+Principle II. Principle V's PASS was downgraded to a stated limit in the same
+pass.
+
+That last one is worth naming plainly: the Constitution Check above originally
+claimed PASS on a principle the artifacts only partly satisfy, and no amount of
+re-reading my own reasoning surfaced it. An outside reader did, immediately.
 
 **Violations requiring justification**: none. Complexity Tracking is omitted
 because it would be empty.

--- a/specs/029-mechanical-removal/plan.md
+++ b/specs/029-mechanical-removal/plan.md
@@ -17,12 +17,25 @@ required by contract to exist. **Slice 5 therefore cannot remove a public atom
 at all; its removal surface is strictly non-public code.** That single finding
 does more to bound this slice than the whole of Phase 7's task text.
 
-The technical approach is consequently inverted from a normal slice. The
-primary deliverable is not the removal but the **neutrality bracket** — a
-baseline captured before, re-captured after, compared field by field, and
-proven capable of detecting a real change before it is trusted to certify the
-absence of one. The removal is whatever survives that bracket's admission
-rules, and may legitimately be empty.
+**The deliverable is the removal.** The **neutrality bracket** — a baseline
+captured before, re-captured after, compared field by field, and proven capable
+of detecting a real change before it is trusted to certify the absence of one —
+is the *admission gate* every removal passes through. It is not the product.
+
+> **Corrected 2026-08-21.** This paragraph originally said the primary
+> deliverable was the bracket rather than the removal. Two independent
+> uncontaminated reviews (LINUS, HOLMES) both called that over-engineering, and
+> they are right: the frozen goal is delete-only-proven-unreachable, and
+> promoting the measuring instrument to the product is how a delete-only slice
+> acquires a platform it was never asked for. The control (C-1, US1 scenario 3)
+> is kept — both reviewers insisted on that unprompted. Only the billing
+> changed.
+>
+> Worth recording honestly: the two *contaminated* reviews of this same
+> question, run from a brief that told the reviewer this decision was
+> deliberate, both endorsed it. The two run without that framing both rejected
+> it. Same question, opposite answers, and the only variable was how the brief
+> was written.
 
 ## Technical Context
 

--- a/specs/029-mechanical-removal/plan.md
+++ b/specs/029-mechanical-removal/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Feature 020 Slice 5 — Mechanical Removal
+
+**Branch**: `029-mechanical-removal` | **Date**: 2026-08-21 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/029-mechanical-removal/spec.md`
+
+## Summary
+
+Delete only code the Slice 4 activation cut already proved unreachable, and
+prove the deletion changed nothing observable.
+
+Phase 0 research turned the roster's prose into a closed boundary. The
+traceability checker already defines "public behaviour unchanged" as an
+equality against a frozen **postactivation** atom set, and that set is defined
+as *kept ∪ introduced* — so every public atom that survived the cut is
+required by contract to exist. **Slice 5 therefore cannot remove a public atom
+at all; its removal surface is strictly non-public code.** That single finding
+does more to bound this slice than the whole of Phase 7's task text.
+
+The technical approach is consequently inverted from a normal slice. The
+primary deliverable is not the removal but the **neutrality bracket** — a
+baseline captured before, re-captured after, compared field by field, and
+proven capable of detecting a real change before it is trusted to certify the
+absence of one. The removal is whatever survives that bracket's admission
+rules, and may legitimately be empty.
+
+## Technical Context
+
+**Language/Version**: Rust, toolchain pinned by `rust-toolchain.toml`; Node and Python for the checker and refreeze tooling
+
+**Primary Dependencies**: none added — this slice only removes
+
+**Storage**: N/A
+
+**Testing**: `cargo test` serial (`--test-threads=1`), the embed feature cell, the Node checkers, the npm suite
+
+**Target Platform**: Linux CI is authority; Windows and macOS cells gate additionally
+
+**Project Type**: single Rust crate exposing an MCP server surface
+
+**Performance Goals**: none — the goal is neutrality, not speed
+
+**Constraints**: public atom set must remain exactly the postactivation set; frozen spec tree byte-identical including checkbox bytes; sealed pins recomputed only by their owning Rust oracle, after `fmt`
+
+**Scale/Scope**: bounded by evidenced-unreachable non-public items; may be empty, and an empty result is a pass
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Assessed against Constitution v1.0.0 (ratified 2026-08-18).
+
+| Principle | Status | How this plan satisfies it |
+|---|---|---|
+| **I. Reporting Invariant** | PASS | Every baseline field carries the command that produced it (data-model), so no field can be present without provenance. Research R4 deliberately leaves the embed question **unresolved** rather than predicting it — asserting T076 complete would be a success claim for an unobserved operation. |
+| **II. RED-First Evidence** | PASS | The bracket is a negative instrument, so it carries its positive control: a deliberate change the comparison must catch, run *before* any removal (research R5, contract C-1). A bracket failing its control is `void` and authorizes nothing. |
+| **III. Frozen Contracts Win** | PASS | `specs/020-…` is input only; SC-005 requires zero bytes changed there. Contract identifiers are quoted exactly. Where the roster's prose and the tree disagree — "legacy mode branches" versus the live `LegacyOpen`/`LegacyClosing` bootstrap states — the plan records the divergence as a stated assumption instead of editing the frozen text. |
+| **IV. Verification Gates** | PASS | Research R6 fixes the full gate set unchanged, one cargo invocation at a time, long runs through Terminal Commander. The slice adds no gate and relaxes none. |
+| **V. Unrepresentable Over Checked** | PASS | Applied to artifacts: `NeutralityComparison` has no edge from `void` to `armed`, so an unproven bracket cannot authorize a removal by oversight. Pin refresh is oracle-only, after `fmt`, with counts that must move downward — an auditable direction, not just a new digest. |
+| **VI. Independent Review Before Merge** | PASS | T077 carries an independent adversarial review including the mandatory cfg-lens sweep; findings fixed RED-first or adjudicated with rationale, never dropped. |
+
+**Post-Phase-1 re-check**: PASS, unchanged. The Phase 1 artifacts strengthened
+two of these rather than straining them — C-2 made Principle III's boundary
+mechanical (a checker error string, not a judgement call), and C-7 made
+Principle I's honesty requirement explicit for the awkward case where the
+honest answer is "nothing was removable".
+
+**Violations requiring justification**: none. Complexity Tracking is omitted
+because it would be empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-mechanical-removal/
+├── plan.md                              # This file
+├── spec.md                              # Feature specification
+├── research.md                          # Phase 0 — R1–R6 + open observations
+├── data-model.md                        # Phase 1 — evidence artifacts
+├── quickstart.md                        # Phase 1 — run and validation guide
+├── contracts/
+│   └── neutrality-bracket-v1.md         # Phase 1 — the evidence contract, C-1…C-7
+├── checklists/
+│   └── requirements.md                  # Spec quality checklist
+└── tasks.md                             # Phase 2 — produced by /speckit-tasks
+```
+
+### Source Code (repository root)
+
+Removal targets and the gates that bound them:
+
+```text
+src/                                     # removal surface — NON-PUBLIC items only
+├── embed.rs                             # T076, gated on the allowlist negative suite
+├── index_lifecycle/
+│   └── activation.rs                    # NOT a target: LegacyOpen/LegacyClosing are live
+└── …                                    # candidates enumerated by evidence, not by name
+
+tests/
+├── preventive_runtime_dark_v11.rs       # owns FULL_SOURCE_PIN_V1 + EXCLUDED_RUNTIME_SOURCE_PIN_V1
+├── activation_cut_v11.rs                # writer-reachability case
+└── fixtures/public-api-v11-consumer/    # all-cfg, compile-fail, dependent-positive
+
+scripts/
+├── validate-lifecycle-oracle-traceability.cjs   # the C-2 three-state public-API gate
+└── slice0-oracle-artifact.cjs                   # fails closed if a control flips
+
+execution/
+└── refreeze_v11.py                      # allowlist / API-atom authority
+
+docs/reviews/
+├── FEATURE-020-SLICE5-BASELINE-v11.md   # T074 output
+└── FEATURE-020-SLICE5-EVIDENCE-v11.md   # T077 output + review record
+```
+
+**Structure Decision**: single-project layout, unchanged. This slice creates no
+module and moves no file; it deletes within `src/`, refreshes two pins in
+`tests/preventive_runtime_dark_v11.rs`, and writes two documents under
+`docs/reviews/`. `src/index_lifecycle/activation.rs` is listed explicitly as a
+**non**-target so the exclusion is visible in the structure rather than buried
+in prose.
+
+## Phase Sequencing
+
+| Phase | Frozen task | Output | Gate to proceed |
+|---|---|---|---|
+| Observe | — | Lifecycle phase recorded | Checker green |
+| Baseline | T074 | `FEATURE-020-SLICE5-BASELINE-v11.md` | Every field has a command |
+| Arm | T074 | Control result | `detected(<field>)`, else stop |
+| Enumerate | T075 | Candidate list with dispositions | Each removal cites evidence |
+| Remove | T075 → T076 | Deletions + pin refresh | T076 only after the allowlist suite speaks |
+| Re-run | T077 | `FEATURE-020-SLICE5-EVIDENCE-v11.md` | No unexplained differing field |
+| Review | T077 | Review record | Findings fixed or adjudicated |
+
+Unlike Slice 4, no part of this slice is indivisible: candidates may land in
+separate changes provided each carries its own bracket result.
+
+## Risks
+
+| Risk | Why it is real here | Mitigation |
+|---|---|---|
+| A quiet bracket certifies a regression | Neutrality instruments report "nothing changed" whether or not they work | C-1's control, run before any removal; a void bracket authorizes nothing |
+| Deleting a frozen V11 seam | Its receipt must bind *this* tree, so deletion destroys evidence, not just code | C-3; seam check precedes every removal |
+| Acting on the roster's naive wording | "Legacy mode branches" exactly describes the live bootstrap states | Recorded as a spec assumption; C-4 rules roster wording inadmissible as evidence |
+| Inventing a removal to avoid an empty slice | The social pressure runs this way when nothing is removable | C-7 names the empty outcome a pass; C-6 forbids substitution |
+| Hand-refreshing a moved pin | Faster than running the oracle, and has silently diverged once already | C-5; counts must move downward by the removed amount |

--- a/specs/029-mechanical-removal/quickstart.md
+++ b/specs/029-mechanical-removal/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart — Feature 020 Slice 5 (Mechanical Removal)
+
+How to run and validate this slice end to end. This is a run guide, not an
+implementation guide: it says what to execute and what the result must look
+like. The rules behind each step are in
+[`contracts/neutrality-bracket-v1.md`](contracts/neutrality-bracket-v1.md).
+
+## Prerequisites
+
+- A clean checkout at the current release ref, `git status` empty.
+- Long cargo runs go through Terminal Commander, one cargo invocation at a
+  time (Constitution IV). The full suite is ~25–40 minutes cold; the Bash tool
+  will kill it mid-write at ten minutes and corrupt `target/`.
+- Node and Python available for the checkers.
+
+## Step 1 — Observe the lifecycle phase before anything else
+
+```
+node scripts/validate-lifecycle-oracle-traceability.cjs
+```
+
+**Expected**: `OK` with its requirement/oracle/category counts.
+
+This step exists to record which frozen set the tree currently matches. Per
+research R1, if the tree is already `postactivation` then **no public atom may
+be removed at all**, which bounds the entire slice. Record the observation;
+do not assume it.
+
+## Step 2 — Capture the baseline (T074)
+
+Run every gate in the set and record each result with the command that
+produced it, into `docs/reviews/FEATURE-020-SLICE5-BASELINE-v11.md`:
+
+```
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --lib --bins --tests -- --test-threads=1
+cargo test --no-default-features --features embed --lib -- --test-threads=1
+cargo build --release
+node scripts/verify-tools.cjs --bin target/release/symforge
+node scripts/validate-lifecycle-oracle-traceability.cjs
+node scripts/slice0-oracle-artifact.cjs
+cd npm && npm test
+```
+
+Also record the two whole-source pins and the activation and
+writer-reachability results.
+
+**Expected**: every gate green, every field paired with its command. A field
+without a command is not a captured field.
+
+## Step 3 — Arm the bracket with a control (do this before removing anything)
+
+Make one deliberate edit that changes a field the baseline claims to cover.
+Re-capture. The comparison **must** name the field that moved.
+
+**Expected**: `control_result = detected(<field>)`.
+
+**If the comparison stays quiet**: the bracket is void. Fix the comparison and
+re-run the control. Do not proceed — a quiet bracket will be equally quiet
+about a real regression, which is the whole failure mode this step exists to
+rule out.
+
+Discard the control edit. Confirm `git status` is clean before Step 4.
+
+## Step 4 — Enumerate candidates, and refuse the ones that fail their gate
+
+For each item considered:
+
+| Check | Refuse if |
+|---|---|
+| Visibility | public — the postactivation set requires it |
+| Frozen V11 seam | yes — its same-tree receipt would be orphaned |
+| Unreachability evidence | absent — "unused" and "the roster says so" are not evidence |
+
+Record retained candidates with their reason. A short candidate list is a
+result, not a shortfall.
+
+## Step 5 — Remove, in order (T075, then T076)
+
+T076 is gated: run the allowlist negative suite first and read its verdict.
+
+```
+python execution/refreeze_v11.py verify-internal --target-ref HEAD
+```
+
+Only after it proves the V10 embed surface unnameable may `src/embed.rs` be
+touched. If no dead code remains there, record a discharge (C-6) and remove
+nothing.
+
+After each removal: `cargo fmt --check` **first**, then refresh the two
+whole-source pins from the Rust oracle's observed actuals.
+
+**Expected**: pin file and byte counts move *downward* by the amount removed.
+Counts that rise or stay flat across a non-empty removal indicate a mistake —
+investigate rather than transcribe.
+
+## Step 6 — Re-run the baseline (T077)
+
+Repeat Step 2 and compare field by field into
+`docs/reviews/FEATURE-020-SLICE5-EVIDENCE-v11.md`.
+
+**Expected**: `differing_fields` is empty, apart from the two source pins,
+whose movement is the removal itself and must match the removed amount.
+
+**If any other field moved**: investigate to root cause before attributing it
+to the removal, and record the cause. A difference explained away without a
+cause is a failed slice.
+
+## Step 7 — Independent adversarial review
+
+One independent review including a cfg-lens sweep (Constitution VI). Every
+finding is fixed RED-first or explicitly adjudicated with recorded rationale.
+Silently dropping a finding is forbidden.
+
+## Validation checklist
+
+- [ ] Lifecycle phase observed and recorded, not assumed
+- [ ] Baseline captured with a command behind every field
+- [ ] Control detected a real change **before** any removal
+- [ ] Control edit discarded; working tree clean before removal
+- [ ] Every removal cites admissible unreachability evidence
+- [ ] No public atom removed; no frozen V11 seam removed
+- [ ] Pins refreshed after `fmt`, from the oracle, counts moving downward
+- [ ] Re-run reports no unexplained differing field
+- [ ] Every roster prediction performed or discharged with evidence
+- [ ] Review findings fixed or adjudicated, none dropped
+- [ ] Frozen tree byte-identical (`git diff` over `specs/020-…` is empty)
+
+## The empty outcome is a pass
+
+If Steps 4–5 find nothing removable, the slice closes with the baseline, the
+armed bracket, the re-run, and a discharge record for every prediction. That
+is a conforming result. Deleting something unevidenced to make the slice look
+productive is not.

--- a/specs/029-mechanical-removal/quickstart.md
+++ b/specs/029-mechanical-removal/quickstart.md
@@ -15,16 +15,22 @@ like. The rules behind each step are in
 
 ## Step 1 — Observe the lifecycle phase before anything else
 
+The traceability checker prints counts, **not the phase**, so it cannot fill
+`lifecycle_phase` on its own. Run both:
+
 ```
 node scripts/validate-lifecycle-oracle-traceability.cjs
+node scripts/lifecycle-phase-probe.cjs
 ```
 
-**Expected**: `OK` with its requirement/oracle/category counts.
+**Expected**: `OK (…)` from the first; from the second, a line naming the phase
+and the three set sizes. At the time of writing that is
+`PHASE: postactivation` with `actual: 34  pre: 83  post: 34`.
 
-This step exists to record which frozen set the tree currently matches. Per
-research R1, if the tree is already `postactivation` then **no public atom may
-be removed at all**, which bounds the entire slice. Record the observation;
-do not assume it.
+Paste the probe's stdout into `commands.lifecycle_phase`. Per research R1, a
+`postactivation` tree means **no 3-segment public atom may be removed at all**,
+which bounds the entire slice — so this field decides the slice's scope and may
+not be inherited from a document. Observe it on the tree you are working on.
 
 ## Step 2 — Capture the baseline (T074)
 
@@ -39,15 +45,26 @@ cargo test --no-default-features --features embed --lib -- --test-threads=1
 cargo build --release
 node scripts/verify-tools.cjs --bin target/release/symforge
 node scripts/validate-lifecycle-oracle-traceability.cjs
+node scripts/lifecycle-phase-probe.cjs
+python execution/refreeze_v11.py verify-internal --target-ref HEAD
 node scripts/slice0-oracle-artifact.cjs
 cd npm && npm test
 ```
 
-Also record the two whole-source pins and the activation and
-writer-reachability results.
+The remaining baseline fields, with the command each one comes from — the
+data model requires a command per field, so none of these is "also record":
+
+| Field | Command |
+|---|---|
+| `writer_reachability_verdict` | `cargo test --test activation_cut_v11 all_ingress_uses_exact_typed_authority_branch -- --exact` |
+| `activation_result` | `cargo test --test activation_cut_v11 preventive_v1_is_the_only_live_mode -- --exact` |
+| `source_pins` | the two constants observed in `tests/preventive_runtime_dark_v11.rs` after the dark-seal test runs above |
 
 **Expected**: every gate green, every field paired with its command. A field
 without a command is not a captured field.
+
+`slice0-oracle-artifact.cjs` spawns `cargo test` per case — budget for it as a
+build, not a quick check.
 
 ## Step 3 — Arm the bracket with a control (do this before removing anything)
 
@@ -100,8 +117,17 @@ investigate rather than transcribe.
 Repeat Step 2 and compare field by field into
 `docs/reviews/FEATURE-020-SLICE5-EVIDENCE-v11.md`.
 
-**Expected**: `differing_fields` is empty, apart from the two source pins,
-whose movement is the removal itself and must match the removed amount.
+Re-run the full public-surface trio, not just the lifecycle checker:
+
+```
+node scripts/validate-lifecycle-oracle-traceability.cjs
+node scripts/lifecycle-phase-probe.cjs
+python execution/refreeze_v11.py verify-internal --target-ref HEAD
+```
+
+**Expected**: `differing_fields` is empty, apart from any source pin whose own
+file set the removal actually intersected. A pin the removal did not touch must
+be byte-identical — see C-5.
 
 **If any other field moved**: investigate to root cause before attributing it
 to the removal, and record the cause. A difference explained away without a
@@ -115,9 +141,10 @@ Silently dropping a finding is forbidden.
 
 ## Validation checklist
 
-- [ ] Lifecycle phase observed and recorded, not assumed
+- [ ] Lifecycle phase observed with `lifecycle-phase-probe.cjs`, not inferred from a green checker
 - [ ] Baseline captured with a command behind every field
 - [ ] Control detected a real change **before** any removal
+- [ ] `refreeze_v11.py verify-internal` re-run after **every** removal, not only the embed one
 - [ ] Control edit discarded; working tree clean before removal
 - [ ] Every removal cites admissible unreachability evidence
 - [ ] No public atom removed; no frozen V11 seam removed

--- a/specs/029-mechanical-removal/research.md
+++ b/specs/029-mechanical-removal/research.md
@@ -8,8 +8,13 @@ from task wording; each decision cites the artifact that establishes it.
 
 ## R1 — What does "do not change public behavior" mean mechanically?
 
-**Decision**: It means the derived public atom set must continue to equal, byte
-for byte, the frozen **postactivation** set — not merely "stay close to it".
+**Decision**: The traceability checker freezes the **3-segment lifecycle atom
+set** — 34 atoms on this tree — and that set must not move. It is **one
+conjunct of public-behaviour neutrality, not the definition of it.**
+
+> **Amended 2026-08-21** after independent review (grok-4-6 MAJOR, composer
+> MAJOR). The original text made this checker the whole definition. It is not,
+> and the gap is load-bearing — see the depth truncation below.
 
 **Rationale**: `scripts/validate-lifecycle-oracle-traceability.cjs` already owns
 this as a three-state check (`ordinaryRetirementLifecycle`). It derives the
@@ -27,15 +32,35 @@ Anything that is neither fails closed with
 This has a consequence sharper than the roster's prose, and it is the single
 most useful thing this research produced:
 
-> **The postactivation set is defined as kept ∪ introduced. Every public atom
-> that survives the cut is therefore already required to exist by the frozen
-> contract. Slice 5 cannot remove a public atom at all** — removing one drops
-> the tree out of both accepted states and fails the gate.
+> **The postactivation set is kept ∪ introduced, filtered to atoms of three
+> `::` segments or fewer. Every 3-segment public atom that survived the cut is
+> therefore required by contract to exist, and removing one fails the gate.**
 
-So Slice 5's removal surface is **strictly non-public code**: private items,
-crate-internal helpers, unreachable branches behind public entry points, and
-tests whose subjects go with them. "Do not change public behavior" is not a
-caution to be careful; it is a closed set the checker enforces.
+**But the filter is the catch.** `directPublicAtoms` drops every atom with more
+than three segments:
+
+```js
+.filter((atom) => typeof atom === "string" && atom.split("::").length <= 3)
+```
+
+The manifest's 64 `introduced_v11_atoms` split by depth as `{2: 1, 3: 29,
+4: 34}`. So **34 of the 64 are associated methods the lifecycle checker never
+sees** — all of them under `embed`, which line 2043 also excludes from the
+regex scan. Deleting `symforge::embed::Claim::value` leaves
+`symforge::embed::Claim` in the derived set and `ordinaryRetirementLifecycle`
+stays green, while real public API shrinks.
+
+So Slice 5's removal surface is **non-public code**, and that boundary is
+enforced by *three* owners, not one:
+
+| Owner | Covers | Command |
+|---|---|---|
+| lifecycle checker | the 34-atom 3-segment set | `node scripts/validate-lifecycle-oracle-traceability.cjs` |
+| refreeze allowlist | the full 64-atom introduced set | `python execution/refreeze_v11.py verify-internal --target-ref HEAD` |
+| consumer fixtures | names the checker does not pin | `tests/fixtures/public-api-v11-consumer/` (compile-fail, dependent-positive) |
+
+**A green lifecycle checker is not "public behaviour unchanged."** It is one
+third of that claim, and the weakest third for method-level API.
 
 **Alternatives considered**: treating the retirement inventory's `disposition`
 fields as the removal authority. Rejected — dispositions describe what the
@@ -48,14 +73,23 @@ still requires.
 
 ## R2 — Which sealed values move when source is deleted, and who may recompute them?
 
-**Decision**: Two whole-source pins in `tests/preventive_runtime_dark_v11.rs`
-move on any `src/` deletion, and only the owning Rust oracle may recompute
-them:
+**Decision**: A whole-source pin moves when the deletion **intersects that
+pin's own file set** — not on any `src/` deletion — and only the owning Rust
+oracle may recompute it.
 
-| Pin | Shape | Current recorded value |
+| Pin | Covers | Current recorded value |
 |---|---|---|
-| `FULL_SOURCE_PIN_V1` | (digest, file count, byte count) | 196 files, 9 300 142 bytes |
-| `EXCLUDED_RUNTIME_SOURCE_PIN_V1` | (digest, file count, byte count) | 20 files, 388 720 bytes |
+| `FULL_SOURCE_PIN_V1` | all of `src/` | 196 files, 9 300 142 bytes |
+| `EXCLUDED_RUNTIME_SOURCE_PIN_V1` | exactly the 20 paths in `EXCLUDED_RUNTIME_SOURCE_PATHS` — 19 `index_lifecycle/*.rs` plus `server_api.rs` | 20 files, 388 720 bytes |
+
+> **Amended 2026-08-21** after independent review (grok-4-6 MAJOR, composer
+> MINOR). The original said both pins move on any `src/` deletion. They do not,
+> and the error was dangerous rather than cosmetic: T076's target `src/embed.rs`
+> is **outside** the excluded pin's set entirely. A real embed deletion moves
+> `FULL_SOURCE_PIN_V1`'s byte count, leaves its *file* count flat (no file was
+> deleted), and leaves `EXCLUDED_RUNTIME_SOURCE_PIN_V1` wholly unchanged. The
+> original C-5 would have refused that correct refresh, and an executor
+> "fixing" the excluded pin to satisfy it would corrupt a seal that never moved.
 
 **Rationale**: Constitution Principle V forbids out-of-band recomputation of
 sealed values outright — "the Rust oracle that owns the seal is the only
@@ -157,8 +191,9 @@ invocation at a time with long runs through Terminal Commander.
 | Full serial suite (`--test-threads=1`) | Behaviour |
 | `cargo test --no-default-features --features embed --lib` | The cfg cell no default-feature gate can see |
 | Release build + `verify-tools.cjs` | Tool correctness |
-| `node scripts/validate-lifecycle-oracle-traceability.cjs` | The R1 three-state public-API check |
-| `node scripts/slice0-oracle-artifact.cjs` | Fails closed if a control's status flips |
+| `node scripts/validate-lifecycle-oracle-traceability.cjs` | The R1 three-state check — the 34-atom 3-segment set only |
+| `python execution/refreeze_v11.py verify-internal --target-ref HEAD` | The full 64-atom introduced set, including the 34 the checker cannot see. **Runs on every removal landing, not only the T076 embed path** (~6 s) |
+| `node scripts/slice0-oracle-artifact.cjs` | Fails closed if a control's status flips. Note: spawns `cargo test` per case — it is a build, not a quick check |
 | npm suite | Package surface |
 
 **Rationale**: Principle IV fixes the set and the serial discipline; the
@@ -186,14 +221,35 @@ nothing, so narrowing the gates assumes the conclusion.
 | Constraints | Public atom set must remain exactly the postactivation set (R1); frozen tree unedited; seals refreshed only by their oracle (R2) |
 | Scale/Scope | Bounded by evidenced-unreachable non-public items; may legitimately be empty |
 
+## Observation 1 — CLOSED 2026-08-21: the tree is `postactivation`
+
+Originally deferred to execution. That was wrong: it is a one-second
+derivation, and deferring an observation that cheap is not caution, it is an
+unobserved field in a record that requires provenance. Both reviewers said so.
+
+Derived by replicating `ordinaryRetirementLifecycle` against the working tree:
+
+```
+scannedModules: [ 'server_api' ]
+actual: 34   pre: 83   post: 34
+PHASE: postactivation
+actualOnly: []   postOnly: []
+```
+
+Cross-check: `node scripts/validate-lifecycle-oracle-traceability.cjs` →
+`OK (78 requirements, 24 acceptance oracles, 13 retirement categories)`.
+
+**Consequence**: R1's bound is live *now*, not contingent on a future cut. No
+3-segment public atom is removable on this tree. The executed baseline still
+records the phase — the value is known, but a baseline that cites this document
+instead of observing the tree it runs on would be inheriting a fact rather than
+capturing one.
+
 ## Open observations the executed plan must make
 
-1. Which lifecycle phase the tree reports today — `preactivation` or
-   `postactivation`. R1 makes this decisive for whether the atom set may move
-   at all, and it is cheap to observe but must not be assumed.
-2. Whether any evidenced-unreachable non-public code actually remains.
-3. Whether `src/embed.rs` still holds dead V10 implementation (R4).
+1. Whether any evidenced-unreachable non-public code actually remains.
+2. Whether `src/embed.rs` still holds dead V10 implementation (R4).
 
-All three are observations, not predictions. If the answer to 2 and 3 is "no",
-the slice closes with the bracket, the baseline, and a recorded discharge —
-which spec Edge Cases already admits as a valid outcome.
+Both are observations, not predictions. If both answers are "no", the slice
+closes with the bracket, the baseline, and a recorded discharge — which spec
+Edge Cases already admits as a valid outcome.

--- a/specs/029-mechanical-removal/research.md
+++ b/specs/029-mechanical-removal/research.md
@@ -1,0 +1,199 @@
+# Phase 0 Research — Feature 020 Slice 5 (Mechanical Removal)
+
+Every unknown in the Technical Context is resolved here, or recorded as an
+observation the plan's first executed step must make. Nothing below is inferred
+from task wording; each decision cites the artifact that establishes it.
+
+---
+
+## R1 — What does "do not change public behavior" mean mechanically?
+
+**Decision**: It means the derived public atom set must continue to equal, byte
+for byte, the frozen **postactivation** set — not merely "stay close to it".
+
+**Rationale**: `scripts/validate-lifecycle-oracle-traceability.cjs` already owns
+this as a three-state check (`ordinaryRetirementLifecycle`). It derives the
+actual public atom set from the source map and compares it against exactly two
+frozen sets:
+
+- **preactivation** — every migration atom in the manifest;
+- **postactivation** — the atoms of every category whose `decision` is `"keep"`,
+  plus `introduced_v11_atoms`.
+
+Anything that is neither fails closed with
+`RETIREMENT_LIFECYCLE_PHASE_INVALID: public API is neither frozen preactivation
+(N) nor postactivation (M); actual=K`.
+
+This has a consequence sharper than the roster's prose, and it is the single
+most useful thing this research produced:
+
+> **The postactivation set is defined as kept ∪ introduced. Every public atom
+> that survives the cut is therefore already required to exist by the frozen
+> contract. Slice 5 cannot remove a public atom at all** — removing one drops
+> the tree out of both accepted states and fails the gate.
+
+So Slice 5's removal surface is **strictly non-public code**: private items,
+crate-internal helpers, unreachable branches behind public entry points, and
+tests whose subjects go with them. "Do not change public behavior" is not a
+caution to be careful; it is a closed set the checker enforces.
+
+**Alternatives considered**: treating the retirement inventory's `disposition`
+fields as the removal authority. Rejected — dispositions describe what the
+*cut* had to do to each member (route / remove / retire). They are not a
+statement about what may be deleted from the tree afterwards, and several
+members with retirement dispositions are public atoms the postactivation set
+still requires.
+
+---
+
+## R2 — Which sealed values move when source is deleted, and who may recompute them?
+
+**Decision**: Two whole-source pins in `tests/preventive_runtime_dark_v11.rs`
+move on any `src/` deletion, and only the owning Rust oracle may recompute
+them:
+
+| Pin | Shape | Current recorded value |
+|---|---|---|
+| `FULL_SOURCE_PIN_V1` | (digest, file count, byte count) | 196 files, 9 300 142 bytes |
+| `EXCLUDED_RUNTIME_SOURCE_PIN_V1` | (digest, file count, byte count) | 20 files, 388 720 bytes |
+
+**Rationale**: Constitution Principle V forbids out-of-band recomputation of
+sealed values outright — "the Rust oracle that owns the seal is the only
+recompute authority, and `rustfmt` runs BEFORE any pin refresh". The rule
+exists because a hand-rolled recompute silently diverged from the oracle once
+already. The pins carry counts as well as a digest, which is what makes a
+refresh auditable: a removal must move the file/byte counts *downward by the
+amount removed*, and a refresh whose counts move the wrong way is evidence of
+a mistake rather than a formality to be updated.
+
+**Alternatives considered**: excluding removed files from the seal's scope so
+the pin does not move. Rejected — that hides the removal from the very seal
+whose job is to notice source changes.
+
+---
+
+## R3 — Where does the reachability evidence Slice 5 consumes actually live?
+
+**Decision**: In the executed Slice 4 reachability cases, not in the
+preactivation census.
+
+**Rationale**: `contracts/v10-authority-retirement-v11.md` states it directly:
+"After activation, the executed Slice 4 reachability cases replace the
+preactivation census." The traceability checker's `source_anchor_policy` says
+the same from the other side: "Every preactivation V10 `src/` retirement member
+resolves on the refreeze tree; release evidence instead covers every frozen V11
+production seam with one same-tree source receipt after retirement."
+
+Two consequences the plan depends on:
+
+1. **Deleting retired V10 code cannot break the census.** Its anchors resolve
+   against the externally approved refreeze ancestor tree, which deletion on
+   the current tree cannot alter.
+2. **Deleting a frozen V11 production seam breaks the release evidence**,
+   because those require a *same-tree* source receipt. This is the real
+   tripwire, and it is why spec FR-005 exists.
+
+**Alternatives considered**: re-deriving reachability from scratch with a
+call-graph sweep. Rejected as both redundant and weaker — Slice 4 already
+executed the cases under review, and a fresh grep-based sweep would be exactly
+the "looks unused" evidence FR-004 forbids.
+
+---
+
+## R4 — Is there dead V10 embed implementation left for T076?
+
+**Decision**: Unresolved by research, and deliberately left so. The plan's
+executed step must observe it.
+
+**Rationale**: `src/embed.rs` is 163 lines with a small surface
+(`EngineInfo`, `engine_info()`, and a `contract` module whose
+`facade_contract_is_stable` test asserts the shape). That is consistent with
+Slice 4's T067 having already retired the raw embed update/remove exports, but
+consistency is not proof, and the frozen ordering forbids acting before the
+allowlist negative suite has spoken.
+
+Recording this as an unresolved observation rather than a conclusion is the
+point: spec FR-011 requires a discharged expectation to be evidenced, and an
+expectation cannot be discharged by a plan that assumed the answer.
+
+**Alternatives considered**: asserting in the plan that T076 is already
+complete. Rejected — that is a success claim for an operation nobody observed,
+which Principle I forbids in exactly these words.
+
+---
+
+## R5 — How is the neutrality bracket shown to work before it is trusted?
+
+**Decision**: By a deliberate control edit that the comparison must catch, run
+before any real removal, and discarded afterwards.
+
+**Rationale**: Principle II requires every negative test to carry its accepting
+positive control in the same test, because "a system that refuses everything
+satisfies a lone negative perfectly". A neutrality bracket is a negative
+instrument — it reports "nothing changed" — so an always-quiet bracket passes
+its own check perfectly while proving nothing. The control is what separates
+an enforced comparison from a vacuous one.
+
+The control must move a field the bracket claims to cover, and the bracket must
+name that field. A control that trips the build instead of the comparison
+proves nothing about the comparison.
+
+**Alternatives considered**: trusting the comparison because it is
+mechanically derived. Rejected on precedent — `format_search_envelope` was
+mechanically derived too, and collapsed to a confident banner on a string
+comparison it never measured.
+
+---
+
+## R6 — What gate set applies, and what is the ordering constraint?
+
+**Decision**: The project's existing gate set, unchanged, run one cargo
+invocation at a time with long runs through Terminal Commander.
+
+| Gate | Purpose here |
+|---|---|
+| `cargo fmt --check` | Must run **before** any pin refresh (Principle V) |
+| `cargo clippy --all-targets -- -D warnings` | Removal commonly orphans an import; this is where that surfaces |
+| Full serial suite (`--test-threads=1`) | Behaviour |
+| `cargo test --no-default-features --features embed --lib` | The cfg cell no default-feature gate can see |
+| Release build + `verify-tools.cjs` | Tool correctness |
+| `node scripts/validate-lifecycle-oracle-traceability.cjs` | The R1 three-state public-API check |
+| `node scripts/slice0-oracle-artifact.cjs` | Fails closed if a control's status flips |
+| npm suite | Package surface |
+
+**Rationale**: Principle IV fixes the set and the serial discipline; the
+ordering constraint (`fmt` before pin refresh) comes from Principle V. The
+slice adds no gate and relaxes none — a removal slice that needed a new gate
+would not be a removal slice.
+
+**Alternatives considered**: running only the gates a removal "could plausibly
+affect". Rejected — the whole premise under test is that the removal affects
+nothing, so narrowing the gates assumes the conclusion.
+
+---
+
+## Resolved Technical Context
+
+| Field | Value |
+|---|---|
+| Language/Version | Rust (repository `rust-toolchain.toml`), with Node and Python for the checker and refreeze tooling |
+| Primary Dependencies | None added; this slice removes only |
+| Storage | N/A |
+| Testing | `cargo test` serial, plus the Node checkers and the npm suite |
+| Target Platform | Linux CI is authority; Windows and macOS cells gate additionally |
+| Project Type | Single Rust crate with an MCP server surface |
+| Performance Goals | None — neutrality, not speed |
+| Constraints | Public atom set must remain exactly the postactivation set (R1); frozen tree unedited; seals refreshed only by their oracle (R2) |
+| Scale/Scope | Bounded by evidenced-unreachable non-public items; may legitimately be empty |
+
+## Open observations the executed plan must make
+
+1. Which lifecycle phase the tree reports today — `preactivation` or
+   `postactivation`. R1 makes this decisive for whether the atom set may move
+   at all, and it is cheap to observe but must not be assumed.
+2. Whether any evidenced-unreachable non-public code actually remains.
+3. Whether `src/embed.rs` still holds dead V10 implementation (R4).
+
+All three are observations, not predictions. If the answer to 2 and 3 is "no",
+the slice closes with the bracket, the baseline, and a recorded discharge —
+which spec Edge Cases already admits as a valid outcome.

--- a/specs/029-mechanical-removal/spec.md
+++ b/specs/029-mechanical-removal/spec.md
@@ -26,18 +26,28 @@ while the tree gets smaller.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - A removal can be proven behaviour-neutral (Priority: P1)
+### User Story 1 - A removal can be proven behaviour-neutral (Priority: P2 — admission instrument)
+
+> **Demoted from P1 on 2026-08-21** by two independent uncontaminated reviews
+> (LINUS, HOLMES). The bracket is the **admission gate for a removal**, not the
+> slice's product. The frozen job is delete-only-proven-unreachable; shipping a
+> bracketing platform so the slice has something to show when it deletes
+> nothing is exactly the inversion they called out. **US2 is P1 whenever
+> anything is evidenced-unreachable.**
+>
+> What is explicitly *kept*: C-1 and Acceptance Scenario 3, the control. Both
+> reviewers said so unprompted — the canary stays, only its billing changes.
 
 A maintainer removes something from `src/` and needs to establish, from evidence
 rather than assertion, that runtime authority, public behaviour, writer
 reachability, and activation mode are unchanged. Today no bracketing artifact
 exists: the only way to argue neutrality is to reason about the diff.
 
-**Why this priority**: Every subsequent removal depends on it, and it carries
-standalone value — once the bracket exists, *any* future removal in this
-codebase can be held to the same standard, whether or not Slice 5 removes a
-single line. It is also the only part of the slice that cannot be skipped if the
-recon finds nothing removable.
+**Why this priority**: Every removal must pass through it, so it gates US2 —
+but it is a gate, not a deliverable. The "standalone value for any future
+removal" argument that originally justified P1 is YAGNI: this slice was not
+asked for a reusable bracketing platform, and building one is how a
+delete-only slice quietly becomes a methodology project.
 
 **Independent Test**: Capture the baseline, introduce a deliberate control
 change, re-capture, and confirm the comparison **names the field that moved**.
@@ -70,15 +80,17 @@ broken comparison would also do.
 
 ---
 
-### User Story 2 - Retired V10 authority is gone from the tree (Priority: P2)
+### User Story 2 - Retired V10 authority is gone from the tree (Priority: P1 when anything is evidenced-unreachable)
 
 A reader of `src/` currently cannot distinguish V10 authority that the cut
 retired from V11 machinery that is live. Both compile; both are named; only one
 runs. The retirement inventory records the disposition, but the source does not.
 
-**Why this priority**: This is the slice's headline product, but it is worthless
-and dangerous without US1's bracket — an unbracketed removal is exactly the
-"confidently wrong" failure this project treats as unrecoverable.
+**Why this priority**: This IS the slice. The frozen goal is to delete code
+proven unreachable; everything else exists to make that safe. It is still
+gated on US1's bracket — an unbracketed removal is exactly the "confidently
+wrong" failure this project treats as unrecoverable — but a gate is not a
+product, and if the recon finds removable code this story is the deliverable.
 
 **Independent Test**: For each candidate, produce the evidence that it is
 unreachable *before* deleting it, delete it, and show the US1 bracket reports no
@@ -98,9 +110,10 @@ and is recorded as retained with the reason.
    is removed, **Then** those tests are removed in the same change, and no test
    with a surviving subject is removed.
 4. **Given** any removal, **When** the whole-source seals are re-derived,
-   **Then** the recorded file count and byte total move in the direction of the
-   removal and the new digests are taken from the tool's own actuals, never
-   hand-computed.
+   **Then** each pin is judged against **its own file set**: a pin the removal
+   intersected shows a lower byte count (and a lower file count only if a whole
+   file went), while a pin the removal did not touch stays byte-identical. New
+   digests come from the tool's own actuals, never hand-computed.
 
 ---
 

--- a/specs/029-mechanical-removal/spec.md
+++ b/specs/029-mechanical-removal/spec.md
@@ -39,10 +39,20 @@ codebase can be held to the same standard, whether or not Slice 5 removes a
 single line. It is also the only part of the slice that cannot be skipped if the
 recon finds nothing removable.
 
-**Independent Test**: Capture the baseline, change nothing at all, re-run the
-baseline, and confirm the two records are identical. A bracket that cannot
-detect the null change is not a bracket; a bracket that reports a difference
-across an empty diff is broken and must be fixed before any removal.
+**Independent Test**: Capture the baseline, introduce a deliberate control
+change, re-capture, and confirm the comparison **names the field that moved**.
+Then discard the control. The story is closed by the bracket detecting a real
+change — not by it staying quiet across an empty diff, which a permanently
+broken comparison would also do.
+
+> **Amended 2026-08-21** after independent review. The original Independent
+> Test was the null re-run alone. Spec-kit Independent Tests are what an
+> executor uses to close a story on its own, so that wording let US1 close
+> without ever exercising the only thing that makes a bracket a bracket — the
+> exact vacuous-negative shape Constitution Principle II forbids, in the same
+> document that invokes Principle II three sections later. The null re-run
+> remains valuable and is kept as Acceptance Scenario 2; it is no longer the
+> standalone proof.
 
 **Acceptance Scenarios**:
 
@@ -158,9 +168,11 @@ no dead code remains, record that finding with its evidence and remove nothing.
 - **FR-005**: The slice MUST NOT remove any frozen V11 production seam.
 - **FR-006**: The slice MUST NOT change runtime authority, public behaviour,
   writer reachability, or activation mode.
-- **FR-007**: The public API atom set after removal MUST equal exactly one of
-  the two frozen sets the traceability checker accepts; landing between them is
-  a failure, not a partial success.
+- **FR-007**: The tree is observed `postactivation`. After removal the derived
+  3-segment lifecycle atom set MUST still equal the frozen postactivation set
+  exactly. Additionally the full 64-atom introduced set MUST still resolve, and
+  the consumer fixtures MUST still compile as expected — the lifecycle checker
+  alone cannot see the 34 four-segment atoms, so its green is not sufficient.
 - **FR-008**: The slice MUST NOT edit any byte of the frozen spec tree,
   including checkbox bytes.
 - **FR-009**: Tests MUST be removed only when their subject was removed in the
@@ -199,8 +211,10 @@ no dead code remains, record that finding with its evidence and remove nothing.
   least one** differing field and names it.
 - **SC-003**: **100%** of removals cite pre-existing unreachability evidence;
   removals citing none: **zero**.
-- **SC-004**: The post-removal public API atom set matches one of the two
-  accepted frozen sets exactly; atoms outside both: **zero**.
+- **SC-004**: The post-removal 3-segment lifecycle atom set matches the frozen
+  postactivation set exactly (atoms outside it: **zero**), **and** the refreeze
+  allowlist resolves all 64 introduced atoms, **and** the consumer fixtures
+  compile as expected. All three, not any one.
 - **SC-005**: Bytes changed inside the frozen spec tree: **zero**.
 - **SC-006**: Frozen V11 production seams removed: **zero**.
 - **SC-007**: Tests removed whose subject still exists: **zero**.

--- a/specs/029-mechanical-removal/spec.md
+++ b/specs/029-mechanical-removal/spec.md
@@ -1,0 +1,241 @@
+# Feature Specification: Feature 020 Slice 5 — Mechanical Removal
+
+**Feature Branch**: `029-mechanical-removal`
+
+**Created**: 2026-08-21
+
+**Status**: Draft
+
+**Input**: Slice 5 of Feature 020 (repository-knowledge-index): mechanical removal. Delete ONLY code already proven unreachable by the Slice 4 activation cut, per the frozen roster T074–T077 (`specs/020-repository-knowledge-index/tasks.md` Phase 7, lines 958–966).
+
+## Governing constraint (frozen, verbatim)
+
+> "Delete only code already proven unreachable in Slice 4; do not change runtime
+> authority, public behavior, writer reachability, or activation mode."
+> — `specs/020-repository-knowledge-index/tasks.md:960-961`
+
+The frozen spec tree `specs/020-repository-knowledge-index/` is immutable input,
+**including its checkbox bytes**. This spec derives from it and must not
+contradict it. Where this spec and the frozen tree disagree, the frozen tree wins
+and this spec is amended.
+
+This slice is unusual and its unusualness is the point: **it is the only slice
+whose success condition is that nothing observable changes.** Every other slice
+is judged by what it makes true. This one is judged by what it leaves identical
+while the tree gets smaller.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A removal can be proven behaviour-neutral (Priority: P1)
+
+A maintainer removes something from `src/` and needs to establish, from evidence
+rather than assertion, that runtime authority, public behaviour, writer
+reachability, and activation mode are unchanged. Today no bracketing artifact
+exists: the only way to argue neutrality is to reason about the diff.
+
+**Why this priority**: Every subsequent removal depends on it, and it carries
+standalone value — once the bracket exists, *any* future removal in this
+codebase can be held to the same standard, whether or not Slice 5 removes a
+single line. It is also the only part of the slice that cannot be skipped if the
+recon finds nothing removable.
+
+**Independent Test**: Capture the baseline, change nothing at all, re-run the
+baseline, and confirm the two records are identical. A bracket that cannot
+detect the null change is not a bracket; a bracket that reports a difference
+across an empty diff is broken and must be fixed before any removal.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean tree at the current release ref, **When** the baseline is
+   captured, **Then** it records the public API atom set, the activation-mode
+   result, the writer-reachability verdict, and the behavioural gate outcomes,
+   each with the exact command that produced it.
+2. **Given** a captured baseline, **When** it is re-captured with no
+   intervening source change, **Then** every recorded field is byte-identical
+   and the comparison reports zero differences.
+3. **Given** a captured baseline, **When** a deliberate behaviour-changing edit
+   is introduced as a control, **Then** the comparison reports a difference and
+   names the field that moved. A bracket that stays quiet through a real change
+   is providing false assurance and fails this scenario.
+
+---
+
+### User Story 2 - Retired V10 authority is gone from the tree (Priority: P2)
+
+A reader of `src/` currently cannot distinguish V10 authority that the cut
+retired from V11 machinery that is live. Both compile; both are named; only one
+runs. The retirement inventory records the disposition, but the source does not.
+
+**Why this priority**: This is the slice's headline product, but it is worthless
+and dangerous without US1's bracket — an unbracketed removal is exactly the
+"confidently wrong" failure this project treats as unrecoverable.
+
+**Independent Test**: For each candidate, produce the evidence that it is
+unreachable *before* deleting it, delete it, and show the US1 bracket reports no
+difference. A candidate whose unreachability cannot be evidenced is not removed
+and is recorded as retained with the reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** a removal candidate, **When** its unreachability is asserted,
+   **Then** the assertion cites the executed Slice 4 reachability case or
+   retirement-inventory disposition that establishes it — never task wording,
+   never a name that merely looks legacy.
+2. **Given** a candidate that is a frozen V11 production seam, **When** removal
+   is considered, **Then** it is refused, because those seams require a
+   same-tree source receipt that deletion would destroy.
+3. **Given** a candidate whose only consumers are tests, **When** the candidate
+   is removed, **Then** those tests are removed in the same change, and no test
+   with a surviving subject is removed.
+4. **Given** any removal, **When** the whole-source seals are re-derived,
+   **Then** the recorded file count and byte total move in the direction of the
+   removal and the new digests are taken from the tool's own actuals, never
+   hand-computed.
+
+---
+
+### User Story 3 - The dead V10 embed implementation is gone, or proven already gone (Priority: P3)
+
+The roster expects a dead V10 embed implementation to remain in `src/embed.rs`.
+Recon suggests the activation cut already retired most of it. Either outcome is
+acceptable; asserting the wrong one is not.
+
+**Why this priority**: Smallest and most contained, and gated on a proof that
+must exist first.
+
+**Independent Test**: Run the allowlist negative suite and read its verdict. If
+it proves the V10 embed surface unnameable and dead code remains, remove it. If
+no dead code remains, record that finding with its evidence and remove nothing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the allowlist negative suite has not been run, **When** removal
+   from the embed surface is attempted, **Then** it is refused — the frozen
+   ordering is "only after ... proves it unnameable".
+2. **Given** the suite proves the surface unnameable, **When** the
+   implementation is inspected, **Then** either dead code is found and removed,
+   or its absence is recorded as a discharged expectation with the evidence
+   that discharged it.
+
+---
+
+### Edge Cases
+
+- **The slice removes nothing.** If no candidate survives its evidence
+  requirement, that is a legitimate closure, not a failure. The slice still
+  produces the bracket, the baseline, the re-run, and an evidence document
+  stating that the expected dead code did not exist. What must never happen is
+  removing something to make the slice feel productive.
+- **A removal moves a seal that a frozen document pins.** Whole-source seals
+  live in the test tree and are refreshed from tool actuals. Digests inside the
+  frozen spec tree are never edited; if a removal would require editing one, the
+  removal is refused and the conflict recorded.
+- **A candidate is unreachable in the default build but reachable in another
+  feature configuration.** Reachability is a property of a configuration set,
+  not of one build. A candidate must be unreachable in every configuration the
+  project builds, or it stays.
+- **A removal is neutral in isolation but not in combination.** The bracket is
+  re-run over the accumulated state, not per-item in isolation.
+- **The baseline and the re-run disagree for an unrelated reason** (a flaky
+  gate, an environment difference). The disagreement is investigated to root
+  cause before it is attributed to the removal, and the cause is recorded. A
+  difference explained away without a cause is a failed slice.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The slice MUST capture a pre-cleanup baseline covering public API,
+  authority reachability, behaviour, and activation result, each field paired
+  with the exact command that produced it.
+- **FR-002**: The slice MUST re-capture that baseline after removal and compare
+  the two records field by field, reporting either zero differences or the exact
+  fields that moved.
+- **FR-003**: The comparison MUST be demonstrated to detect a real change before
+  it is trusted to certify the absence of one.
+- **FR-004**: Every removal MUST cite pre-existing evidence of unreachability.
+  Task wording, a legacy-sounding name, and "it looks unused" are not evidence.
+- **FR-005**: The slice MUST NOT remove any frozen V11 production seam.
+- **FR-006**: The slice MUST NOT change runtime authority, public behaviour,
+  writer reachability, or activation mode.
+- **FR-007**: The public API atom set after removal MUST equal exactly one of
+  the two frozen sets the traceability checker accepts; landing between them is
+  a failure, not a partial success.
+- **FR-008**: The slice MUST NOT edit any byte of the frozen spec tree,
+  including checkbox bytes.
+- **FR-009**: Tests MUST be removed only when their subject was removed in the
+  same change.
+- **FR-010**: Whole-source seals affected by removal MUST be refreshed from the
+  producing tool's own observed output, never hand-computed.
+- **FR-011**: An expectation that recon discharges (dead code the roster
+  predicts, which does not exist) MUST be recorded as discharged with its
+  evidence, not silently dropped and not satisfied by removing something else.
+- **FR-012**: The slice MUST end with an independent adversarial review whose
+  findings are fixed or explicitly adjudicated with rationale, never silently
+  dropped.
+- **FR-013**: Every claim in the slice's evidence document MUST state what was
+  observed and what the observation would have emitted had it failed.
+
+### Key Entities
+
+- **Removal candidate**: a named item in `src/`, its evidence of
+  unreachability, its disposition (removed / retained), and, when retained, the
+  reason.
+- **Neutrality baseline**: the recorded pre-removal state — public API atom
+  set, activation result, writer-reachability verdict, behavioural gate
+  outcomes — with the command that produced each field.
+- **Neutrality comparison**: the field-by-field diff of two baselines, plus the
+  control result proving the comparison can detect a real change.
+- **Discharged expectation**: a roster-predicted removal that recon proves
+  unnecessary, with the evidence that proved it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The baseline re-run over an unchanged tree reports **zero**
+  differing fields.
+- **SC-002**: The control run over a deliberately changed tree reports **at
+  least one** differing field and names it.
+- **SC-003**: **100%** of removals cite pre-existing unreachability evidence;
+  removals citing none: **zero**.
+- **SC-004**: The post-removal public API atom set matches one of the two
+  accepted frozen sets exactly; atoms outside both: **zero**.
+- **SC-005**: Bytes changed inside the frozen spec tree: **zero**.
+- **SC-006**: Frozen V11 production seams removed: **zero**.
+- **SC-007**: Tests removed whose subject still exists: **zero**.
+- **SC-008**: Every verification gate that was green before the slice is green
+  after it; newly failing gates: **zero**.
+- **SC-009**: Every roster-predicted removal is either performed with evidence
+  or recorded as discharged with evidence; silently dropped predictions:
+  **zero**.
+- **SC-010**: Adversarial review findings left neither fixed nor explicitly
+  adjudicated: **zero**.
+
+## Assumptions
+
+- **An empty removal is a valid outcome.** The slice's obligation is honest
+  disposition of every predicted removal, not a minimum line count. Slice 4's
+  retirement work may already have discharged most of Phase 7's scope; the
+  recon that suggested this is treated as a hypothesis the slice must confirm,
+  not as a conclusion.
+- **"Legacy mode branches" does not mean the activation machine's own bootstrap
+  states.** `LegacyOpen` and `LegacyClosing` are the live entry states of the
+  machine the cut installed — the process boots into the first, drains through
+  the second, and only then opens the preventive mode. They are reachable on
+  every start. The phrase refers to the V10 authority branches that machine
+  replaced. This assumption is recorded because acting on the other reading
+  would delete the startup path while looking like faithful task execution.
+- **Deleting retired V10 code cannot break the retirement census**, because
+  preactivation members resolve against the externally approved refreeze
+  ancestor tree rather than the current tree. Frozen V11 production seams are
+  the opposite case and are protected by FR-005.
+- **Reachability evidence already exists** as the executed Slice 4 reachability
+  cases and the retirement inventory dispositions. The slice consumes that
+  evidence; it does not re-derive it, and it does not invent new evidence for a
+  candidate that lacks it.
+- **The verification gate set is the project's existing one.** This slice adds
+  no gate and relaxes none.
+- **Removal is staged, not atomic.** Unlike Slice 4, no part of this slice is
+  indivisible; candidates may land in separate changes provided each carries its
+  own bracket result.

--- a/tests/project_index_lifecycle_slice0.rs
+++ b/tests/project_index_lifecycle_slice0.rs
@@ -106,7 +106,7 @@ fn write_project_files(root: &Path, prefix: &str, count: usize) {
 ///
 /// A refusal must be a refusal: no project slot, no watcher, no session.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defect 2.1; remove this attribute in Slice 2 (T030-T040) when admission refusal is a typed outcome"]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.1. CONTROL-STALE as of the 2026-08-21 Track A read: V11 answers a refused open with Ok plus a typed SourceRefusal and a non-ready slot, not the Err-plus-zero-slots this body asserts, and FR-004 strict acquisition is the lease. Retarget the body to the typed refusal; do NOT switch production to satisfy the old encoding. Unmeasured residual: activate still starts a watcher (daemon.rs:3398-3403)"]
 fn capacity_refused_open_creates_no_slot_and_no_watcher() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -153,7 +153,7 @@ fn capacity_refused_open_creates_no_slot_and_no_watcher() {
 /// An empty placeholder must not accept mutations: it is the absence of a
 /// publication, not an empty one.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defects 2.2/2.3; observed still red at the watcher seam after the Slice 4 activation cut (spec 028) — remove when a never-published placeholder refuses watcher mutation there"]
+#[ignore = "Feature 020 Slice 0 RED control for design defects 2.2/2.3. CODE-WRONG as of the 2026-08-21 Track A read: add_file (live_index/store.rs:2820-2831) has no EmptyBootstrap gate, and the default-suite check at store.rs:6402-6412 papers over it rather than closing it. Keep ignored and fail-closed until a seam owner exists"]
 fn empty_placeholder_publication_refuses_watcher_mutation() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -260,7 +260,7 @@ fn empty_placeholder_publication_refuses_watcher_mutation() {
 /// bootstrap path; on reload it propagates, which is exactly the `?` that skips
 /// the watcher restart.)
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defect 2.10; observed still red at the daemon seam after the Slice 4 activation cut (spec 028) — remove when observer handoff is non-destructive there"]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.10. CODE-WRONG as of the 2026-08-21 Track A read: the path aborts the watcher and then returns via ?, installing no replacement on the Err branch, so the recovery observer is lost. Keep ignored and fail-closed until a seam owner exists"]
 fn failed_reload_retains_the_recovery_observer() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -372,7 +372,7 @@ fn failed_reload_retains_the_recovery_observer() {
 /// about the window rather than a race: the predecessor is stopped and awaited
 /// before the write, and the successor starts after it.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for observer replacement gaps; observed still red at the daemon seam after the Slice 4 activation cut (spec 028) — remove when handoff latches the gap there"]
+#[ignore = "Feature 020 Slice 0 RED control for observer replacement gaps. CODE-WRONG as of the 2026-08-21 Track A read: recompute_freshness_locked drops the historical gap and rederives Current, so nothing latches. Keep ignored and fail-closed until a seam owner exists"]
 fn observer_replacement_gap_is_latched_as_non_current() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -480,7 +480,7 @@ fn observer_replacement_gap_is_latched_as_non_current() {
 /// present state, so the next clean publication erases it. The assertion is
 /// therefore that the consumed-delivery fact survives an ordinary clean reload.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for old-observer delivery after promotion; observed still red at the daemon seam after the Slice 4 activation cut (spec 028) — remove when a stable observer token fences delivery there"]
+#[ignore = "Feature 020 Slice 0 RED control for old-observer delivery after promotion. CODE-WRONG as of the 2026-08-21 Track A read: the same rederive path runs with no stable observer token fencing delivery. Keep ignored and fail-closed until a seam owner exists"]
 fn old_observer_delivery_after_promotion_is_not_current() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -573,7 +573,7 @@ fn old_observer_delivery_after_promotion_is_not_current() {
 /// mutations survive promotion. Losing them and reporting success is the one
 /// outcome that must not happen.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defects 2.7/2.9; observed still red (precondition window unreachable) after the Slice 4 activation cut (spec 028) — remove when candidate isolation is observable at this seam"]
+#[ignore = "Feature 020 Slice 0 RED control for design defects 2.7/2.9. CODE-WRONG. The earlier claim that the precondition window was unreachable is FALSE on this tree: live_index/store.rs:2403-2436 still reaches swap_and_publish and IsolatedCandidate appears nowhere in store.rs, so the seam never routes through the candidate pipeline. Keep ignored and fail-closed until a deterministic pause exists at this seam; the official TEST-CANDIDATE case does not retire it"]
 fn watcher_mutation_during_candidate_build_is_not_discarded() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -671,7 +671,7 @@ fn watcher_mutation_during_candidate_build_is_not_discarded() {
 ///
 /// Sibling B's latest must survive source A's publication.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for FR-008/FR-009/SC-005; observed still red (precondition window unreachable) after the Slice 4 activation cut (spec 028) — remove when whole-project publication is observable at this seam"]
+#[ignore = "Feature 020 Slice 0 RED control for FR-008/FR-009/SC-005. CONTROL-STALE as of the 2026-08-21 Track A read: the frozen oracle is pause A / publish B / rebase / tokens / one store, but this body races V10 LiveIndex::reload against 1500 files in 150ms. Retarget the body to the frozen oracle; making reload win that race is not the property"]
 fn whole_project_publication_preserves_latest_siblings() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -774,7 +774,7 @@ fn whole_project_publication_preserves_latest_siblings() {
 /// A snapshot is a seed, not a publication: nothing from it may answer a query
 /// before its identity and completeness are re-proved.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defect 2.11; observed still red at the daemon seam after the Slice 4 activation cut (spec 028) — remove when SnapshotStore per-entry verify-state wiring lands (recorded residual)"]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.11. CODE-WRONG as of the 2026-08-21 Track A read: persist hydrates files immediately, get_file has no Pending gate, and is_ready() is status-only. The SnapshotStore per-entry verify-state wiring remains a recorded open residual. Keep ignored and fail-closed until a seam owner exists"]
 fn snapshot_seed_is_not_queryable_before_verification() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -855,7 +855,7 @@ fn snapshot_seed_is_not_queryable_before_verification() {
 ///
 /// A configured ceiling must bound the process, not each load in isolation.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defect 2.5; remove this attribute in Slice 2 (T030-T040) when capacity is a process-wide reservation"]
+#[ignore = "Feature 020 Slice 0 RED control for design defect 2.5. CONTROL-STALE as of the 2026-08-21 Track A read: FR-004 makes capacity a per-candidate catalog and SC-025 owns the ProcessCapacityPool, while SYMFORGE_MAX_INDEX_FILES is per discovery pass. Making that env var process-wide would fight FR-004 and still miss SC-025. Retarget the body at ProcessCapacityPool"]
 fn configured_capacity_bounds_the_process_not_each_load() {
     run_daemon_test(async {
         const CEILING: usize = 10;
@@ -919,7 +919,7 @@ fn configured_capacity_bounds_the_process_not_each_load() {
 /// survives a subsequent clean publication: V10's freshness is a pure function
 /// of present state, so a transient non-Current proves nothing.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for same-path physical-root replacement; remove this attribute in Slice 1 (T022-T029) when physical root identity is canonical and fenced"]
+#[ignore = "Feature 020 Slice 0 RED control for same-path physical-root replacement. CODE-WRONG as of the 2026-08-21 Track A read: the registry stays path-keyed and publishes Current, so a replaced root at the same path is adopted silently. Slice 1 shipped without discharging it. Keep ignored and fail-closed until a seam owner exists"]
 fn same_path_root_replacement_is_not_silently_adopted() {
     run_daemon_test(async {
         let parent = TempDir::new().expect("parent dir");


### PR DESCRIPTION
Six commits of documentation and test-attribute prose. **No production code changes** — `git diff origin/main..HEAD -- src/` is empty, so no whole-source seal moves.

## What's here

**The Slice 5 execution spec** (`specs/029-mechanical-removal/`) — spec, plan, Phase 0 research, data model, evidence contract, quickstart, checklist. Derived from the frozen Phase 7 roster; the frozen tree is byte-identical (`git diff` over `specs/020-…` is empty).

**Four independent reviews, and the amendments they forced.** Grok 4.6 and Composer 2.5 reviewed the spec/plan; LINUS and HOLMES reviewed Track A and the two open design questions. Every accepted finding was verified against source before being applied.

The two that would have caused damage rather than confusion:

- **C-5's pin arithmetic was wrong.** It required both whole-source pins to move downward on any removal. `EXCLUDED_RUNTIME_SOURCE_PIN_V1` covers only 19 `index_lifecycle/*.rs` plus `server_api.rs`, and T076's own target `src/embed.rs` sits outside it. An executor obeying the clause would have refreshed a seal that never moved.
- **C-2 claimed the lifecycle checker defined public-behaviour neutrality.** `directPublicAtoms` filters to `<= 3` segments and 34 of 64 introduced atoms are 4-segment methods under `embed`, which is also excluded from the regex scan. Deleting `Claim::value` would have left that gate green while public API shrank. Now three named owners, with `refreeze_v11.py verify-internal` on every removal landing.

**Track A dispositions** (`tests/project_index_lifecycle_slice0.rs`). Ten `#[ignore]` strings rewritten to carry their disposition and live miss: **3 control-stale**, **7 code-wrong**. Nothing un-ignored, no production code moved, roster unchanged.

One string was asserting something false. `watcher_mutation_during_candidate_build_is_not_discarded` claimed its precondition window was unreachable. Verified before rewriting: `store.rs:2403-2436` still reaches `swap_and_publish` and `IsolatedCandidate` appears zero times in `store.rs` — the window is reachable, the seam just never routes through the candidate pipeline.

**`scripts/lifecycle-phase-probe.cjs`** — the traceability checker decides the lifecycle phase internally and prints only `OK (…)`, so no command could answer "which frozen set does this tree match?". The spec required that as a baseline field. Now it is obtainable: `PHASE: postactivation, actual: 34, pre: 83, post: 34`.

## What is deliberately NOT here

- **No Slice 5 execution.** The spec is ready; running it is a separate campaign.
- **No Track A implementation.** Seven code-wrong controls with no seam owner is a design question, not seven bug fixes.
- **`src/daemon.rs`'s stale `#[ignore]` string.** The correction is written and was reverted unapplied: `daemon.rs` is inside `FULL_SOURCE_PIN_V1`'s file set, so editing it moves a seal only the Rust oracle may recompute. Recorded as owed in the ledger rather than half-done.

## Caveat worth stating before checks run

`validate_file_syntax` reports the edited test file parses, but that is a tree-sitter parse, not `rustc`. **CI is the first real compiler check on those ten string literals.** If one is malformed it surfaces in the `rust` job, not before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn