### PR TITLE
test(activation): cover the bounded re-admit loop, not just its window

### DIFF
--- a/src/index_lifecycle/activation.rs
+++ b/src/index_lifecycle/activation.rs
@@ -1191,6 +1191,9 @@ pub fn admit_project_with_outcome(
         let binding = project_source_authority(canonical_root).admission_binding();
         let (attempt, owner) = execute_plan_with_outcome(&registry, &plan, binding)?;
         let cleanup_candidate = attempt.cleanup_candidate();
+        // The window a concurrent `stop` uses to strand this joiner.
+        #[cfg(all(test, feature = "server"))]
+        admit_before_install::fire();
         match registry.install(&key, Some(owner)) {
             Ok(live) => {
                 return Ok(ProjectAdmission {
@@ -1225,6 +1228,178 @@ pub fn admit_project_with_outcome(
 
 /// Feature 020 V11, T066 — activation machine oracles (in-crate per the
 /// discharged fixture-door precondition; see `runtime.rs`).
+/// Deterministic observation point inside [`admit_project_with_outcome`],
+/// fired after a successful admit and BEFORE its `install`. That is exactly
+/// the window a concurrent `stop` uses to strand a joiner, so a test can
+/// occupy it on purpose instead of hoping a stress run trips the race.
+///
+/// Unlike `store.rs`'s mid-commit hook this is deliberately NOT consumed on
+/// fire. The property under test is how many times the bounded retry re-enters
+/// the window, so the observation must land on EVERY pass; a consume-once hook
+/// would silently measure one.
+///
+/// Gated on `server` as well as `test` for the reason recorded in `store.rs`:
+/// under `--no-default-features --features embed` the lib tests still compile,
+/// and a bare `#[cfg(test)]` module whose only consumer is server-only is an
+/// unused item there, which `-D warnings` rejects.
+#[cfg(all(test, feature = "server"))]
+pub(crate) mod admit_before_install {
+    use std::cell::RefCell;
+
+    type Hook = Box<dyn Fn()>;
+
+    thread_local! {
+        static HOOK: RefCell<Option<Hook>> = const { RefCell::new(None) };
+    }
+
+    /// RAII guard so a hook cannot leak across the thread-local into a sibling
+    /// test sharing this thread.
+    pub(crate) struct BeforeInstallGuard;
+
+    impl Drop for BeforeInstallGuard {
+        fn drop(&mut self) {
+            HOOK.with(|h| *h.borrow_mut() = None);
+        }
+    }
+
+    pub(crate) fn install(hook: impl Fn() + 'static) -> BeforeInstallGuard {
+        HOOK.with(|h| *h.borrow_mut() = Some(Box::new(hook)));
+        BeforeInstallGuard
+    }
+
+    /// Take the hook out for the duration of the call, then re-arm it. Taking
+    /// it first means a hook that re-enters this window cannot double-borrow
+    /// the `RefCell`; re-arming only when the slot is still empty means a hook
+    /// that deliberately uninstalls itself stays uninstalled.
+    pub(crate) fn fire() {
+        let Some(hook) = HOOK.with(|h| h.borrow_mut().take()) else {
+            return;
+        };
+        hook();
+        HOOK.with(|h| {
+            let mut slot = h.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(hook);
+            }
+        });
+    }
+}
+
+/// Coverage for the bounded re-admit loop itself.
+///
+/// The window control in `tests/project_registry_lifecycle_v11.rs` pins that
+/// the empty occupancy is reachable and that a fresh admit clears it. It never
+/// enters the loop, so neither the retry nor its bound was exercised. These do
+/// both, deterministically, by occupying the admit/install window on purpose.
+#[cfg(all(test, feature = "server"))]
+mod admit_retry_loop {
+    use super::{
+        SurfaceKind, admit_before_install, admit_project_with_outcome, process_project_registry,
+    };
+    use crate::domain::index::SourceAccessMode;
+    use crate::domain::{ProjectStateDir, StatePlacement};
+    use crate::live_index::index_lifecycle::registry::ProjectKey;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn placement(root: &std::path::Path) -> StatePlacement {
+        StatePlacement::ProjectLocal {
+            directory: ProjectStateDir::new(root.join(".symforge")),
+        }
+    }
+
+    /// The retry fires: a joiner stranded ONCE re-admits and still returns a
+    /// live slot, instead of surfacing the D17 refusal.
+    ///
+    /// The first admission must install, because the race needs an admit that
+    /// JOINS a live occupancy and therefore holds no pending claim of its own.
+    /// A pending occupancy cannot be stranded this way at all: `stop`
+    /// re-inserts what it refused to remove.
+    #[test]
+    fn a_joiner_stranded_once_is_re_admitted() {
+        let root = tempfile::tempdir().expect("root");
+        let id = "d17-loop-retry-once";
+        let key = ProjectKey::new(id);
+        let registry = process_project_registry();
+
+        admit_project_with_outcome(
+            SurfaceKind::Stdio,
+            root.path(),
+            id,
+            SourceAccessMode::NormalProject,
+            &placement(root.path()),
+        )
+        .expect("the first admission installs and goes live");
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&fired);
+        let strand = Arc::clone(&registry);
+        let stranded_key = key.clone();
+        let _hook = admit_before_install::install(move || {
+            // Strand the FIRST pass only, so the retry has something to prove.
+            if counter.fetch_add(1, Ordering::SeqCst) == 0 {
+                let _ = strand.stop(&stranded_key);
+            }
+        });
+
+        admit_project_with_outcome(
+            SurfaceKind::Stdio,
+            root.path(),
+            id,
+            SourceAccessMode::NormalProject,
+            &placement(root.path()),
+        )
+        .expect("a joiner stranded mid-flight must re-admit, not refuse");
+
+        assert_eq!(
+            fired.load(Ordering::SeqCst),
+            2,
+            "the window must be entered twice: the stranded pass and its retry"
+        );
+    }
+
+    /// The bound terminates: a key held torn-down on every pass propagates
+    /// after exactly `TORN_DOWN_ADMIT_ATTEMPTS` entries rather than spinning.
+    ///
+    /// `stop` clears a live occupancy and `cancel` clears a pending one, so
+    /// firing both keeps the key empty whichever shape each pass produced.
+    #[test]
+    fn a_permanently_torn_down_key_propagates_after_the_bound() {
+        let root = tempfile::tempdir().expect("root");
+        let id = "d17-loop-bound-exhausts";
+        let key = ProjectKey::new(id);
+        let registry = process_project_registry();
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&fired);
+        let strand = Arc::clone(&registry);
+        let stranded_key = key.clone();
+        let _hook = admit_before_install::install(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            let _ = strand.stop(&stranded_key);
+            let _ = strand.cancel(&stranded_key);
+        });
+
+        let refused = admit_project_with_outcome(
+            SurfaceKind::Stdio,
+            root.path(),
+            id,
+            SourceAccessMode::NormalProject,
+            &placement(root.path()),
+        );
+
+        assert!(
+            refused.is_err(),
+            "a key that is torn down on every pass must eventually refuse, not spin"
+        );
+        assert_eq!(
+            fired.load(Ordering::SeqCst),
+            4,
+            "the bound is four attempts; a change here is a deliberate change to              TORN_DOWN_ADMIT_ATTEMPTS, not an incidental one"
+        );
+    }
+}
+
 #[cfg(all(test, feature = "server"))]
 mod activation_oracles {
     use super::{ActivationCut, ActivationMode, ActivationRefusal, RegisteredLane};

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1002,15 +1002,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "ae896edff76f2ceae15b59b6aa8ab58a1cf423771dcb68a51e7cc9b61f6c9c5a",
+    "db6bad87336a07b83ac417b7d2efda450b644408f081da2680530a843c886f08",
     20,
-    396_938,
+    403_688,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "963f6ff16db44d60d23abbebf3d75854ce39f68ac4ed60888667e44e096e5cbe",
+    "575a95f48d5f3af80a0d9fd18b6e21918947051f9c79378c6d06b9f3d70143e5",
     196,
-    9_312_113,
+    9_318_863,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Closes the residual Linus flagged on #625. Rebased onto `2e7f2ed6` so it sits on top of #626.

## The gap

`a_stopped_occupancy_refuses_install_and_live_until_readmitted` pins that the empty occupancy is reachable and that a fresh admit clears it. It never enters the retry loop. So neither the re-admit nor its bound was exercised, and describing it as covering "the strategy the fix relies on" blurred that. Linus was right to call it.

## The hook

A deterministic observation point fired between a successful admit and its `install` — exactly the window a concurrent `stop` uses to strand a joiner.

**Unlike `store.rs`'s `reload_mid_commit` hook, this one is deliberately NOT consumed on fire.** The property under test is how many times the bounded loop re-enters; a consume-once hook would have measured a single pass and reported success. It takes the hook out for the duration of the call and re-arms only when the slot is still empty, so a re-entrant hook cannot double-borrow the `RefCell` and a hook that uninstalls itself stays uninstalled.

## The two tests

- `a_joiner_stranded_once_is_re_admitted` — strands the first pass only, asserts the window is entered **twice**. The first admission must *install* before the second joins, because the race needs an admit that JOINED a live occupancy and so holds no pending claim of its own. A pending occupancy cannot be stranded this way at all: `stop` re-inserts what it refused to remove.
- `a_permanently_torn_down_key_propagates_after_the_bound` — fires `stop` **and** `cancel` each pass so the key stays empty whichever shape that pass produced, then asserts the refusal propagates after exactly **4** entries rather than spinning.

## Falsified before trusted

Setting `TORN_DOWN_ADMIT_ATTEMPTS` to 3 makes the bound test fail with `left: 3, right: 4`. It measures real loop re-entry, not a constant against itself. Restored to 4.

## cfg gating

Hook and call site are both `#[cfg(all(test, feature = "server"))]`, for the reason recorded in `store.rs`: under `--no-default-features --features embed` the lib tests still compile, so a bare `#[cfg(test)]` item whose only consumer is server-only is an unused item and `-D warnings` rejects it. That's the 2026-08-12 trap, so I ran that cell explicitly rather than assuming the default gates cover it.

## Gates

- `embed` cell (`--no-default-features --features embed --lib`) — **exit 0**
- `clippy --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — clean. It caught two import-order diffs on the first pass, fixed **before** any pin was computed, per Principle V ordering.
- Full suite on Linux via WSL — the only failures were the two source pin tests, which were deliberately left uncomputed until this rebase. Everything else passed.
- Both source pins refreshed from the oracle's observed actuals and independently recomputed to agree. Identical **+6,750** on each, correct signature for one file in both sets.

## src re-review, as the pin assertion requires

The diff adds exactly one trait impl, `impl Drop for BeforeInstallGuard`, and it is inside the `cfg(all(test, server))` module — the RAII guard that stops a hook leaking across the thread-local into a sibling test. No production reachability, so not a bridge in the sense the pin guards. Nothing else added: no `pub fn`, no macro, no re-export, no registration.

## Compose

Dry-run merged clean against #626 before it landed — my `fire()` at `:1195`, its widened `live()` arm at `:1213`, different hunks of the same function.