### PR TITLE
test(daemon): report the status and body when the caller-root guard fails

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12581,9 +12581,21 @@ mod tests {
             .send()
             .await
             .expect("matched request");
+        // The status and body are read BEFORE asserting. A bare `assert!` on
+        // `is_success()` reports only its own message, so a failure here could
+        // not be told apart from a 409 the guard raised, a 5xx the sidecar
+        // returned, or anything else non-2xx -- which is exactly what left
+        // Release 32660381244 undiagnosable. Reading the body consumes the
+        // response, which is safe: nothing uses `matched` after this.
+        let matched_status = matched.status();
+        let matched_body = matched
+            .text()
+            .await
+            .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
         assert!(
-            matched.status().is_success(),
-            "caller_root=B (the active project) must be served"
+            matched_status.is_success(),
+            "caller_root=B (the active project) must be served, got {matched_status}: \
+             {matched_body}"
         );
 
         let unpinned = client.get(url("")).send().await.expect("unpinned request");

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1008,9 +1008,9 @@ const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "8449321f123d87ab65f9954df37e3de720cd592742ef253cd9e29fa48c8c5f2b",
+    "2b3f42b0606e898e5bc3951f702c718f052796df85c7de0f05482c74e0bdcca0",
     196,
-    9_325_254,
+    9_325_959,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Release 32660381244 failed `test_daemon_sidecar_enforces_caller_root_guard` at `daemon.rs:12584` and left no way to tell a flake from a regression. This makes the next run answer that question.

## Why it was undiagnosable

The test has two adjacent assertions with very different diagnostic value:

| Assertion | Form | What a failure tells you |
|---|---|---|
| A must 409 once B is active | `assert_eq!(status, CONFLICT)` | the actual status — which is how House confirmed ACTIVE had left A |
| B must be served | `assert!(status.is_success(), "...")` | only the message |

So the run established that B was not 2xx and nothing more. A 409 from the guard, a 5xx from the sidecar, and anything else are indistinguishable in the log. One line apart, and only one of them could answer a question.

## What changed

Read `matched.status()` and the body before asserting, and put both in the failure message. Consuming the response is safe — nothing uses `matched` afterwards.

No product code changes. The test passes locally with the instrumentation in place (1 passed), so this cannot itself be the thing that reddens the next run.

## Pins

**Only `FULL_SOURCE_PIN_V1` moves**, not both. `src/daemon.rs` is not a member of `EXCLUDED_RUNTIME_SOURCE_PATHS` — that set is the 19 `index_lifecycle/*.rs` files plus `server_api.rs`. Confirmed two ways: by membership, and by `excluded_runtime_source_set_matches_reviewed_baseline` passing against its unchanged pin in the same run that failed `FULL` (9 passed, 1 failed).

- `FULL` → `2b3f42b0606e898e5bc3951f702c718f052796df85c7de0f05482c74e0bdcca0` / 196 / 9_325_959
- `EXCLUDED` unchanged at `db6bad87…` / 20 / 403_688

The baseline `FULL` failed against was `8449321f…`, c86741aa's value — incidental confirmation that #632's squash tree matched.

## Gates

- `preventive_runtime_dark_v11`: 10 passed, 0 failed
- `clippy --all-targets -D warnings`: exit 0
- `fmt`: clean
- `test_daemon_sidecar_enforces_caller_root_guard`: 1 passed

## Note

`unpinned.status().is_success()`, three lines below, is a bare `assert!` with the same blindness. I left it alone rather than widen the scope — flagging it for a call rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn
