### PR TITLE
docs: record the switch that arms Phase 8's release gates

### DIFF
--- a/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
+++ b/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
@@ -271,6 +271,54 @@ in the repo.
 Central artifact for all of T078–T090:
 `docs/reviews/FEATURE-020-V11-RELEASE-GATE.md` — **does not exist**.
 
+### The switch that arms Phase 8's release gates
+
+**`.github/release-evidence-requirements-v11.json`** — found 2026-08-21 while
+tracing why two V11 gates never appear in a Release run.
+
+Two steps in `.github/workflows/release.yml` are guarded by
+`if: needs.resolve-release-ref.outputs.lifecycle_gate_active == 'true'`:
+
+- *Verify Feature 020 V11 refreeze integrity* (`refreeze_v11.py verify-internal`)
+- *Test and verify Feature 020 V11 lifecycle traceability*
+
+`lifecycle_gate_active` is derived from that JSON file, which currently reads:
+
+```json
+{ "phase": "pre_activation",
+  "required_oracle_receipts": [],
+  "required_review_documents": [],
+  "required_task_receipts": [] }
+```
+
+So both steps **skip on every Release run**, and have since the file was
+frozen. The workflow asserts the inverse too — `gate-release-ref` fails with
+*"The pre-activation Feature 020 lifecycle gate unexpectedly ran"* if the phase
+is `pre_activation` and the gate did not skip. This is intentional and
+self-consistent, not a hole.
+
+**Two things a Phase 8 executor needs from this:**
+
+1. **Flipping `phase` to `active` is Track D work.** Once flipped, those two
+   Release gates arm, and the three `required_*` arrays stop being empty — they
+   become the receipt roster T089/T090 must satisfy. The file is the switch; do
+   not treat it as configuration to be tidied.
+2. **The skip does not mean those paths are unexercised.** `ci.yml:78-86` runs
+   both gates **unconditionally** on every PR, with no `if:` guard. They ran on
+   every PR that reached `main`. The Release-side skip means only that *that
+   run* did not exercise them.
+
+The distinction matters because the two statements read almost identically and
+only one is true: *"the gates did not run on that Release run"* is correct;
+*"those paths were not exercised"* is not.
+
+There is a real oddity to sit with, though, and it is not a defect: the tree
+**activated** in V11 — 11.0.0 shipped, `PreventiveV1Open` is the only live mode
+— while the release-evidence phase still says `pre_activation`. That is
+correct today, because the phase tracks Phase 8's *evidence* obligation rather
+than the runtime's mode, and Phase 8 has not started. It will read as a
+contradiction to whoever finds it cold, which is why it is written down here.
+
 Never-materialized code artifacts:
 
 | Path | Owed by | Status |

--- a/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
+++ b/docs/reviews/FEATURE-020-POST-V11-LEDGER.md
@@ -303,8 +303,11 @@ self-consistent, not a hole.
    Release gates arm, and the three `required_*` arrays stop being empty — they
    become the receipt roster T089/T090 must satisfy. The file is the switch; do
    not treat it as configuration to be tidied.
-2. **The skip does not mean those paths are unexercised.** `ci.yml:78-86` runs
-   both gates **unconditionally** on every PR, with no `if:` guard. They ran on
+2. **The skip does not mean those paths are unexercised.** `ci.yml` runs both
+   gates **unconditionally** on every PR, with no `if:` guard — the steps named
+   *Verify Feature 020 V11 refreeze integrity* and *Test and verify Feature 020
+   V11 lifecycle traceability*, inside the `rust` job. Grep the step names; do
+   not trust a line number here, they move. They ran on
    every PR that reached `main`. The Release-side skip means only that *that
    run* did not exercise them.
 


### PR DESCRIPTION
One ledger section, 48 lines, no code.

## What it records

Two V11 gates never appear in a Release run — *Verify Feature 020 V11 refreeze integrity* and *Test and verify Feature 020 V11 lifecycle traceability*. Both are guarded by `lifecycle_gate_active`, derived from **`.github/release-evidence-requirements-v11.json`**, which still reads:

```json
{ "phase": "pre_activation", "required_oracle_receipts": [], "required_review_documents": [], "required_task_receipts": [] }
```

So both skip on **every** Release run, and have since the file was frozen. `gate-release-ref` asserts the inverse too — it fails with *"The pre-activation Feature 020 lifecycle gate unexpectedly ran"* if a `pre_activation` phase did not skip them. Intentional and self-consistent, not a hole.

## Why it is worth a ledger entry

**1. The file is the switch, and flipping it is Track D work.** Once `phase` becomes `active`, those two Release gates arm and the three `required_*` arrays stop being empty — they become the receipt roster T089/T090 must satisfy. Someone tidying it as stale configuration would disarm Phase 8's own evidence gate.

**2. The skip does not mean those paths went unexercised.** `ci.yml:78-86` runs both gates **unconditionally** on every PR, no `if:` guard. They ran on every PR that reached `main`.

That second point is the reason this exists. *"The gates did not run on that Release run"* and *"those paths were not exercised"* read almost identically, and only the first is true. Without the note, the next person re-derives the distinction or gets it wrong.

It also records the oddity a cold reader will hit: the tree **activated** in V11 and 11.0.0 shipped, while the release-evidence phase still says `pre_activation`. Correct — the phase tracks Phase 8's evidence obligation, not the runtime's mode — but it reads as a contradiction until someone says so.

## Provenance

Found by tracing a reviewer's warning about the skipped gates to the `if:` condition and the JSON behind it, rather than accepting or dismissing it. Nothing else in flight: Slice 5 stays unexecuted, Track A stays unowned, `daemon.rs`'s stale `#[ignore]` string stays owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn