### PR TITLE
fix(daemon): restart the observer when an in-place reload fails

### DIFF
--- a/scripts/slice0-oracle-artifact.cjs
+++ b/scripts/slice0-oracle-artifact.cjs
@@ -69,6 +69,19 @@ const SUITES = [
       "--ignored",
     ],
   },
+  {
+    target: "tests/project_index_lifecycle_slice0.rs::failed_reload_retains_the_recovery_observer",
+    expected: "green",
+    args: [
+      "test",
+      "--test",
+      "project_index_lifecycle_slice0",
+      "failed_reload_retains_the_recovery_observer",
+      "--",
+      "--exact",
+      "--test-threads=1",
+    ],
+  },
 ];
 
 const NEWLINE = String.fromCharCode(10);
@@ -90,7 +103,6 @@ const RED_CASES = [
   "capacity_refused_open_creates_no_slot_and_no_watcher",
   "configured_capacity_bounds_the_process_not_each_load",
   "empty_placeholder_publication_refuses_watcher_mutation",
-  "failed_reload_retains_the_recovery_observer",
   "internals::daemon::tests::concurrent_first_open_performs_exactly_one_cold_load",
   "observer_replacement_gap_is_latched_as_non_current",
   "old_observer_delivery_after_promotion_is_not_current",
@@ -105,6 +117,19 @@ const RED_CASES = [
 // delete the regression guard and leave this artifact silent about the transition
 // it exists to evidence.
 const RESOLVED_CASES = new Map([
+  [
+    "failed_reload_retains_the_recovery_observer",
+    {
+      // Track A seam 2. No frozen slice task owns this one: every slice that
+      // could have owned it had already shipped by the time the control was
+      // written, which is exactly why it sat RED after the cut. Recorded
+      // against the campaign rather than attributed to an invented task id.
+      slice: null,
+      tasks: [],
+      defect: "2.10 a failed reload loses the recovery observer",
+      fix: "src/daemon.rs::ProjectSlot::reload_with starts a replacement observer before propagating the rebuild error",
+    },
+  ],
   [
     "internals::watcher::tests::generation_before_root_split_cannot_authorize_root_a_reindex_into_root_b",
     {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3545,7 +3545,30 @@ impl ProjectSlot {
         };
         abort_watcher_task(&mut watcher_task, &old_stop_token);
 
-        reload_index(&index, canonical_root)?;
+        // A failed rebuild must not leave the project blind. The abort above
+        // stopped the observer and `take()` already cleared its handle, so
+        // returning straight through `?` here drops the project's only
+        // source-change trigger until it is reopened -- the retained index
+        // stays queryable, but no later edit is ever observed. Start a
+        // replacement before propagating the error, on the root the project is
+        // STILL bound to: the success path below is what retargets
+        // `canonical_root`, so on this path the old root is the one to watch.
+        if let Err(error) = reload_index(&index, canonical_root) {
+            let retained_root = self.metadata.read().canonical_root.clone();
+            let stop_token = Arc::new(AtomicBool::new(false));
+            let watcher_task = start_project_watcher(
+                retained_root,
+                Arc::clone(&index),
+                Arc::clone(&watcher_info),
+                Arc::clone(&stop_token),
+            );
+            {
+                let mut project = self.metadata.write();
+                project.stop_token = stop_token;
+                project.watcher_task = watcher_task;
+            }
+            return Err(error);
+        }
         let published = index.published_state();
         let counts = (published.file_count, published.symbol_count);
         let stop_token = Arc::new(AtomicBool::new(false));

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -985,9 +985,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "7d1dc7cca03304d1c52ad3fa1b0f317bab799c20056250823d67eb52db25ec70",
+    "5b17ac5bc7e808462984ee0d4116c25b840a929708a256895fedfa8749a6a784",
     196,
-    9_301_150,
+    9_302_359,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/project_index_lifecycle_slice0.rs
+++ b/tests/project_index_lifecycle_slice0.rs
@@ -260,7 +260,6 @@ fn empty_placeholder_publication_refuses_watcher_mutation() {
 /// bootstrap path; on reload it propagates, which is exactly the `?` that skips
 /// the watcher restart.)
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for design defect 2.10. CODE-WRONG as of the 2026-08-21 Track A read: the path aborts the watcher and then returns via ?, installing no replacement on the Err branch, so the recovery observer is lost. Keep ignored and fail-closed until a seam owner exists"]
 fn failed_reload_retains_the_recovery_observer() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");

--- a/tests/project_index_lifecycle_slice0.rs
+++ b/tests/project_index_lifecycle_slice0.rs
@@ -242,12 +242,15 @@ fn empty_placeholder_publication_refuses_watcher_mutation() {
 }
 
 /// Design defect 2.10 — a failed reload removes the recovery observer.
+/// **Resolved by Track A seam 2.** This is now a regression guard, not a
+/// positive control, and it carries no `#[ignore]`.
 ///
 /// `ProjectSlot::reload_with` stops the old watcher before building the
-/// replacement (`src/daemon.rs:3341`). When the build fails, `?` returns before
-/// a replacement watcher starts, so last-known-good content stays in memory
-/// with its only source-change retry trigger gone: later edits are never
-/// observed and nothing retries.
+/// replacement. When the build failed, the error path returned without
+/// starting one, so last-known-good content stayed in memory with its only
+/// source-change retry trigger gone: later edits were never observed and
+/// nothing retried. That path now starts a replacement observer before
+/// propagating the error, on the root the project is still bound to.
 ///
 /// A failed reload must leave the project as observable as it was before.
 ///
@@ -256,9 +259,9 @@ fn empty_placeholder_publication_refuses_watcher_mutation() {
 /// in `ensure_project_slot_for_binding` while the old watcher is still running.
 /// `index_folder` on an open project is the path that reloads it in place, and
 /// a catalog-capacity limit imposed between the two calls is what makes that
-/// rebuild fail. (Capacity refusal is only converted to `Ok(empty)` on the cold
-/// bootstrap path; on reload it propagates, which is exactly the `?` that skips
-/// the watcher restart.)
+/// rebuild fail. Capacity refusal is only converted to `Ok(empty)` on the cold
+/// bootstrap path; on reload it propagates, which is what drives the error path
+/// this control exercises.
 #[test]
 fn failed_reload_retains_the_recovery_observer() {
     run_daemon_test(async {


### PR DESCRIPTION
Track A seam 2. Closes Feature 020 Slice 0 control `failed_reload_retains_the_recovery_observer` — design defect 2.10.

## The defect

`ProjectSlot::reload_with` aborts the project watcher and `take()`s its handle, then rebuilds:

```rust
abort_watcher_task(&mut watcher_task, &old_stop_token);
reload_index(&index, canonical_root)?;   // Err returns here
...
let watcher_task = start_project_watcher(...);  // only reached on Ok
```

On the error path the function returned through the `?` having stopped the observer and cleared its handle, and never started a replacement. A failed in-place reload therefore left the project **with no observer at all** — the retained index stayed queryable, but no later edit was ever seen until the project was reopened.

## The fix

Start a replacement observer on the error path before propagating, watching the root the project is **still bound to**. Retargeting `canonical_root` only happens on the success path, so on failure the old root is the correct one to watch.

## Evidence

RED first, both observed:

```
before  test result: FAILED. 0 passed; 1 failed   (10.22s, burned the full deadline; 8 files before, 8 after)
after   test result: ok.     1 passed; 0 failed   (0.31s, the restarted observer saw the edit immediately)
```

The timing corroborates it — the failing run spent 10s polling a file count that never moved.

## Roster transition

Resolving a control is three coordinated edits, not one. The RED suite runs `-- --ignored`, which selects **only** ignored tests, so removing `#[ignore]` alone would make the case vanish from the artifact and fail closed as a missing case. So: un-ignore, move `RED_CASES` → `RESOLVED_CASES`, and add its own non-ignored suite entry.

`node scripts/slice0-oracle-artifact.cjs` → `expected_outcomes_preserved`, red 11→10, resolved 1→2, no missing or unexpected cases.

`resolved_by` records `slice: null, tasks: []` rather than inventing a task id — no frozen slice owns seam 2, since every slice that could have had already shipped when the control was written. That is why it sat RED after the cut.

## Gates run locally

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — exit 0
- `cargo test --lib --bins --tests -- --test-threads=1` — **3277 passed, 1 failed**

The one failure is `internals::daemon::tests::daemon_idle_shutdown_waits_for_authenticated_activity_then_notifies`, and it is **not from this change**. It reproduces identically on unmodified `main` at `60003830` — `main:6706` and this branch's `:6729` are the same `assert!`, offset by exactly the 23 lines added above it. It passes in CI, so it is a local divergence on `main` rather than a regression here. Logged, not chased — out of scope for this seam.

CI is the authority on all of the above.