### PR TITLE
ci: cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   conventional-commits:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conventional-commits:
     runs-on: ubuntu-latest

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1118,7 +1118,7 @@ fn full_source_set_matches_reviewed_darkness_baseline() {
 /// workflow can edit this too. What it buys is that the edit is never
 /// silent.
 const WORKFLOW_FINGERPRINTS: &[(&str, &str)] = &[
-    ("ci.yml", "38f09be155e1980a:13931"),
+    ("ci.yml", "26d8df149f93dc45:14056"),
     ("release.yml", "8ee888c1cf1be6a0:110910"),
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Workflow-only change: add top-level `concurrency` so a new push on the same ref cancels the superseded in-progress CI run.

- Concurrency only; no other workflow edits.
- `paths-ignore` omitted because tests/CI read `docs/` (e.g. honesty_gate, stel gates, perl corpus, golden replay, refreeze_v11).
- `on.push` not narrowed to main+tags (policy leftover); `tags-ignore: v*` unchanged.

Do not merge from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2faa905b-b94c-4432-9a15-5deec4d84857?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2faa905b-b94c-4432-9a15-5deec4d84857&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

