### PR TITLE
fix(activation): re-admit when a joined occupancy is stopped mid-flight

### DIFF
--- a/src/index_lifecycle/activation.rs
+++ b/src/index_lifecycle/activation.rs
@@ -1157,33 +1157,67 @@ pub fn admit_project_with_outcome(
         crate::domain::StatePlacement::UserLocal { .. } => AdmissionStatePlacement::UserLocal,
         crate::domain::StatePlacement::MemoryOnly { .. } => AdmissionStatePlacement::MemoryOnly,
     };
-    let plan = plan_admission(
-        &runtime,
-        surface,
-        key.clone(),
-        protection,
-        authorized,
-        requested,
-    )?;
-    let binding = project_source_authority(canonical_root).admission_binding();
-    let (attempt, owner) = execute_plan_with_outcome(&registry, &plan, binding)?;
-    let cleanup_candidate = attempt.cleanup_candidate();
-    match registry.install(&key, Some(owner)) {
-        Ok(live) => Ok(ProjectAdmission {
-            slot: live,
-            cleanup_candidate,
-        }),
-        // Not pending any more: either a concurrent opener installed between
-        // our admit and install, or the admit above JOINED an occupancy that
-        // is already live. Both resolve to the same live slot.
-        Err(RegistryRefusal::NotAdmitted) => registry
-            .live(&key)
-            .map(|live| ProjectAdmission {
-                slot: live,
-                cleanup_candidate,
-            })
-            .map_err(AdapterRefusal::Registry),
-        Err(refusal) => Err(AdapterRefusal::Registry(refusal)),
+    // D17 is fail-never under contention, and the install/live pair below has
+    // THREE outcomes rather than the two its original comment named. An admit
+    // that JOINS an already-live occupancy holds no pending claim of its own.
+    // So when the last session closes and `ProjectRegistry::stop` removes that
+    // live occupancy in the window between our admit and our install, `install`
+    // refuses `NotAdmitted` because nothing is pending AND `live` refuses
+    // `NotAdmitted` because nothing is live. Propagating that is what broke
+    // `open_project_session` under contention.
+    //
+    // A torn-down occupancy is a lost race, not a refusal, so re-admit into a
+    // fresh occupancy instead. Retrying is side-effect free: `plan_admission`
+    // only resolves an owner and validates placement, and
+    // `execute_plan_with_outcome` takes no capacity permit, so a discarded pass
+    // leaves nothing behind. Bounded, because an unbounded retry would turn a
+    // genuinely persistent refusal into a spin.
+    //
+    // Note `stop` cannot produce this against a PENDING occupancy: it
+    // re-inserts what it refused to remove, precisely so a joiner's claim
+    // survives. Only the joined-live shape reaches here.
+    const TORN_DOWN_ADMIT_ATTEMPTS: u32 = 4;
+    let mut torn_down_retries = 0u32;
+    loop {
+        let plan = plan_admission(
+            &runtime,
+            surface,
+            key.clone(),
+            protection,
+            authorized,
+            requested,
+        )?;
+        let binding = project_source_authority(canonical_root).admission_binding();
+        let (attempt, owner) = execute_plan_with_outcome(&registry, &plan, binding)?;
+        let cleanup_candidate = attempt.cleanup_candidate();
+        match registry.install(&key, Some(owner)) {
+            Ok(live) => {
+                return Ok(ProjectAdmission {
+                    slot: live,
+                    cleanup_candidate,
+                });
+            }
+            // Not pending any more: either a concurrent opener installed between
+            // our admit and install, or the admit above JOINED an occupancy that
+            // is already live. Both resolve to the same live slot.
+            Err(RegistryRefusal::NotAdmitted) => match registry.live(&key) {
+                Ok(live) => {
+                    return Ok(ProjectAdmission {
+                        slot: live,
+                        cleanup_candidate,
+                    });
+                }
+                // Neither pending nor live: stopped mid-flight. Re-admit.
+                Err(RegistryRefusal::NotAdmitted)
+                    if torn_down_retries + 1 < TORN_DOWN_ADMIT_ATTEMPTS =>
+                {
+                    torn_down_retries += 1;
+                    continue;
+                }
+                Err(refusal) => return Err(AdapterRefusal::Registry(refusal)),
+            },
+            Err(refusal) => return Err(AdapterRefusal::Registry(refusal)),
+        }
     }
 }
 

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1002,15 +1002,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "407dc7c863884a1eab073898600af23c01675793dcabb04f4e4eb693562e6580",
+    "173b4c20f721c47be0311eced42a323dec80b1588b85e3161eeb059b331661d5",
     20,
-    394_848,
+    396_766,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "c58d6be8caad5175202ffcaa722c7109624ad291bd24c062fb105c464848f41c",
+    "c1101906628e9e40209c64433bbb0df846350ab0f36e86757ea138e982ae40af",
     196,
-    9_310_023,
+    9_311_941,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/project_registry_lifecycle_v11.rs
+++ b/tests/project_registry_lifecycle_v11.rs
@@ -767,3 +767,75 @@ fn overlapping_admits_of_one_key_mint_one_identity() {
     let live = registry.install(&key, None).expect("install");
     assert_eq!(live.slot(), slots[0]);
 }
+
+/// D17 regression window: a stopped occupancy refuses BOTH `install` and
+/// `live`, and re-admitting is what resolves it.
+///
+/// `admit_project_with_outcome` recovers from `install` refusing `NotAdmitted`
+/// by asking `live`, on the reading that a concurrent opener must have
+/// installed the slot. That reading has a third case. An admit that JOINS an
+/// already-live occupancy holds no pending claim, so when the last session
+/// closes and `stop` removes the live occupancy in that window, `install`
+/// refuses because nothing is pending and `live` refuses because nothing is
+/// live. Under contention that propagated out of `open_project_session`, which
+/// D17 forbids.
+///
+/// This pins the shape rather than the race: the double refusal is reachable
+/// deterministically, and a fresh admit clears it. The accepting control is in
+/// the same test because a registry that refuses everything would satisfy the
+/// negative half perfectly.
+#[test]
+fn a_stopped_occupancy_refuses_install_and_live_until_readmitted() {
+    let registry = ProjectRegistry::new();
+    let key = ProjectKey::new("d17-torn-down-occupancy");
+
+    registry
+        .admit(
+            key.clone(),
+            binding(),
+            RootProtection::Normal,
+            false,
+            StatePlacement::MemoryOnly,
+        )
+        .expect("first admission is pending");
+    let live = registry.install(&key, None).expect("pending installs");
+    let first_slot = live.slot();
+    drop(live);
+
+    registry.stop(&key).expect("the live occupancy stops");
+
+    // The window itself: neither pending nor live, so BOTH doors refuse.
+    assert_eq!(
+        registry
+            .install(&key, None)
+            .expect_err("a stopped occupancy has nothing pending to install"),
+        RegistryRefusal::NotAdmitted
+    );
+    assert_eq!(
+        registry
+            .live(&key)
+            .expect_err("a stopped occupancy has nothing live to hand back"),
+        RegistryRefusal::NotAdmitted
+    );
+
+    // The accepting control, and the strategy the caller relies on: a torn-down
+    // occupancy is a lost race, not a refusal, so re-admitting succeeds and
+    // yields a DIFFERENT slot identity than the one that was stopped.
+    registry
+        .admit(
+            key.clone(),
+            binding(),
+            RootProtection::Normal,
+            false,
+            StatePlacement::MemoryOnly,
+        )
+        .expect("re-admission after a stop is accepted");
+    let readmitted = registry
+        .install(&key, None)
+        .expect("the re-admitted occupancy installs");
+    assert_ne!(
+        readmitted.slot(),
+        first_slot,
+        "a re-admission must mint a new slot identity, not resurrect the stopped one"
+    );
+}


### PR DESCRIPTION
Unblocks the 11.0.2 Release. Pre-existing product race, surfaced by `test_concurrent_session_lifecycle_no_deadlock_or_panic` panicking with `Registry(NotAdmitted)` against D17 fail-never.

## The window, narrower than first diagnosed

`ProjectRegistry::stop` **cannot** destroy a `Pending` occupancy — it re-inserts what it refused to remove, with a comment saying why. So the race only bites when an admit **JOINED an already-Live** occupancy and therefore holds no pending claim of its own:

- Thread A closes the last session, `stop` removes the Live occupancy.
- Thread B is between its admit and its `install`.
- `install` refuses `NotAdmitted` — nothing pending.
- `live` refuses `NotAdmitted` — nothing live.

The existing recovery comment names only two outcomes, "a concurrent opener installed" or "our admit joined a live occupancy", and assumes `live()` will therefore find the slot. There is a third: the occupancy was torn down. That propagates and breaks D17.

## The fix

Bounded re-admit, 4 attempts. A torn-down occupancy is a lost race, not a refusal.

Chosen over deferring `registry.stop` because retrying here is provably side-effect free — `plan_admission` only resolves an owner and validates placement, `execute_plan_with_outcome` takes no capacity permit — whereas tracking in-flight cold loads adds state to the stop path, a much larger surface for a release-blocking fix.

**No edit to `registry.rs`, `stop`, `stop_if_unheld`, or `install`.**

## On verification — read this before trusting it

**This race is not reproducible on demand.** 0/25 Windows standalone, 0/40 Linux standalone, 0/4 Linux full-suite, plus parallel-contention runs. CI has hit it once. I am not claiming the fix is verified by reproduction.

What does hold: **the retry is unreachable from any healthy path.** It fires only when `install` refuses `NotAdmitted` AND `live` refuses `NotAdmitted` — a state whose only outcome today is the D17 violation itself. It converts a certain failure into a retry and cannot alter a path that currently passes.

The window is pinned deterministically instead. `a_stopped_occupancy_refuses_install_and_live_until_readmitted` proves the double-refusal state is reachable without threads, and carries its accepting control in the same test: a fresh admit succeeds and mints a **different** slot identity — the exact strategy the fix relies on.

## Gates

- `cargo fmt --check` clean, `clippy --all-targets -D warnings` exit 0
- Full suite **on Linux via WSL**, `--lib --bins --tests --test-threads=1`: **exit 0**. TC reported `outcome_trust: reconstructed` for that run because its daemon restarted mid-run, so the exit code is from the durable receipt rather than witnessed live.
- Both source pins refreshed — `activation.rs` is in EXCLUDED **and** FULL, both moved by an identical +1,918, taken from the oracle's observed actuals and independently recomputed to agree.

## Composition with #623

Per Linus's condition: this is an explicit bounded re-admit of 4 and does **not** change `stop_if_unheld` to leave `Pending`, so the paths compose and #623's test still holds. This should land first — #623 manufactures the same empty occupancy, which widens the hole until re-admit exists.

## Windows-only, not in scope here

Linux is 4/4 clean on `--lib` at `84989188`. The three failures I see locally are Windows-only: `daemon_idle_shutdown_…` (#619), and `daemon_proxy_success_without_receipt_…` plus `daemon_degraded_clears_on_next_success`, which House reads as a separate fake-server-readiness disease.