### PR TITLE
docs: brief the publication-authority review and record the CI workflow seal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,34 @@ phrases survived in `AGENTS.md`. CI went red 25 minutes later, on `main`.
 A docs edit is a code change when a test reads the docs. Run the suite, or at minimum
 replicate the assertion — the check is pure string containment and takes seconds.
 
+### CI workflows are pinned by a test too (as_of 2026-08-22 — binding)
+
+`tests/preventive_runtime_dark_v11.rs` carries `WORKFLOW_FINGERPRINTS`, a
+whole-file `<fnv1a-64>:<bytes>` seal over **`.github/workflows/ci.yml` and
+`.github/workflows/release.yml`**. Any byte of either workflow moving fails the
+suite. The file states its own purpose: *"no workflow byte may change without a
+human revisiting the judgement that no gate builds doctests."* It is a change
+detector, not a security boundary — FNV-1a is not collision-resistant and
+whoever edits a workflow can edit the pin. What it buys is that the edit is
+never silent.
+
+**So every CI workflow edit is a two-file change**: the workflow, and its
+fingerprint in the same commit. Nothing in either workflow file says it is
+load-bearing; the only thing that tells you is a red `rust` job. PR #612 — a
+four-line `concurrency:` block — went red on exactly this before anyone noticed
+the seal existed.
+
+Recompute is arithmetic, not judgement: FNV-1a-64 over the LF-normalized file,
+`:` , then the normalized byte length. The `rust` job is the observing authority;
+a pin refreshed any other way is plausible rather than verified. Same-file
+neighbours `CARGO_LINES` pin the occurrence count of each cargo invocation, so
+adding, rewording, or duplicating a cargo gate needs that reconciled too — and
+reconciled deliberately, never by loosening the pin.
+
+This is the same trap as the README/AGENTS.md phrase pinning above, in different
+clothes: **a workflow edit is a code change when a test reads the workflow.**
+Before touching either workflow, grep `tests/` for its filename.
+
 ### Never hand-write volatile state (binding, as_of 2026-08-05)
 
 Handover and campaign docs rot because volatile facts get TYPED into them. Reading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ missing-crate error as a code defect until the build directory is known clean.
 
 ## CI Gates
 
-- PR and push CI run version sync, `cargo fmt --check`,
+- PR CI runs version sync, `cargo fmt --check`,
   `cargo clippy --all-targets -- -D warnings`, the full Rust test suite,
   `cargo build --release`, and npm tests.
 - The `rust` job is compile-dominated (~25 min wall as_of 2026-08-05; the suite
@@ -85,9 +85,29 @@ missing-crate error as a code defect until the build directory is known clean.
   a `cargo check` pass, so running both compiled the graph twice for one answer.
 - `cargo build --release` is NOT droppable from PR CI: the tool-correctness
   harness runs `verify-tools.cjs --bin target/release/symforge`.
-- One CI run per PR (`pull_request`); `push` runs fire only on `main` after a
-  merge. Verified 2026-08-05 against `gh run list` — feature-branch pushes do
-  not double-trigger.
+- One CI run per PR (`pull_request`). **`push` never triggers `ci.yml` at all** —
+  not on branches, not on `main` (as_of 2026-08-22). All-time counts:
+  `gh api "repos/:owner/:repo/actions/workflows/ci.yml/runs?event=push"` returns
+  `total_count` **0**, against **666** for `event=pull_request`. The earlier note
+  here said push runs "fire only on `main` after a merge"; that was wrong. The 37
+  push runs visible in `gh run list` all belong to `release.yml`, which declares
+  `on: push: branches: [main]`.
+
+  **The cause is `ci.yml`'s own trigger.** It declares `push:` with only
+  `tags-ignore: ["v*"]`. When a push trigger carries *only* tag filters, GitHub
+  does not run it for branch pushes at all — so this filter means "non-`v*` tag
+  pushes only", and the only tags this repo pushes are `v*`. The trigger is
+  therefore unreachable in both directions.
+
+  **What that costs:** `ci.yml`'s `Validate pushed commit subjects` step
+  (`conventional_commits.py check-push-range`) has never executed, ever. It is
+  the gate meant to stop a non-conventional subject reaching `main` outside a PR
+  — the exact failure that reddened Release run #938. Adding `branches: ['**']`
+  to the push trigger would arm it, at the cost of a full CI run on every merge
+  to `main`. That is a live cost/benefit call, not a typo fix; do not flip it
+  casually. Note also that arming it is what would make a per-run concurrency
+  group for `main` meaningful — while push CI stays unreachable, any such change
+  guards a queue that has no entrants.
 - Scheduled and manual CI additionally run ignored performance smoke coverage:
   `test_load_perf_1000_files` and `calibrate_current_repo_smoke`.
 - Full real-repo coupling calibration is operator-triggered with

--- a/docs/reviews/APPENDIX-publication-authority-suspicions-2026-08-22.md
+++ b/docs/reviews/APPENDIX-publication-authority-suspicions-2026-08-22.md
@@ -1,0 +1,96 @@
+# SEALED APPENDIX — publication-authority invariant suspicions
+
+> **Do not read this before your Parts 1–5 are written.**
+>
+> This question was routed to you specifically *because* you had not seen the
+> tension. Another reader raised it and therefore could not be the first lens.
+> Everything below is unverified belief.
+>
+> If your Parts 1–5 are not on disk, close this file.
+
+---
+
+## S1 — Where the tension came from
+
+The chain that produced this brief, so you can judge whether it was reasoned or
+merely alarming:
+
+1. HOLMES, reading seam 3, wrote: *"The machine is already there; the data
+   plane is not"*, citing `activation.rs:337-339` — the `ObservationLane` doc
+   saying the LiveIndex data plane keeps serving admissions mid-cut while the
+   lane runs dark beside it.
+2. That comment says the arrangement lasts *"until C4/C5 make it the root."*
+3. C4 and C5 are commit groups in spec 028. Both executed on 2026-08-19. Per
+   the execution map, C4 was ownership structure and C5 was **"THE EXPOSURE
+   FLIP"** — the public census, the `internals` remount, the embed surface,
+   `server_api` going `pub`. Neither made the lane the publication root.
+4. So the comment names two owners that ran and did something else.
+5. Then the companion invariant at `:19-24` says the V11 publication root
+   "serves only in `PreventiveV1Open`" — and the process is in
+   `PreventiveV1Open`.
+
+Suspicion: 1–5 cannot all be true under the plain reading of "serves".
+
+## S2 — The most likely resolution, and I hold it loosely
+
+"Serves" probably means **write/publication authority** — which root may
+*publish* state — rather than which structure answers a read. Under that
+reading the invariant is about not having two things publishing at once, the
+V10 data plane is a cache/serving layer rather than a publication root, and
+nothing is violated.
+
+If that is right, the invariant is **sound and its wording is misleading**,
+which is a documentation defect worth fixing precisely because it cost this
+much attention to resolve.
+
+## S3 — The reading I am afraid of
+
+That "the V11 publication root serves only in `PreventiveV1Open`" was written
+as a statement of what *would be true after the cut*, and the cut delivered the
+mode without delivering the serving. That would make it an unearned guarantee
+in a shipped release: true of the design, false of the artifact.
+
+I do not think this is the likely answer. I think it is the one worth ruling
+out explicitly rather than by assumption, because this repository's stated
+product is being trustworthy about what it knows, and an invariant that
+overclaims is that failure in its purest form.
+
+## S4 — What the counts made me think, and why I distrust it
+
+226 `data_plane()` sites versus zero production callers of a type documented as
+*"The SOLE publication root"* looks damning. But "sole" may be a statement of
+intended design in a type that is legitimately ahead of its wiring — this
+codebase lands dark machinery on purpose and has a whole discipline around it.
+A count is not a verdict, and I put that sentence in the brief because I needed
+to hear myself say it.
+
+## S5 — The pattern I think this belongs to
+
+Three artifacts now name a future owner that already came and went without
+discharging the obligation:
+
+- `#[ignore]` strings predicting "remove in Slice 1/2" after those slices shipped
+- "precondition window unreachable", which was false on the tree
+- `until C4/C5 make it the root`, after C4/C5 ran
+
+Suspicion: this is one defect class — **prose that predicts, aging into prose
+that asserts** — and it is worth naming as such rather than fixing three times.
+If your pass finds a fourth, that is more valuable than the answer to the main
+question.
+
+## S6 — What I most expect to be wrong
+
+That I have framed this as binary. "Holds / does not hold" may be the wrong
+shape: the honest answer may be that the sentence mixes a type-level guarantee
+with a runtime claim and only one half is enforced. If so, say that rather than
+picking a side to satisfy the brief.
+
+## What I kept out of the brief
+
+- Every reading above.
+- That I consider S2 most likely and S3 the one to rule out.
+- The C4/C5 chain, except as a bare citation of `:337-339`.
+- Any suggestion that this is or is not a release defect.
+
+If your independent reading differs from all of the above, yours is the
+document that matters.

--- a/docs/reviews/REVIEW-FINDINGS-linus-publication-authority-2026-08-22.md
+++ b/docs/reviews/REVIEW-FINDINGS-linus-publication-authority-2026-08-22.md
@@ -1,0 +1,113 @@
+# REVIEW-FINDINGS — publication-authority invariant (`activation.rs:19-24`)
+
+Reviewer: LINUS
+Tree: `main` @ `48d1d0ab` (src/ byte-identical to `fd4de8dc`; compare `fd4de8dc...48d1d0ab` has no `src/` files)
+Brief: `docs/reviews/REVIEW-REQUEST-publication-authority-invariant-2026-08-22.md` @ `8f5a39e4`
+Status: **on origin.** Parts 1–5 only.
+
+---
+
+## Part 1 — the reading
+
+### What "serves" means here
+
+The sentence does not bind "serves" to a function, a type, or a test.
+
+The same file uses the word in two incompatible ways:
+
+- `ActivationMode::LegacyOpen` is documented as "Legacy authority serves" (`activation.rs:59`). That is a mode label. The only production `ActivationMode` check in `src/` is `activate_surface` (`activation.rs:1044`): if the process machine is still `LegacyOpen`, run the ceremony and flip to `PreventiveV1Open` before the surface attaches. After that, nothing in protocol, daemon, sidecar, or server reads the mode again. `gh search code ActivationMode --repo special-place-ai-heaven/symforge` returns `activation.rs` and tests/docs. Query ingress does not key off the machine.
+- `ProjectRuntimeHandle::data_plane` (`activation.rs:984-986`) is what actually answers. It returns `&SharedIndex`. Call sites include `protocol/mod.rs`, `protocol/edit_tools.rs`, `sidecar/handlers.rs`, `server/mod.rs`, `server/admin/api_v1.rs`. The brief's 226-count is consistent with that door; I sampled the production files and did not re-count every hit.
+- The same handle's comment says the handle is "the replacement, not a root" and that every `index: SharedIndex` field is a "V10 publication root" (`activation.rs:932-934`).
+- `ObservationLane` says the opposite of a completed cut: "The LiveIndex data plane keeps serving admissions itself mid-cut … until C4/C5 make it the root" (`activation.rs:337-339`).
+- The frozen retirement inventory's publication_roots assertion is "Only ProjectPublicationRoot is query-visible" (`specs/020-repository-knowledge-index/contracts/v10-authority-retirement-v11.md`, category `publication_roots`, `status: planned_not_executed`). That is the nearest technical meaning of "serves" the tree actually writes down: query-visible. It is still planned.
+
+So: if "serves" means "the activation machine is in this mode", it is a tautology of `ActivationMode`. If "serves" means "answers a query", the tree names `data_plane() → SharedIndex`, not a V11 root. The sentence uses both vocabularies and defines neither.
+
+### Which two roots the invariant names
+
+The sentence names roles, not types: "legacy authority" and "the V11 publication root".
+
+Types in the tree that could be those roles:
+
+| Candidate | Why it might be a "publication root" | Why it might not |
+|---|---|---|
+| `SharedIndex` / `data_plane()` | Comment at `activation.rs:933` calls every such field a V10 publication root. This is what queries hit. | Same comment says `ProjectRuntimeHandle` is not a root. |
+| `ProjectPublicationRoot` (`runtime.rs:186-197`) | Documented "SOLE publication root for a project's runtime state". `load()` is the only method. | No production callers outside `runtime.rs`. `publication_root()` is used inside that file (identity swap / tests). Not query-visible. |
+| `ProjectArtifactRoot` (`candidate.rs`; field on `ObservationLane` at `activation.rs:347`) | Carries "root" in the name. | Artifact store, not a publication. |
+
+I cannot determine the pair without guessing. The sentence's own pair is the two *roles*. The types those roles would have to be (`SharedIndex` vs `ProjectPublicationRoot`) are the pair a reader would guess. That guess is not established by construction: both types exist at once, and only `SharedIndex` is reached from ingress.
+
+"Simultaneously authoritative" appears only in this doc comment. No test names it.
+
+### Verdict
+
+**cannot be evaluated as written.**
+
+The predicate is unbound. "Enforced by construction across the cut" is a claim about types. The types do not make dual authority unrepresentable, and they do not make "serves" a compiler fact.
+
+### What would change the verdict
+
+- Bind "serves" to `ActivationMode` occupancy only → **holds** (one `u8`, monotonic, no reverse edge). That would be evaluating a different sentence than the one that says "publication roots".
+- Bind "serves" to query-visible via `ProjectPublicationRoot` (the retirement inventory's words) → **does not hold**. See Part 2.
+- A single query door, ActivationMode-gated, whose V11 side is `ProjectPublicationRoot` and whose legacy side is uninhabited after `open_preventive` → evaluable, and then a holds/does-not-hold question.
+
+### Confidence
+
+High on cannot-evaluate. Raised only by a definition I missed: a `serve` method, a type alias, or a test that names the two roots and the exclusive predicate. I grepped `ActivationMode` and `ProjectPublicationRoot` on the repo and read the comment cluster at `activation.rs:19-24`, `:337-339`, `:920-986`, and `runtime.rs:184-317`.
+
+---
+
+## Part 2 — if it does not hold
+
+Conditional on the only operational reading the frozen inventory writes down: "serves" = query-visible.
+
+Under that reading: **does not hold.**
+
+**Since when (as far as the tree shows).** On `48d1d0ab` the companion comment, the V10 `data_plane()` accessors, and an unwired `ProjectPublicationRoot` coexist. The retirement inventory still says `publication_roots` is `planned_not_executed`. `activate_surface` (`activation.rs:1037-1064`) already records that "after this PR's compile-time flip there is no legacy traffic left to drain at runtime" and drives the machine to `PreventiveV1Open` before the first request. The process is in the mode where the V11 root is supposed to serve. The V11 root does not.
+
+**Documentation defect, not a runtime dual-authority defect.** One thing answers queries: `SharedIndex` through `data_plane()`. `ProjectPublicationRoot` is not also answering. The wording overclaims exclusive V11-root service. It does not hide two live roots. The special-case smell is the comment: "enforced by construction" papers over a predicate the types do not encode.
+
+**What a reader of the shipped release is entitled to assume that is not true.** That after the cut, only the V11 publication root is query-visible, and legacy authority is not. What they get: the machine is `PreventiveV1Open`; every sampled ingress reads `SharedIndex`; `ProjectPublicationRoot` is dark.
+
+---
+
+## Part 3 — open questions
+
+1. **Is "enforced by construction" true here, and by which construction?**
+   True of *mode*: `ActivationMode` is a closed enum behind one process `ActivationCut` (`activation.rs:57-65`, `:177-189`). Transitions require the prior mode (`:202+`, `:252+`). No reverse edge. Unrepresentable-over-checked works for the machine.
+   False of *publication exclusivity*. `SharedIndex` and `ProjectPublicationRoot` are both inhabitable. Nothing in the type of a query path mentions `ActivationMode`. Constitution Principle V is not doing the work the comment claims.
+
+2. **Does `ProjectPublicationRoot` having no production callers mean anything, or is it legitimately ahead of its wiring?**
+   Both, and they are not in conflict. It is ahead of wiring: inventory status `planned_not_executed`, Slice 4 tasks T066/T067 still listed. It also means the named V11 root does not serve. "Ahead of wiring" is not a license for a comment that says the V11 root already serves in `PreventiveV1Open`.
+
+3. **Does any ingress key off `ActivationMode` rather than data-plane readiness?**
+   No production ingress I found. Mode is read in `activate_surface` to run the ceremony, then forgotten. Readiness that *is* checked is admission liveness on `acquire()` (`activation.rs:972-980`): tombstoned slot → `RegistryRefusal`. `data_plane()` (`:984-986`) does not even do that. Queries use `data_plane()`.
+
+4. **Is the invariant falsifiable as written, or is it prose that reads like a guarantee?**
+   Prose. You cannot write a failing case until "serves" and "the two publication roots" are bound. Absence of a test named "simultaneously authoritative" is not itself a defect (the brief is right that construction can replace tests). Here construction does not encode the claim, so the missing test is the missing definition.
+
+5. **What did this brief fail to ask about?**
+   The dual door: `acquire()` is live-gated, `data_plane()` is not, and ingress uses the ungated one. Whether "legacy authority" is a type (`BindingAuthority` / `SourceRuntime`) or only a mode name. Whether C4/C5 "make it the root" (`activation.rs:339`) is still the live plan after shipping `PreventiveV1Open` as 11.0.0. I did not treat FR-008's two-ArcSwap story as in scope; the brief did not name it.
+
+---
+
+## Part 4 — Outside the questions asked
+
+`ObservationLane` (`activation.rs:337-339`) already admits the mid-cut shape: LiveIndex keeps serving; the authority plane runs beside it until C4/C5. The process machine is nonetheless already `PreventiveV1Open` at first request (`activation.rs:1034-1064`). The companion invariant and the ObservationLane comment cannot both be describing a finished cut.
+
+`ProjectPublicationRoot` itself is a coherent ArcSwap of `ProjectRuntimePublication` with a never-reused `PublicationIdentity` (`runtime.rs:186-217`, used at `:537-558`). That is a publication root. It is not the one queries hit.
+
+I accepted the brief's `data_plane()` file split without a full recount. I verified the return type, the "not a root" comment, and production call sites in protocol/server/sidecar. I verified `src/` did not move: `gh api .../compare/fd4de8dc...48d1d0ab` lists `.github/workflows/ci.yml` and `tests/preventive_runtime_dark_v11.rs` only.
+
+PR #609 not read. `specs/020` read only for the retirement inventory assertion above. No cargo. No appendix opened.
+
+---
+
+## Part 5 — Negatives
+
+- The mode machine is sound as a mode machine: three states, monotonic, process-wide, non-configurable, ceremony serialized on `PROCESS_BOOTSTRAP` (`activation.rs:1010-1070`). Out-of-order transitions refuse. That part I would ship.
+- `ProjectRuntimeHandle` is an enumerable census door for V10 fields, as its comment says (`activation.rs:920-923`). Counting `data_plane()` sites is a real construction. It is a construction of *reroute work*, not of exclusive authority.
+- `ProjectPublicationRoot::load` / identity rebase inside `runtime.rs` is internally consistent. Dark, not wrong.
+- I did not find a second process `ActivationCut`, a reverse edge, or a config/env read that selects a mode.
+- I did not find `ProjectPublicationRoot` answering a protocol/daemon/sidecar query. The failure mode is "V11 root does not serve", not "two roots serve".
+

--- a/docs/reviews/REVIEW-FINDINGS-linus-publication-authority-2026-08-22.md
+++ b/docs/reviews/REVIEW-FINDINGS-linus-publication-authority-2026-08-22.md
@@ -3,7 +3,7 @@
 Reviewer: LINUS
 Tree: `main` @ `48d1d0ab` (src/ byte-identical to `fd4de8dc`; compare `fd4de8dc...48d1d0ab` has no `src/` files)
 Brief: `docs/reviews/REVIEW-REQUEST-publication-authority-invariant-2026-08-22.md` @ `8f5a39e4`
-Status: **on origin.** Parts 1–5 only.
+Status: **on origin.** Parts 1–6. Part 6 after appendix `ac266d12`.
 
 ---
 
@@ -99,7 +99,7 @@ Under that reading: **does not hold.**
 
 I accepted the brief's `data_plane()` file split without a full recount. I verified the return type, the "not a root" comment, and production call sites in protocol/server/sidecar. I verified `src/` did not move: `gh api .../compare/fd4de8dc...48d1d0ab` lists `.github/workflows/ci.yml` and `tests/preventive_runtime_dark_v11.rs` only.
 
-PR #609 not read. `specs/020` read only for the retirement inventory assertion above. No cargo. No appendix opened.
+PR #609 not read. `specs/020` read only for the retirement inventory assertion above. No cargo. Appendix opened only for Part 6.
 
 ---
 
@@ -111,3 +111,44 @@ PR #609 not read. `specs/020` read only for the retirement inventory assertion a
 - I did not find a second process `ActivationCut`, a reverse edge, or a config/env read that selects a mode.
 - I did not find `ProjectPublicationRoot` answering a protocol/daemon/sidecar query. The failure mode is "V11 root does not serve", not "two roots serve".
 
+
+---
+
+## Part 6 — Delta
+
+Appendix: `docs/reviews/APPENDIX-publication-authority-suspicions-2026-08-22.md` @ `ac266d12`.
+Read after Parts 1–5. Nothing in Parts 1–5 was rewritten. The Part 1 verdict survives.
+
+### Already reached
+
+| Suspicion | Mine, independently |
+|---|---|
+| S1 tension (machine in `PreventiveV1Open`; LiveIndex still serving; `:337-339` vs `:19-24`) | Yes. Part 1 and Part 4. I did not need Holmes. |
+| S1.3 C4/C5 ran and did something else | The "until C4/C5" hang I already named (Part 3 Q5, Part 4). The appendix's dates and "THE EXPOSURE FLIP" I did not have. I checked: execution map pins C4a–C4c and C5 as executed 2026-08-19; C5 is the public-census / `pub` flip (`activation-cut-execution-map.md:199-294`, `src/main.rs` C5 comment). Confirmed: those owners ran. They did not make the lane the publication root. |
+| S3 unearned guarantee (mode without serving) | Yes, as the *conditional* in Part 2, under query-visible. I did not adopt it as the Part 1 verdict because the sentence is unbound. |
+| S4 count is not a verdict; dark wiring is a real discipline | Yes. Part 3 Q2. 226 vs 0 is a fact. It does not decide "serves". |
+| S6 binary is the wrong shape; type-level half vs runtime half | **This was the Part 1 verdict.** "cannot be evaluated as written" is S6 said first, without the appendix. Mode construction holds. Publication exclusivity is not a construction. I refused to pick holds/does-not-hold to satisfy the brief. |
+
+### Now think are wrong
+
+**S2 is not a resolution.** I did not reach "serves = write/publication authority" and I do not adopt it now. It is another unbound guess. The same file that would have to host that meaning calls every `SharedIndex` field a "V10 publication root" (`activation.rs:933`) and hands that type to ingress via `data_plane()`. `ProjectPublicationRoot` still has no production callers. Writers retirement is also `planned_not_executed`. If "serves" meant publish, the production publisher is still `SharedIndex`, not the type documented as SOLE. S2's "V10 is a cache/serving layer, nothing is violated" does not survive contact with `:933` or with `swap_and_publish` living on that store. Wording-is-misleading is true either way. "Invariant is sound" is not established.
+
+**S3 as "the unlikely one".** Under any bound operational reading (query-visible, or publish-visible), S3 is the one that matches the artifact: the machine is in the post-cut mode; the named V11 root does not serve. The appendix author's prior (S2 likely, S3 rule-out) is the thing I reject. I still will not promote S3 to the Part 1 verdict, because that would pretend the sentence defined "serves".
+
+### Changed a verdict
+
+None. Part 1 remains **cannot be evaluated as written.** Part 2 remains the conditional: bind query-visible → does not hold, documentation overclaim, not two roots answering.
+
+S6 is the appendix agreeing with Part 1 after the fact. That is not a change.
+
+### S5 — fourth
+
+The class is real. I already had two members in this file: `:337-339` ("until C4/C5 make it the root") and `:19-24` itself (predicts exclusive V11 service; the mode shipped; the service did not).
+
+A sibling on the same tree, not named in Parts 1–5: `activate_surface` asserts "after this PR's compile-time flip there is no legacy traffic left to drain at runtime" (`activation.rs:1037-1039`) and then flips the machine. Ingress still drains `SharedIndex`. Same class: prose that predicted a flip, now written as an observation.
+
+The retirement inventory's "Only ProjectPublicationRoot is query-visible" is *not* a fourth. It still says `planned_not_executed`. That one aged honestly.
+
+### What I did not take from the appendix
+
+I did not take S2 as the likely answer. I did not reclassify this as a release defect or as sound-but-misleading. I did not open #609. I did not run cargo.

--- a/docs/reviews/REVIEW-REQUEST-publication-authority-invariant-2026-08-22.md
+++ b/docs/reviews/REVIEW-REQUEST-publication-authority-invariant-2026-08-22.md
@@ -1,0 +1,158 @@
+# Review request — what "serves" means in the publication-authority invariant, and whether it holds
+
+## The question
+
+`src/index_lifecycle/activation.rs:19-24` states a companion invariant:
+
+```
+//! Companion invariant (enforced by construction across the cut, recorded
+//! here): the two publication roots are never simultaneously authoritative —
+//! legacy authority serves only in `LegacyOpen`, the V11 publication root
+//! serves only in `PreventiveV1Open`, and the window between them is
+//! drain-only.
+```
+
+The shipped process is in `PreventiveV1Open`.
+
+> **What does "serves" mean in that sentence, and is the invariant satisfied on
+> `main` @ `fd4de8dc`?**
+
+Answer it as a reading of this tree. If "serves" has a narrower technical
+meaning than answering a query, say what it is and what establishes it. If the
+invariant does not hold, say that. If the sentence cannot be evaluated as
+written, say that — that is a legitimate verdict and possibly the most
+important one.
+
+## Why it is being asked
+
+A campaign is about to be specified on top of this area. Its scope depends
+entirely on this answer, and no one has checked it. It is being asked cold
+rather than confirmed, so treat every framing below as a fact to verify, not a
+conclusion to agree with.
+
+## Rules of engagement
+
+- **Read-only.** Change no file except your own findings file.
+- **No build.** No `cargo build`, `cargo test`, `cargo clippy`.
+- **No patch, no PR, no un-ignore, no reclassify.**
+- `specs/020-repository-knowledge-index/` is frozen — read only.
+- **PR #609 is out of scope.** It stays draft and touches none of this.
+- Findings stay off `origin` unless Rob authorizes a push. Say "not on remote"
+  rather than implying a branch exists.
+
+## Tree
+
+`main` @ **`48d1d0ab`**
+
+Every fact in the table below was established on `fd4de8dc`. `src/` is
+**byte-identical** between the two — verified with
+`git diff --stat fd4de8dc 48d1d0ab -- src/`, which is empty. The two commits
+since then touched only `.github/workflows/ci.yml`, `tests/`, and `docs/`.
+Read `48d1d0ab`; nothing in scope moved.
+
+## Facts already verified, so you need not re-establish them
+
+Verify any you doubt — these are given to save time, not to constrain you.
+
+| Fact | Value |
+|---|---|
+| Invariant text | `src/index_lifecycle/activation.rs:19-24` |
+| Activation mode machine | `ActivationMode` `activation.rs:57-65`; `LegacyOpen → LegacyClosing → PreventiveV1Open`, monotonic, no reverse edge, non-configurable |
+| Current mode | `PreventiveV1Open` — the Slice 4 cut shipped as 11.0.0 |
+| **`data_plane()` call sites in `src/`** | **226** |
+| — `src/protocol/tools.rs` | 78 |
+| — `src/sidecar/handlers.rs` | 72 |
+| — `src/daemon.rs` | 31 |
+| — `src/protocol/edit_tools.rs` | 27 |
+| — `src/protocol/mod.rs` | 16 |
+| — `src/server/mod.rs` | 1 |
+| — `src/server/admin/api_v1.rs` | 1 |
+| `data_plane()` returns | `&crate::live_index::store::SharedIndex` (`activation.rs:984-986`) |
+| `ProjectPublicationRoot` | `runtime.rs:190`, documented at `:186` as *"The SOLE publication root for a project's runtime state"* |
+| **Its production callers outside `runtime.rs`** | **none found** |
+| `ProjectArtifactRoot` | `candidate.rs:158` — a second type carrying "root" in its role |
+| The phrase "simultaneously authoritative" | appears **only** in the `activation.rs` doc comment; **no test names it**, despite "enforced by construction" |
+| A related comment | `activation.rs:933` refers to *"every `index: SharedIndex(Handle)` field as a V10 publication root"* |
+| Another related comment | `activation.rs:337-339` — the `ObservationLane` doc, on what the data plane does mid-cut |
+
+## Things worth being careful about
+
+- **"Enforced by construction" is a claim about types, not tests.** The absence
+  of a test naming the invariant is not by itself evidence it is unenforced —
+  unrepresentable-over-checked is this codebase's stated preference
+  (Constitution Principle V). Whether construction actually enforces it here is
+  part of the question.
+- **Two types carry "root" in their name** (`ProjectPublicationRoot`,
+  `ProjectArtifactRoot`) and a comment calls `SharedIndex` fields a "V10
+  publication root". Whether "the two publication roots" in the invariant means
+  the pair you would guess is worth establishing before evaluating the claim.
+- **A count is not a verdict.** 226 `data_plane()` sites and zero
+  `ProjectPublicationRoot` callers are facts; what they imply about "serves"
+  is the thing being asked.
+
+## What to produce
+
+```
+docs/reviews/REVIEW-FINDINGS-<your-name>-publication-authority-2026-08-22.md
+```
+
+### Part 1 — the reading
+
+- **What "serves" means here**, with what establishes that meaning.
+- **Which two roots** the invariant names, and how you determined it.
+- **Verdict**: holds / does not hold / cannot be evaluated as written.
+- **What would change the verdict** if you are wrong.
+- **Confidence**, and what would raise it.
+
+### Part 2 — if it does not hold
+
+- Since when, as far as the tree shows.
+- Whether it is a documentation defect (the wording overclaims) or a runtime
+  defect (the property is genuinely absent).
+- What a reader of the shipped release would be entitled to assume that is not
+  true.
+
+### Part 3 — open questions
+
+1. Is "enforced by construction" true here, and by which construction?
+2. Does `ProjectPublicationRoot` having no production callers mean anything, or
+   is it legitimately ahead of its wiring?
+3. Does any ingress key off `ActivationMode` rather than data-plane readiness?
+4. Is the invariant falsifiable at all as written, or is it prose that reads
+   like a guarantee?
+5. What did this brief fail to ask about?
+
+### Part 4 — Outside the questions asked (MANDATORY)
+
+Anything the above does not cover. If nothing, write "nothing" and say what you
+looked at.
+
+### Part 5 — Negatives
+
+What you checked and found sound, specific enough that a reader can tell.
+
+## Only after Parts 1–5 are written
+
+**The sealed appendix is deliberately not in this commit.**
+
+A sealed appendix that ships alongside its brief is not sealed — nothing but
+good manners stops a reader opening it first, and the whole value of this
+exercise is that your reading was formed without mine. Under a remote-only
+protocol the seal cannot be enforced by an instruction, so it is enforced by
+publication order instead.
+
+So: commit your Parts 1–5. Once they are on `origin`, say so, and
+`APPENDIX-publication-authority-suspicions-2026-08-22.md` will be pushed to this
+directory. Then append:
+
+### Part 6 — Delta
+
+Which suspicions you had already reached, which you now think are wrong, which
+changed a verdict above.
+
+If a verdict in Parts 1–5 does not survive the appendix, **amend it in place and
+say what changed it.** A Part 6 that quietly contradicts Part 1 is worse than
+either.
+
+This question is being asked cold on purpose — one reader already has a view of
+it, which is why the request came to you.


### PR DESCRIPTION
Publishes the cold review request on the `activation.rs` companion invariant, and records the `WORKFLOW_FINGERPRINTS` seal in CLAUDE.md.

**The brief.** `docs/reviews/REVIEW-REQUEST-publication-authority-invariant-2026-08-22.md` asks one question: what does "serves" mean in the invariant at `src/index_lifecycle/activation.rs:19-24`, and does it hold. The answer decides the scope of the Track A campaign, so it is being asked cold rather than confirmed.

**The seal is withheld on purpose.** `APPENDIX-publication-authority-suspicions-2026-08-22.md` is NOT in this PR. A sealed appendix that ships with its brief is not sealed. Under a remote-only review protocol, publication order is the only thing that can enforce it, so the appendix is pushed only after the reviewer's Parts 1-5 are on origin.

**CLAUDE.md.** `tests/preventive_runtime_dark_v11.rs` seals every byte of `ci.yml` and `release.yml` via `WORKFLOW_FINGERPRINTS`. PR #612 went red on it. Nothing in either workflow file says it is load-bearing, which makes it the same trap as the README/AGENTS.md phrase pinning already recorded there.

Tree note: the brief's verified facts were established on `fd4de8dc`; `src/` is byte-identical at `48d1d0ab`, verified with an empty `git diff --stat fd4de8dc 48d1d0ab -- src/`.