### PR TITLE
fix(freshness): latch the observer gap and do not retire it on an ordinary reconcile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,17 @@ every default-feature gate above passes. Run that exact command before pushing
 anything that adds a `#[cfg(test)]` helper. Found the slow way on 2026-08-12: green
 locally and on the `rust` job, red on `embed-build`.
 
+**But that gate only catches unused *imports*, not unused *items* (as_of
+2026-08-23).** `src/lib.rs:4` carries
+`#![cfg_attr(not(feature = "server"), allow(dead_code))]`, so under the embed cell
+`dead_code` is blanket-allowed crate-wide. A non-`cfg(test)` item -- an ordinary
+`pub(crate) fn` -- whose only caller lives in a `server`-gated module therefore
+passes `embed-build` silently. `unused_imports` is a separate lint and stays armed,
+which is why the import case above really does go red. Do not read a green embed
+cell as proof that a newly server-only-consumed item is still reachable; it cannot
+observe that. Measured on 2026-08-23 while landing seam 3a, whose
+`latch_observer_gap` is exactly this shape.
+
 When such a helper's consumer is server-only, gate it on
 `#[cfg(all(test, feature = "server"))]`. The Feature 020 retirement census
 understands cfg predicates: `all(..)` is test-only when any conjunct is, `any(..)`

--- a/scripts/slice0-oracle-artifact.cjs
+++ b/scripts/slice0-oracle-artifact.cjs
@@ -82,6 +82,32 @@ const SUITES = [
       "--test-threads=1",
     ],
   },
+  {
+    target: "tests/project_index_lifecycle_slice0.rs::observer_replacement_gap_is_latched_as_non_current",
+    expected: "green",
+    args: [
+      "test",
+      "--test",
+      "project_index_lifecycle_slice0",
+      "observer_replacement_gap_is_latched_as_non_current",
+      "--",
+      "--exact",
+      "--test-threads=1",
+    ],
+  },
+  {
+    target: "tests/project_index_lifecycle_slice0.rs::old_observer_delivery_after_promotion_is_not_current",
+    expected: "green",
+    args: [
+      "test",
+      "--test",
+      "project_index_lifecycle_slice0",
+      "old_observer_delivery_after_promotion_is_not_current",
+      "--",
+      "--exact",
+      "--test-threads=1",
+    ],
+  },
 ];
 
 const NEWLINE = String.fromCharCode(10);
@@ -104,8 +130,6 @@ const RED_CASES = [
   "configured_capacity_bounds_the_process_not_each_load",
   "empty_placeholder_publication_refuses_watcher_mutation",
   "internals::daemon::tests::concurrent_first_open_performs_exactly_one_cold_load",
-  "observer_replacement_gap_is_latched_as_non_current",
-  "old_observer_delivery_after_promotion_is_not_current",
   "same_path_root_replacement_is_not_silently_adopted",
   "snapshot_seed_is_not_queryable_before_verification",
   "watcher_mutation_during_candidate_build_is_not_discarded",
@@ -140,6 +164,29 @@ const RESOLVED_CASES = new Map([
       // both values from one `Arc<PublishedGeneration>`, so the generation and
       // the root that publication served cannot disagree.
       fix: "src/watcher/mod.rs::effective_fence_generation reads one published generation",
+    },
+  ],
+  [
+    "observer_replacement_gap_is_latched_as_non_current",
+    {
+      // Track A seam 3a. Deliberately no task id: no frozen Feature 020 task
+      // owns this seam, and inventing one would name an owner the roster does
+      // not have.
+      slice: null,
+      tasks: [],
+      defect: "2.6 an observer replacement gap is not latched and any later clean publication erases it",
+      fix: "src/live_index/store.rs::latch_observer_gap latches WatcherUnavailable when an observer is cancelled, and the reload trunk carries it forward instead of rebuilding freshness without it",
+    },
+  ],
+  [
+    "old_observer_delivery_after_promotion_is_not_current",
+    {
+      slice: null,
+      tasks: [],
+      defect: "2.8 a predecessor observation delivered after promotion leaves the promoted generation claiming Current",
+      // Same latch: the gap is retained rather than rederived, so the promoted
+      // generation cannot report Current about a window it never observed.
+      fix: "src/live_index/store.rs::latch_observer_gap, retained verbatim by recompute_freshness_locked",
     },
   ],
 ]);

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -2066,17 +2066,20 @@ impl SharedIndexHandle {
             None => true,
         };
         self.scout_plan.store(Some(Arc::clone(&scout_plan)));
-        // The ONLY place a latched observer gap is retired. Reaching here means
-        // this pass survived every stale-generation rejection above and is
-        // committing its plan, so complete coverage here is observed rather
-        // than intended. The sweep's own `Complete` check authorizes catalog
-        // removals and can still abort before publish, which is why the latch
-        // is not cleared there.
-        let coverage_complete = scout_plan.coverage == crate::domain::CoverageStatus::Complete;
+        // A latched observer gap is deliberately NOT retired here. This lane
+        // runs on every ordinary file event -- `watcher::run_watcher_with_stop`
+        // publishes a reconciled plan per event and its coverage is `Complete`
+        // in the steady state -- so retiring on it clears the latch at the
+        // first event after any handoff, whether or not the missed window was
+        // ever recovered. That is not a latch, and
+        // `observer_replacement_gap_is_latched_as_non_current` fails on it.
+        //
+        // Nor would a full rebuild serve: a file created and deleted inside the
+        // gap leaves no trace in present state, so no amount of re-walking can
+        // prove it was not missed. Retirement belongs to the observer handoff
+        // that can prove a successor's coverage began before the predecessor's
+        // ended; until that exists the honest answer stays Degraded.
         let freshness_changed = self.recompute_freshness_locked(&live, Some(&scout_plan));
-        if coverage_complete {
-            self.retire_observer_gap_locked();
-        }
         if scout_plan_changed || freshness_changed {
             // The scout plan and freshness are part of the published trust
             // bundle. Republish only when that bundle changed; an unchanged
@@ -2150,37 +2153,6 @@ impl SharedIndexHandle {
             }));
         let live = (*self.live.load_full()).clone();
         self.swap_and_publish_retaining_content(live);
-    }
-
-    /// Retire a latched observer gap. Callers MUST hold `write_mutex` and MUST
-    /// have observed a committed reconcile whose coverage is `Complete`;
-    /// anything weaker retires a gap nothing proved was recovered.
-    fn retire_observer_gap_locked(&self) {
-        let current = self.freshness_status.load_full();
-        let FreshnessStatus::Degraded {
-            last_valid_content_generation,
-            reason_codes,
-        } = current.as_ref()
-        else {
-            return;
-        };
-        if !reason_codes.contains(&FreshnessReason::WatcherUnavailable) {
-            return;
-        }
-        let remaining: Vec<FreshnessReason> = reason_codes
-            .iter()
-            .copied()
-            .filter(|reason| *reason != FreshnessReason::WatcherUnavailable)
-            .collect();
-        self.freshness_status
-            .store(Arc::new(if remaining.is_empty() {
-                FreshnessStatus::Current
-            } else {
-                FreshnessStatus::Degraded {
-                    last_valid_content_generation: *last_valid_content_generation,
-                    reason_codes: remaining,
-                }
-            }));
     }
 
     pub(crate) fn set_freshness_status(&self, status: FreshnessStatus) {
@@ -7417,6 +7389,52 @@ mod tests {
             "an unchanged Complete reconciliation must not mint a publication"
         );
         assert_eq!(unchanged.content_generation, healed.content_generation);
+    }
+
+    #[test]
+    fn a_latched_gap_survives_an_ordinary_complete_reconcile() {
+        let project = TempDir::new().unwrap();
+        write_file(
+            project.path(),
+            "main.rs",
+            "fn main() {}
+",
+        );
+        let shared = LiveIndex::load(project.path()).unwrap();
+        let complete_plan = (*shared.scout_plan().expect("cold scout plan")).clone();
+        let project_generation = shared.current_project_generation();
+
+        shared.latch_observer_gap();
+        // Positive control: the latch engaged and reached the published
+        // bundle, so the survival asserted below is a real retention and not
+        // a reason that was never there.
+        assert!(
+            matches!(
+                shared.published_generation().freshness.as_ref(),
+                FreshnessStatus::Degraded { reason_codes, .. }
+                    if reason_codes.contains(&FreshnessReason::WatcherUnavailable)
+            ),
+            "the latch must reach the published bundle"
+        );
+
+        // The reconciled-publication lane runs on EVERY ordinary file event and
+        // its coverage is Complete in the steady state. If that retired the
+        // gap, the first event after any handoff would clear it while proving
+        // nothing about the missed window.
+        assert!(shared.publish_reconciled_scout_plan_at_generation(
+            Some(&complete_plan),
+            complete_plan.clone(),
+            project_generation,
+        ));
+        assert!(
+            matches!(
+                shared.published_generation().freshness.as_ref(),
+                FreshnessStatus::Degraded { reason_codes, .. }
+                    if reason_codes.contains(&FreshnessReason::WatcherUnavailable)
+            ),
+            "an ordinary Complete reconcile must not retire an observer gap: it \
+             rebuilds present state and proves nothing about the missed window"
+        );
     }
 
     #[test]

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -2066,7 +2066,17 @@ impl SharedIndexHandle {
             None => true,
         };
         self.scout_plan.store(Some(Arc::clone(&scout_plan)));
+        // The ONLY place a latched observer gap is retired. Reaching here means
+        // this pass survived every stale-generation rejection above and is
+        // committing its plan, so complete coverage here is observed rather
+        // than intended. The sweep's own `Complete` check authorizes catalog
+        // removals and can still abort before publish, which is why the latch
+        // is not cleared there.
+        let coverage_complete = scout_plan.coverage == crate::domain::CoverageStatus::Complete;
         let freshness_changed = self.recompute_freshness_locked(&live, Some(&scout_plan));
+        if coverage_complete {
+            self.retire_observer_gap_locked();
+        }
         if scout_plan_changed || freshness_changed {
             // The scout plan and freshness are part of the published trust
             // bundle. Republish only when that bundle changed; an unchanged
@@ -2102,6 +2112,75 @@ impl SharedIndexHandle {
     #[must_use]
     pub fn freshness_status(&self) -> Arc<FreshnessStatus> {
         Arc::clone(&self.published_generation().freshness)
+    }
+
+    /// Latch an observer-replacement gap as a durable freshness reason.
+    ///
+    /// A gap is a HISTORICAL fact: for some window no observer covered this
+    /// root, so a change could have landed unseen. Freshness is otherwise a
+    /// pure function of present state, which is why a later publication that
+    /// happens to look clean used to rederive `Current` with nothing having
+    /// proved the missed window was recovered.
+    ///
+    /// `WatcherUnavailable` is the carrier because
+    /// [`Self::recompute_freshness_locked`] already retains it verbatim rather
+    /// than rederiving it, so the latch survives every ordinary republication.
+    /// Only a committed reconcile that proves complete coverage retires it —
+    /// see `publish_reconciled_scout_plan_at_generation`.
+    pub(crate) fn latch_observer_gap(&self) {
+        let _wg = self.write_mutex.lock();
+        let current = self.freshness_status.load_full();
+        let (last_valid, mut reasons) = match current.as_ref() {
+            FreshnessStatus::Degraded {
+                last_valid_content_generation,
+                reason_codes,
+            } => (*last_valid_content_generation, reason_codes.clone()),
+            FreshnessStatus::Current | FreshnessStatus::Verifying => {
+                (self.published_generation().content_generation, Vec::new())
+            }
+        };
+        if reasons.contains(&FreshnessReason::WatcherUnavailable) {
+            return;
+        }
+        reasons.push(FreshnessReason::WatcherUnavailable);
+        self.freshness_status
+            .store(Arc::new(FreshnessStatus::Degraded {
+                last_valid_content_generation: last_valid,
+                reason_codes: reasons,
+            }));
+        let live = (*self.live.load_full()).clone();
+        self.swap_and_publish_retaining_content(live);
+    }
+
+    /// Retire a latched observer gap. Callers MUST hold `write_mutex` and MUST
+    /// have observed a committed reconcile whose coverage is `Complete`;
+    /// anything weaker retires a gap nothing proved was recovered.
+    fn retire_observer_gap_locked(&self) {
+        let current = self.freshness_status.load_full();
+        let FreshnessStatus::Degraded {
+            last_valid_content_generation,
+            reason_codes,
+        } = current.as_ref()
+        else {
+            return;
+        };
+        if !reason_codes.contains(&FreshnessReason::WatcherUnavailable) {
+            return;
+        }
+        let remaining: Vec<FreshnessReason> = reason_codes
+            .iter()
+            .copied()
+            .filter(|reason| *reason != FreshnessReason::WatcherUnavailable)
+            .collect();
+        self.freshness_status
+            .store(Arc::new(if remaining.is_empty() {
+                FreshnessStatus::Current
+            } else {
+                FreshnessStatus::Degraded {
+                    last_valid_content_generation: *last_valid_content_generation,
+                    reason_codes: remaining,
+                }
+            }));
     }
 
     pub(crate) fn set_freshness_status(&self, status: FreshnessStatus) {
@@ -2414,14 +2493,32 @@ impl SharedIndexHandle {
         let _wg = self.write_mutex.lock();
         self.source_exclusions.store(Arc::new(source_exclusions));
         self.scout_plan.store(Some(scout_plan));
-        self.freshness_status.store(Arc::new(if is_degraded {
-            FreshnessStatus::Degraded {
-                last_valid_content_generation: self.published_generation().content_generation,
-                reason_codes: vec![FreshnessReason::ReconciliationPending],
-            }
-        } else {
-            FreshnessStatus::Current
-        }));
+        // A latched observer gap outlives a reload. This rebuild proves present
+        // state; it does not prove the missed window was recovered, and the two
+        // are not the same claim. Carrying it forward is the whole difference
+        // between "the tree looks clean now" and "nothing was lost". Only a
+        // committed reconcile with complete coverage retires it.
+        let latched_gap = matches!(
+            self.freshness_status.load_full().as_ref(),
+            FreshnessStatus::Degraded { reason_codes, .. }
+                if reason_codes.contains(&FreshnessReason::WatcherUnavailable)
+        );
+        let mut reason_codes = Vec::new();
+        if is_degraded {
+            reason_codes.push(FreshnessReason::ReconciliationPending);
+        }
+        if latched_gap {
+            reason_codes.push(FreshnessReason::WatcherUnavailable);
+        }
+        self.freshness_status
+            .store(Arc::new(if reason_codes.is_empty() {
+                FreshnessStatus::Current
+            } else {
+                FreshnessStatus::Degraded {
+                    last_valid_content_generation: self.published_generation().content_generation,
+                    reason_codes,
+                }
+            }));
         self.project_state_dir
             .store(project_state_dir.map(Arc::new));
         self.project_generation.fetch_add(1, Ordering::AcqRel);

--- a/src/live_index/store.rs
+++ b/src/live_index/store.rs
@@ -2468,8 +2468,12 @@ impl SharedIndexHandle {
         // A latched observer gap outlives a reload. This rebuild proves present
         // state; it does not prove the missed window was recovered, and the two
         // are not the same claim. Carrying it forward is the whole difference
-        // between "the tree looks clean now" and "nothing was lost". Only a
-        // committed reconcile with complete coverage retires it.
+        // between "the tree looks clean now" and "nothing was lost".
+        //
+        // Nothing retires the latch. No lane reachable from here can prove a
+        // change that landed unseen was recovered -- a file created and
+        // deleted inside the gap leaves no trace to rebuild from -- so the
+        // latch is one-way for the life of this handle.
         let latched_gap = matches!(
             self.freshness_status.load_full().as_ref(),
             FreshnessStatus::Degraded { reason_codes, .. }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1274,8 +1274,16 @@ pub async fn run_watcher_with_stop(
     }
 
     if cancelled {
-        let mut info = watcher_info.lock();
-        info.state = WatcherState::Off;
+        {
+            let mut info = watcher_info.lock();
+            info.state = WatcherState::Off;
+        }
+        // The observer is going away. Until a successor proves complete
+        // coverage, no one is watching this root, so any change landing in that
+        // window is unseen. Latch it: freshness is otherwise a pure function of
+        // present state, and the next publication that happens to look clean
+        // would rederive `Current` with nothing having proved the gap closed.
+        shared.latch_observer_gap();
     }
 }
 

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1278,11 +1278,14 @@ pub async fn run_watcher_with_stop(
             let mut info = watcher_info.lock();
             info.state = WatcherState::Off;
         }
-        // The observer is going away. Until a successor proves complete
-        // coverage, no one is watching this root, so any change landing in that
-        // window is unseen. Latch it: freshness is otherwise a pure function of
-        // present state, and the next publication that happens to look clean
-        // would rederive `Current` with nothing having proved the gap closed.
+        // The observer is going away and nothing covers this root, so any
+        // change landing before a successor takes over is unseen. Latch it:
+        // freshness is otherwise a pure function of present state, and the next
+        // publication that happens to look clean would rederive `Current` with
+        // nothing having proved the gap closed.
+        //
+        // The latch is one-way. A successor absorbing later events proves
+        // present state, not the missed window, so nothing here retires it.
         shared.latch_observer_gap();
     }
 }

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1008,9 +1008,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "575a95f48d5f3af80a0d9fd18b6e21918947051f9c79378c6d06b9f3d70143e5",
+    "d475f66d074dc5b20b34d4d89acaad36f4298366685ed490bb61e446fedf0b3b",
     196,
-    9_318_863,
+    9_323_828,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1008,9 +1008,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "3e57e34a3cccc7e9eb65e9f62e4f8a157a1d3b58f2fa3306568f987d025e60e2",
+    "8449321f123d87ab65f9954df37e3de720cd592742ef253cd9e29fa48c8c5f2b",
     196,
-    9_324_899,
+    9_325_254,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1008,9 +1008,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "d475f66d074dc5b20b34d4d89acaad36f4298366685ed490bb61e446fedf0b3b",
+    "3e57e34a3cccc7e9eb65e9f62e4f8a157a1d3b58f2fa3306568f987d025e60e2",
     196,
-    9_323_828,
+    9_324_899,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {

--- a/tests/project_index_lifecycle_slice0.rs
+++ b/tests/project_index_lifecycle_slice0.rs
@@ -374,7 +374,6 @@ fn failed_reload_retains_the_recovery_observer() {
 /// about the window rather than a race: the predecessor is stopped and awaited
 /// before the write, and the successor starts after it.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for observer replacement gaps. CODE-WRONG as of the 2026-08-21 Track A read: recompute_freshness_locked drops the historical gap and rederives Current, so nothing latches. Keep ignored and fail-closed until a seam owner exists"]
 fn observer_replacement_gap_is_latched_as_non_current() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");
@@ -482,7 +481,6 @@ fn observer_replacement_gap_is_latched_as_non_current() {
 /// present state, so the next clean publication erases it. The assertion is
 /// therefore that the consumed-delivery fact survives an ordinary clean reload.
 #[test]
-#[ignore = "Feature 020 Slice 0 RED control for old-observer delivery after promotion. CODE-WRONG as of the 2026-08-21 Track A read: the same rederive path runs with no stable observer token fencing delivery. Keep ignored and fail-closed until a seam owner exists"]
 fn old_observer_delivery_after_promotion_is_not_current() {
     run_daemon_test(async {
         let project = TempDir::new().expect("project dir");


### PR DESCRIPTION
Seam 3a. A cancelled watcher leaves its root uncovered until something proves coverage resumed. Freshness was a pure function of present state, so the next publication that happened to look clean rederived `Current` with nothing having proved the missed window was recovered.

## What this does

| Site | Where | Why |
|---|---|---|
| **Set** | `watcher/mod.rs`, the `if cancelled` tail | The observer is going away and nothing covers the root |
| **Preserve** | `store.rs` reload trunk | It stored a fresh status and discarded every reason |

`WatcherUnavailable` needed no new machinery: `recompute_freshness_locked` already retains it verbatim rather than rederiving it. The carrier was designed for this and never wired.

**There is deliberately no clear.** Two earlier shapes were tried and both are wrong:

1. Retire beside `recompute_freshness_locked` â€” mutates freshness outside the publish guard, so an unchanged `Complete` reconcile skips the republish and strands the latch in the published bundle. Caught by Linus. RED oracle reproduced it: `left: Degraded { reason_codes: [WatcherUnavailable] } / right: Current`.
2. Retire inside `recompute_freshness_locked`, gated on observed `Complete` coverage â€” fixes the wiring and thereby exposes the real defect. `reconcile_stale_files_with_stop_and_hook` publishes a reconciled plan through the commit point on **every file event**, and its coverage is `Complete` in the steady state. So the latch is cleared by the first file event after any handoff. `observer_replacement_gap_is_latched_as_non_current` fails at its gap-window precondition, with `absorbed` already true.

A full rebuild is no better: a file created *and deleted* inside the gap leaves no trace in present state, which is why the control rejects a clean `reload()` too. Retirement needs proof that a successor's coverage began before the predecessor's ended. No such proof exists yet, so this seam latches and stops, and the honest answer stays `Degraded`.

Removing the retirement also satisfies the structural requirement more completely than gating it did â€” with no second freshness writer, a write outside the publish guard does not merely become unrepresentable, it does not exist.

## Roster

Both controls resolved, three edits each per the fail-closed rule (un-ignore alone reports `missing_cases`):

| Control | Defect | Edits |
|---|---|---|
| `observer_replacement_gap_is_latched_as_non_current` | 2.6 | un-ignore, `RED_CASES` to `RESOLVED_CASES`, live suite entry |
| `old_observer_delivery_after_promotion_is_not_current` | 2.8 | same |

`slice: null`, `tasks: []` â€” no frozen Feature 020 task owns this seam, and inventing a task id would name an owner the roster does not have. Suite entries are templated on `failed_reload_retains_the_recovery_observer`.

Oracle observed: **12 controls preserved, 8 red and 4 resolved-green**, exit 0.

## Gates

- Full suite `--no-fail-fast`: exactly one target failed, the source pin, now refreshed. No behavioral failures.
- `preventive_runtime_dark_v11`: 10 passed, 0 failed.
- `clippy --all-targets -D warnings`: exit 0.
- embed cell: 1355 passed, exit 0.
- `FULL_SOURCE_PIN_V1` refreshed from the oracle's post-`fmt` actual.
- `EXCLUDED_RUNTIME_SOURCE_PIN_V1` unchanged, confirmed twice: neither file is a member of `EXCLUDED_RUNTIME_SOURCE_PATHS`, and its control was observed passing against the unchanged pin.

## Corrections to this PR's earlier claims

Three claims in the first revision were wrong and are withdrawn:

- **"Slice-0: 9 RED to 7 RED"** asserted a roster transition that was never performed. The controls were still `#[ignore]`d and still listed RED; what was observed was two ignored tests passing under `--ignored`. Only one of them actually passed at that revision.
- **`healed_observation_restores_current_freshness` as the canary** â€” it only ever exercises `ObservationFailed` and never latches `WatcherUnavailable`, so it could not discriminate the separation it was offered as evidence for.
- **"blast radius empty"** was empty of *test* failures, which is not the same as correct. No existing test latched a gap and then committed an unchanged `Complete` plan, which is why the defect needed a new oracle rather than a suite run.

## Third commit (Linus's nits, 838aa6f0)

Two comments still described the v1 retirement: the reload trunk said "Only a committed reconcile with complete coverage retires it", and the watcher-cancel site said "Until a successor proves complete coverage". Both imply something can close the gap. Nothing can.

Replaced with the property that holds — the latch is one-way for the life of the handle — so the residual is recorded in the code rather than only in review. The diff is comment-only, machine-verified (no non-comment line moved in `src/`), so behavior is identical to 838aa6f0 and its green CI still stands; only `FULL_SOURCE_PIN_V1` moves, to `8449321f…` / 196 / 9_325_254. `EXCLUDED_RUNTIME_SOURCE_PIN_V1` and `WORKFLOW_FINGERPRINTS` untouched.

## Second commit

The embed cell **cannot observe** an unused item: `src/lib.rs:4` carries `#![cfg_attr(not(feature = "server"), allow(dead_code))]`, so `dead_code` is blanket-allowed with `server` off. It still catches unused **imports** (the real 2026-08-12 trap). Recorded in CLAUDE.md so a future green embed cell is not read as proof of reachability it never measured.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn

