### PR TITLE
docs(activation): record D1 mid-cut leftover door in comments (Track A)

### DIFF
--- a/src/index_lifecycle/activation.rs
+++ b/src/index_lifecycle/activation.rs
@@ -17,11 +17,19 @@
 //! stranding the machine short of `PreventiveV1Open`: a mis-sequenced
 //! bootstrap fails loudly at the cut, never silently half-open.
 //!
-//! Companion invariant (enforced by construction across the cut, recorded
-//! here): the two publication roots are never simultaneously authoritative —
-//! legacy authority serves only in `LegacyOpen`, the V11 publication root
-//! serves only in `PreventiveV1Open`, and the window between them is
-//! drain-only.
+//! Two claims, recorded separately because they are not the same construction.
+//!
+//! Mode occupancy is enforced by [`ActivationMode`] (one `u8` behind
+//! [`ActivationCut::process`]) and the typed transitions below: the process
+//! is in exactly one of `LegacyOpen`, `LegacyClosing`, `PreventiveV1Open`.
+//! No reverse edge. `LegacyClosing` is drain-only for the mode machine —
+//! [`LaneRegistration`] tokens, not publication.
+//!
+//! Publication exclusivity is not enforced here. Ingress still answers
+//! through [`ProjectRuntimeHandle::data_plane`] → [`crate::live_index::store::SharedIndex`].
+//! That leftover door is the D1 mid-cut already recorded at the
+//! `ObservationLane` doc and at the `ProjectRuntimeHandle` mid-cut claim.
+//! Retiring it is not this pass.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -334,9 +342,13 @@ struct AuthorityInner {
 /// PERMIT-FREE, per the frozen contract (observation never mutates source
 /// bytes; it has no business in the mutation lane).
 ///
-/// D1 applies: this is the AUTHORITY plane. The LiveIndex data plane keeps
-/// serving admissions itself mid-cut; the lane runs the frozen lifecycle
-/// semantics beside it (dark stamp payloads) until C4/C5 make it the root.
+/// D1 applies: this is the AUTHORITY plane (`ObservationLane`). The
+/// LiveIndex data plane (`ProjectRuntimeHandle::data_plane` → `SharedIndex`)
+/// still serves admissions. C5 landed (`ProjectSourceAuthority` residual
+/// at `:310`). It did not make this lane, nor `ProjectPublicationRoot`,
+/// query-visible. The leftover door is this `data_plane` path — the same
+/// D1 mid-cut recorded on `ProjectRuntimeHandle` (`:925-928`). Retiring
+/// it is not this pass.
 #[derive(Debug)]
 struct ObservationLane {
     slot: ObserverSlot,
@@ -1034,10 +1046,12 @@ pub fn process_project_registry() -> Arc<ProjectRegistry> {
 /// The ceremony runs BEFORE the surface serves its first request, which is
 /// what makes each drain confirmation truthful: at that moment the
 /// bootstrapper IS every lane's owner, and it can observe that nothing has
-/// entered the legacy gate because serving has not begun. After this PR's
-/// compile-time flip there is no legacy traffic left to drain at runtime;
-/// the machine records that observation as typed evidence instead of
-/// assuming it.
+/// entered the legacy gate because serving has not begun. After [`ActivationCut::open_preventive`], [`ActivationMode`] is
+/// `PreventiveV1Open` and the `LegacyOpen` gate admits no further
+/// [`LaneRegistration`]. That is the observation the ceremony records as
+/// typed evidence. Query traffic is a different door: it still goes through
+/// [`ProjectRuntimeHandle::data_plane`] → `SharedIndex` (D1 mid-cut,
+/// `:337-339` and `:925-928`). Retiring that door is not this pass.
 pub fn activate_surface(surface: SurfaceKind) {
     let _bootstrap = PROCESS_BOOTSTRAP.lock().expect("process bootstrap lock");
     let machine = ActivationCut::process();

--- a/src/index_lifecycle/activation.rs
+++ b/src/index_lifecycle/activation.rs
@@ -344,11 +344,11 @@ struct AuthorityInner {
 ///
 /// D1 applies: this is the AUTHORITY plane (`ObservationLane`). The
 /// LiveIndex data plane (`ProjectRuntimeHandle::data_plane` → `SharedIndex`)
-/// still serves admissions. C5 landed (`ProjectSourceAuthority` residual
-/// at `:310`). It did not make this lane, nor `ProjectPublicationRoot`,
+/// still serves admissions. C5 landed (the `ProjectSourceAuthority` residual).
+/// It did not make this lane, nor `ProjectPublicationRoot`,
 /// query-visible. The leftover door is this `data_plane` path — the same
-/// D1 mid-cut recorded on `ProjectRuntimeHandle` (`:925-928`). Retiring
-/// it is not this pass.
+/// D1 mid-cut recorded on `ProjectRuntimeHandle`'s `data_plane` naming comment.
+/// Retiring it is not this pass.
 #[derive(Debug)]
 struct ObservationLane {
     slot: ObserverSlot,
@@ -1046,12 +1046,14 @@ pub fn process_project_registry() -> Arc<ProjectRegistry> {
 /// The ceremony runs BEFORE the surface serves its first request, which is
 /// what makes each drain confirmation truthful: at that moment the
 /// bootstrapper IS every lane's owner, and it can observe that nothing has
-/// entered the legacy gate because serving has not begun. After [`ActivationCut::open_preventive`], [`ActivationMode`] is
+/// entered the legacy gate because serving has not begun. After
+/// [`ActivationCut::open_preventive`], [`ActivationMode`] is
 /// `PreventiveV1Open` and the `LegacyOpen` gate admits no further
 /// [`LaneRegistration`]. That is the observation the ceremony records as
 /// typed evidence. Query traffic is a different door: it still goes through
-/// [`ProjectRuntimeHandle::data_plane`] → `SharedIndex` (D1 mid-cut,
-/// `:337-339` and `:925-928`). Retiring that door is not this pass.
+/// [`ProjectRuntimeHandle::data_plane`] → `SharedIndex` (the D1 mid-cut
+/// recorded at `ObservationLane` and at `ProjectRuntimeHandle`). Retiring
+/// that door is not this pass.
 pub fn activate_surface(surface: SurfaceKind) {
     let _bootstrap = PROCESS_BOOTSTRAP.lock().expect("process bootstrap lock");
     let machine = ActivationCut::process();

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -979,15 +979,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "708b73184ab9b356e0b0dbcd18f0e760aaf31dd0045a185d11fa071214dde1c7",
+    "54da605e1214c203ec2bcdd1c64d8a09bab768d451eb787f9db31ed8c573d031",
     20,
-    388_720,
+    389_672,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "96b7a77fa130a6edee6803786c06e4a673396018364e28fa9f4ba893203d478a",
+    "54bcae02957707dae0f19631e7d677ec5d1bad6900cb44d2882b6ba0606cfa20",
     196,
-    9_300_142,
+    9_301_094,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -979,15 +979,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "54da605e1214c203ec2bcdd1c64d8a09bab768d451eb787f9db31ed8c573d031",
+    "8815b1cc4d7b85d87d6ec338dacfaa9e20b11c39cdda6314890f87c4816c220e",
     20,
-    389_672,
+    389_728,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "54bcae02957707dae0f19631e7d677ec5d1bad6900cb44d2882b6ba0606cfa20",
+    "7d1dc7cca03304d1c52ad3fa1b0f317bab799c20056250823d67eb52db25ec70",
     196,
-    9_301_094,
+    9_301_150,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Track A comment-only pass per Holmes SHIP draft.

## Changes

Comment-only edits in `src/index_lifecycle/activation.rs`:

1. **Companion invariant block** — Replaced the "enforced by construction" publication exclusivity claim with separate mode-occupancy vs publication-exclusivity claims; records the D1 mid-cut leftover `data_plane` door without naming an owner for retiring it.
2. **`ObservationLane` doc** — Records C5 landed on the `ProjectSourceAuthority` residual, not an exposure flip; clarifies authority vs data plane and that `ProjectPublicationRoot` is not query-visible. Stale `:NNN` line cites removed; cross-refs use item names (`ProjectRuntimeHandle`'s `data_plane` naming comment).
3. **`activate_surface` doc** — Replaced "After this PR's compile-time flip" prose; kept the ceremony-before-serve sentence; records typed evidence vs query-traffic door. Wrapped to file comment width; D1 cross-refs name `ObservationLane` and `ProjectRuntimeHandle` (no line numbers).

**Unchanged:** `ProjectRuntimeHandle` mid-cut claim, `data_plane` field naming comment, C5 typed-bootstrap sentence.

## Pin refresh

Re-reviewed the complete `src/` diff before updating `EXCLUDED_RUNTIME_SOURCE_PIN_V1` and `FULL_SOURCE_PIN_V1`: only doc comments in `src/index_lifecycle/activation.rs` changed; no new direct, aliased, macro-generated, trait, inherent-method, registration, or re-export bridge.

| Pin | New tuple |
|-----|-----------|
| `EXCLUDED_RUNTIME_SOURCE_PIN_V1` | `("8815b1cc4d7b85d87d6ec338dacfaa9e20b11c39cdda6314890f87c4816c220e", 20, 389_728)` |
| `FULL_SOURCE_PIN_V1` | `("7d1dc7cca03304d1c52ad3fa1b0f317bab799c20056250823d67eb52db25ec70", 196, 9_301_150)` |

## cargo doc

`cargo doc --no-deps --document-private-items` on this tree (`2ec29779`) is **not clean** (exit 101: `could not document symforge`). Track A comments in `activation.rs` have **zero** rustdoc warnings; named links (`ActivationCut`, `ActivationMode`, `LaneRegistration`, `ProjectRuntimeHandle::data_plane`, `SharedIndex`) resolve. The 39 failures are 35 `broken_intra_doc_links` + 4 `invalid-html-tags` elsewhere on the same class as `main`. No `private_intra_doc_links`. No `activation.rs` change for that pass. No CI/doc gate.

## Out of scope

- T050 / `activation_cut_v11.rs`
- Wiring `ProjectPublicationRoot`
- `WORKFLOW_FINGERPRINTS` / `ci.yml`
- PRs #609/#610/#611/#613/#614
- The 39 pre-existing rustdoc errors on `main`

## Residuals

- Query traffic still enters via `ProjectRuntimeHandle::data_plane` → `SharedIndex` (D1 mid-cut; documented at `ObservationLane`, `ProjectRuntimeHandle` mid-cut claim, and `activate_surface`).
- `ProjectPublicationRoot` not query-visible; not wired this pass.
- `ProjectSourceAuthority` C5 residual (rebinding) remains owned by post-cut follow-up in `docs/reviews/FEATURE-020-SLICE4-ACTIVATION-EVIDENCE-v11.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->
