### PR TITLE
docs(activation): replace a falsified bridging claim with the call-site state

### DIFF
--- a/src/index_lifecycle/activation.rs
+++ b/src/index_lifecycle/activation.rs
@@ -934,10 +934,15 @@ pub fn project_source_authority(root: &Path) -> Arc<ProjectSourceAuthority> {
 /// acquisitions progressively narrow — a `data_plane()` call site is a
 /// member of the rerouting set by construction, not by grep luck.
 ///
-/// Mid-cut bridging claim, recorded: the accessors expose the V10 data
-/// plane unchanged (behavior-preserving ownership move); typed acquisition
-/// branches arrive at the dispatch necks with C4's bootstrap and gating
-/// commits, not by rewriting each handler body.
+/// Recorded ownership claim: the accessors expose the V10 data plane
+/// unchanged, so moving a field onto this handle is behavior-preserving.
+///
+/// `acquire` is the typed branch -- it refuses when the carried admission
+/// slot is no longer the live occupancy of its key. It is NOT how the
+/// dispatch necks acquire in general: only a surface that binds WITH a slot
+/// can be gated at all, and the untyped `data_plane` / `shared` doors carry
+/// the rest. That is the state of the call sites, enumerable through the two
+/// accessors above; nothing here promises it changes.
 // No Debug derive: `SharedIndexHandle` itself carries none.
 #[derive(Clone)]
 pub struct ProjectRuntimeHandle {

--- a/tests/preventive_runtime_dark_v11.rs
+++ b/tests/preventive_runtime_dark_v11.rs
@@ -1002,15 +1002,15 @@ const EXCLUDED_RUNTIME_SOURCE_PATHS: &[&str] = &[
 ];
 const EXCLUDED_RUNTIME_SOURCE_DOMAIN_V1: &[u8] = b"symforge-excluded-runtime-source-set-v1\0";
 const EXCLUDED_RUNTIME_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "db6bad87336a07b83ac417b7d2efda450b644408f081da2680530a843c886f08",
+    "707dd7a7dcbf1d5c70a21983ede40b4b0c56c3c43e70ea398a1690da5f08faad",
     20,
-    403_688,
+    403_999,
 );
 const FULL_SOURCE_DOMAIN_V1: &[u8] = b"symforge-full-source-set-v1\0";
 const FULL_SOURCE_PIN_V1: (&str, usize, usize) = (
-    "2b3f42b0606e898e5bc3951f702c718f052796df85c7de0f05482c74e0bdcca0",
+    "eb10e17a11560049a7886da3f446f38b2e0a1565a4d30807138de3d3db3599bf",
     196,
-    9_325_959,
+    9_326_270,
 );
 
 fn crlf_to_lf(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
`ProjectRuntimeHandle` carried a mid-cut claim that outlived the cut:

> typed acquisition branches arrive at the dispatch necks with C4's bootstrap and gating commits, not by rewriting each handler body.

C4 shipped in 11.0.0 on 2026-08-20. The prose is **falsified, not pending**, and it names a future owner for work no frozen task holds.

## Measured, not assumed

| | |
|---|---|
| `.acquire()` call sites | **1** — `daemon.rs:1993`, the dispatch neck |
| `.data_plane()` call sites | **226** |
| `bind_admitted` callers | **1** (daemon) |
| `ProjectRuntimeHandle::bind` callers | 17 |

The typed branch exists and is correct, but it gates one neck — the only surface that binds *with* an admission slot. Every other surface binds `None`, so its consumers cannot be gated at all and take the untyped `data_plane` / `shared` doors.

The replacement states that. It keeps the behavior-preserving half of the original claim, which is still true, and writes no count into the comment so it cannot rot the way the old one did.

## Pins

Comment-only, machine-verified that no non-comment line moved in `src/`. Both pins move because `activation.rs` is a member of `EXCLUDED_RUNTIME_SOURCE_PATHS` **and** of the full `src/` set:

- `FULL` → `eb10e17a11560049a7886da3f446f38b2e0a1565a4d30807138de3d3db3599bf` / 196 / 9_326_270
- `EXCLUDED` → `707dd7a7dcbf1d5c70a21983ede40b4b0c56c3c43e70ea398a1690da5f08faad` / 20 / 403_999

**Both deltas are +311 bytes** — the same bytes counted twice. That equality is the cross-check that exactly one dual-membership file changed; had they differed, something outside the excluded set moved unnoticed. File counts hold at 20 and 196.

Rebased onto `c0bff505` with `--onto` (the branch predated #632's squash). The prose applied clean; only the pin constant collided, and it was recomputed from the oracle rather than resolved to either side. `EXCLUDED` passed **unchanged** across the rebase, confirming #634 touched nothing in that set.

## Gates

`preventive_runtime_dark_v11` 10 passed 0 failed · `clippy --all-targets -D warnings` exit 0 · `fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpTAxUUg5D2d5vwYEp5LNn
